### PR TITLE
Added some 128 px icons

### DIFF
--- a/elementary-xfce/apps/128/accessories-calculator.svg
+++ b/elementary-xfce/apps/128/accessories-calculator.svg
@@ -1,0 +1,1466 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg3478"
+   sodipodi:version="0.32"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="accessories-calculator.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape">
+  <metadata
+     id="metadata94">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     inkscape:window-height="749"
+     inkscape:window-width="1278"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     guidetolerance="10.0"
+     gridtolerance="10.0"
+     objecttolerance="10.0"
+     borderopacity="1.0"
+     bordercolor="#666666"
+     pagecolor="#ffffff"
+     id="base"
+     showgrid="false"
+     inkscape:zoom="2.8284272"
+     inkscape:cx="63.302254"
+     inkscape:cy="57.44439"
+     inkscape:window-x="65"
+     inkscape:window-y="28"
+     inkscape:current-layer="svg3478"
+     inkscape:window-maximized="0" />
+  <defs
+     id="defs3480">
+    <linearGradient
+       id="linearGradient4608">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4610" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.02714999" />
+      <stop
+         offset="0.97000045"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4614" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4616" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         id="stop3430"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3436"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3432"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.507806"
+       y1="39"
+       x2="11.507806"
+       y2="47.015659"
+       id="linearGradient6620"
+       xlink:href="#linearGradient3428"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="3"
+       cy="43"
+       r="2"
+       fx="3"
+       fy="43"
+       id="radialGradient6618"
+       xlink:href="#linearGradient3414"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,35,-43)" />
+    <linearGradient
+       id="linearGradient3414">
+      <stop
+         id="stop3416"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3418"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="3"
+       cy="43"
+       r="2"
+       fx="3"
+       fy="43"
+       id="radialGradient6616"
+       xlink:href="#linearGradient3414"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-13,-129)" />
+    <linearGradient
+       id="linearGradient2490-654-721">
+      <stop
+         id="stop2913"
+         style="stop-color:#6e6e6e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2915"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2556">
+      <stop
+         id="stop2558"
+         style="stop-color:#dcdcdc;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2564"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3341">
+      <stop
+         id="stop3343"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3345"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3251">
+      <stop
+         id="stop3253"
+         style="stop-color:#888986;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3255"
+         style="stop-color:#888986;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3426">
+      <stop
+         id="stop3428"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426"
+       id="linearGradient2487"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(2.689662,0,0,2.7272793,-0.5516503,-2.0002726)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3251"
+       id="linearGradient2517"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6449249,0,0,2.6671609,-25.908806,0.300079)"
+       x1="22.344988"
+       y1="37.998562"
+       x2="22.344988"
+       y2="39.508205" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3341"
+       id="linearGradient2533"
+       gradientUnits="userSpaceOnUse"
+       x1="22.162495"
+       y1="13.755174"
+       x2="21.643173"
+       y2="3.6441264"
+       gradientTransform="matrix(2.7325908,0,0,2.9221824,-1.5819497,-6.4555262)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2556"
+       id="linearGradient2540"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.686673,0,0,3.0162391,-7.1982941,-15.237974)"
+       x1="22.505953"
+       y1="7.5892501"
+       x2="22.505953"
+       y2="44.996727" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2490-654-721"
+       id="linearGradient2542"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6075512,0,0,2.6831841,1.4189936,-3.0999093)"
+       x1="31.278551"
+       y1="56.744396"
+       x2="31.278551"
+       y2="4.0075235" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4608"
+       id="linearGradient3958"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2162216,0,0,2.8648718,10.810921,-4.7570114)"
+       x1="23.99999"
+       y1="5.3220015"
+       x2="23.99999"
+       y2="42.597485" />
+    <linearGradient
+       id="linearGradient3924-803-1">
+      <stop
+         id="stop3252-6"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8" />
+      <stop
+         id="stop3256-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999"
+       gradientTransform="matrix(1.8918964,0,0,0.59459605,18.594721,13.729503)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984"
+       xlink:href="#linearGradient3924-803-1"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.81081276,0,0,0.16216255,24.540681,102.10811)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1"
+       xlink:href="#linearGradient3924-803-1-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6">
+      <stop
+         id="stop3252-6-1"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3" />
+      <stop
+         id="stop3256-6-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9"
+       id="linearGradient2487-1"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(1.3103482,0,0,1.2727303,12.551831,91.999958)" />
+    <linearGradient
+       id="linearGradient3426-9">
+      <stop
+         id="stop3428-8"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,27.513657,86.108064)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0"
+       xlink:href="#linearGradient3924-803-1-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6">
+      <stop
+         id="stop3252-6-1-3"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0" />
+      <stop
+         id="stop3256-6-1-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3"
+       id="linearGradient2487-1-2"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,19.10357,75.999919)" />
+    <linearGradient
+       id="linearGradient3426-9-3">
+      <stop
+         id="stop3428-8-5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,27.513657,70.108015)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-0"
+       xlink:href="#linearGradient3924-803-1-6-6-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-9">
+      <stop
+         id="stop3252-6-1-3-0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-6" />
+      <stop
+         id="stop3256-6-1-3-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-0"
+       id="linearGradient2487-1-2-4"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,19.10357,59.999877)" />
+    <linearGradient
+       id="linearGradient3426-9-3-0">
+      <stop
+         id="stop3428-8-5-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,27.513657,54.107975)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-6"
+       xlink:href="#linearGradient3924-803-1-6-6-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-7">
+      <stop
+         id="stop3252-6-1-3-9"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-1" />
+      <stop
+         id="stop3256-6-1-3-8"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-9"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-5"
+       id="linearGradient2487-1-2-7"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,19.10357,43.999839)" />
+    <linearGradient
+       id="linearGradient3426-9-3-5">
+      <stop
+         id="stop3428-8-5-2"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-9"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,47.513706,54.107975)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-6-2"
+       xlink:href="#linearGradient3924-803-1-6-6-7-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-7-6">
+      <stop
+         id="stop3252-6-1-3-9-2"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-1-2" />
+      <stop
+         id="stop3256-6-1-3-8-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-9-9"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-5-8"
+       id="linearGradient2487-1-2-7-7"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,39.103619,43.999839)" />
+    <linearGradient
+       id="linearGradient3426-9-3-5-8">
+      <stop
+         id="stop3428-8-5-2-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-9-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,47.513706,70.108015)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-0-4"
+       xlink:href="#linearGradient3924-803-1-6-6-9-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-9-5">
+      <stop
+         id="stop3252-6-1-3-0-9"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-6-6" />
+      <stop
+         id="stop3256-6-1-3-7-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-7-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-0-2"
+       id="linearGradient2487-1-2-4-9"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,39.103619,59.999877)" />
+    <linearGradient
+       id="linearGradient3426-9-3-0-2">
+      <stop
+         id="stop3428-8-5-7-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-1-7"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,47.513706,86.108064)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-8"
+       xlink:href="#linearGradient3924-803-1-6-6-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-6">
+      <stop
+         id="stop3252-6-1-3-2"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-8" />
+      <stop
+         id="stop3256-6-1-3-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-99"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-54"
+       id="linearGradient2487-1-2-44"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,39.103619,75.999919)" />
+    <linearGradient
+       id="linearGradient3426-9-3-54">
+      <stop
+         id="stop3428-8-5-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-18"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,67.513755,54.107975)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-6-9"
+       xlink:href="#linearGradient3924-803-1-6-6-7-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-7-8">
+      <stop
+         id="stop3252-6-1-3-9-6"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-1-7" />
+      <stop
+         id="stop3256-6-1-3-8-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-9-4"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-5-1"
+       id="linearGradient2487-1-2-7-9"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,59.103668,43.999839)" />
+    <linearGradient
+       id="linearGradient3426-9-3-5-1">
+      <stop
+         id="stop3428-8-5-2-3"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-9-3"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,67.513755,70.108015)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-0-6"
+       xlink:href="#linearGradient3924-803-1-6-6-9-9"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-9-9">
+      <stop
+         id="stop3252-6-1-3-0-94"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-6-0" />
+      <stop
+         id="stop3256-6-1-3-7-8"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-7-5"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-0-4"
+       id="linearGradient2487-1-2-4-99"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,59.103668,59.999877)" />
+    <linearGradient
+       id="linearGradient3426-9-3-0-4">
+      <stop
+         id="stop3428-8-5-7-8"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-1-9"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,67.513755,86.108064)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-81"
+       xlink:href="#linearGradient3924-803-1-6-6-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-8">
+      <stop
+         id="stop3252-6-1-3-4"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-3" />
+      <stop
+         id="stop3256-6-1-3-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-07"
+       id="linearGradient2487-1-2-1"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,59.103668,75.999919)" />
+    <linearGradient
+       id="linearGradient3426-9-3-07">
+      <stop
+         id="stop3428-8-5-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-6"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,87.513804,54.107975)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-6-1"
+       xlink:href="#linearGradient3924-803-1-6-6-7-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-7-1">
+      <stop
+         id="stop3252-6-1-3-9-9"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-1-9" />
+      <stop
+         id="stop3256-6-1-3-8-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-9-95"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-5-13"
+       id="linearGradient2487-1-2-7-6"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,79.103717,43.999839)" />
+    <linearGradient
+       id="linearGradient3426-9-3-5-13">
+      <stop
+         id="stop3428-8-5-2-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-9-1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,87.513804,70.108015)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-0-1"
+       xlink:href="#linearGradient3924-803-1-6-6-9-1"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-9-1">
+      <stop
+         id="stop3252-6-1-3-0-90"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-6-4" />
+      <stop
+         id="stop3256-6-1-3-7-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-7-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-0-28"
+       id="linearGradient2487-1-2-4-997"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,79.103717,59.999877)" />
+    <linearGradient
+       id="linearGradient3426-9-3-0-28">
+      <stop
+         id="stop3428-8-5-7-72"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-1-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="40.287071"
+       x2="23.99999"
+       y1="6.4195294"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.59459605,87.513804,83.729678)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-88"
+       xlink:href="#linearGradient3924-803-1-6-6-98"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-98">
+      <stop
+         id="stop3252-6-1-3-90"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-9" />
+      <stop
+         id="stop3256-6-1-3-15"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-3"
+       id="linearGradient2487-1-2-6"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,2.7272793,79.103717,67.999893)" />
+    <linearGradient
+       id="linearGradient3426-9-3-3">
+      <stop
+         id="stop3428-8-5-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-0"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="34.466667"
+       x2="23.99999"
+       y1="10.688878"
+       x1="23.99999"
+       gradientTransform="matrix(0.2702709,0,0,0.16216255,67.513755,102.10811)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3984-1-0-6-9-9"
+       xlink:href="#linearGradient3924-803-1-6-6-7-8-5"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3924-803-1-6-6-7-8-5">
+      <stop
+         id="stop3252-6-1-3-9-6-8"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3254-8-3-0-1-7-4" />
+      <stop
+         id="stop3256-6-1-3-8-2-8"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3258-0-8-6-9-4-3"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3426-9-3-5-1-9"
+       id="linearGradient2487-1-2-7-9-6"
+       gradientUnits="userSpaceOnUse"
+       x1="24"
+       y1="17"
+       x2="24"
+       y2="4.9924679"
+       gradientTransform="matrix(0.6206912,0,0,1.2727303,59.103668,91.999958)" />
+    <linearGradient
+       id="linearGradient3426-9-3-5-1-9">
+      <stop
+         id="stop3428-8-5-2-3-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3431-3-0-9-3-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <g
+     style="opacity:0.3"
+     id="g3438"
+     transform="matrix(2.3620952,0,0,2.6409833,6.9747144,-1.1242151)">
+    <rect
+       style="fill:url(#radialGradient6616);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect3404"
+       transform="scale(-1,-1)"
+       y="-47"
+       x="-7"
+       height="8"
+       width="4" />
+    <rect
+       style="fill:url(#radialGradient6618);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect3422"
+       y="39"
+       x="41"
+       height="8"
+       width="4" />
+    <rect
+       style="fill:url(#linearGradient6620);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect3426"
+       y="39"
+       x="7"
+       height="8"
+       width="34" />
+  </g>
+  <rect
+     style="fill:url(#linearGradient2540);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2542);stroke-width:2.03012204;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:6;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:1.4;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2157"
+     y="9.0148096"
+     x="21.015188"
+     ry="4.0220995"
+     rx="4.0220995"
+     height="109.97015"
+     width="85.970093" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045"
+     y="14.999764"
+     x="27.000145"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="26.000067"
+     width="74.000183" />
+  <rect
+     style="opacity:0.6;fill:none;stroke:url(#linearGradient2517);stroke-width:1.99201202;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:6;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:1.4;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3261"
+     y="102.9857"
+     x="30.034489"
+     ry="0"
+     rx="0"
+     height="5.3343663"
+     width="27.371857" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424"
+     y="12.999759"
+     x="25.000141"
+     ry="4.291862"
+     rx="4.291862"
+     height="30.000074"
+     width="78.000191" />
+  <path
+     style="font-size:6px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;fill:#ffffff;fill-opacity:1;stroke:none;font-family:URW Gothic L;-inkscape-font-specification:URW Gothic L Book"
+     d="m 67.924107,29.889338 c 1.151223,-0.132061 2.5827,0.454879 2.661424,1.763973 0.229589,1.310203 -1.102914,2.556646 -2.390519,2.114213 -1.194344,-0.007 -0.931089,-1.819687 -1.826781,-1.766177 -0.564046,0 -1.128088,0 -1.692132,0 0.02266,2.12285 1.97451,3.895742 4.080012,3.792014 2.068893,0.09674 3.9607,-1.677697 3.963126,-3.75533 0.319951,-1.41112 -0.968429,-2.824634 -1.710597,-3.363236 1.713581,-1.418739 0.726758,-4.488405 -1.345371,-4.98395 -1.816948,-0.61353 -4.07797,0.699609 -4.090808,2.711612 0.09738,0.376201 0.931548,0.08132 1.339258,0.174861 1.098104,0.407645 0.752337,-1.139439 1.796394,-1.072005 1.628594,0.04324 1.151029,2.651671 -0.401753,2.32001 -0.694238,-0.11096 -0.263176,0.85582 -0.382253,1.296307 0,0.255899 0,0.511801 0,0.767702 z m 6.632774,5.696022 c 0.709336,0 1.418673,0 2.128012,0 0,-0.682669 0,-1.36534 0,-2.048007 -0.709339,0 -1.418676,0 -2.128012,0 0,0.682667 0,1.365338 0,2.048007 z m 7.252779,0 c 0.709335,0 1.418673,0 2.12801,0 0,-3.941347 0,-7.882697 0,-11.824045 -1.20534,0 -2.410678,0 -3.616014,0 0,0.666668 0,1.333337 0,2.000007 0.496001,0 0.992002,0 1.488004,0 0,3.27468 0,6.549358 0,9.824038 z m 5.032771,-3.504013 c 0,0.576 0,1.152002 0,1.728005 1.701339,0 3.402683,0 5.104023,0 0,0.592002 0,1.184007 0,1.776008 0.709336,0 1.418671,0 2.128005,0 0,-0.592001 0,-1.184006 0,-1.776008 0.373293,-0.09292 1.123473,0.191061 1.248005,-0.15062 0,-0.58446 0,-1.168919 0,-1.753379 -0.373291,-0.09292 -1.123468,0.191061 -1.248005,-0.15062 0,-2.664468 0,-5.328938 0,-7.993406 -0.597333,0 -1.194668,0 -1.792004,0 -1.813342,2.773343 -3.626684,5.546687 -5.440024,8.320032 z m 5.104023,-0.176 c -0.981338,0 -1.962675,0 -2.944013,0 0.981338,-1.520005 1.962675,-3.040012 2.944013,-4.560017 0,1.520005 0,3.040012 0,4.560017 z"
+     id="text2469"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:type="inkscape:offset"
+     inkscape:radius="0.31920615"
+     inkscape:original="M 26.25 8.75 C 25.568647 8.5199265 24.723565 9.0267516 24.71875 9.78125 C 24.755266 9.9223244 25.065859 9.8086703 25.21875 9.84375 C 25.630538 9.9966167 25.514731 9.4122119 25.90625 9.4375 C 26.516972 9.4537159 26.33229 10.436872 25.75 10.3125 C 25.489662 10.270893 25.638403 10.616068 25.59375 10.78125 C 25.59375 10.877212 25.59375 10.997788 25.59375 11.09375 C 26.025457 11.044226 26.564229 11.259092 26.59375 11.75 C 26.679845 12.241324 26.17035 12.697162 25.6875 12.53125 C 25.239623 12.528606 25.335883 11.854934 25 11.875 C 24.788484 11.875 24.586516 11.875 24.375 11.875 C 24.383499 12.671066 25.116689 13.351398 25.90625 13.3125 C 26.682081 13.34878 27.40534 12.654109 27.40625 11.875 C 27.52623 11.345832 27.028311 10.826975 26.75 10.625 C 27.39259 10.092975 27.027045 8.9358285 26.25 8.75 z M 30.25 8.78125 C 30.25 9.0312502 30.25 9.28125 30.25 9.53125 C 30.436 9.5312502 30.6265 9.53125 30.8125 9.53125 C 30.8125 10.75925 30.8125 11.99075 30.8125 13.21875 C 31.0785 13.21875 31.327749 13.21875 31.59375 13.21875 C 31.59375 11.74075 31.59375 10.25925 31.59375 8.78125 C 31.141749 8.7812502 30.702 8.78125 30.25 8.78125 z M 34.71875 8.78125 C 34.038749 9.8212501 33.3675 10.86625 32.6875 11.90625 C 32.6875 12.122249 32.6875 12.3465 32.6875 12.5625 C 33.3255 12.5625 33.95575 12.5625 34.59375 12.5625 C 34.59375 12.7845 34.59375 12.99675 34.59375 13.21875 C 34.85975 13.21875 35.14025 13.21875 35.40625 13.21875 C 35.40625 12.99675 35.40625 12.7845 35.40625 12.5625 C 35.546234 12.527656 35.828301 12.628129 35.875 12.5 C 35.875 12.280828 35.875 12.062922 35.875 11.84375 C 35.735017 11.808905 35.45295 11.909378 35.40625 11.78125 C 35.40625 10.782078 35.40625 9.780422 35.40625 8.78125 C 35.18225 8.7812502 34.94275 8.78125 34.71875 8.78125 z M 34.59375 10.125 C 34.59375 10.695 34.59375 11.27375 34.59375 11.84375 C 34.22575 11.84375 33.868 11.84375 33.5 11.84375 C 33.868 11.27375 34.22575 10.695 34.59375 10.125 z M 28.09375 12.4375 C 28.09375 12.6935 28.09375 12.96275 28.09375 13.21875 C 28.35975 13.21875 28.609 13.21875 28.875 13.21875 C 28.875 12.96275 28.875 12.6935 28.875 12.4375 C 28.609 12.4375 28.35975 12.4375 28.09375 12.4375 z "
+     style="font-size:6px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;opacity:0.05;fill:#ffffff;fill-opacity:1;stroke:none;font-family:URW Gothic L;-inkscape-font-specification:URW Gothic L Book"
+     id="path3332"
+     d="m 25.671875,8.3886719 c -0.673083,0.099696 -1.266737,0.6466815 -1.271484,1.390625 a 0.31923807,0.31923807 0 0 0 0.0098,0.082031 c 0.03924,0.1516059 0.197306,0.2660059 0.298828,0.2929689 0.101522,0.02696 0.172794,0.01963 0.236328,0.01563 0.127069,-0.008 0.243885,-0.0058 0.201172,-0.01563 l -0.03906,-0.01172 c 0.103552,0.03844 0.215162,-1.73e-4 0.326172,-0.01953 -0.0179,0.01471 -0.04597,0.0033 -0.06055,0.02148 -0.102603,0.127753 -0.100831,0.242954 -0.101563,0.322266 -0.0015,0.158624 -0.0019,0.288142 0.01367,0.230469 a 0.31923807,0.31923807 0 0 0 -0.0098,0.08398 l 0,0.3125 a 0.31923807,0.31923807 0 0 0 0.355468,0.316406 c 0.148987,-0.01709 0.334691,0.01668 0.457032,0.08594 0.122341,0.06926 0.179556,0.141344 0.1875,0.273437 a 0.31923807,0.31923807 0 0 0 0.0039,0.03516 c 0.04335,0.247374 -0.240627,0.508924 -0.488281,0.423828 a 0.31923807,0.31923807 0 0 0 -0.101563,-0.01563 c -0.03188,-1.89e-4 -0.005,0.0075 -0.01758,-0.0059 -0.01255,-0.0134 -0.04394,-0.06568 -0.07813,-0.142578 -0.03419,-0.0769 -0.06889,-0.175656 -0.152344,-0.287109 -0.08345,-0.111453 -0.271737,-0.232006 -0.460937,-0.220703 l -0.605469,0 a 0.31923807,0.31923807 0 0 0 -0.318359,0.322265 c 0.01051,0.984633 0.874269,1.788712 1.849609,1.75 0.953944,0.03523 1.784877,-0.760757 1.810547,-1.71289 0.07207,-0.367443 -0.05486,-0.705729 -0.222656,-0.962891 -0.110862,-0.169905 -0.234744,-0.263938 -0.357422,-0.376953 0.219747,-0.338919 0.30793,-0.7383189 0.203125,-1.1054689 C 27.205769,9.001018 26.851843,8.574597 26.335938,8.4453125 26.117687,8.3744154 25.891061,8.3562063 25.671875,8.3886719 Z m 4.546875,0.074219 A 0.31923807,0.31923807 0 0 0 29.931641,8.78125 l 0,0.75 A 0.31923807,0.31923807 0 0 0 30.25,9.8496094 l 0.244141,0 0,3.3691406 a 0.31923807,0.31923807 0 0 0 0.318359,0.318359 l 0.78125,0 a 0.31923807,0.31923807 0 0 0 0.318359,-0.318359 l 0,-4.4375 A 0.31923807,0.31923807 0 0 0 31.59375,8.4628906 l -1.34375,0 a 0.31923807,0.31923807 0 0 0 -0.03125,0 z m 4.46875,0 a 0.31923807,0.31923807 0 0 0 -0.236328,0.1445313 c -0.680944,1.0414423 -1.352193,2.0864421 -2.03125,3.1250001 a 0.31923807,0.31923807 0 0 0 -0.05078,0.173828 l 0,0.65625 a 0.31923807,0.31923807 0 0 0 0.318359,0.318359 l 1.587891,0 0,0.337891 a 0.31923807,0.31923807 0 0 0 0.318359,0.318359 l 0.8125,0 a 0.31923807,0.31923807 0 0 0 0.318359,-0.318359 l 0,-0.339844 c 0.04688,9.19e-4 0.0908,0.0058 0.158203,-0.01172 0.0949,-0.02465 0.241296,-0.116036 0.292969,-0.257813 A 0.31923807,0.31923807 0 0 0 36.193359,12.5 l 0,-0.65625 a 0.31923807,0.31923807 0 0 0 -0.242187,-0.310547 c -0.118219,-0.02943 -0.162294,-0.0099 -0.226563,-0.002 l 0,-2.75 A 0.31923807,0.31923807 0 0 0 35.40625,8.4628906 l -0.6875,0 a 0.31923807,0.31923807 0 0 0 -0.03125,0 z m -8.783203,1.2949219 c 0.0444,0.00212 0.04408,0.00628 0.04883,0.013672 0.0053,0.00829 0.01694,0.047931 0.0078,0.097656 -0.0091,0.049725 -0.0382,0.098506 -0.06055,0.1171875 -0.02235,0.018681 -0.02579,0.026101 -0.08398,0.013672 a 0.31923807,0.31923807 0 0 0 -0.01563,-0.00195 c -0.03699,-0.00591 -0.07863,0.038108 -0.123047,0.042969 0.07137,-0.068514 0.139297,-0.1436748 0.167969,-0.1933598 0.03372,-0.058432 0.05191,-0.080308 0.05859,-0.089844 z m 8.371094,1.4609375 0,0.306641 -0.195313,0 c 0.0651,-0.102627 0.130522,-0.2041 0.195313,-0.306641 z M 28.0625,12.119141 A 0.31923807,0.31923807 0 0 0 27.775391,12.4375 l 0,0.78125 a 0.31923807,0.31923807 0 0 0 0.318359,0.318359 l 0.78125,0 a 0.31923807,0.31923807 0 0 0 0.318359,-0.318359 l 0,-0.78125 A 0.31923807,0.31923807 0 0 0 28.875,12.119141 l -0.78125,0 a 0.31923807,0.31923807 0 0 0 -0.03125,0 z"
+     transform="matrix(2.6666766,0,0,2.6666766,-0.3352397,0.3348725)" />
+  <path
+     sodipodi:type="inkscape:offset"
+     inkscape:radius="0.21575621"
+     inkscape:original="M 26.25 8.75 C 25.568647 8.5199265 24.723565 9.0267516 24.71875 9.78125 C 24.755266 9.9223244 25.065859 9.8086703 25.21875 9.84375 C 25.630538 9.9966167 25.514731 9.4122119 25.90625 9.4375 C 26.516972 9.4537159 26.33229 10.436872 25.75 10.3125 C 25.489662 10.270893 25.638403 10.616068 25.59375 10.78125 C 25.59375 10.877212 25.59375 10.997788 25.59375 11.09375 C 26.025457 11.044226 26.564229 11.259092 26.59375 11.75 C 26.679845 12.241324 26.17035 12.697162 25.6875 12.53125 C 25.239623 12.528606 25.335883 11.854934 25 11.875 C 24.788484 11.875 24.586516 11.875 24.375 11.875 C 24.383499 12.671066 25.116689 13.351398 25.90625 13.3125 C 26.682081 13.34878 27.40534 12.654109 27.40625 11.875 C 27.52623 11.345832 27.028311 10.826975 26.75 10.625 C 27.39259 10.092975 27.027045 8.9358285 26.25 8.75 z M 30.25 8.78125 C 30.25 9.0312502 30.25 9.28125 30.25 9.53125 C 30.436 9.5312502 30.6265 9.53125 30.8125 9.53125 C 30.8125 10.75925 30.8125 11.99075 30.8125 13.21875 C 31.0785 13.21875 31.327749 13.21875 31.59375 13.21875 C 31.59375 11.74075 31.59375 10.25925 31.59375 8.78125 C 31.141749 8.7812502 30.702 8.78125 30.25 8.78125 z M 34.71875 8.78125 C 34.038749 9.8212501 33.3675 10.86625 32.6875 11.90625 C 32.6875 12.122249 32.6875 12.3465 32.6875 12.5625 C 33.3255 12.5625 33.95575 12.5625 34.59375 12.5625 C 34.59375 12.7845 34.59375 12.99675 34.59375 13.21875 C 34.85975 13.21875 35.14025 13.21875 35.40625 13.21875 C 35.40625 12.99675 35.40625 12.7845 35.40625 12.5625 C 35.546234 12.527656 35.828301 12.628129 35.875 12.5 C 35.875 12.280828 35.875 12.062922 35.875 11.84375 C 35.735017 11.808905 35.45295 11.909378 35.40625 11.78125 C 35.40625 10.782078 35.40625 9.780422 35.40625 8.78125 C 35.18225 8.7812502 34.94275 8.78125 34.71875 8.78125 z M 34.59375 10.125 C 34.59375 10.695 34.59375 11.27375 34.59375 11.84375 C 34.22575 11.84375 33.868 11.84375 33.5 11.84375 C 33.868 11.27375 34.22575 10.695 34.59375 10.125 z M 28.09375 12.4375 C 28.09375 12.6935 28.09375 12.96275 28.09375 13.21875 C 28.35975 13.21875 28.609 13.21875 28.875 13.21875 C 28.875 12.96275 28.875 12.6935 28.875 12.4375 C 28.609 12.4375 28.35975 12.4375 28.09375 12.4375 z "
+     style="font-size:6px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;opacity:0.1;fill:#ffffff;fill-opacity:1;stroke:none;font-family:URW Gothic L;-inkscape-font-specification:URW Gothic L Book"
+     id="path3334"
+     d="m 25.689453,8.4921875 c -0.625205,0.093588 -1.181167,0.6008756 -1.185547,1.2871094 a 0.21577778,0.21577778 0 0 0 0.0059,0.056641 c 0.02948,0.1139028 0.146067,0.1973715 0.226562,0.2187505 0.0805,0.02138 0.143762,0.01742 0.203125,0.01367 0.118725,-0.0075 0.234564,-0.01273 0.230469,-0.01367 l -0.02539,-0.0078 c 0.141902,0.05268 0.301949,0.04788 0.414063,-0.02148 0.112113,-0.069367 0.160932,-0.1621712 0.199218,-0.228516 0.03829,-0.066345 0.06729,-0.112802 0.08398,-0.1289062 0.01669,-0.016104 0.0056,-0.018546 0.05078,-0.015625 a 0.21577778,0.21577778 0 0 0 0.0078,0 c 0.09456,0.00251 0.115796,0.026916 0.138671,0.0625 0.02288,0.035583 0.03651,0.1025808 0.02344,0.1738281 -0.01307,0.071247 -0.05154,0.1388691 -0.0957,0.1757811 -0.04416,0.03691 -0.08537,0.05559 -0.171875,0.03711 a 0.21577778,0.21577778 0 0 0 -0.01172,-0.002 c -0.10783,-0.01723 -0.253156,0.0136 -0.330078,0.109375 -0.07692,0.09578 -0.07748,0.187718 -0.07813,0.257813 -0.0013,0.140189 0.0065,0.270028 0.0098,0.257812 a 0.21577778,0.21577778 0 0 0 -0.0059,0.05664 l 0,0.3125 a 0.21577778,0.21577778 0 0 0 0.240235,0.214844 c 0.170657,-0.01958 0.374502,0.01555 0.519531,0.09766 0.145029,0.0821 0.230081,0.18859 0.240234,0.357422 a 0.21577778,0.21577778 0 0 0 0.002,0.02344 c 0.0572,0.326436 -0.299169,0.652303 -0.623047,0.541016 a 0.21577778,0.21577778 0 0 0 -0.06836,-0.01172 c -0.05784,-3.41e-4 -0.06608,-0.0095 -0.09375,-0.03906 -0.02767,-0.02954 -0.06257,-0.09101 -0.09766,-0.169922 -0.03508,-0.07892 -0.06761,-0.172679 -0.138672,-0.267578 -0.07106,-0.0949 -0.21795,-0.188953 -0.373047,-0.179688 l -0.611328,0 a 0.21577778,0.21577778 0 0 0 -0.214844,0.216797 c 0.0099,0.923759 0.830597,1.687548 1.746094,1.648438 0.898837,0.03594 1.696755,-0.729481 1.710938,-1.628907 0.06558,-0.332219 -0.04987,-0.642867 -0.208985,-0.886718 -0.114448,-0.175401 -0.24655,-0.278342 -0.373047,-0.390625 0.254867,-0.322333 0.311984,-0.7465863 0.205078,-1.1210941 -0.125703,-0.4403588 -0.456739,-0.835668 -0.93164,-0.953125 -0.203026,-0.066794 -0.413953,-0.083449 -0.619141,-0.052734 z m 4.539063,0.074219 A 0.21577778,0.21577778 0 0 0 30.035156,8.78125 l 0,0.75 A 0.21577778,0.21577778 0 0 0 30.25,9.7460938 l 0.347656,0 0,3.4726562 a 0.21577778,0.21577778 0 0 0 0.214844,0.214844 l 0.78125,0 a 0.21577778,0.21577778 0 0 0 0.214844,-0.214844 l 0,-4.4375 A 0.21577778,0.21577778 0 0 0 31.59375,8.5664062 l -1.34375,0 a 0.21577778,0.21577778 0 0 0 -0.02148,0 z m 4.46875,0 a 0.21577778,0.21577778 0 0 0 -0.158204,0.097656 c -0.680638,1.0409749 -1.351887,2.0859745 -2.03125,3.1249995 a 0.21577778,0.21577778 0 0 0 -0.03516,0.117188 l 0,0.65625 a 0.21577778,0.21577778 0 0 0 0.214844,0.214844 l 1.691406,0 0,0.441406 a 0.21577778,0.21577778 0 0 0 0.214844,0.214844 l 0.8125,0 a 0.21577778,0.21577778 0 0 0 0.214844,-0.214844 l 0,-0.439453 c 0.02174,8.76e-4 0.01976,7.79e-4 0.04297,0.002 0.05538,0.0028 0.115856,0.006 0.191407,-0.01367 0.07555,-0.01962 0.183946,-0.08715 0.222656,-0.193359 A 0.21577778,0.21577778 0 0 0 36.089844,12.5 l 0,-0.65625 a 0.21577778,0.21577778 0 0 0 -0.16211,-0.208984 c -0.138643,-0.03451 -0.231481,-0.0089 -0.30664,-0.002 l 0,-2.851562 A 0.21577778,0.21577778 0 0 0 35.40625,8.5664062 l -0.6875,0 a 0.21577778,0.21577778 0 0 0 -0.02148,0 z m -0.31836,2.2988278 0,0.763672 -0.486328,0 c 0.162543,-0.255175 0.325078,-0.50885 0.486328,-0.763672 z m -6.30664,1.357422 a 0.21577778,0.21577778 0 0 0 -0.19336,0.214844 l 0,0.78125 a 0.21577778,0.21577778 0 0 0 0.214844,0.214844 l 0.78125,0 a 0.21577778,0.21577778 0 0 0 0.214844,-0.214844 l 0,-0.78125 A 0.21577778,0.21577778 0 0 0 28.875,12.222656 l -0.78125,0 a 0.21577778,0.21577778 0 0 0 -0.02148,0 z"
+     transform="matrix(2.6666766,0,0,2.6666766,-0.3352397,0.3348725)" />
+  <path
+     sodipodi:type="inkscape:offset"
+     inkscape:radius="0.095311165"
+     inkscape:original="M 26.25 8.75 C 25.568647 8.5199265 24.723565 9.0267516 24.71875 9.78125 C 24.755266 9.9223244 25.065859 9.8086703 25.21875 9.84375 C 25.630538 9.9966167 25.514731 9.4122119 25.90625 9.4375 C 26.516972 9.4537159 26.33229 10.436872 25.75 10.3125 C 25.489662 10.270893 25.638403 10.616068 25.59375 10.78125 C 25.59375 10.877212 25.59375 10.997788 25.59375 11.09375 C 26.025457 11.044226 26.564229 11.259092 26.59375 11.75 C 26.679845 12.241324 26.17035 12.697162 25.6875 12.53125 C 25.239623 12.528606 25.335883 11.854934 25 11.875 C 24.788484 11.875 24.586516 11.875 24.375 11.875 C 24.383499 12.671066 25.116689 13.351398 25.90625 13.3125 C 26.682081 13.34878 27.40534 12.654109 27.40625 11.875 C 27.52623 11.345832 27.028311 10.826975 26.75 10.625 C 27.39259 10.092975 27.027045 8.9358285 26.25 8.75 z M 30.25 8.78125 C 30.25 9.0312502 30.25 9.28125 30.25 9.53125 C 30.436 9.5312502 30.6265 9.53125 30.8125 9.53125 C 30.8125 10.75925 30.8125 11.99075 30.8125 13.21875 C 31.0785 13.21875 31.327749 13.21875 31.59375 13.21875 C 31.59375 11.74075 31.59375 10.25925 31.59375 8.78125 C 31.141749 8.7812502 30.702 8.78125 30.25 8.78125 z M 34.71875 8.78125 C 34.038749 9.8212501 33.3675 10.86625 32.6875 11.90625 C 32.6875 12.122249 32.6875 12.3465 32.6875 12.5625 C 33.3255 12.5625 33.95575 12.5625 34.59375 12.5625 C 34.59375 12.7845 34.59375 12.99675 34.59375 13.21875 C 34.85975 13.21875 35.14025 13.21875 35.40625 13.21875 C 35.40625 12.99675 35.40625 12.7845 35.40625 12.5625 C 35.546234 12.527656 35.828301 12.628129 35.875 12.5 C 35.875 12.280828 35.875 12.062922 35.875 11.84375 C 35.735017 11.808905 35.45295 11.909378 35.40625 11.78125 C 35.40625 10.782078 35.40625 9.780422 35.40625 8.78125 C 35.18225 8.7812502 34.94275 8.78125 34.71875 8.78125 z M 34.59375 10.125 C 34.59375 10.695 34.59375 11.27375 34.59375 11.84375 C 34.22575 11.84375 33.868 11.84375 33.5 11.84375 C 33.868 11.27375 34.22575 10.695 34.59375 10.125 z M 28.09375 12.4375 C 28.09375 12.6935 28.09375 12.96275 28.09375 13.21875 C 28.35975 13.21875 28.609 13.21875 28.875 13.21875 C 28.875 12.96275 28.875 12.6935 28.875 12.4375 C 28.609 12.4375 28.35975 12.4375 28.09375 12.4375 z "
+     style="font-size:6px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;font-family:URW Gothic L;-inkscape-font-specification:URW Gothic L Book"
+     id="path3336"
+     d="M 25.996094,8.6015625 C 25.323757,8.5491719 24.627656,9.0590328 24.623047,9.78125 a 0.0953207,0.0953207 0 0 0 0.0039,0.023437 c 0.01812,0.070006 0.08266,0.1179358 0.138672,0.1328125 0.05601,0.014877 0.11151,0.013205 0.166016,0.00977 0.109011,-0.00688 0.224758,-0.019142 0.265625,-0.00977 l -0.01172,-0.00391 c 0.120155,0.044605 0.229386,0.037288 0.308594,-0.011719 0.07921,-0.049007 0.121343,-0.1216745 0.158203,-0.1855469 0.03686,-0.063872 0.06983,-0.1218693 0.105468,-0.15625 0.03564,-0.034381 0.06796,-0.051694 0.142579,-0.046875 a 0.0953207,0.0953207 0 0 0 0.0039,0 c 0.127008,0.00337 0.193023,0.049826 0.236328,0.1171875 0.04331,0.067361 0.05869,0.1634601 0.04102,0.2597656 -0.01767,0.096306 -0.06716,0.1899088 -0.136719,0.2480468 -0.06956,0.05814 -0.15591,0.08607 -0.275391,0.06055 a 0.0953207,0.0953207 0 0 0 -0.0039,0 c -0.08397,-0.01342 -0.171727,0.0079 -0.21875,0.06641 -0.04702,0.05855 -0.05023,0.124231 -0.05078,0.183594 -0.0011,0.118725 0.01686,0.2464 0.0059,0.287109 a 0.0953207,0.0953207 0 0 0 -0.0039,0.02539 l 0,0.3125 a 0.0953207,0.0953207 0 0 0 0.107422,0.09375 c 0.195888,-0.02247 0.420353,0.01818 0.591797,0.115234 0.171443,0.09706 0.288056,0.241519 0.300781,0.453125 a 0.0953207,0.0953207 0 0 0 0.002,0.0098 c 0.07333,0.418484 -0.368627,0.817563 -0.78125,0.675781 a 0.0953207,0.0953207 0 0 0 -0.03125,-0.0059 c -0.08806,-5.2e-4 -0.134413,-0.02783 -0.179688,-0.07617 -0.04527,-0.04834 -0.08301,-0.121862 -0.11914,-0.203125 -0.03613,-0.08126 -0.07033,-0.168513 -0.126953,-0.244141 -0.05663,-0.07563 -0.152187,-0.139706 -0.267578,-0.132812 l -0.619141,0 a 0.0953207,0.0953207 0 0 0 -0.0957,0.09766 c 0.0091,0.853999 0.78385,1.572978 1.630859,1.53125 0.824965,0.0338 1.575848,-0.685444 1.589844,-1.511719 l 0.002,-0.01953 c 0.05883,-0.291815 -0.04597,-0.571902 -0.195312,-0.800781 -0.129184,-0.197984 -0.286657,-0.350028 -0.423829,-0.460938 0.282118,-0.293796 0.346734,-0.7108992 0.240235,-1.083984 -0.11627,-0.407311 -0.422804,-0.7705102 -0.851563,-0.8730469 -0.09001,-0.029514 -0.182628,-0.049412 -0.27539,-0.056641 z m 4.24414,0.083984 a 0.0953207,0.0953207 0 0 0 -0.08594,0.095703 l 0,0.75 a 0.0953207,0.0953207 0 0 0 0.0957,0.095703 l 0.466797,0 0,3.5917969 a 0.0953207,0.0953207 0 0 0 0.0957,0.0957 l 0.78125,0 a 0.0953207,0.0953207 0 0 0 0.0957,-0.0957 l 0,-4.4375 a 0.0953207,0.0953207 0 0 0 -0.0957,-0.095703 l -1.34375,0 a 0.0953207,0.0953207 0 0 0 -0.0098,0 z m 4.46875,0 a 0.0953207,0.0953207 0 0 0 -0.07031,0.042969 c -0.680283,1.0404307 -1.351532,2.0854304 -2.03125,3.1250004 a 0.0953207,0.0953207 0 0 0 -0.01563,0.05273 l 0,0.65625 a 0.0953207,0.0953207 0 0 0 0.0957,0.0957 l 1.810547,0 0,0.560547 a 0.0953207,0.0953207 0 0 0 0.0957,0.0957 l 0.8125,0 a 0.0953207,0.0953207 0 0 0 0.0957,-0.0957 l 0,-0.5625 c 0.0493,2.97e-4 0.09712,0.0023 0.167969,0.0059 0.05066,0.0026 0.103226,0.0021 0.15625,-0.01172 0.05302,-0.01377 0.115054,-0.05239 0.138672,-0.117188 a 0.0953207,0.0953207 0 0 0 0.0059,-0.0332 l 0,-0.65625 a 0.0953207,0.0953207 0 0 0 -0.07227,-0.0918 c -0.10539,-0.02623 -0.21049,-0.0044 -0.296876,0 -0.04319,0.0022 -0.08028,6.07e-4 -0.09766,-0.0039 -0.0043,-0.0011 -3.98e-4,2.04e-4 -0.002,0 l 0,-2.966797 a 0.0953207,0.0953207 0 0 0 -0.0957,-0.095703 l -0.6875,0 a 0.0953207,0.0953207 0 0 0 -0.0098,0 z m -0.210937,1.7656251 0,1.296875 -0.824219,0 c 0.276787,-0.431619 0.549079,-0.865705 0.824219,-1.296875 z m -6.414063,1.890625 a 0.0953207,0.0953207 0 0 0 -0.08594,0.0957 l 0,0.78125 a 0.0953207,0.0953207 0 0 0 0.0957,0.0957 l 0.78125,0 a 0.0953207,0.0953207 0 0 0 0.0957,-0.0957 l 0,-0.78125 a 0.0953207,0.0953207 0 0 0 -0.0957,-0.0957 l -0.78125,0 a 0.0953207,0.0953207 0 0 0 -0.0098,0 z"
+     transform="matrix(2.6666766,0,0,2.6666766,-0.3352397,0.3348725)" />
+  <path
+     style="opacity:0.3;fill:url(#linearGradient2533);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3336"
+     d="m 29.330486,13.999763 c -1.834687,0 -3.330347,1.474576 -3.330347,3.378776 l 0,14.621268 76.000181,-11.75987 0,-2.861398 c 0,-1.9042 -1.49566,-3.378776 -3.330339,-3.378776 l -69.339495,0 z"
+     inkscape:connector-curvature="0" />
+  <rect
+     width="82.000198"
+     height="106.00026"
+     rx="2.0000048"
+     ry="2.000005"
+     x="23.000135"
+     y="10.999754"
+     id="rect6741-1"
+     style="opacity:0.8;fill:none;stroke:url(#linearGradient3958);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     width="70.000175"
+     height="22.000053"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="29.000151"
+     y="16.999767"
+     id="rect6741-1-2"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984);stroke-width:2.00000477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0"
+     y="100.99999"
+     x="27.000145"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="34.000084" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6"
+     y="98.999969"
+     x="25.000141"
+     ry="4.291862"
+     rx="4.291863"
+     height="14.000034"
+     width="38.000095" />
+  <rect
+     width="30.000074"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="29.000153"
+     y="102.99999"
+     id="rect6741-1-2-2"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2"
+     y="84.999939"
+     x="27.000145"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6"
+     y="82.999939"
+     x="25.000139"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="29.000153"
+     y="86.999954"
+     id="rect6741-1-2-2-2"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-0"
+     y="68.999908"
+     x="27.000145"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-4);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-7"
+     y="66.999901"
+     x="25.000139"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="29.000153"
+     y="70.999908"
+     id="rect6741-1-2-2-2-7"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-0);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-5"
+     y="52.999863"
+     x="27.000145"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-7);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-4"
+     y="50.999859"
+     x="25.000139"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="29.000153"
+     y="54.99987"
+     id="rect6741-1-2-2-2-5"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-6);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-07"
+     y="84.999939"
+     x="47.000179"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-44);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-9"
+     y="82.999939"
+     x="45.000175"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="49.000183"
+     y="86.999954"
+     id="rect6741-1-2-2-2-77"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-8);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-0-9"
+     y="68.999908"
+     x="47.000179"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-4-9);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-7-4"
+     y="66.999901"
+     x="45.000175"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="49.000183"
+     y="70.999908"
+     id="rect6741-1-2-2-2-7-3"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-0-4);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-5-7"
+     y="52.999863"
+     x="47.000179"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-7-7);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-4-3"
+     y="50.999859"
+     x="45.000175"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="49.000183"
+     y="54.99987"
+     id="rect6741-1-2-2-2-5-9"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-6-2);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-7"
+     y="84.999939"
+     x="67.000229"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-1);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-1"
+     y="82.999939"
+     x="65.000221"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="69.000237"
+     y="86.999954"
+     id="rect6741-1-2-2-2-2"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-81);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-0-6"
+     y="68.999908"
+     x="67.000229"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-4-99);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-7-5"
+     y="66.999901"
+     x="65.000221"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="69.000237"
+     y="70.999908"
+     id="rect6741-1-2-2-2-7-6"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-0-6);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-5-9"
+     y="52.999863"
+     x="67.000229"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-7-9);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-4-37"
+     y="50.999859"
+     x="65.000221"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="69.000237"
+     y="54.99987"
+     id="rect6741-1-2-2-2-5-0"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-6-9);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-54"
+     y="84.999939"
+     x="87.000275"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="26.000065"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-6);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-3"
+     y="82.999939"
+     x="85.000275"
+     ry="4.291862"
+     rx="4.2918625"
+     height="30.000074"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="22.000053"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="89.000282"
+     y="86.999954"
+     id="rect6741-1-2-2-2-6"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-88);stroke-width:2.00000477;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-0-3"
+     y="68.999908"
+     x="87.000275"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-4-997);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-7-3"
+     y="66.999901"
+     x="85.000275"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="89.000282"
+     y="70.999908"
+     id="rect6741-1-2-2-2-7-0"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-0-1);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-5-6"
+     y="52.999863"
+     x="87.000275"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-7-6);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-4-9"
+     y="50.999859"
+     x="85.000275"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="89.000282"
+     y="54.99987"
+     id="rect6741-1-2-2-2-5-06"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-6-1);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <rect
+     style="fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3045-0-2-5-9-7"
+     y="100.99999"
+     x="67.000229"
+     ry="2.3524821"
+     rx="2.3525927"
+     height="10.000025"
+     width="14.000034" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient2487-1-2-7-9-6);stroke-width:2.00000501;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3424-6-6-4-37-6"
+     y="98.999969"
+     x="65.000221"
+     ry="4.291862"
+     rx="4.2918625"
+     height="14.000034"
+     width="18.000046" />
+  <rect
+     width="10.000025"
+     height="6.0000148"
+     rx="1.0774801"
+     ry="1.0774801"
+     x="69.000237"
+     y="102.99999"
+     id="rect6741-1-2-2-2-5-0-5"
+     style="opacity:0.1;fill:none;stroke:url(#linearGradient3984-1-0-6-9-9);stroke-width:2.00000501;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+</svg>

--- a/elementary-xfce/apps/128/accessories-text-editor.svg
+++ b/elementary-xfce/apps/128/accessories-text-editor.svg
@@ -1,0 +1,696 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   id="svg3598"
+   version="1.1"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="accessories-text-editor.svg">
+  <defs
+     id="defs3600">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3290-678"
+       id="linearGradient3151"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922608,2.2808559,-13.096549,-18.049122)"
+       x1="9"
+       y1="29.056757"
+       x2="9"
+       y2="26.02973" />
+    <linearGradient
+       id="linearGradient3290-678">
+      <stop
+         id="stop2607"
+         style="stop-color:#ece5a5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2609"
+         style="stop-color:#fcfbf2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3191-577"
+       id="linearGradient3153"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4942564,0.06449445,0.06441509,1.4924135,48.789109,-27.719484)"
+       x1="5.5178981"
+       y1="37.371799"
+       x2="9.5220556"
+       y2="41.391716" />
+    <linearGradient
+       id="linearGradient3191-577">
+      <stop
+         id="stop2613"
+         style="stop-color:#dbce48;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2615"
+         style="stop-color:#c5b625;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3223-699"
+       id="linearGradient3156"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922606,2.2808557,-9.543179,-21.619903)"
+       x1="30.037716"
+       y1="24.989594"
+       x2="30.037716"
+       y2="30.000141" />
+    <linearGradient
+       id="linearGradient3223-699">
+      <stop
+         id="stop2599"
+         style="stop-color:#b1b1b1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2601"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2603"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3240-907"
+       id="linearGradient3159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922606,2.2808557,-9.05595,-22.109524)"
+       x1="30.037716"
+       y1="24.989594"
+       x2="30.037716"
+       y2="30.000141" />
+    <linearGradient
+       id="linearGradient3240-907">
+      <stop
+         id="stop2591"
+         style="stop-color:#565656;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2593"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2595"
+         style="stop-color:#545454;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3223-768"
+       id="linearGradient3162"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922606,2.2808557,-11.244483,-19.910266)"
+       x1="30.037716"
+       y1="24.989594"
+       x2="30.037716"
+       y2="30.000141" />
+    <linearGradient
+       id="linearGradient3223-768">
+      <stop
+         id="stop2583"
+         style="stop-color:#b1b1b1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2585"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2587"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3240-686"
+       id="linearGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922606,2.2808557,-10.757252,-20.399882)"
+       x1="30.037716"
+       y1="24.989594"
+       x2="30.037716"
+       y2="30.000141" />
+    <linearGradient
+       id="linearGradient3240-686">
+      <stop
+         id="stop2575"
+         style="stop-color:#565656;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2577"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2579"
+         style="stop-color:#545454;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3223-789"
+       id="linearGradient3168"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922606,2.2808557,-12.937598,-18.208844)"
+       x1="30.037716"
+       y1="24.989594"
+       x2="30.037716"
+       y2="30.000141" />
+    <linearGradient
+       id="linearGradient3223-789">
+      <stop
+         id="stop2567"
+         style="stop-color:#b1b1b1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2569"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2571"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3240-279"
+       id="linearGradient3171"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7013012,-1.7096412,2.2922606,2.2808557,-12.450368,-18.698463)"
+       x1="30.037716"
+       y1="24.989594"
+       x2="30.037716"
+       y2="30.000141" />
+    <linearGradient
+       id="linearGradient3240-279">
+      <stop
+         id="stop2559"
+         style="stop-color:#565656;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2561"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2563"
+         style="stop-color:#545454;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3155-40"
+       id="linearGradient3176"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.750794,-1.7593764,1.958665,1.9489197,-6.034429,-9.695865)"
+       spreadMethod="pad"
+       x1="23.575972"
+       y1="25.356892"
+       x2="23.575972"
+       y2="31.210939" />
+    <linearGradient
+       id="linearGradient3155-40">
+      <stop
+         id="stop2541"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2543"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="0.13482948" />
+      <stop
+         id="stop2545"
+         style="stop-color:#a4a4a4;stop-opacity:1"
+         offset="0.20224422" />
+      <stop
+         id="stop2547"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0.26965895" />
+      <stop
+         id="stop2549"
+         style="stop-color:#8d8d8d;stop-opacity:1"
+         offset="0.44650277" />
+      <stop
+         id="stop2551"
+         style="stop-color:#959595;stop-opacity:1"
+         offset="0.57114136" />
+      <stop
+         id="stop2553"
+         style="stop-color:#cecece;stop-opacity:1"
+         offset="0.72038066" />
+      <stop
+         id="stop2555"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104"
+       id="linearGradient3302"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6665783,0,0,2.6665783,-0.333111,-61.662749)"
+       x1="22.004084"
+       y1="44.854229"
+       x2="22.004084"
+       y2="3.0718794" />
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3454"
+       id="linearGradient3245-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.43245,0,0,2.8756918,-118.1763,-63.220503)"
+       x1="68.437271"
+       y1="4.410717"
+       x2="68.437271"
+       y2="40.927929" />
+    <linearGradient
+       id="linearGradient3454">
+      <stop
+         id="stop3456"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.0097359"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3458" />
+      <stop
+         id="stop3460"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.99001008" />
+      <stop
+         id="stop3462"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-8-8"
+       id="linearGradient3250-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843525,0,0,1.1183944,79.550865,1.1533356)"
+       x1="-51.786404"
+       y1="53.514328"
+       x2="-51.786404"
+       y2="3.6336823" />
+    <linearGradient
+       id="linearGradient3104-8-8">
+      <stop
+         id="stop3106-5-4"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3108-4-3"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3359"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08918772,0,0,0.01646992,-1.9026808,51.961501)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3361"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03052185,0,0,0.01646992,27.194158,51.961535)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.03052185,0,0,0.01646992,33.470457,51.961535)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3596"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3600-9-2-6">
+      <stop
+         id="stop3602-3-2-9"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7-9-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="48.545383"
+       x2="25.132275"
+       y1="2.3464241"
+       x1="25.132275"
+       gradientTransform="matrix(2.6285896,0,0,2.3467572,0.9138346,-57.924938)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3115"
+       xlink:href="#linearGradient3600-9-2-6"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3104-8-8-97">
+      <stop
+         id="stop3106-5-4-3"
+         style="stop-color:#000000;stop-opacity:0.32173914;"
+         offset="0" />
+      <stop
+         id="stop3108-4-3-7"
+         style="stop-color:#000000;stop-opacity:0.27826086;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="3.6336823"
+       x2="-51.786404"
+       y1="53.514328"
+       x1="-51.786404"
+       gradientTransform="matrix(2.1687207,0,0,2.236805,159.10233,-61.694207)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3929"
+       xlink:href="#linearGradient3104-8-8-97"
+       inkscape:collect="always" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3949"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06104414,0,0,0.03294008,70.276327,39.922926)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3952"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.06104414,0,0,0.03294008,57.723639,39.922926)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3955"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17837673,0,0,0.03294008,-0.470461,39.922858)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#c57a38"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="63.024973"
+     inkscape:cy="53.587667"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:document-units="px"
+     inkscape:grid-bbox="true"
+     inkscape:window-width="1535"
+     inkscape:window-height="876"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata3603">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,64)">
+    <rect
+       style="opacity:0.2;fill:url(#linearGradient3955);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.04588675;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect3706"
+       y="52.000263"
+       x="20.934755"
+       height="7.9997339"
+       width="86.130478" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.2;fill:url(#radialGradient3952);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.04588675;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path3708"
+       d="m 20.934749,52.000612 c 0,0 0,7.999292 0,7.999292 -3.143623,0.015 -7.599749,-1.792235 -7.599749,-4.000161 0,-2.207924 3.508046,-3.999129 7.599749,-3.999131 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.2;fill:url(#radialGradient3949);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.04588675;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path3710"
+       d="m 107.06523,52.000612 c 0,0 0,7.999292 0,7.999292 3.14362,0.015 7.59975,-1.792235 7.59975,-4.000161 0,-2.207924 -3.50805,-3.999129 -7.59975,-3.999131 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:none;stroke:url(#linearGradient3929);stroke-width:1.9998579;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path2855-8"
+       d="m 19.685363,-52.996836 88.631147,0 2.68374,109.996816 -94.00068,-0.05666 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:url(#linearGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992174;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path2855-7"
+       d="m 20.628302,-52.000808 86.745378,0 2.62664,108.000781 -92.000665,-0.05563 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;fill:none;stroke:url(#linearGradient3245-0);stroke-width:2.00001454;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path2855-3"
+       d="m 21.571091,-51.000879 84.859759,0 2.56954,106.000923 -90.000806,-0.0546 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.59069764;fill:#80b3ff;fill-rule:evenodd;stroke:#f6abab;stroke-width:1.00000703;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path5685"
+       d="M 33.499311,-50.330092 32.332473,55.000048" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path6656"
+       d="M 106.48319,-35.330294 20.671931,-35.822361" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path6658"
+       d="M 106.68054,-29.997135 20.648984,-30.489213" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path6660"
+       d="M 106.90085,-24.663979 20.428679,-25.156046" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path6662"
+       d="M 107.12115,-19.330822 20.208379,-19.822894" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path6664"
+       d="M 107.12115,-13.997665 20.208379,-14.489737" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path6666"
+       d="M 107.34146,-8.664509 19.988075,-9.156584" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7637"
+       d="M 107.34146,-3.3313523 19.988076,-3.8234218" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7639"
+       d="M 107.56175,2.0018043 19.767773,1.5097327" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7641"
+       d="M 107.56175,7.3349609 19.767775,6.8428893" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7645"
+       d="M 108.00236,12.668117 19.327171,12.176054" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7647"
+       d="M 108.00236,17.972294 19.32717,17.480218" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7649"
+       d="M 108.66327,23.334431 18.666262,22.842359" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7651"
+       d="M 108.66327,28.548734 18.666262,28.056661" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7653"
+       d="M 108.66326,33.836954 18.666264,33.344885" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7655"
+       d="M 108.66327,39.125173 18.666262,38.633093" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7657"
+       d="M 108.66326,44.413395 18.666264,43.921321" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.43720931;fill:#80b3ff;fill-opacity:1;fill-rule:evenodd;stroke:#80b3ff;stroke-width:0.50000352;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path7659"
+       d="M 108.66326,50.000213 18.666264,49.508142" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.59069764;fill:none;stroke:#b9d5ff;stroke-width:1.00000703;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+       id="path7671"
+       d="M 93.663774,-50.550392 96.462369,54.779746" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:url(#linearGradient3302);stroke-width:2.00001454px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3715"
+       d="m 34.329565,-31.000656 6.261046,0 m 0.894436,0 5.813828,0 m 0.935853,0 5.187723,0 m 0.853021,0 2.236086,0 m 0.894436,0 5.008836,0 m 0.98388,0 13.148197,0 m 0.89444,0 10.017673,0 m 0.894436,0 3.041078,0 m -57.064969,6.000043 9.708031,0 m 1.12946,0 4.638717,0 m 0.857511,0 2.289124,0 m 0.931361,0 4.272941,0 m 0.894438,0 4.38211,0 m 0.8272,0 6.880948,0 m 0.89444,0 9.077586,0 m -46.783867,5.973413 8.216866,0 m 0.863182,0 13.53245,0 m 0.829386,0 6.562945,0 m 0.84118,0 6.139557,0 m 0.880452,0 5.230016,0 m 0.841184,0 8.225496,0.05326 m -52.162714,5.973413 11.424559,0 m 0.897125,0 12.347799,0 m 0.85302,0 4.852265,0 m 0.894439,0 11.549287,0 m 0.77734,0 7.915835,0 m 0.894438,0 3.132987,0 m 0.894438,0 1.732987,0 m -58.166519,6.000043 4.264485,0 m 1.310208,0 15.79014,0 m -21.364833,26.000188 9.708031,0 m 1.12946,0 4.638717,0 m 0.857511,0 2.289124,0 m 0.931361,0 4.272941,0 m 0.894438,0 4.38211,0 m 0.8272,0 6.880948,0 m -36.811841,7.918247 8.216866,0 m 0.863182,0 13.53245,0 m 0.829386,0 6.562945,0 m 23.192028,0.163622 13.404618,0 m -66.601475,-14.081912 11.424559,0 m 0.897125,0 12.347799,0 m 0.85302,0 4.852265,0 m 0.894439,0 11.549287,0 M 34.329565,0.999575 l 6.261046,0 m 0.894436,0 5.813828,0 m 0.935853,0 5.187723,0 m 0.853021,0 2.236086,0 m 0.894436,0 5.008836,0 m 0.98388,0 13.148197,0 m 0.89444,0 10.017673,0 m -53.129455,6.0000434 10.544407,0 m 0.829422,0 11.196831,0 m 0.85302,0 4.378337,0 m 0.826734,0 10.533729,0 m 0.845044,0 11.504145,0 m -51.511669,26.0011636 9.853558,0 m 1.057733,0 4.344166,0 m 1.017499,0 2.166748,0 m 0.689723,0 4.277285,0 m 0.567846,0 22.644806,0 m 1.065527,0 6.04482,0 m 0.812792,0 1.526281,0 m -44.84318,5.999068 3.214267,0 m -14.439871,0 10.284675,0 m 4.977254,0 7.478546,0 m 0.791094,0 10.978041,0 m 0.85302,0 7.447374,0 m 0.749679,0 1.534645,0 m 0.839123,0 9.456868,0 m 0.966817,0 4.951144,0 m -50.082676,6.000043 4.53838,0 m -15.763984,0 10.284675,0 m 6.462845,0 6.3805,0"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.15;fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path2422"
+       d="m 99.247453,1.1872784 c -0.462004,-0.271962 -0.819486,-0.2012215 -1.055654,-0.0499 l -31.455245,20.0298006 -5.789274,3.696823 -0.178241,0.0748 -6.854168,15.444952 16.986483,0.511634 0.141001,-0.09436 5.8265,-3.677231 31.447405,-20.202547 c 0.94469,-0.605294 -0.54936,-4.616949 -3.3515,-9.014701 -2.10161,-3.2982959 -4.3313,-5.9033867 -5.717321,-6.7192666 l 0,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3176);fill-opacity:1;stroke:#0c0c0c;stroke-width:1.00000727;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect2383"
+       d="m 63.155422,20.077217 c 1.189082,-0.89228 4.525461,0.781486 7.591449,3.83222 3.058656,3.043434 4.6703,6.300063 3.798221,7.500786 -0.0032,0.0046 0.07504,0.06678 0.07162,0.07128 l 42.692038,-42.901318 c 1.08392,-1.08923 -0.6002,-4.531331 -3.76352,-7.678911 -3.16332,-3.147583 -6.61386,-4.814605 -7.69778,-3.725369 L 63.155422,20.077217 Z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.8;fill:#ffb6ed;fill-opacity:1;stroke:#e28ccd;stroke-width:1.00000727;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect3175"
+       d="m 100.63722,-17.588319 c 1.18908,-0.892279 4.52546,0.781489 7.59144,3.832219 3.05866,3.043434 4.6703,6.300064 3.79822,7.500785 -0.003,0.0046 0.075,0.06676 0.0716,0.07128 l 5.21024,-5.235778 0.10634,-0.106841 c 0.003,-0.0046 -0.075,-0.06672 -0.0716,-0.07128 0.87206,-1.200721 -0.73958,-4.457348 -3.79824,-7.50078 -3.06598,-3.050732 -6.40236,-4.724502 -7.59144,-3.83222 l -0.10634,0.106841 -5.21023,5.235776 0,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.6;fill:#0c0c0c;fill-opacity:1;stroke:none"
+       id="path3208"
+       d="m 63.155422,20.077211 c 1.189082,-0.892278 4.525463,0.78149 7.591447,3.83222 3.058656,3.043436 4.670302,6.300063 3.798221,7.500786 -0.0032,0.0046 0.07504,0.06678 0.07166,0.07128 L 104.01735,1.9367618 104.1237,1.829901 c 0.003,-0.0046 -0.075,-0.06672 -0.0716,-0.07128 0.87206,-1.2007307 -0.73959,-4.4573562 -3.79824,-7.5007922 -3.065988,-3.0507298 -6.40237,-4.7244978 -7.591453,-3.8322158 l -0.106341,0.106841 -29.400594,29.544738 -1.4e-5,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3171);fill-opacity:1;stroke:none"
+       id="path3233"
+       d="m 94.797173,-11.719651 c 1.18908,-0.892282 4.525466,0.781488 7.591447,3.83222 3.05866,3.0434318 4.6703,6.3000593 3.79822,7.500784 -0.003,0.0046 0.075,0.06678 0.0716,0.07128 l 0.53166,-0.5342718 c 0.003,-0.0046 -0.075,-0.06672 -0.0716,-0.07128 0.87208,-1.2007227 -0.73957,-4.4573523 -3.79822,-7.5007802 -3.06599,-3.050734 -6.402368,-4.724502 -7.591449,-3.832222 l -0.531657,0.534264 0,4e-6 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3168);fill-opacity:1;stroke:none"
+       id="path3216"
+       d="m 94.309941,-11.230033 c 1.189087,-0.892283 4.525469,0.781485 7.591449,3.832217 3.05866,3.0434343 4.67031,6.3000599 3.79822,7.5007826 -0.003,0.0046 0.075,0.06678 0.0716,0.071281 l 0.53165,-0.5342679 c 0.003,-0.0046 -0.075,-0.06672 -0.0716,-0.071281 0.87208,-1.2007187 -0.73956,-4.4573482 -3.79822,-7.5007807 -3.06596,-3.05073 -6.40234,-4.724502 -7.591429,-3.832219 l -0.531654,0.534266 0,2e-6 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3165);fill-opacity:1;stroke:none"
+       id="path3248"
+       d="m 96.490291,-13.421069 c 1.189082,-0.892283 4.525459,0.781485 7.591449,3.83222 3.05865,3.043432 4.6703,6.300057 3.79822,7.5007817 -0.003,0.0046 0.075,0.06676 0.0716,0.07128 l 0.53166,-0.5342638 c 0.003,-0.0046 -0.075,-0.066721 -0.0716,-0.07128 0.87208,-1.2007207 -0.73957,-4.4573519 -3.79823,-7.5007819 -3.06598,-3.050732 -6.402355,-4.724503 -7.591445,-3.83222 l -0.531654,0.534264 0,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3162);fill-opacity:1;stroke:none"
+       id="path3250"
+       d="m 96.003059,-12.931452 c 1.189089,-0.892282 4.525471,0.781486 7.591451,3.832218 3.05866,3.043434 4.6703,6.3000596 3.79822,7.5007823 -0.003,0.0046 0.075,0.066781 0.0716,0.071281 l 0.53166,-0.5342659 c 0.003,-0.0046 -0.075,-0.066721 -0.0716,-0.07128 0.87209,-1.2007227 -0.73956,-4.4573544 -3.79821,-7.5007824 -3.06598,-3.050732 -6.402366,-4.724504 -7.591455,-3.83222 l -0.531656,0.534266 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3159);fill-opacity:1;stroke:none"
+       id="path3256"
+       d="m 98.191593,-15.130712 c 1.189081,-0.89228 4.525457,0.781488 7.591447,3.83222 3.05865,3.043432 4.6703,6.3000597 3.79822,7.5007824 -0.003,0.0046 0.075,0.06678 0.0716,0.07128 l 0.53165,-0.5342659 c 0.003,-0.0046 -0.075,-0.06672 -0.0716,-0.07128 0.87208,-1.2007207 -0.73956,-4.4573525 -3.79822,-7.5007845 -3.06598,-3.05073 -6.40236,-4.724502 -7.591445,-3.832215 l -0.531654,0.534261 2e-6,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
+       id="path3258"
+       d="m 97.704366,-14.641094 c 1.189076,-0.892283 4.525464,0.781486 7.591444,3.832222 3.05865,3.04343 4.67031,6.3000592 3.79822,7.5007779 -0.003,0.0046 0.075,0.06678 0.0716,0.07128 l 0.53168,-0.5342594 c 0.003,-0.0046 -0.075,-0.06672 -0.0716,-0.071281 0.87209,-1.2007267 -0.73956,-4.4573545 -3.79821,-7.5007845 -3.06599,-3.050734 -6.40237,-4.724504 -7.591452,-3.83222 l -0.531654,0.534262 0,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3151);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3153);stroke-width:1.00000727;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3270"
+       d="m 54.974091,39.494989 19.422646,-7.921971 0.165481,-0.165461 c 0.872081,-1.200733 -0.760581,-4.457612 -3.819237,-7.501054 -3.065986,-3.05073 -6.398423,-4.715248 -7.587507,-3.822966 l -8.181375,19.411452 -1.4e-5,0 z" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:#0c0c0c;stroke-width:1.00000727;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       id="path3281"
+       d="m 57.190201,34.237561 -2.217302,5.236652 5.297528,-2.171751 c -0.424589,-0.50858 -0.816554,-1.025148 -1.326332,-1.532388 -0.58689,-0.583972 -1.16415,-1.057795 -1.753894,-1.532513 z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/128/applets-screenshooter.svg
+++ b/elementary-xfce/apps/128/applets-screenshooter.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/devices/128/camera-photo.svg

--- a/elementary-xfce/apps/128/browser.svg.svg
+++ b/elementary-xfce/apps/128/browser.svg.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/calc.svg
+++ b/elementary-xfce/apps/128/calc.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-calculator.svg

--- a/elementary-xfce/apps/128/epiphany-browser.svg
+++ b/elementary-xfce/apps/128/epiphany-browser.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/epiphany-gecko.svg
+++ b/elementary-xfce/apps/128/epiphany-gecko.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/epiphany-icon.svg
+++ b/elementary-xfce/apps/128/epiphany-icon.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/epiphany-webkit.svg
+++ b/elementary-xfce/apps/128/epiphany-webkit.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/epiphany.svg
+++ b/elementary-xfce/apps/128/epiphany.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/galeon.svg
+++ b/elementary-xfce/apps/128/galeon.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/gedit-icon.svg
+++ b/elementary-xfce/apps/128/gedit-icon.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/gedit-logo.svg
+++ b/elementary-xfce/apps/128/gedit-logo.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/gnome-calculator.svg
+++ b/elementary-xfce/apps/128/gnome-calculator.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-calculator.svg

--- a/elementary-xfce/apps/128/gnome-web-browser.svg
+++ b/elementary-xfce/apps/128/gnome-web-browser.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/gnome-word.svg
+++ b/elementary-xfce/apps/128/gnome-word.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/internet-web-browser.svg
+++ b/elementary-xfce/apps/128/internet-web-browser.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/leafpad.svg
+++ b/elementary-xfce/apps/128/leafpad.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/mousepad.svg
+++ b/elementary-xfce/apps/128/mousepad.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/text-editor.svg
+++ b/elementary-xfce/apps/128/text-editor.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/web-browser.svg
+++ b/elementary-xfce/apps/128/web-browser.svg
@@ -1,0 +1,273 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3759"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="web-browser.svg">
+  <metadata
+     id="metadata100981">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1535"
+     inkscape:window-height="876"
+     id="namedview100979"
+     showgrid="true"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="41.140107"
+     inkscape:cy="62.015368"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3759">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3204"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3761">
+    <radialGradient
+       cx="17.81411"
+       cy="24.149399"
+       r="9.125"
+       fx="17.81411"
+       fy="24.149399"
+       id="radialGradient2418"
+       xlink:href="#linearGradient4845"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.643979,0,2.93653e-8,2.534421,78.72514,-37.986139)" />
+    <linearGradient
+       id="linearGradient4845">
+      <stop
+         id="stop4847"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4849"
+         style="stop-color:#b6b6b6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="62.200409"
+       y1="-12.489107"
+       x2="62.200409"
+       y2="-1.4615115"
+       id="linearGradient3697"
+       xlink:href="#linearGradient4873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1153734,0,0,2.1153252,-107.57708,31.426557)" />
+    <linearGradient
+       id="linearGradient4873">
+      <stop
+         id="stop4875"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4877"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="61.240059"
+       cy="-8.7256308"
+       r="9.7552834"
+       fx="61.240059"
+       fy="-8.7256308"
+       id="radialGradient3705"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,3.5234091,-3.5234073,0,-6.7439676,-205.79862)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148">
+      <stop
+         id="stop4627"
+         style="stop-color:#51cfee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4629"
+         style="stop-color:#49a3d2;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop4631"
+         style="stop-color:#3470b4;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop4633"
+         style="stop-color:#273567;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20"
+       y1="43"
+       x2="20"
+       y2="2.6887112"
+       id="linearGradient3713"
+       xlink:href="#linearGradient3707-319-631"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98001402,0,0,0.97999168,0.08994011,0.8703621)" />
+    <linearGradient
+       id="linearGradient3707-319-631">
+      <stop
+         id="stop4637"
+         style="stop-color:#254b6d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4639"
+         style="stop-color:#415b73;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop4641"
+         style="stop-color:#6195b5;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8838">
+      <stop
+         id="stop8840"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8842"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient3757"
+       xlink:href="#linearGradient8838"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.341176,0,3.047059)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4873"
+       id="linearGradient3016"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.8315699,0,0,5.8314371,-298.726,84.473673)"
+       x1="62.200409"
+       y1="-12.489107"
+       x2="62.200409"
+       y2="-1.4615115" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148"
+       id="radialGradient3020"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,9.5764447,-9.5764399,0,-19.560535,-560.5804)"
+       cx="61.240059"
+       cy="-8.7256308"
+       fx="61.240059"
+       fy="-8.7256308"
+       r="9.7552834" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3707-319-631"
+       id="linearGradient3022"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6636277,0,0,2.6635669,-0.98632694,1.1352782)"
+       x1="20"
+       y1="43"
+       x2="20"
+       y2="2.6887112" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8838"
+       id="radialGradient3025"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.7058822,0,0,1.7493214,-230.70589,101.32325)"
+       cx="62.625"
+       cy="4.625"
+       fx="62.625"
+       fy="4.625"
+       r="10.625" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="radialGradient3027"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.643979,0,2.93653e-8,2.534421,78.72514,-37.986139)"
+       cx="17.81411"
+       cy="24.149399"
+       fx="17.81411"
+       fy="24.149399"
+       r="9.125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4845"
+       id="radialGradient3208"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-6.9414143,0.09594968,0.09117476,6.7121065,201.48893,-104.7921)"
+       cx="17.81411"
+       cy="24.149399"
+       fx="17.81411"
+       fy="24.149399"
+       r="9.125" />
+  </defs>
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.4;fill:url(#radialGradient3025);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path8836"
+     d="m 113.99999,109.41387 a 49.999998,18.586565 0 0 1 -99.99999,0 49.999998,18.586565 0 1 1 99.99999,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3020);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3022);stroke-width:1.99999976;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path6495"
+     d="m 116.99999,63.998576 c 0,29.272037 -23.730652,53.001854 -52.999327,53.001854 C 34.729309,117.00043 11,93.270333 11,63.998576 11,34.727886 34.729309,11.000457 64.000663,11.000457 c 29.268675,0 52.999327,23.727429 52.999327,52.998119 l 0,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.4;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path6534"
+     d="m 64.895915,12.952439 -6.42073,0.735088 -7.062807,1.929606 c 0.601628,-0.210968 1.211106,-0.441224 1.834498,-0.643204 l -0.825528,-1.470174 -2.75174,0.45943 -1.375872,1.286404 -2.109668,0.275658 -1.926218,0.918858 -0.917246,0.459432 -0.27518,0.367542 -1.375868,0.275658 -0.825516,1.745834 -1.100704,-2.205262 -0.366896,0.918858 0.18348,2.480922 -1.742771,1.470174 -1.008972,2.664693 2.109673,0 0.825516,-1.745834 0.275178,-0.6432 c 0.927604,-0.657131 1.806976,-1.388961 2.751744,-2.021493 l 2.20139,0.73509 c 1.43327,0.97547 2.876612,1.966361 4.311066,2.940351 l 2.10964,-1.929607 -2.384842,-1.010744 -1.100696,-2.205262 -4.03589,-0.459432 -0.09174,-0.459428 1.742766,0.367542 1.008976,-1.010746 2.201394,-0.45943 c 0.520956,-0.253802 1.033424,-0.43662 1.559318,-0.6432 l -1.37587,1.286402 4.953136,3.399782 0,2.021489 -1.92622,1.929608 2.56829,5.145618 1.742772,-1.010752 2.201395,-3.399778 c 3.094998,-0.958566 5.884404,-2.073984 8.80558,-3.399784 l -0.18346,1.286406 1.467592,1.010744 2.568292,-1.745832 -1.284148,-1.470177 -1.742772,1.010747 -0.550348,-0.183759 c 0.1264,-0.05786 0.239942,-0.12494 0.366894,-0.18376 l 2.56832,-6.6158 -5.595208,-2.205262 z m -25.132579,9.923683 2.109668,1.470176 1.742772,0 0,-1.745832 -2.109666,-0.918859 -1.742774,1.194515 z m 48.705832,-1.194515 -3.76071,0.918859 -2.38484,1.562062 0,1.378288 -3.760716,2.389032 0.733802,3.58356 2.20139,-1.562066 1.37587,1.562066 1.559324,0.91886 1.008968,-2.664696 -0.550346,-1.56206 0.550346,-1.102636 2.201398,-2.02149 1.00897,0 -1.00897,2.20527 0,2.021486 c 0.907348,-0.247416 1.8232,-0.343774 2.75174,-0.459432 l -2.568292,1.837728 -0.18346,1.102622 -2.935192,2.480928 -3.02692,-0.735092 0,-1.745836 -1.375868,0.918862 0.642072,1.562066 -2.201392,0 -1.192421,2.021492 -1.467596,1.65395 -2.660016,0.55131 1.55932,1.562066 0.366896,1.562058 -1.926216,0 -2.568294,1.378293 0,4.042976 1.192422,0 1.100696,1.194522 2.476568,-1.194522 0.917244,-2.480922 1.834497,-1.102628 0.3669,-0.91886 2.935188,-0.735089 1.651044,1.837717 1.742774,0.91886 -1.008976,2.021498 1.559328,-0.459432 0.825518,-2.021496 -2.01794,-2.297147 0.825518,0 2.017944,1.653949 0.366902,2.205264 1.742768,2.021494 0.458624,-2.940352 0.917246,-0.459434 c 0.976356,1.015356 1.745966,2.257066 2.568294,3.399786 l 3.026916,0.18378 1.742767,1.102634 -0.825519,1.194518 -1.74277,1.562062 -2.568296,0 -3.393812,-1.10263 -1.74277,0.18378 -1.284146,1.47018 -3.668994,-3.675444 -2.568288,-0.735086 -3.760717,0.45943 -3.302088,0.918858 c -1.883708,2.139298 -3.812292,4.302156 -5.595212,6.523912 l -2.109666,5.145608 1.008972,1.102633 -1.834494,2.664694 2.017944,4.686186 c 1.679146,1.902806 3.368154,3.792758 5.04486,5.696918 l 2.476566,-2.11336 1.008976,1.2864 2.66002,-1.74584 0.917243,1.01076 2.660016,0 1.559322,1.74582 -0.917248,3.12412 1.834492,2.11338 -0.09174,3.675439 1.37587,2.6647 -1.008968,2.29714 c -0.09836,1.64754 -0.18346,3.22216 -0.18346,4.86996 0.809288,2.23238 1.62066,4.459249 2.384844,6.707657 l 0.55035,3.58356 0,1.83772 1.467594,0 2.10967,-1.3783 2.568296,0 3.852438,-4.31864 -0.458626,-1.470168 2.568295,-2.297136 -1.926221,-2.113373 2.29311,-1.83772 2.2014,-1.3783 1.00897,-1.10262 -0.64207,-2.48092 c 0,-2.08868 1e-5,-4.1593 0,-6.248239 l 1.74277,-3.85922 2.20139,-2.38904 2.38485,-5.880698 0,-1.562064 c -1.18677,0.14976 -2.3243,0.284788 -3.48554,0.36755 l 2.38484,-2.38904 3.30209,-2.205262 1.74277,-2.021495 0,-2.20526 c -0.39528,-0.746732 -0.79445,-1.550384 -1.19243,-2.29713 l -1.55932,1.837716 -1.19242,-1.378286 -1.74277,-1.37829 0,-2.848468 2.01794,2.29715 2.29312,-0.275656 c 1.0345,0.940788 2.02784,1.77732 2.93519,2.848464 l 1.46763,-1.653994 c 0,-1.780612 -2.00196,-10.57097 -6.329,-18.009651 C 104.68847,31.060512 97.091292,24.254414 97.091298,24.254414 l -0.550352,1.010744 -2.017946,2.205266 -2.56829,-2.664694 2.56829,0 1.192424,-1.286406 -4.769684,-0.918858 -2.476572,-0.918859 z m -55.126563,1.194515 -0.917248,2.389036 c 0,0 -1.605874,0.265598 -2.01794,0.367546 -5.262504,4.857908 -15.874645,15.394918 -18.344946,35.192331 0.09781,0.459006 1.74277,3.124117 1.74277,3.124117 l 4.035888,2.38904 4.035888,1.10263 1.742772,2.113378 2.660016,2.021492 1.559318,-0.275658 1.1007,0.551318 0,0.367542 -1.467598,4.13486 -1.19242,1.74584 0.366896,0.82698 -0.917246,3.307899 3.393816,6.24824 3.48554,3.03224 1.559318,2.20526 -0.18346,4.594289 1.100698,2.572788 -1.100698,4.96186 c 0,0 -0.14688,-0.0408 0,0.45942 0.14818,0.50046 6.131501,3.8672 6.512451,3.58356 0.379648,-0.28894 0.7338,-0.55132 0.7338,-0.55132 l -0.366898,-1.10264 1.559322,-1.47016 0.550346,-1.56208 2.47657,-0.82696 1.926216,-4.778072 -0.550346,-1.286396 1.284144,-2.021489 2.935194,-0.6432 1.467598,-3.49166 -0.366902,-4.31864 2.293118,-3.216 0.366898,-3.307899 c -3.14627,-1.56296 -6.233116,-3.1689 -9.35592,-4.77808 l -1.559322,-3.03224 -2.843466,-0.6432 -1.55932,-4.13487 -3.760713,0.45943 -3.302094,-2.38903 -3.485538,3.032236 0,0.45943 c -1.044002,-0.301868 -2.280762,-0.346288 -3.210352,-0.91886 l -0.733796,-2.205264 0,-2.389036 -2.384844,0.275656 c 0.19192,-1.521758 0.448818,-3.072803 0.642068,-4.594295 l -1.375872,0 -1.37587,1.745831 -1.284147,0.643202 -1.926219,-1.102629 -0.18345,-2.389036 0.366899,-2.572806 2.843467,-2.205268 2.293116,0 0.458626,-1.2864 2.843468,0.643196 2.109668,2.664696 0.366898,-4.410528 3.66899,-3.032236 1.284144,-3.216006 2.751746,-1.102632 1.467592,-2.205266 3.485541,-0.643203 1.742772,-2.572808 c -1.724992,0 -3.503322,0 -5.228313,0 l 3.302095,-1.562062 2.293114,0 2.935194,-1.010742 0.550348,2.848464 1.284146,-2.021492 -1.467598,-1.010748 0.3669,-1.194514 -1.19242,-1.102634 -1.28415,-0.367542 0.3669,-1.378288 -1.00897,-1.929602 -2.293122,0.918856 0.366902,-1.745832 -2.66002,-1.562064 -2.109665,3.675438 0.18346,1.286404 -2.109668,0.91886 -1.284146,2.848466 -0.64207,-2.664696 -3.577268,-1.470174 -0.642072,-2.021492 4.86141,-2.756578 2.109668,-2.021494 0.18346,-2.389036 -1.19242,-0.6432 -1.559324,-0.18376 z m 39.349912,4.410534 0,1.470166 0.825524,0.918862 0,2.205268 -0.458626,2.940348 2.384842,-0.45943 1.742776,-1.74583 -1.559324,-1.470182 C 75.122037,29.79692 74.609565,28.580466 73.976667,27.286656 l -1.28415,0 z m -2.017948,2.940342 -1.46759,0.45944 0.366896,2.664688 1.926218,-1.010754 -0.825524,-2.113374 z m 26.875353,24.166017 2.201388,2.572804 2.66002,5.696933 1.65104,1.837716 -0.82551,1.929614 1.46759,1.745832 c -0.67348,0.04466 -1.32572,0.0919 -2.01794,0.0919 -1.25752,-2.647104 -2.25276,-5.316668 -3.21037,-8.085963 l -1.651046,-1.837716 -0.917248,-3.307898 0.642076,-0.643202 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3016);stroke-width:2.00000119;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+     id="path8655"
+     d="m 114.99999,63.998644 c 0,28.167429 -22.835154,51.001786 -50.999351,51.001786 -28.166774,0 -51.00064,-22.834617 -51.00064,-51.001786 0,-28.166126 22.833866,-50.998187 51.00064,-50.998187 28.164197,0 50.999351,22.832061 50.999351,50.998187 l 0,0 z" />
+  <path
+     d="m 76.999997,53.009221 45.224813,43.081332 -20.3376,0.943333 8.77527,17.758584 c 2.73329,7.90886 -9.04039,11.05158 -11.09036,5.11996 l -8.118922,-17.7677 -14.453201,15.75882 z"
+     id="path3970"
+     style="fill:url(#radialGradient3208);fill-opacity:1;fill-rule:evenodd;stroke:#666666;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     d="m 78.999998,58.000453 38.399992,36.4 -18.599995,0.8 10.399995,21.759097 c 0.8,3.04088 -5.19999,5.04088 -7.23769,3.32104 l -9.962304,-21.680148 -13,13.999988 z"
+     id="path4853"
+     style="opacity:0.4;fill:none;stroke:#ffffff;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/apps/128/www-browser.svg
+++ b/elementary-xfce/apps/128/www-browser.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/web-browser.svg

--- a/elementary-xfce/apps/128/xfce-editor.svg
+++ b/elementary-xfce/apps/128/xfce-editor.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/apps/128/xfce4-notes-plugin.svg
+++ b/elementary-xfce/apps/128/xfce4-notes-plugin.svg
@@ -1,0 +1,954 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   id="svg1307"
+   sodipodi:version="0.32"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="xfce4-notes-plugin.svg"
+   inkscape:export-filename="/home/ulisse/icone/sticky-notes/scalable/sticky-notes.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90"
+   version="1.1">
+  <defs
+     id="defs1309">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2832">
+      <stop
+         style="stop-color:black;stop-opacity:1;"
+         offset="0"
+         id="stop2834" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop2836" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2822">
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="0"
+         id="stop2824" />
+      <stop
+         id="stop2830"
+         offset="0.5"
+         style="stop-color:black;stop-opacity:1;" />
+      <stop
+         style="stop-color:black;stop-opacity:0;"
+         offset="1"
+         id="stop2826" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2934">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1;"
+         offset="0"
+         id="stop2936" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:1"
+         offset="1"
+         id="stop2938" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2926"
+       inkscape:collect="always">
+      <stop
+         id="stop2928"
+         offset="0"
+         style="stop-color:#edd400;stop-opacity:1" />
+      <stop
+         id="stop2930"
+         offset="1"
+         style="stop-color:#c4a000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2910">
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="0"
+         id="stop2912" />
+      <stop
+         style="stop-color:#fce94f;stop-opacity:1"
+         offset="1"
+         id="stop2914" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2898">
+      <stop
+         style="stop-color:white;stop-opacity:1;"
+         offset="0"
+         id="stop2900" />
+      <stop
+         style="stop-color:white;stop-opacity:0;"
+         offset="1"
+         id="stop2902" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2882">
+      <stop
+         id="stop2908"
+         offset="0"
+         style="stop-color:#fce94f;stop-opacity:1;" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:1"
+         offset="1"
+         id="stop2886" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2837">
+      <stop
+         style="stop-color:white;stop-opacity:1;"
+         offset="0"
+         id="stop2839" />
+      <stop
+         style="stop-color:white;stop-opacity:0;"
+         offset="1"
+         id="stop2841" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2825">
+      <stop
+         style="stop-color:white;stop-opacity:1;"
+         offset="0"
+         id="stop2827" />
+      <stop
+         style="stop-color:white;stop-opacity:0;"
+         offset="1"
+         id="stop2829" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2807">
+      <stop
+         id="stop2809"
+         offset="0"
+         style="stop-color:#c4a000;stop-opacity:1" />
+      <stop
+         id="stop2811"
+         offset="1"
+         style="stop-color:#edd400;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2214"
+       inkscape:collect="always">
+      <stop
+         id="stop2216"
+         offset="0"
+         style="stop-color:#edd400;stop-opacity:1" />
+      <stop
+         id="stop2218"
+         offset="1"
+         style="stop-color:#c4a000;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2281">
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0"
+         id="stop2283" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop2285" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2207">
+      <stop
+         style="stop-color:#fef8c1;stop-opacity:1"
+         offset="0"
+         id="stop2209" />
+      <stop
+         style="stop-color:#edd400;stop-opacity:1"
+         offset="1"
+         id="stop2211" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2207"
+       id="linearGradient2213"
+       x1="21"
+       y1="23.833796"
+       x2="23.139471"
+       y2="29.708212"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9931437,0,0,2.4038472,-6.4827409,-86.894543)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2281"
+       id="linearGradient2287"
+       x1="6.3131518"
+       y1="27.126162"
+       x2="6.8376656"
+       y2="31"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8582327,0,0,2.0000062,-4.7201387,-68.000312)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2214"
+       id="linearGradient2295"
+       x1="28.870058"
+       y1="22.477673"
+       x2="29.495005"
+       y2="25.004829"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9931437,0,0,2.4038472,-6.4827409,-79.68292)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2807"
+       id="linearGradient2226"
+       x1="27.534513"
+       y1="36.90781"
+       x2="27.534513"
+       y2="28.79846"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9230837,0,0,2.9166757,-6.1537439,-82.375356)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2825"
+       id="linearGradient2831"
+       x1="39.875"
+       y1="19.0625"
+       x2="40.167702"
+       y2="21.125"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2882"
+       id="linearGradient2888"
+       x1="37.207386"
+       y1="16.975407"
+       x2="38.323223"
+       y2="20.749966"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8443645,0,0,1.9217884,-3.9024637,-68.94084)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2898"
+       id="linearGradient2904"
+       x1="16.357021"
+       y1="23.864025"
+       x2="16.632799"
+       y2="45.10363"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9729798,0,0,3.0000093,-7.3512519,-84.500362)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2910"
+       id="linearGradient2916"
+       x1="33.1875"
+       y1="25.5"
+       x2="33.25"
+       y2="30.0625"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9230837,0,0,2.9166757,-6.1537439,-82.375356)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2926"
+       id="linearGradient2924"
+       x1="39.279198"
+       y1="18.280069"
+       x2="40.481865"
+       y2="22.897709"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8443645,0,0,1.9217884,-3.9024637,-68.94084)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2934"
+       id="linearGradient2940"
+       x1="24"
+       y1="35.625"
+       x2="24"
+       y2="30.762564"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8421119,0,0,2.8000087,-4.21042,-77.600342)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2822"
+       id="linearGradient2828"
+       x1="20"
+       y1="39.5"
+       x2="20"
+       y2="33.982628"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2832"
+       id="radialGradient2838"
+       cx="40"
+       cy="36.75"
+       fx="40"
+       fy="36.75"
+       r="3"
+       gradientTransform="matrix(2,0,0,0.916667,-40,3.0625)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2832"
+       id="radialGradient2850"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2,0,0,-0.916667,88,70.4375)"
+       cx="40"
+       cy="36.75"
+       fx="40"
+       fy="36.75"
+       r="3" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2837"
+       id="linearGradient4120"
+       gradientUnits="userSpaceOnUse"
+       x1="-6.3561172"
+       y1="-7.5830092"
+       x2="6.6739359"
+       y2="27.933392"
+       gradientTransform="matrix(3.1474086,0,0,2.0000062,-11.131869,-68.366765)" />
+    <linearGradient
+       y2="26.02973"
+       x2="9"
+       y1="29.056757"
+       x1="9"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.1461221,1.1404197,52.09977,60.074045)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3151"
+       xlink:href="#linearGradient3290-678"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3290-678">
+      <stop
+         offset="0"
+         style="stop-color:#ece5a5;stop-opacity:1"
+         id="stop2607" />
+      <stop
+         offset="1"
+         style="stop-color:#fcfbf2;stop-opacity:1"
+         id="stop2609" />
+    </linearGradient>
+    <linearGradient
+       y2="41.391716"
+       x2="9.5220556"
+       y1="37.371799"
+       x1="5.5178981"
+       gradientTransform="matrix(0.74712277,0.03224699,0.03220731,0.74620134,83.04238,55.238899)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3191-577"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3191-577">
+      <stop
+         offset="0"
+         style="stop-color:#dbce48;stop-opacity:1"
+         id="stop2613" />
+      <stop
+         offset="1"
+         style="stop-color:#c5b625;stop-opacity:1"
+         id="stop2615" />
+    </linearGradient>
+    <linearGradient
+       y2="30.000141"
+       x2="30.037716"
+       y1="24.989594"
+       x1="30.037716"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,53.876442,58.288668)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3156"
+       xlink:href="#linearGradient3223-699"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3223-699">
+      <stop
+         offset="0"
+         style="stop-color:#b1b1b1;stop-opacity:1"
+         id="stop2599" />
+      <stop
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2601" />
+      <stop
+         offset="1"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         id="stop2603" />
+    </linearGradient>
+    <linearGradient
+       y2="30.000141"
+       x2="30.037716"
+       y1="24.989594"
+       x1="30.037716"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,54.120055,58.043859)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3159"
+       xlink:href="#linearGradient3240-907"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3240-907">
+      <stop
+         offset="0"
+         style="stop-color:#565656;stop-opacity:1"
+         id="stop2591" />
+      <stop
+         offset="0.5"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop2593" />
+      <stop
+         offset="1"
+         style="stop-color:#545454;stop-opacity:1"
+         id="stop2595" />
+    </linearGradient>
+    <linearGradient
+       y2="30.000141"
+       x2="30.037716"
+       y1="24.989594"
+       x1="30.037716"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,53.025796,59.14348)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3162"
+       xlink:href="#linearGradient3223-768"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3223-768">
+      <stop
+         offset="0"
+         style="stop-color:#b1b1b1;stop-opacity:1"
+         id="stop2583" />
+      <stop
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2585" />
+      <stop
+         offset="1"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         id="stop2587" />
+    </linearGradient>
+    <linearGradient
+       y2="30.000141"
+       x2="30.037716"
+       y1="24.989594"
+       x1="30.037716"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,53.26941,58.898674)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3165"
+       xlink:href="#linearGradient3240-686"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3240-686">
+      <stop
+         offset="0"
+         style="stop-color:#565656;stop-opacity:1"
+         id="stop2575" />
+      <stop
+         offset="0.5"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop2577" />
+      <stop
+         offset="1"
+         style="stop-color:#545454;stop-opacity:1"
+         id="stop2579" />
+    </linearGradient>
+    <linearGradient
+       y2="30.000141"
+       x2="30.037716"
+       y1="24.989594"
+       x1="30.037716"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,52.179245,59.994185)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3168"
+       xlink:href="#linearGradient3223-789"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3223-789">
+      <stop
+         offset="0"
+         style="stop-color:#b1b1b1;stop-opacity:1"
+         id="stop2567" />
+      <stop
+         offset="0.5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2569" />
+      <stop
+         offset="1"
+         style="stop-color:#8f8f8f;stop-opacity:1"
+         id="stop2571" />
+    </linearGradient>
+    <linearGradient
+       y2="30.000141"
+       x2="30.037716"
+       y1="24.989594"
+       x1="30.037716"
+       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,52.422858,59.749377)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3171"
+       xlink:href="#linearGradient3240-279"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3240-279">
+      <stop
+         offset="0"
+         style="stop-color:#565656;stop-opacity:1"
+         id="stop2559" />
+      <stop
+         offset="0.5"
+         style="stop-color:#9a9a9a;stop-opacity:1"
+         id="stop2561" />
+      <stop
+         offset="1"
+         style="stop-color:#545454;stop-opacity:1"
+         id="stop2563" />
+    </linearGradient>
+    <linearGradient
+       y2="31.210939"
+       x2="23.575972"
+       y1="25.356892"
+       x1="23.575972"
+       spreadMethod="pad"
+       gradientTransform="matrix(0.87539065,-0.87968181,0.97932539,0.97445279,55.630805,64.250643)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3176"
+       xlink:href="#linearGradient3155-40"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3155-40">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2541" />
+      <stop
+         offset="0.13482948"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop2543" />
+      <stop
+         offset="0.20224422"
+         style="stop-color:#a4a4a4;stop-opacity:1"
+         id="stop2545" />
+      <stop
+         offset="0.26965895"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2547" />
+      <stop
+         offset="0.44650277"
+         style="stop-color:#8d8d8d;stop-opacity:1"
+         id="stop2549" />
+      <stop
+         offset="0.57114136"
+         style="stop-color:#959595;stop-opacity:1"
+         id="stop2551" />
+      <stop
+         offset="0.72038066"
+         style="stop-color:#cecece;stop-opacity:1"
+         id="stop2553" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2555" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1"
+         id="stop3106" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop3108" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3454">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3456" />
+      <stop
+         id="stop3458"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.0097359" />
+      <stop
+         offset="0.99001008"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3460" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3462" />
+    </linearGradient>
+    <linearGradient
+       y2="3.6336823"
+       x2="-51.786404"
+       y1="53.514328"
+       x1="-51.786404"
+       gradientTransform="matrix(1.0843525,0,0,1.1183944,79.550865,1.1533356)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3250-3"
+       xlink:href="#linearGradient3104-8-8"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient3104-8-8">
+      <stop
+         offset="0"
+         style="stop-color:#a0a0a0;stop-opacity:1;"
+         id="stop3106-5-4" />
+      <stop
+         offset="1"
+         style="stop-color:#bebebe;stop-opacity:1;"
+         id="stop3108-4-3" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.08918772,0,0,0.01646992,-1.9026808,51.961501)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3359"
+       xlink:href="#linearGradient5048"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.03052185,0,0,0.01646992,27.194158,51.961535)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3361"
+       xlink:href="#linearGradient5060"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3596"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03052185,0,0,0.01646992,33.470457,51.961535)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient3600-9-2-6">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3-2-9" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7-9-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-8-8-97">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.32173914;"
+         id="stop3106-5-4-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.27826086;"
+         id="stop3108-4-3-7" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.2813106"
+     inkscape:cx="64.144388"
+     inkscape:cy="67.064737"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:grid-points="true"
+     inkscape:window-width="1523"
+     inkscape:window-height="847"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     fill="#2e3436"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="false"
+     showborder="true"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       id="GridFromPre046Settings"
+       type="xygrid"
+       originx="0px"
+       originy="0px"
+       spacingx="0.5px"
+       spacingy="0.5px"
+       color="#3f3fff"
+       empcolor="#3f3fff"
+       opacity="0.15"
+       empopacity="0.38"
+       empspacing="2" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1312">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Ulisse Perusin</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title></dc:title>
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title>Lapo Calamandrei</dc:title>
+          </cc:Agent>
+        </dc:contributor>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/GPL/2.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/GPL/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/SourceCode" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,80)">
+    <g
+       id="g2852"
+       style="opacity:0.2745098"
+       transform="matrix(2.8181882,0,0,2.7272804,-3.6362555,-75.727576)">
+      <rect
+         y="34"
+         x="8"
+         height="5.5"
+         width="32"
+         id="rect2815"
+         style="color:#000000;fill:url(#linearGradient2828);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+      <path
+         id="path2820"
+         d="m 40,39.5 c 3.312,0 6,-1.232 6,-2.75 C 46,35.232 43.312,34 40,34 l 0,5.5 z"
+         style="color:#000000;fill:url(#radialGradient2838);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path2848"
+         d="m 8,34 c -3.312,0 -6,1.232 -6,2.75 0,1.518 2.688,2.75 6,2.75 L 8,34 Z"
+         style="color:#000000;fill:url(#radialGradient2850);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="color:#000000;fill:url(#linearGradient2916);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2226);stroke-width:2.00000453;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       d="m 17.230925,-43.000233 -10.2307931,53.958501 0,16.041716 114.0002581,0 0,-16.041716 -8.76925,-53.958501 -95.000215,0 z"
+       id="path2191"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0" />
+    <g
+       transform="matrix(-1.8324574,0,0,1.8211814,84.382395,-54.39825)"
+       style="fill:#424242;fill-opacity:1"
+       id="g3680">
+      <path
+         style="fill:#424242;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3674"
+         d="m 14.628268,29.924566 c 0.113601,0.965157 -0.746583,1.292888 -0.596518,2.253099 l -1.927453,1.478078 c -0.132972,-0.943369 1.197608,-4.069827 0.991079,-5.00031 z"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#424242;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3676"
+         d="m 17.665061,28.673198 c -0.02417,2.079247 0.678,1.192783 -1.910963,2.589105 0.815412,-1.303562 2.191632,-2.618366 3.548625,-1.445006 2.591189,0.421672 -1.433848,2.481989 0.355171,0.314327 2.600013,-2.269865 2.222306,-0.997521 4.404319,-0.868565 1.780222,0.430207 1.796194,0.05633 -0.570253,1.416663 0.03203,-0.02793 0.06406,-0.05585 0.09609,-0.08377 l 2.238621,-0.946961 c -0.02529,0.03869 -0.05058,0.07738 -0.07587,0.116068 -2.811349,1.677475 -1.668398,1.183753 -3.647289,0.92631 -1.86635,-0.327685 -2.87539,-0.553295 -0.220839,-1.484714 -1.139443,1.293919 -2.981215,3.299891 -4.618598,1.882935 -1.588509,-1.170545 2.132535,-2.413333 0.764613,-0.73098 -2.682553,1.478611 -2.400461,1.55186 -2.560742,-0.565921 l 2.197119,-1.119488 z"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#424242;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3678"
+         d="m 29.174994,26.230789 c 0.14593,1.507956 0.225786,3.019542 0.405142,4.524683 1.423472,1.850746 -1.826977,4.633968 -1.347225,1.808834 0.342081,-3.243811 0.650319,-3.84417 3.528747,-4.879984 0.547689,0.983343 0.847731,2.137946 1.704024,2.727959 -4.840075,2.551671 1.693745,-1.481215 2.420946,-1.867341 0.464921,-0.109143 0.939853,-0.165325 1.412287,-0.230751 l -1.920756,1.437314 c -0.464844,0.06807 -0.935057,0.1189 -1.384984,0.261165 2.998581,-1.911568 -0.568404,0.841891 -2.506019,1.817551 -0.923746,-0.724224 -1.143464,-1.894425 -1.783232,-2.880314 3.14599,-2.218804 0.63263,-0.141231 0.637903,2.577332 -0.28354,2.350093 -3.320174,3.549885 -2.814981,0.306459 -0.172764,-1.481806 -0.250004,-2.982368 -0.530099,-4.447333 l 2.178247,-1.155574 z"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       style="opacity:0.18431373;fill:url(#linearGradient2287);fill-opacity:1;fill-rule:evenodd;stroke:none"
+       d="m 11.000141,-6.000118 106.000249,0 -3.51982,-18.00764 -102.480429,14.007628 0,4.000012 z"
+       id="path2271"
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="color:#000000;fill:url(#linearGradient2940);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect2845"
+       width="108.00024"
+       height="14.000044"
+       x="10.000133"
+       y="11.999923" />
+    <path
+       style="opacity:0.53333285;color:#000000;fill:none;stroke:url(#linearGradient2904);stroke-width:2.00000525;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       d="m 18.848133,-41.000227 -9.847996,52.500162 0,13.500042 110.000253,0 0,-13.500042 -8.54731,-52.500162 -91.604947,0 z"
+       id="path2799"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;fill:url(#linearGradient2888);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2924);stroke-width:2.00000525;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       d="m 17.230155,-42.996763 95.000225,-0.0035 c 3.42212,17.356149 0.48611,18.26046 -5.20262,18.26046 l -94.976536,9.72573 z"
+       id="rect2179"
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:type="inkscape:offset"
+       inkscape:radius="-0.99436891"
+       inkscape:original="M 8 13.5 L 5.3125 28 L 39 23 C 41 23 41.703125 22.53125 40.5 13.5 L 8 13.5 z "
+       style="opacity:0.67058824;color:#000000;fill:none;stroke:url(#linearGradient2831);stroke-width:1.00000036;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path2815"
+       d="M 8.828125,14.494141 6.5449219,26.810547 38.853516,22.015625 A 0.99446835,0.99446835 0 0 1 39,22.005859 c 0.461157,0 0.707442,-0.05645 0.759766,-0.08594 0.05232,-0.02949 0.118574,-0.03593 0.220703,-0.498047 0.181626,-0.821826 0.01479,-3.345348 -0.416016,-6.927734 l -30.736328,0 z"
+       transform="matrix(2.0000046,0,0,2.0000062,1.2847722,-69.985693)" />
+    <path
+       style="color:#000000;fill:url(#linearGradient2213);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2295);stroke-width:2.00000405;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+       d="m 1.000118,-15.981048 99.591252,-38.344769 c -3.107525,11.398033 5.63827,31.379009 11.15507,29.931303 L 8.2110117,-9.000127 c -4.4897153,0 -7.2108937,-3.375149 -7.2108937,-6.980921 z"
+       id="rect2195"
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0" />
+    <path
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:url(#linearGradient4120);fill-opacity:1;stroke:none;stroke-width:0.79714775;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;font-family:sans-serif;-inkscape-font-specification:sans-serif"
+       d="m 98.2174,-52.723169 -100.0054,37.73157 0.098357,0.562502 c 0.2107376,0.827404 0.3669642,1.851937 1.3769913,2.687509 1.1033766,0.912799 2.7209337,1.437505 4.6227565,1.437505 l 0.098356,0 C 9.024703,-65.61366 151.80616,17.029519 108.03261,-24.569694 c -1.80909,-1.638429 -3.30962,-3.718696 -4.75266,-6.377278 -2.5702,-4.342098 -5.15332,-11.903175 -5.06255,-21.776197 z m -1.318559,2.232184 c -0.153,4.482229 1.104273,14.236752 5.341839,21.034985 1.50755,2.41852 1.62055,3.541074 3.4156,5.301467 L 4.3101042,-11.929088 c -0.039428,0 -0.060212,3.62e-4 -0.098356,0 -1.2304967,-0.0116 -1.8345618,-0.214623 -2.5572697,-0.812503 -0.2541372,-0.210242 -0.4132532,-0.813404 -0.5901391,-1.375005 z"
+       id="path2835"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsscccccscccscc" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="m 8.0001342,13.999941 112.0002558,0 0,2.000006 -112.0002558,0 z"
+       id="path4122"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4124"
+       d="m 8.0001342,17.999954 112.0002558,0 0,2.000006 -112.0002558,0 z"
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="m 8.0001342,21.999966 112.0002558,0 0,2.000007 -112.0002558,0 z"
+       id="path4126"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4128"
+       d="m 8.0001342,9.999929 112.0002558,0 0,2.000006 -112.0002558,0 z"
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none" />
+    <g
+       id="g4429"
+       transform="matrix(2.0000046,0,0,2.0000062,-109.21065,-171.0928)">
+      <path
+         d="m 108.27137,69.692176 c -0.23101,-0.13598 -0.40974,-0.10061 -0.52783,-0.02495 l -15.72751,10.014828 -2.89461,1.848398 -0.0891,0.0374 -3.42706,7.72242 8.49318,0.255815 0.0705,-0.04718 2.91323,-1.838602 15.72359,-10.1012 c 0.47234,-0.302645 -0.27468,-2.308458 -1.67574,-4.507318 -1.0508,-1.649136 -2.16564,-2.951672 -2.85864,-3.359609 l -2e-5,0 z"
+         id="path2422"
+         style="opacity:0.15;fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.22548,79.137077 c 0.59454,-0.446137 2.26271,0.39074 3.7957,1.916096 1.52931,1.521706 2.33513,3.150009 1.89909,3.750366 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 21.34587,-21.450504 c 0.54195,-0.544611 -0.3001,-2.265649 -1.88175,-3.839428 -1.58164,-1.57378 -3.3069,-2.407285 -3.84886,-1.862671 L 90.22548,79.137077 Z"
+         id="rect2383"
+         style="fill:url(#linearGradient3176);fill-opacity:1;stroke:#0c0c0c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 108.96624,60.304445 c 0.59454,-0.446136 2.26272,0.390742 3.7957,1.916096 1.52932,1.521706 2.33513,3.150009 1.89909,3.750365 -0.002,0.0023 0.0375,0.03338 0.0358,0.03564 l 2.6051,-2.61787 0.0532,-0.05342 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43603,-0.600356 -0.36979,-2.228658 -1.8991,-3.750363 -1.53298,-1.525355 -3.20116,-2.362234 -3.7957,-1.916096 l -0.0532,0.05342 -2.60509,2.617869 0,0 z"
+         id="rect3175"
+         style="opacity:0.8;fill:#ffb6ed;fill-opacity:1;stroke:#e28ccd;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 90.22548,79.137074 c 0.59454,-0.446136 2.26272,0.390742 3.7957,1.916096 1.52931,1.521707 2.33513,3.150009 1.89909,3.750366 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 14.7002,-14.772261 0.0532,-0.05343 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43603,-0.600361 -0.36979,-2.228662 -1.89911,-3.750369 -1.53298,-1.525354 -3.20116,-2.362232 -3.79569,-1.916094 l -0.0532,0.05342 -14.70018,14.772262 0,0 z"
+         id="path3208"
+         style="opacity:0.6;fill:#0c0c0c;fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.04624,63.238758 c 0.59454,-0.446138 2.26272,0.390741 3.7957,1.916096 1.52931,1.521705 2.33513,3.150007 1.89909,3.750365 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 0.26583,-0.267134 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43604,-0.600357 -0.36978,-2.22866 -1.89909,-3.750363 -1.53299,-1.525356 -3.20116,-2.362234 -3.7957,-1.916097 l -0.26583,0.26713 0,2e-6 z"
+         id="path3233"
+         style="fill:url(#linearGradient3171);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 105.80263,63.483565 c 0.59454,-0.446138 2.26272,0.39074 3.79569,1.916095 1.52932,1.521706 2.33514,3.150007 1.8991,3.750364 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 0.26583,-0.267132 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43604,-0.600355 -0.36978,-2.228658 -1.8991,-3.750363 -1.53298,-1.525354 -3.20116,-2.362234 -3.7957,-1.916096 l -0.26582,0.267131 0,10e-7 z"
+         id="path3216"
+         style="fill:url(#linearGradient3168);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.89279,62.388055 c 0.59454,-0.446138 2.26272,0.39074 3.7957,1.916096 1.52932,1.521705 2.33513,3.150006 1.8991,3.750364 -0.002,0.0023 0.0375,0.03338 0.0358,0.03564 l 0.26582,-0.26713 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43604,-0.600356 -0.36978,-2.22866 -1.89909,-3.750364 -1.53298,-1.525355 -3.20116,-2.362234 -3.7957,-1.916096 l -0.26583,0.26713 0,0 z"
+         id="path3248"
+         style="fill:url(#linearGradient3165);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 106.64918,62.632862 c 0.59454,-0.446138 2.26272,0.39074 3.7957,1.916095 1.52932,1.521706 2.33513,3.150007 1.8991,3.750364 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 0.26583,-0.267131 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43604,-0.600357 -0.36978,-2.228661 -1.8991,-3.750364 -1.53298,-1.525355 -3.20115,-2.362235 -3.79569,-1.916096 l -0.26584,0.267131 z"
+         id="path3250"
+         style="fill:url(#linearGradient3162);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 107.74344,61.53324 c 0.59454,-0.446137 2.26271,0.390741 3.79569,1.916096 1.52932,1.521705 2.33514,3.150007 1.8991,3.750364 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 0.26583,-0.267131 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43603,-0.600356 -0.36978,-2.22866 -1.8991,-3.750365 -1.53298,-1.525354 -3.20116,-2.362234 -3.7957,-1.916094 l -0.26582,0.267129 0,0 z"
+         id="path3256"
+         style="fill:url(#linearGradient3159);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 107.49983,61.778047 c 0.59453,-0.446138 2.26271,0.39074 3.79569,1.916097 1.52932,1.521704 2.33514,3.150007 1.8991,3.750362 -0.002,0.0023 0.0375,0.03339 0.0358,0.03564 l 0.26582,-0.267128 c 0.002,-0.0023 -0.0375,-0.03336 -0.0358,-0.03564 0.43604,-0.600359 -0.36978,-2.228661 -1.89909,-3.750365 -1.53298,-1.525356 -3.20116,-2.362235 -3.7957,-1.916096 l -0.26582,0.267129 0,0 z"
+         id="path3258"
+         style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 86.13484,88.845893 9.71126,-3.960957 0.0827,-0.08273 c 0.43603,-0.600362 -0.38029,-2.22879 -1.90961,-3.7505 C 92.48621,79.526352 90.82,78.694099 90.22547,79.140237 l -4.09062,9.705656 -1e-5,0 z"
+         id="path3270"
+         style="fill:url(#linearGradient3151);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3153);stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+      <path
+         d="m 87.24289,86.217198 -1.10864,2.618307 2.64874,-1.085868 c -0.21229,-0.254288 -0.40827,-0.51257 -0.66316,-0.766188 -0.29344,-0.291984 -0.58207,-0.528894 -0.87694,-0.766251 z"
+         id="path3281"
+         style="fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:#0c0c0c;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>

--- a/elementary-xfce/apps/128/zim.svg
+++ b/elementary-xfce/apps/128/zim.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/apps/128/accessories-text-editor.svg

--- a/elementary-xfce/devices/128/camera-photo.svg
+++ b/elementary-xfce/devices/128/camera-photo.svg
@@ -1,0 +1,1008 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg5954"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="camera-photo.svg">
+  <metadata
+     id="metadata177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1535"
+     inkscape:window-height="876"
+     id="namedview175"
+     showgrid="true"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="4.34375"
+     inkscape:cx="63.550366"
+     inkscape:cy="62.836691"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5954">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3924"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs5956">
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient5928"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0628545,0,0,0.02058823,1.294955,34.451367)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient5931"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0628545,0,0,0.02058823,1.2825853,34.451367)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient5934"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0628545,0,0,0.02058823,46.705044,34.451367)" />
+    <linearGradient
+       id="linearGradient18344">
+      <stop
+         id="stop18346"
+         style="stop-color:#2f3537;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop18354"
+         style="stop-color:#8a8e8e;stop-opacity:1"
+         offset="0.30000001" />
+      <stop
+         id="stop18348"
+         style="stop-color:#2f3537;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5428">
+      <stop
+         id="stop5430"
+         style="stop-color:#7a7c7c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5432"
+         style="stop-color:#33393a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient25793">
+      <stop
+         id="stop25795"
+         style="stop-color:#f0f0f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop25819"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0.03744119" />
+      <stop
+         id="stop25817"
+         style="stop-color:#eeeeec;stop-opacity:0.69594592"
+         offset="0.39254159" />
+      <stop
+         id="stop25803"
+         style="stop-color:#a1a29f;stop-opacity:1"
+         offset="0.90799886" />
+      <stop
+         id="stop25799"
+         style="stop-color:#555753;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26816">
+      <stop
+         id="stop26818"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop26820"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26830">
+      <stop
+         id="stop26832"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop26834"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient18403">
+      <stop
+         id="stop18405"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop18407"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26168">
+      <stop
+         id="stop26170"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop26172"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26128">
+      <stop
+         id="stop26130"
+         style="stop-color:#eeeeec;stop-opacity:0.9527027"
+         offset="0" />
+      <stop
+         id="stop26146"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="0.47988781" />
+      <stop
+         id="stop26148"
+         style="stop-color:#eeeeec;stop-opacity:0.99324322"
+         offset="0.5229584" />
+      <stop
+         id="stop26132"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="0.63153976" />
+      <stop
+         id="stop26134"
+         style="stop-color:#eeeeec;stop-opacity:0.23529412"
+         offset="0.7383545" />
+      <stop
+         id="stop26136"
+         style="stop-color:#ffffff;stop-opacity:0.71621621"
+         offset="0.83400774" />
+      <stop
+         id="stop26142"
+         style="stop-color:#f6f6f5;stop-opacity:0.27027026"
+         offset="0.90514386" />
+      <stop
+         id="stop26144"
+         style="stop-color:#f2f2f0;stop-opacity:0.27702704"
+         offset="0.90514386" />
+      <stop
+         id="stop26138"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26021">
+      <stop
+         id="stop26023"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop26029"
+         style="stop-color:#eeeeec;stop-opacity:0.49803922"
+         offset="0.86670214" />
+      <stop
+         id="stop26025"
+         style="stop-color:#eeeeec;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26120">
+      <stop
+         id="stop26122"
+         style="stop-color:#2e3436;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop26124"
+         style="stop-color:#2e3436;stop-opacity:0"
+         offset="0.47336468" />
+      <stop
+         id="stop26126"
+         style="stop-color:#0f1112;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26075">
+      <stop
+         id="stop26077"
+         style="stop-color:#555753;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop26079"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8690">
+      <stop
+         id="stop8692"
+         style="stop-color:#3a3a3a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8694"
+         style="stop-color:#3a3a3a;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8660">
+      <stop
+         id="stop8662"
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8664"
+         style="stop-color:#555753;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26091">
+      <stop
+         id="stop26093"
+         style="stop-color:#2e3436;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop26095"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26099">
+      <stop
+         id="stop26101"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop26103"
+         style="stop-color:#babdb6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9785">
+      <stop
+         id="stop9787"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop9789"
+         style="stop-color:#090908;stop-opacity:0.96621621"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient9688">
+      <stop
+         id="stop9690"
+         style="stop-color:#eeeeec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop9692"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient26371">
+      <stop
+         id="stop26373"
+         style="stop-color:#777777;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop26375"
+         style="stop-color:#2b2b2b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <filter
+       x="-0.34117648"
+       y="-0.34117648"
+       width="1.6823529"
+       height="1.6823529"
+       id="filter9094"
+       style="color-interpolation-filters:sRGB">
+      <feGaussianBlur
+         stdDeviation="0.28648224"
+         id="feGaussianBlur9096" />
+    </filter>
+    <linearGradient
+       id="linearGradient5895">
+      <stop
+         id="stop5897"
+         style="stop-color:#888a85;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5899"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2230">
+      <stop
+         id="stop2232"
+         style="stop-color:#eeeeee;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2234"
+         style="stop-color:#a2a2a2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3301">
+      <stop
+         id="stop3303"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3305"
+         style="stop-color:#d7dbc7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient17941">
+      <stop
+         id="stop17943"
+         style="stop-color:#e9e9e9;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop17945"
+         style="stop-color:#a7a7a7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop17947"
+         style="stop-color:#bebebe;stop-opacity:1"
+         offset="0.52899867" />
+      <stop
+         id="stop17949"
+         style="stop-color:#e7e7e7;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient17963">
+      <stop
+         id="stop17965"
+         style="stop-color:#dee3e0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop17967"
+         style="stop-color:#dee3e0;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5404">
+      <stop
+         id="stop5406"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5408"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10695">
+      <stop
+         id="stop10697"
+         style="stop-color:#b100cb;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop10699"
+         style="stop-color:#204a87;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient10695"
+       id="radialGradient3929"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62063729,0,0,0.62063729,-31.072802,-37.0032)"
+       cx="171.25"
+       cy="188.5"
+       fx="171.25"
+       fy="188.5"
+       r="19" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5404"
+       id="linearGradient3932"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6499752,0,0,2.5832805,0.40131901,-4.6655495)"
+       x1="10.666382"
+       y1="20.521324"
+       x2="11.692044"
+       y2="53.913837" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17963"
+       id="radialGradient3935"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-9.0602034e-6,-6.0138743,9.0218733,-1.4405396e-5,-68.853996,131.32445)"
+       cx="14.738829"
+       cy="12.007012"
+       fx="14.738829"
+       fy="12.007012"
+       r="0.546875" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17941"
+       id="radialGradient3938"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.3800876,-1.245778e-6,5.0398902e-7,1.1875605,8.7801045,20.347945)"
+       cx="9.2365828"
+       cy="17.108955"
+       fx="9.2365828"
+       fy="17.108955"
+       r="2.9610097" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient17963"
+       id="radialGradient3941"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.6136537,7.3443202,0,-113.33518,61.825432)"
+       cx="9.1189642"
+       cy="20.823402"
+       fx="9.1189642"
+       fy="20.823402"
+       r="3.1769876" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3301"
+       id="linearGradient3944"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.5613484,0,0,2.8025547,76.515122,-30.763631)"
+       x1="6.5595827"
+       y1="28.780806"
+       x2="6.5595827"
+       y2="30.191154" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2230"
+       id="linearGradient3946"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1772983,0,0,1.0931951,76.852247,22.097522)"
+       x1="5.334765"
+       y1="29.179651"
+       x2="8.5602255"
+       y2="22.712967" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5895"
+       id="linearGradient3949"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7965027,0,0,1.7965027,21.687007,13.456324)"
+       x1="22.0625"
+       y1="22.125"
+       x2="24"
+       y2="24.9375" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5895"
+       id="linearGradient3954"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8618071,0,0,2.8686752,11.075114,-14.174)"
+       x1="21.568329"
+       y1="21.015778"
+       x2="24.082361"
+       y2="26.86837" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26371"
+       id="radialGradient3957"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.471197e-5,-3.7055329,0.68966141,0,36.894267,1716.2699)"
+       cx="442.29459"
+       cy="62.526134"
+       fx="442.29459"
+       fy="62.526134"
+       r="77.922958" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9688"
+       id="radialGradient3961"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46318668,-0.00626022,0.00475869,0.35220971,-33.902012,24.189139)"
+       cx="258.76035"
+       cy="183.6442"
+       fx="258.76035"
+       fy="183.6442"
+       r="18.578125" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9785"
+       id="radialGradient3965"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10838235,-0.43835612,0.67343014,0.17056409,-53.63275,172.00604)"
+       cx="251.69016"
+       cy="171.7894"
+       fx="251.69016"
+       fy="171.7894"
+       r="21.53125" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient9688"
+       id="linearGradient3968"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.37020637,0,0,0.35646228,-9.302655,22.012261)"
+       x1="236.75015"
+       y1="171.61981"
+       x2="222.73204"
+       y2="179.03932" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26099"
+       id="radialGradient3972"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.18942645,-0.15120785,0.30797849,0.40967328,-44.186156,99.10864)"
+       cx="439.04871"
+       cy="111.3"
+       fx="439.04871"
+       fy="111.3"
+       r="75.752426" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26091"
+       id="linearGradient3974"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19322404,0,0,0.26958413,-8.3403392,38.926547)"
+       x1="457.19556"
+       y1="289.77823"
+       x2="457.19556"
+       y2="114.22821" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8660"
+       id="radialGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.40059638,0.41112341,-0.52988129,-0.54380746,306.35464,-56.665718)"
+       cx="434.12521"
+       cy="98.974625"
+       fx="434.12521"
+       fy="98.974625"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8690"
+       id="radialGradient3979"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03431132,-0.23720696,0.77781382,-0.11850006,-6.6640417,186.86697)"
+       cx="441.3573"
+       cy="130.89047"
+       fx="441.3573"
+       fy="130.89047"
+       r="75.756241" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8660"
+       id="radialGradient3982"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.37469049,-0.36656852,0.32816194,-0.3478028,222.44788,275.93111)"
+       cx="469.91165"
+       cy="131.83463"
+       fx="469.91165"
+       fy="131.83463"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26075"
+       id="radialGradient3985"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03659679,-0.65992402,0.24971354,-0.01479947,37.997051,313.05687)"
+       cx="344.26065"
+       cy="218.66101"
+       fx="344.26065"
+       fy="218.66101"
+       r="74.907745" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26075"
+       id="linearGradient3988"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24919699,0,0,0.34767688,-33.930934,17.483569)"
+       x1="469.35895"
+       y1="126.83501"
+       x2="280.0184"
+       y2="225.83026" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26120"
+       id="radialGradient3991"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.26765933,-0.26922604,0,105.68002,-63.007364)"
+       cx="529.39941"
+       cy="95.381569"
+       fx="529.39941"
+       fy="95.381569"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26021"
+       id="radialGradient3994"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.25734348,0.28161628,0,33.388914,190.6334)"
+       cx="449.88171"
+       cy="165.51567"
+       fx="449.88171"
+       fy="165.51567"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26128"
+       id="radialGradient3997"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40250963,-6.2012056e-8,3.4701254e-8,0.33249758,-105.09997,21.837216)"
+       cx="459.45273"
+       cy="170.414"
+       fx="459.45273"
+       fy="170.414"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26168"
+       id="radialGradient4000"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27977629,-0.19421598,0.09565635,0.15202475,-64.459003,158.77742)"
+       cx="502.53064"
+       cy="217.46133"
+       fx="502.53064"
+       fy="217.46133"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18403"
+       id="radialGradient4004"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.1953859,0.27267894,-0.21788885,-0.9551862,617.4356,-26.549893)"
+       cx="427.79684"
+       cy="33.604549"
+       fx="427.79684"
+       fy="33.604549"
+       r="74.907745" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26830"
+       id="radialGradient4007"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.5120163,-0.24831695,0.32518056,1.1669663,-966.63936,7.579015)"
+       cx="399.8783"
+       cy="127.24747"
+       fx="399.8783"
+       fy="127.24747"
+       r="2.0221689" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26816"
+       id="radialGradient4010"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8978297,8.5081486e-5,-3.8596833e-5,1.3625823,-1081.2554,-118.42499)"
+       cx="400.29608"
+       cy="127.65469"
+       fx="400.29608"
+       fy="127.65469"
+       r="2.0221689" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient25793"
+       id="linearGradient4013"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.41557856,0,0,0.40880687,-235.03586,-88.000911)"
+       x1="697.91443"
+       y1="327.78354"
+       x2="700.41443"
+       y2="496.33771" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5428"
+       id="radialGradient4016"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(11.286995,5.1683125e-8,0,0.37389597,-795.23503,40.637138)"
+       cx="76.16552"
+       cy="14.781876"
+       fx="76.16552"
+       fy="14.781876"
+       r="20.999798" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient18344"
+       id="linearGradient4018"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6831372,0,0,2.6669709,-139.9177,13.659078)"
+       x1="8.5625"
+       y1="4.646832"
+       x2="8.5625"
+       y2="45.818478" />
+  </defs>
+  <g
+     style="opacity:0.3"
+     id="g5936"
+     transform="matrix(2.6666836,0,0,2.6666836,3.164e-4,-8.0011279)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient5934);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path5387"
+       d="m 8.8251297,42.000171 c 0,0 0,4.999724 0,4.999724 C 5.5882785,47.009307 0.99999808,45.879711 1,44.499712 c 0,-1.38 3.6120828,-2.49954 7.8251297,-2.499541 l 0,0 z" />
+    <rect
+       style="fill:url(#linearGradient5931);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="rect5373"
+       y="42"
+       x="8.8251247"
+       height="4.9999995"
+       width="30.349743" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient5928);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+       id="path5375"
+       d="m 39.174869,42.000171 c 0,0 0,4.999724 0,4.999724 3.236851,0.0094 7.825131,-1.120184 7.825129,-2.500183 0,-1.38 -3.612082,-2.49954 -7.825129,-2.499541 l 0,0 z" />
+  </g>
+  <rect
+     style="fill:url(#radialGradient4016);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4018);stroke-width:2.02001286;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+     id="rect5438"
+     y="39.009216"
+     x="9.0103779"
+     ry="4.2008967"
+     rx="4.9497781"
+     height="71.980461"
+     width="109.9807" />
+  <rect
+     style="fill:url(#linearGradient4013);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="rect5445"
+     y="45.999249"
+     x="10.000385"
+     ry="3.3146279"
+     rx="3.3146279"
+     height="64.000412"
+     width="108.00069" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.27227723;fill:url(#radialGradient4010);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5451"
+     d="m 85.973626,51.688035 a 7.2440715,7.0325893 0 0 1 -14.488143,0 7.2440715,7.0325893 0 1 1 14.488143,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient4007);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5453"
+     d="m 85.940606,55.094065 a 7.2110501,4.8250728 0 0 1 -14.4221,0 7.2110501,4.8250728 0 1 1 14.4221,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient4004);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5463"
+     d="m 106.66766,77.332757 a 26.666832,26.66685 0 0 1 -53.333663,0 26.666832,26.66685 0 1 1 53.333663,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5465"
+     d="m 104.00098,77.332757 a 24.000155,24.000157 0 0 1 -48.00031,0 24.000155,24.000157 0 1 1 48.00031,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient4000);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5467"
+     d="m 109.33435,77.332757 a 29.333522,29.333519 0 0 1 -58.667044,0 29.333522,29.333519 0 1 1 58.667044,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3997);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5469"
+     d="m 106.50099,78.499424 a 26.66683,26.666839 0 0 1 -53.33366,0 26.66683,26.666839 0 1 1 53.33366,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3994);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5471"
+     d="m 101.51866,76.432791 a 21.517837,20.850523 0 0 1 -43.035672,0 21.517837,20.850523 0 1 1 43.035672,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.85148513;fill:url(#radialGradient3991);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5473"
+     d="m 98.667611,77.332757 a 18.666785,18.666785 0 0 1 -37.33357,0 18.666785,18.666785 0 1 1 37.33357,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3988);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5475"
+     d="m 98.667611,77.332737 a 18.666785,18.666785 0 0 1 -37.33357,0 18.666785,18.666785 0 1 1 37.33357,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3985);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5477"
+     d="m 98.667611,79.999434 a 18.666785,18.666785 0 0 1 -37.33357,0 18.666785,18.666785 0 1 1 37.33357,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.53960422;fill:url(#radialGradient3982);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5479"
+     d="m 95.29108,79.859733 a 15.37679,16.000105 0 0 1 -30.753579,0 15.37679,16.000105 0 1 1 30.753579,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3977);fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient3979);stroke-width:0.29699233;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+     id="path5481"
+     d="m 95.136261,81.332763 a 15.135436,14.46877 0 0 1 -30.27087,0 15.135436,14.46877 0 1 1 30.27087,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3972);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3974);stroke-width:0.28917611;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1"
+     id="path5483"
+     d="m 94.474802,85.332788 c 0,7.989651 -6.484339,14.473992 -14.473974,14.473992 -7.989637,0 -14.473977,-6.484341 -14.473977,-14.473992 0,-7.989631 6.48434,-14.473966 14.473977,-14.473966 7.989635,0 14.473974,6.484335 14.473974,14.473966 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5485"
+     d="m 92.00091,85.332788 a 12.000078,12.000076 0 0 1 -24.000155,0 12.000078,12.000076 0 1 1 24.000155,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.23267326;fill:url(#linearGradient3968);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5487"
+     d="m 77.932091,78.574805 c -0.226562,0.0708 -0.443721,0.153401 -0.659429,0.245061 0.215442,-0.0922 0.433075,-0.173801 0.659429,-0.245061 z m 4.720128,0.133601 c 0.09334,0.0352 0.186341,0.0724 0.277652,0.1114 -0.09166,-0.039 -0.183942,-0.0762 -0.277652,-0.1114 z m -6.15468,0.501283 c -0.150981,0.0872 -0.296387,0.181001 -0.439618,0.278482 0.142161,-0.0976 0.289843,-0.191201 0.439618,-0.278482 z m -0.439618,0.278482 c -0.172301,0.1172 -0.337291,0.236241 -0.497466,0.367602 0.158101,-0.130201 0.327657,-0.251122 0.497466,-0.367602 z m 8.734549,0.501263 c 0.09898,0.0864 0.195582,0.175801 0.289228,0.267362 -0.09362,-0.0912 -0.190301,-0.181202 -0.289228,-0.267362 z m -9.405548,0.0224 c -0.12698,0.111401 -0.252161,0.225242 -0.370206,0.345322 0.118321,-0.1204 0.243042,-0.233401 0.370206,-0.345322 z m -0.370206,0.345322 c -0.899662,0.915146 -1.53663,2.067073 -1.781619,3.352982 -6.82e-4,0.004 6.86e-4,0.008 0,0.012 l 0,2.372695 c 0.371138,1.966673 1.6466,3.628523 3.401267,4.589449 l 6.929799,0 c 1.681194,-0.920686 2.915898,-2.484736 3.343425,-4.344367 l 0,-0.0224 0,-2.818298 c -0.190241,-0.840645 -0.541232,-1.62711 -1.029635,-2.316994 -0.379924,-0.489364 -0.819463,-0.844106 -1.29572,-1.035967 l -9.301431,0 c -0.09366,0.0698 -0.179901,0.139601 -0.266082,0.211661 z m -1.781619,5.736817 c -0.03606,-0.190801 -0.06168,-0.381943 -0.08098,-0.579244 0.0186,0.196601 0.04488,0.387863 0.08098,0.579244 z m 0,-2.372695 c -0.03618,0.191801 -0.0624,0.382142 -0.08098,0.579243 0.0192,-0.194601 0.04494,-0.388442 0.08098,-0.579243 z m 12.158955,-3.15246 c 0.06778,0.0754 0.132421,0.155601 0.196662,0.233921 -0.06518,-0.0794 -0.127901,-0.157601 -0.196662,-0.233921 z m -7.542946,10.638148 c 0.140881,0.046 0.283282,0.0852 0.428053,0.1226 -0.144861,-0.0376 -0.287076,-0.0764 -0.428053,-0.1226 z m 4.500317,0 c -0.141661,0.046 -0.282464,0.085 -0.428051,0.1226 0.144781,-0.0374 0.287166,-0.0766 0.428051,-0.1226 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.37556559;fill:url(#radialGradient3965);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5489"
+     d="m 73.959179,77.332737 c -1.427579,1.025967 -2.573686,2.409395 -3.291747,4.003466 l 0,7.85609 c 0.751867,1.67025 1.971373,3.10066 3.494943,4.140546 l 11.812367,0 c 1.438013,-0.982766 2.602033,-2.314275 3.359477,-3.866345 l 0,-8.390793 c -0.723764,-1.48399 -1.818603,-2.774018 -3.169834,-3.742964 l -12.205206,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5491"
+     d="m 77.957533,78.408144 c -0.223816,0.0716 -0.438345,0.155401 -0.651442,0.248261 0.212829,-0.0936 0.42783,-0.176001 0.651442,-0.248261 z m 4.662936,0.135401 c 0.09218,0.0356 0.184081,0.0734 0.274287,0.1128 -0.09056,-0.0394 -0.181741,-0.0772 -0.274287,-0.1128 z m -6.080105,0.507823 c -0.149141,0.0884 -0.2928,0.183401 -0.434293,0.282122 0.140421,-0.0988 0.286332,-0.193601 0.434293,-0.282122 z m -0.434293,0.282122 c -0.170221,0.118801 -0.333202,0.239301 -0.491439,0.372402 0.156221,-0.131801 0.323688,-0.254402 0.491439,-0.372402 z m 8.628715,0.507823 c 0.09778,0.0876 0.193201,0.178001 0.285726,0.270842 -0.09248,-0.0924 -0.187981,-0.183601 -0.285726,-0.270842 z m -9.291583,0.0226 c -0.125461,0.113001 -0.249096,0.228182 -0.365721,0.349822 0.116901,-0.122 0.240108,-0.236441 0.365721,-0.349822 z m -0.365721,0.349822 c -0.888759,0.927106 -1.518011,2.094094 -1.760033,3.396802 -6.74e-4,0.004 6.78e-4,0.008 0,0.012 l 0,2.403716 c 0.366642,1.992372 1.626649,3.675943 3.360058,4.649409 l 6.845831,0 c 1.660825,-0.932706 2.880571,-2.517196 3.302915,-4.401128 l 0,-0.0226 0,-2.855098 C 86.638332,82.54519 86.29158,81.748465 85.809095,81.049561 85.433775,80.553798 84.999562,80.194415 84.529073,80.000054 l -9.188731,0 c -0.0925,0.0706 -0.177741,0.141601 -0.262854,0.214401 z m -1.760033,5.811778 c -0.0356,-0.193402 -0.06094,-0.386923 -0.08,-0.586824 0.0184,0.199201 0.04432,0.392942 0.08,0.586824 z m 0,-2.403696 c -0.03576,0.194201 -0.06166,0.387143 -0.08,0.586824 0.019,-0.197201 0.0444,-0.393543 0.08,-0.586824 z m 12.011633,-3.19366 c 0.06696,0.0764 0.130801,0.157601 0.194301,0.236981 -0.06438,-0.0804 -0.126341,-0.159601 -0.194301,-0.236981 z M 77.87753,91.205326 c 0.139181,0.0464 0.27985,0.0862 0.422863,0.1242 -0.143121,-0.038 -0.283596,-0.0774 -0.422863,-0.1242 z m 4.445789,0 c -0.139941,0.0468 -0.279042,0.0862 -0.422867,0.1242 0.143021,-0.0378 0.28369,-0.0776 0.422867,-0.1242 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.23267326;fill:url(#radialGradient3961);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path5493"
+     d="m 77.957533,78.241463 c -0.223816,0.0726 -0.438345,0.157401 -0.651442,0.251481 0.212829,-0.0946 0.42783,-0.178401 0.651442,-0.251481 z m 4.662936,0.137201 c 0.09218,0.0362 0.184081,0.0744 0.274287,0.1142 -0.09056,-0.04 -0.181741,-0.0782 -0.274287,-0.1142 z m -6.080105,0.514383 c -0.149141,0.0894 -0.2928,0.185801 -0.434293,0.285762 0.140421,-0.100001 0.286332,-0.196201 0.434293,-0.285762 z m -0.434293,0.285762 c -0.170221,0.120401 -0.333202,0.242401 -0.491439,0.377222 0.156221,-0.133401 0.323688,-0.257681 0.491439,-0.377222 z m 8.628715,0.514383 c 0.09778,0.0886 0.193201,0.180401 0.285726,0.274322 -0.09248,-0.0936 -0.187981,-0.186001 -0.285726,-0.274322 z m -9.291583,0.023 c -0.125461,0.114401 -0.249096,0.231122 -0.365721,0.354342 0.116901,-0.1236 0.240108,-0.239521 0.365721,-0.354342 z m -0.365721,0.354342 c -0.888759,0.939046 -1.518011,2.121094 -1.760033,3.440602 -6.74e-4,0.004 6.78e-4,0.008 0,0.012 l 0,2.434695 c 0.366642,2.018093 1.626649,3.723364 3.360058,4.70939 l 6.845831,0 c 1.660825,-0.944746 2.880571,-2.549676 3.302915,-4.457908 l 0,-0.023 0,-2.891939 c -0.187921,-0.862605 -0.534673,-1.669631 -1.017158,-2.377555 -0.37532,-0.502143 -0.809533,-0.866166 -1.280022,-1.063027 l -9.188731,0 c -0.0925,0.0716 -0.177741,0.143401 -0.262854,0.217161 z m -1.760033,5.886658 c -0.0356,-0.195801 -0.06094,-0.391922 -0.08,-0.594384 0.0184,0.201802 0.04432,0.397983 0.08,0.594384 z m 0,-2.434715 c -0.03576,0.196801 -0.06166,0.392142 -0.08,0.594403 0.019,-0.199601 0.0444,-0.398602 0.08,-0.594403 z m 12.011633,-3.234841 c 0.06696,0.0774 0.130801,0.159601 0.194301,0.240041 -0.06438,-0.0814 -0.126341,-0.161601 -0.194301,-0.240041 z m -7.451552,10.91617 c 0.139181,0.0472 0.27985,0.0874 0.422863,0.1258 -0.143121,-0.0384 -0.283596,-0.0784 -0.422863,-0.1258 z m 4.445789,0 c -0.139941,0.0474 -0.279042,0.0872 -0.422867,0.1258 0.143021,-0.0384 0.28369,-0.0786 0.422867,-0.1258 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0.50543482;fill-rule:nonzero;stroke:none"
+     id="path5495"
+     d="m 80.03189,79.982434 c -2.746272,0 -5.000634,2.061213 -5.293626,4.70195 -0.0122,0.111201 -0.02134,0.222601 -0.0264,0.335862 -0.0038,0.081 -0.0134,0.159801 -0.0134,0.241822 0,0.018 -1.78e-4,0.036 0,0.0538 -1.78e-4,0.018 0,0.0358 0,0.0538 0.0016,0.08 0.008,0.162801 0.0134,0.241822 0.0054,0.113201 0.0142,0.224561 0.0264,0.335842 0.292984,2.640757 2.547354,4.70197 5.293626,4.70197 2.746268,0 5.000634,-2.061213 5.29362,-4.70197 0.0122,-0.111201 0.02134,-0.222581 0.0264,-0.335842 0.0064,-0.0966 0.0122,-0.197601 0.0134,-0.295562 -9.86e-4,-0.098 -0.007,-0.199001 -0.0134,-0.295542 -0.0054,-0.113201 -0.0142,-0.224561 -0.0264,-0.335862 -0.292982,-2.640757 -2.547354,-4.70195 -5.29362,-4.70195 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:none;stroke:url(#radialGradient3957);stroke-width:2.00001287;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+     id="path5497"
+     d="m 108.04441,77.332757 a 28.043583,28.043574 0 0 1 -56.087165,0 28.043583,28.043574 0 1 1 56.087165,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3954);stroke-width:1.95357203;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path5499"
+     d="m 81.368249,51.984813 a 5.3658885,5.378766 0 0 1 -10.731777,0 5.3658885,5.378766 0 1 1 10.731777,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.34705882;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path5501"
+     d="m 78.22508,52.005315 a 2.1845726,2.1898154 0 0 1 -4.369143,0 2.1845726,2.1898154 0 1 1 4.369143,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.30588235;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.1;marker:none;visibility:visible;display:inline;overflow:visible;filter:url(#filter9094);enable-background:accumulate"
+     id="path5503"
+     transform="matrix(1.8485355,0,0,1.8529718,26.040449,23.394654)"
+     d="m 28.416853,16.44536 a 0.8396895,0.8396895 0 1 1 -1.679379,0 0.8396895,0.8396895 0 1 1 1.679379,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3949);stroke-width:0.94737446;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path5505"
+     d="m 65.813603,54.888162 a 3.3684435,3.3684435 0 0 1 -6.736887,0 3.3684435,3.3684435 0 1 1 6.736887,0 z" />
+  <rect
+     style="fill:url(#linearGradient3944);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3946);stroke-width:1.51914418;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;font-family:Bitstream Vera Sans"
+     id="rect5507"
+     y="48.758835"
+     x="90.760445"
+     ry="1.5910004"
+     rx="1.8608569"
+     height="6.4809074"
+     width="22.481009" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#2e3436;fill-opacity:1;fill-rule:evenodd;stroke:url(#radialGradient3941);stroke-width:0.99141163;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10;stroke-opacity:0.99607843;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path5511"
+     d="m 49.94232,42.321797 a 9.9485892,4.3114031 0 1 1 -19.897177,0 9.9485892,4.3114031 0 1 1 19.897177,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3938);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.37656182;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path5513"
+     d="m 48.000621,40.665847 a 8.0000509,3.3333545 0 0 1 -16.0001,0 8.0000509,3.3333545 0 1 1 16.0001,0 z" />
+  <rect
+     style="fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:url(#radialGradient3935);stroke-width:0.60435402;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none"
+     id="rect5515"
+     y="42.559135"
+     x="37.764889"
+     ry="1.1130044"
+     rx="1.0240251"
+     height="3.8953242"
+     width="3.8478515" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3932);stroke-width:2.00167847;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+     id="rect5519"
+     y="47.000095"
+     x="11.001225"
+     ry="2.6314366"
+     rx="2.6314366"
+     height="61.998734"
+     width="105.99902" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.8;fill:url(#radialGradient3929);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.94462639;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path10013"
+     d="m 89.334219,86.127313 c 0,5.154673 -4.178704,9.333387 -9.333393,9.333387 -5.154689,0 -9.333394,-4.178714 -9.333394,-9.333387 0,-5.154693 4.178705,-9.333399 9.333394,-9.333399 5.154689,0 9.333393,4.178706 9.333393,9.333399 z" />
+  <rect
+     style="opacity:0.5;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect5950"
+     y="65.999374"
+     x="30.000513"
+     ry="2.0000129"
+     rx="2.0000129"
+     height="28.000179"
+     width="6.0000381" />
+  <rect
+     style="opacity:0.2;fill:#555753;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="rect5952"
+     y="69.999397"
+     x="40.000553"
+     ry="2.0000129"
+     rx="2.0000129"
+     height="20.000128"
+     width="6.0000381" />
+</svg>

--- a/elementary-xfce/devices/128/camera.svg
+++ b/elementary-xfce/devices/128/camera.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/devices/128/camera-photo.svg

--- a/elementary-xfce/places/128/edittrash.svg
+++ b/elementary-xfce/places/128/edittrash.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg

--- a/elementary-xfce/places/128/emptytrash.svg
+++ b/elementary-xfce/places/128/emptytrash.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash.svg

--- a/elementary-xfce/places/128/gnome-fs-trash-empty-accept.svg
+++ b/elementary-xfce/places/128/gnome-fs-trash-empty-accept.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg

--- a/elementary-xfce/places/128/gnome-fs-trash-empty.svg
+++ b/elementary-xfce/places/128/gnome-fs-trash-empty.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash.svg

--- a/elementary-xfce/places/128/gnome-fs-trash-full.svg
+++ b/elementary-xfce/places/128/gnome-fs-trash-full.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg

--- a/elementary-xfce/places/128/gnome-stock-trash-full.svg
+++ b/elementary-xfce/places/128/gnome-stock-trash-full.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg

--- a/elementary-xfce/places/128/gnome-stock-trash.svg
+++ b/elementary-xfce/places/128/gnome-stock-trash.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash.svg

--- a/elementary-xfce/places/128/stock_trash_full.svg
+++ b/elementary-xfce/places/128/stock_trash_full.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg

--- a/elementary-xfce/places/128/trashcan_empty.svg
+++ b/elementary-xfce/places/128/trashcan_empty.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash.svg

--- a/elementary-xfce/places/128/trashcan_full.svg
+++ b/elementary-xfce/places/128/trashcan_full.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg

--- a/elementary-xfce/places/128/user-trash-full.svg
+++ b/elementary-xfce/places/128/user-trash-full.svg
@@ -1,0 +1,2539 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg3695"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="user-trash-full.svg">
+  <metadata
+     id="metadata11265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1535"
+     inkscape:window-height="876"
+     id="namedview11263"
+     showgrid="true"
+     inkscape:snap-global="false"
+     inkscape:zoom="4.9166665"
+     inkscape:cx="54.365778"
+     inkscape:cy="66.449934"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3695">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3062"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3697">
+    <pattern
+       inkscape:collect="always"
+       xlink:href="#Polkadots-small"
+       id="pattern6315"
+       patternTransform="matrix(9.9991935,-0.12700076,0.12700076,9.9991935,7.9322033,32.135593)" />
+    <pattern
+       inkscape:stockid="Polka dots, small"
+       id="Polkadots-small"
+       patternTransform="translate(0,0) scale(10,10)"
+       height="10"
+       width="10"
+       patternUnits="userSpaceOnUse"
+       inkscape:collect="always">
+      <circle
+         id="circle5257"
+         r="0.05"
+         cy="0.810"
+         cx="2.567"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5259"
+         r="0.05"
+         cy="2.33"
+         cx="3.048"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5261"
+         r="0.05"
+         cy="2.415"
+         cx="4.418"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5263"
+         r="0.05"
+         cy="3.029"
+         cx="1.844"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5265"
+         r="0.05"
+         cy="1.363"
+         cx="6.08"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5267"
+         r="0.05"
+         cy="4.413"
+         cx="5.819"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5269"
+         r="0.05"
+         cy="4.048"
+         cx="4.305"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5271"
+         r="0.05"
+         cy="3.045"
+         cx="5.541"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5273"
+         r="0.05"
+         cy="5.527"
+         cx="4.785"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5275"
+         r="0.05"
+         cy="5.184"
+         cx="2.667"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5277"
+         r="0.05"
+         cy="1.448"
+         cx="7.965"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5279"
+         r="0.05"
+         cy="5.049"
+         cx="7.047"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5281"
+         r="0.05"
+         cy="0.895"
+         cx="4.340"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5283"
+         r="0.05"
+         cy="0.340"
+         cx="7.125"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5285"
+         r="0.05"
+         cy="1.049"
+         cx="9.553"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5287"
+         r="0.05"
+         cy="2.689"
+         cx="7.006"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5289"
+         r="0.05"
+         cy="2.689"
+         cx="8.909"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5291"
+         r="0.05"
+         cy="4.407"
+         cx="9.315"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5293"
+         r="0.05"
+         cy="3.870"
+         cx="7.820"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5295"
+         r="0.05"
+         cy="5.948"
+         cx="8.270"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5297"
+         r="0.05"
+         cy="7.428"
+         cx="7.973"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5299"
+         r="0.05"
+         cy="8.072"
+         cx="9.342"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5301"
+         r="0.05"
+         cy="9.315"
+         cx="8.206"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5303"
+         r="0.05"
+         cy="9.475"
+         cx="9.682"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5305"
+         r="0.05"
+         cy="6.186"
+         cx="9.688"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5307"
+         r="0.05"
+         cy="6.296"
+         cx="3.379"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5309"
+         r="0.05"
+         cy="8.204"
+         cx="2.871"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5311"
+         r="0.05"
+         cy="8.719"
+         cx="4.59"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5313"
+         r="0.05"
+         cy="9.671"
+         cx="3.181"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5315"
+         r="0.05"
+         cy="7.315"
+         cx="5.734"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5317"
+         r="0.05"
+         cy="6.513"
+         cx="6.707"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5319"
+         r="0.05"
+         cy="9.670"
+         cx="5.730"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5321"
+         r="0.05"
+         cy="8.373"
+         cx="6.535"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5323"
+         r="0.05"
+         cy="7.154"
+         cx="4.37"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5325"
+         r="0.05"
+         cy="7.25"
+         cx="0.622"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5327"
+         r="0.05"
+         cy="5.679"
+         cx="0.831"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5329"
+         r="0.05"
+         cy="8.519"
+         cx="1.257"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5331"
+         r="0.05"
+         cy="6.877"
+         cx="1.989"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5333"
+         r="0.05"
+         cy="3.181"
+         cx="0.374"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5335"
+         r="0.05"
+         cy="1.664"
+         cx="1.166"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5337"
+         r="0.05"
+         cy="0.093"
+         cx="1.151"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5339"
+         r="0.05"
+         cy="10.093"
+         cx="1.151"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5341"
+         r="0.05"
+         cy="4.451"
+         cx="1.302"
+         style="fill:black;stroke:none" />
+      <circle
+         id="circle5343"
+         r="0.05"
+         cy="3.763"
+         cx="3.047"
+         style="fill:black;stroke:none" />
+    </pattern>
+    <linearGradient
+       id="linearGradient6213"
+       osb:paint="solid">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6215" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="62.71241"
+       cy="108.02493"
+       r="47.38271"
+       fx="62.71241"
+       fy="108.02493"
+       id="radialGradient3269"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3587806,0,0,0.2110472,1.5000008,15.20272)" />
+    <linearGradient
+       id="linearGradient3384">
+      <stop
+         id="stop3386"
+         style="stop-color:#6e6e6e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3388"
+         style="stop-color:#9f9fa1;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="31.048019"
+       y1="45"
+       x2="31.048019"
+       y2="5.5"
+       id="linearGradient3266"
+       xlink:href="#linearGradient3384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2)" />
+    <linearGradient
+       id="linearGradient2793-2-0-403">
+      <stop
+         id="stop4645"
+         style="stop-color:#8d909a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4647"
+         style="stop-color:#d9d9d9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.93083"
+       y1="26.410894"
+       x2="21.514704"
+       y2="26.410894"
+       id="linearGradient3264"
+       xlink:href="#linearGradient2793-2-0-403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2083478,0,0,1.5198788,-1.979478,-15.055094)"
+       spreadMethod="reflect" />
+    <radialGradient
+       cx="19.308081"
+       cy="21.029308"
+       r="14.500172"
+       fx="19.308081"
+       fy="21.029308"
+       id="radialGradient3258"
+       xlink:href="#linearGradient3254-8-457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.679283,-1.6454754,0,48.823182,-18.496093)"
+       spreadMethod="pad" />
+    <linearGradient
+       id="linearGradient3355-273">
+      <stop
+         id="stop4657"
+         style="stop-color:#f0f0f0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3619"
+         style="stop-color:#777779;stop-opacity:1"
+         offset="0.44955608" />
+      <stop
+         id="stop4659"
+         style="stop-color:#6c6c70;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.999979"
+       y1="9.3726854"
+       x2="23.999979"
+       y2="2.0968478"
+       id="linearGradient3255"
+       xlink:href="#linearGradient3355-273"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1598658,0,0,1.3742464,-3.8367541,-0.9326014)" />
+    <linearGradient
+       id="linearGradient3320">
+      <stop
+         id="stop3323"
+         style="stop-color:#4e4e4e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3325"
+         style="stop-color:#b9bac2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="9.0003471"
+       y1="8"
+       x2="24"
+       y2="8"
+       id="linearGradient3253"
+       xlink:href="#linearGradient3320"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3627">
+      <stop
+         id="stop3629"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3190"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0.5" />
+      <stop
+         id="stop3631"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="24"
+       cy="7.7919979"
+       r="14.507708"
+       fx="24"
+       fy="7.7919979"
+       id="radialGradient3250"
+       xlink:href="#linearGradient3627"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.2042761e-8,0.6892888,-3.1574826,0,48.603098,-13.542931)"
+       spreadMethod="pad" />
+    <linearGradient
+       id="linearGradient3254-8-457">
+      <stop
+         id="stop4669"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4671"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574"
+       id="linearGradient3247"
+       xlink:href="#linearGradient3254-8-457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2227969,0,0,1.9458981,-4.735753,-31.362975)" />
+    <linearGradient
+       id="linearGradient3254-3-182">
+      <stop
+         id="stop4663"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4665"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.25"
+       y1="20.230709"
+       x2="17.125"
+       y2="34.173542"
+       id="linearGradient3261"
+       xlink:href="#linearGradient3254-3-182"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8965013,0,0,1.365896,4.7251825,-8.808688)" />
+    <linearGradient
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43"
+       id="linearGradient3389"
+       xlink:href="#linearGradient3205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0.3684052,0,1,0,-4.9734702)" />
+    <linearGradient
+       id="linearGradient3205">
+      <stop
+         id="stop3207"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3209"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45"
+       id="linearGradient3373"
+       xlink:href="#linearGradient3205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0.04605065,0,1,0,-0.9440383)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205"
+       id="linearGradient3032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3446684,0.06174712,0,1.3408524,3.7449637,-1.1154458)"
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205"
+       id="linearGradient3035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3446684,0.49397698,0,1.3408524,0.72796073,-6.5183192)"
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-3-182"
+       id="linearGradient3038"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4109938,0,0,3.5764598,13.163528,-19.835747)"
+       x1="12.25"
+       y1="20.230709"
+       x2="17.125"
+       y2="34.173542" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-8-457"
+       id="linearGradient3041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6442563,0,0,2.6091619,-6.6400562,-41.902748)"
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3627"
+       id="radialGradient3044"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.5713984,-8.4915335,3.2942488e-7,131.16601,-29.367709)"
+       spreadMethod="pad"
+       cx="23.816956"
+       cy="7.8258715"
+       fx="23.816956"
+       fy="7.8258715"
+       r="14.507708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3320"
+       id="linearGradient3047"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="9.0003471"
+       y1="8"
+       x2="24"
+       y2="8"
+       gradientTransform="matrix(2.6893366,0,0,2.6817046,0.45593178,0.300738)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3355-273"
+       id="linearGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1192696,0,0,3.6853228,-9.8623969,-2.200222)"
+       x1="23.999979"
+       y1="9.3726854"
+       x2="23.999979"
+       y2="2.0968478" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-8-457"
+       id="radialGradient3052"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.5033412,-4.4252374,0,131.75789,-49.300319)"
+       spreadMethod="pad"
+       cx="19.308081"
+       cy="21.029308"
+       fx="19.308081"
+       fy="21.029308"
+       r="14.500172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2793-2-0-403"
+       id="linearGradient3055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.249654,0,0,4.075866,-4.8675502,-40.072576)"
+       spreadMethod="reflect"
+       x1="11.93083"
+       y1="26.410894"
+       x2="21.514704"
+       y2="26.410894" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3384"
+       id="linearGradient3057"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893366,0,0,2.6817046,0.45593188,5.664148)"
+       x1="31.048019"
+       y1="45"
+       x2="31.048019"
+       y2="5.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.90750385,0,0,0.4220944,7.0882495,62.40544)"
+       cx="62.71241"
+       cy="108.02493"
+       fx="62.71241"
+       fy="108.02493"
+       r="47.38271" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205"
+       id="linearGradient5339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3446684,0.06174712,0,1.3408524,-2.2550363,-1.1154458)"
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-8-457"
+       id="linearGradient5341"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2885126,0,0,5.2183238,-12.280112,-83.805496)"
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3242">
+      <stop
+         id="stop3244"
+         style="stop-color:#4fc5e7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246"
+         style="stop-color:#4293c8;stop-opacity:1"
+         offset="0.49876043" />
+      <stop
+         id="stop3248"
+         style="stop-color:#2c67ab;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2490">
+      <stop
+         id="stop2492"
+         style="stop-color:#8fd8ff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4118"
+         style="stop-color:#496984;stop-opacity:1"
+         offset="0.25483045" />
+      <stop
+         id="stop2494"
+         style="stop-color:#5987a5;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503"
+       id="linearGradient3123"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,16.2553,6.2553)"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3242"
+       id="linearGradient3121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.047918,1.0468973)"
+       spreadMethod="reflect"
+       x1="27"
+       y1="24.650604"
+       x2="27"
+       y2="12.711448" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2490"
+       id="linearGradient3124"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.047918,1.0468973)"
+       spreadMethod="reflect"
+       x1="20"
+       y1="12.711448"
+       x2="20"
+       y2="23.258751" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient3126"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-19.047918,1.0468973)"
+       spreadMethod="reflect"
+       x1="20"
+       y1="12.711448"
+       x2="20"
+       y2="21.276361" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-4"
+       id="linearGradient3114"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4820056,0,0,0.4820056,69.182824,-22.55727)"
+       x1="10.50172"
+       y1="3.6100161"
+       x2="48.798885"
+       y2="54.698483" />
+    <linearGradient
+       id="linearGradient6036-4">
+      <stop
+         id="stop6038-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519-6"
+       id="linearGradient3117-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,69.173515,-22.251833)"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       id="linearGradient3519-6">
+      <stop
+         id="stop3521-7"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523-7"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511-2"
+       id="linearGradient3120-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,69.173515,-22.251833)"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       id="linearGradient3511-2">
+      <stop
+         id="stop3513-1"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515-6"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503-7"
+       id="linearGradient3123-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,69.173515,-22.251833)"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       id="linearGradient3503-7">
+      <stop
+         id="stop3505-2"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507-2"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495"
+       id="linearGradient3126-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,69.173515,-22.251833)"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487"
+       id="linearGradient3129"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4891673,0.01382104,-0.01382104,0.4891673,69.512355,-22.580114)"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3263"
+       id="linearGradient3132"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.6000053,-0.6000053,0,41.860125,3.5998693)"
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dedbde;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3269"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3772"
+       id="linearGradient3134"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5121951,0,0,0.5121951,41.452835,5.7073167)"
+       x1="-21.915663"
+       y1="3"
+       x2="-21.915663"
+       y2="45.032898" />
+    <linearGradient
+       id="linearGradient3772">
+      <stop
+         id="stop3774"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3776"
+         style="stop-color:#969696;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="14.2033"
+       x2="35.391201"
+       y1="32.4165"
+       x1="12.2744"
+       gradientTransform="matrix(0,0.6000053,-0.6000053,0,94.778339,-24.907263)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3269"
+       xlink:href="#linearGradient3263"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="45.032898"
+       x2="-21.915663"
+       y1="3"
+       x1="-21.915663"
+       gradientTransform="matrix(0.5121951,0,0,0.5121951,94.371049,-22.799816)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3271"
+       xlink:href="#linearGradient3772"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519-3"
+       id="linearGradient3117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,67.682681,-29.774734)"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       id="linearGradient3519-3">
+      <stop
+         id="stop3521-2"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523-3"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511-9"
+       id="linearGradient3120"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,67.682681,-29.774734)"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       id="linearGradient3511-9">
+      <stop
+         id="stop3513-8"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515-1"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503-0"
+       id="linearGradient3123-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,67.682681,-29.774734)"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       id="linearGradient3503-0">
+      <stop
+         id="stop3505-7"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507-3"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495-9"
+       id="linearGradient3126-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4893625,0,0,0.4893625,67.682681,-29.774734)"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       id="linearGradient3495-9">
+      <stop
+         id="stop3497-7"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499-5"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487-3"
+       id="linearGradient3129-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4891673,0.01382104,-0.01382104,0.4891673,68.021521,-30.103015)"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       id="linearGradient3487-3">
+      <stop
+         id="stop3489-9"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491-0"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3437"
+       id="linearGradient3137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.9561695,14.754519,-28.160612)"
+       x1="52.672863"
+       y1="5.9285936"
+       x2="59.672863"
+       y2="-3.6927242" />
+    <linearGradient
+       id="linearGradient3437">
+      <stop
+         id="stop3439"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3441"
+         style="stop-color:#5d5f6b;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="linearGradient3140"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.9561695,-36.672862,7.8694218)"
+       x1="49.925751"
+       y1="1.7133857"
+       x2="64.672821"
+       y2="1.7133857" />
+    <linearGradient
+       id="linearGradient3865">
+      <stop
+         id="stop3867"
+         style="stop-color:#b8b4b4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3869"
+         style="stop-color:#f1f1f0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104"
+       id="linearGradient3142"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8074968,0,0,0.8948322,22.73737,6.8037908)"
+       x1="-11.285484"
+       y1="16.208538"
+       x2="-11.285484"
+       y2="-2.087147" />
+    <linearGradient
+       id="linearGradient3104">
+      <stop
+         id="stop3106"
+         style="stop-color:#a2a2a2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3108"
+         style="stop-color:#e1e1e1;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="1.7133857"
+       x2="64.672821"
+       y1="1.7133857"
+       x1="49.925751"
+       gradientTransform="matrix(1,0,0,0.9561695,14.754519,-28.160612)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3322"
+       xlink:href="#linearGradient3865"
+       inkscape:collect="always" />
+    <linearGradient
+       y2="-2.087147"
+       x2="-11.285484"
+       y1="16.208538"
+       x1="-11.285484"
+       gradientTransform="matrix(0.8074968,0,0,0.8948322,74.164751,-29.226243)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3324"
+       xlink:href="#linearGradient3104"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="linearGradient3333"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.9561695,14.754519,-28.160612)"
+       x1="49.925751"
+       y1="1.7133857"
+       x2="64.672821"
+       y2="1.7133857" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104"
+       id="linearGradient3335"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8074968,0,0,0.8948322,74.164751,-29.226243)"
+       x1="-11.285484"
+       y1="16.208538"
+       x2="-11.285484"
+       y2="-2.087147" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3437"
+       id="linearGradient3337"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.9561695,14.754519,-28.160612)"
+       x1="52.672863"
+       y1="5.9285936"
+       x2="59.672863"
+       y2="-3.6927242" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3865"
+       id="linearGradient3948"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.9561695,14.754519,-28.160612)"
+       x1="49.925751"
+       y1="1.7133857"
+       x2="64.672821"
+       y2="1.7133857" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104"
+       id="linearGradient3950"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8074968,0,0,0.8948322,74.164751,-29.226243)"
+       x1="-11.285484"
+       y1="16.208538"
+       x2="-11.285484"
+       y2="-2.087147" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3437"
+       id="linearGradient3952"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.9561695,14.754519,-28.160612)"
+       x1="52.672863"
+       y1="5.9285936"
+       x2="59.672863"
+       y2="-3.6927242" />
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop23423" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3263-7"
+       y2="14.2033"
+       x2="35.391201"
+       y1="32.4165"
+       x1="12.2744">
+      <stop
+         offset="0"
+         style="stop-color:#dedbde;stop-opacity:1"
+         id="stop3265-3" />
+      <stop
+         offset="0.5"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop3267-0" />
+      <stop
+         offset="1"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         id="stop3269-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.7714354,-0.7714354,0,33.82016,-2.5144531)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3263-7"
+       id="linearGradient3431"
+       y2="14.2033"
+       x2="35.391201"
+       y1="32.4165"
+       x1="12.2744" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3519-34"
+       id="linearGradient3454"
+       y2="20.612656"
+       x2="9.7297754"
+       y1="17.886322"
+       x1="10.609375" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3511-29"
+       id="linearGradient3452"
+       y2="13.461712"
+       x2="14.609327"
+       y1="16.188046"
+       x1="12.371647" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3503-8"
+       id="linearGradient3450"
+       y2="10.732353"
+       x2="16.994024"
+       y1="13.045606"
+       x1="14.084608" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3495-0"
+       id="linearGradient3448"
+       y2="9.7956104"
+       x2="21.047453"
+       y1="11.200086"
+       x1="17.494959" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3487-1"
+       id="linearGradient3446"
+       y2="9.8622112"
+       x2="24.27351"
+       y1="10.774516"
+       x1="20.580074" />
+    <linearGradient
+       id="linearGradient3519-34">
+      <stop
+         offset="0"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         id="stop3521-9" />
+      <stop
+         offset="1"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         id="stop3523-35" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3519-34"
+       id="linearGradient3444"
+       y2="20.612656"
+       x2="9.7297754"
+       y1="17.886322"
+       x1="10.609375" />
+    <linearGradient
+       id="linearGradient3511-29">
+      <stop
+         offset="0"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         id="stop3513-81" />
+      <stop
+         offset="1"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         id="stop3515-7" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3511-29"
+       id="linearGradient3442"
+       y2="13.461712"
+       x2="14.609327"
+       y1="16.188046"
+       x1="12.371647" />
+    <linearGradient
+       id="linearGradient3503-8">
+      <stop
+         offset="0"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         id="stop3505-8" />
+      <stop
+         offset="1"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         id="stop3507-1" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3503-8"
+       id="linearGradient3440"
+       y2="10.732353"
+       x2="16.994024"
+       y1="13.045606"
+       x1="14.084608" />
+    <linearGradient
+       id="linearGradient3495-0">
+      <stop
+         offset="0"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         id="stop3497-2" />
+      <stop
+         offset="1"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         id="stop3499-2" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3495-0"
+       id="linearGradient3438"
+       y2="9.7956104"
+       x2="21.047453"
+       y1="11.200086"
+       x1="17.494959" />
+    <linearGradient
+       id="linearGradient3487-1">
+      <stop
+         offset="0"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         id="stop3489-8" />
+      <stop
+         offset="1"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         id="stop3491-7" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3487-1"
+       id="linearGradient3436"
+       y2="9.8622112"
+       x2="24.27351"
+       y1="10.774516"
+       x1="20.580074" />
+    <linearGradient
+       id="linearGradient3772-8">
+      <stop
+         offset="0"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         id="stop3774-2" />
+      <stop
+         offset="1"
+         style="stop-color:#969696;stop-opacity:1"
+         id="stop3776-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.6585366,0,0,0.6585366,0.195122,0.195122)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3772-8"
+       id="linearGradient3409"
+       y2="45.17627"
+       x2="20.018932"
+       y1="3"
+       x1="20.018932" />
+    <linearGradient
+       id="linearGradient3428">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3430" />
+      <stop
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         id="stop3432" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.6875,0,0,0.6875,-0.5000014,-0.5000005)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3428"
+       id="linearGradient3427"
+       y2="32.509201"
+       x2="21.448364"
+       y1="15.5"
+       x1="21.448364" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop4015" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6036-1">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6038-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6040-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.3283222,0,0,-0.3283221,8.0063392,24.208052)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6036-1"
+       id="linearGradient3406"
+       y2="45.962208"
+       x2="18.203465"
+       y1="4.0378027"
+       x1="18.775953" />
+    <radialGradient
+       gradientTransform="matrix(0.48613589,0,0,0.1546652,0.65624961,21.060353)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient23419-5"
+       id="radialGradient4248"
+       fy="41.63604"
+       fx="23.334524"
+       r="22.627417"
+       cy="41.63604"
+       cx="23.334524" />
+    <linearGradient
+       id="linearGradient23419-5">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop23421-1" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop23423-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3772-1">
+      <stop
+         offset="0"
+         style="stop-color:#b4b4b4;stop-opacity:1"
+         id="stop3774-7" />
+      <stop
+         offset="1"
+         style="stop-color:#969696;stop-opacity:1"
+         id="stop3776-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.4656319,0,0,0.4656319,24.22985,8.8248332)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3772-1"
+       id="linearGradient3074"
+       y2="45.032898"
+       x2="-21.915663"
+       y1="3"
+       x1="-21.915663" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3263-8"
+       y2="14.2033"
+       x2="35.391201"
+       y1="32.4165"
+       x1="12.2744">
+      <stop
+         offset="0"
+         style="stop-color:#dedbde;stop-opacity:1"
+         id="stop3265-7" />
+      <stop
+         offset="0.5"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop3267-3" />
+      <stop
+         offset="1"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         id="stop3269-8" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.54545936,-0.54545936,0,24.600113,6.908972)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3263-8"
+       id="linearGradient3072"
+       y2="14.2033"
+       x2="35.391201"
+       y1="32.4165"
+       x1="12.2744" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3519-7"
+       id="linearGradient2488"
+       y2="20.612656"
+       x2="9.7297754"
+       y1="17.886322"
+       x1="10.609375" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3511-1"
+       id="linearGradient2486"
+       y2="13.461712"
+       x2="14.609327"
+       y1="16.188046"
+       x1="12.371647" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3503-4"
+       id="linearGradient2484"
+       y2="10.732353"
+       x2="16.994024"
+       y1="13.045606"
+       x1="14.084608" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3495-3"
+       id="linearGradient2482"
+       y2="9.7956104"
+       x2="21.047453"
+       y1="11.200086"
+       x1="17.494959" />
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3487-5"
+       id="linearGradient2480"
+       y2="9.8622112"
+       x2="24.27351"
+       y1="10.774516"
+       x1="20.580074" />
+    <linearGradient
+       id="linearGradient3519-7">
+      <stop
+         offset="0"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         id="stop3521-3" />
+      <stop
+         offset="1"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         id="stop3523-2" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3519-7"
+       id="linearGradient2500"
+       y2="20.612656"
+       x2="9.7297754"
+       y1="17.886322"
+       x1="10.609375" />
+    <linearGradient
+       id="linearGradient3511-1">
+      <stop
+         offset="0"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         id="stop3513-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         id="stop3515-8" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3511-1"
+       id="linearGradient2498"
+       y2="13.461712"
+       x2="14.609327"
+       y1="16.188046"
+       x1="12.371647" />
+    <linearGradient
+       id="linearGradient3503-4">
+      <stop
+         offset="0"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         id="stop3505-4" />
+      <stop
+         offset="1"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         id="stop3507-7" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3503-4"
+       id="linearGradient2496"
+       y2="10.732353"
+       x2="16.994024"
+       y1="13.045606"
+       x1="14.084608" />
+    <linearGradient
+       id="linearGradient3495-3">
+      <stop
+         offset="0"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         id="stop3497-1" />
+      <stop
+         offset="1"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         id="stop3499-0" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3495-3"
+       id="linearGradient2494"
+       y2="9.7956104"
+       x2="21.047453"
+       y1="11.200086"
+       x1="17.494959" />
+    <linearGradient
+       id="linearGradient3487-5">
+      <stop
+         offset="0"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         id="stop3489-6" />
+      <stop
+         offset="1"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         id="stop3491-6" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="reflect"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3487-5"
+       id="linearGradient2492"
+       y2="9.8622112"
+       x2="24.27351"
+       y1="10.774516"
+       x1="20.580074" />
+    <linearGradient
+       id="linearGradient4011-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013-1" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-4" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.45945944,0,0,0.45945944,-20.958749,8.3493769)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4011-6"
+       id="linearGradient4112"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
+    <linearGradient
+       id="linearGradient6036-2">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop6038-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6040-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.2272999,0,0,-0.2272999,6.4659271,25.682498)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient6036-2"
+       id="linearGradient3065"
+       y2="45.962208"
+       x2="18.203465"
+       y1="4.0378027"
+       x1="18.775953" />
+    <linearGradient
+       id="linearGradient3428-3">
+      <stop
+         offset="0"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         id="stop3430-1" />
+      <stop
+         offset="1"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         id="stop3432-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.4374999,0,0,0.4374999,1.5,9.4999996)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3428-3"
+       id="linearGradient3068"
+       y2="32.509201"
+       x2="21.448364"
+       y1="15.5"
+       x1="21.448364" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3263-8"
+       id="linearGradient4297"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.54545936,-0.54545936,0,77.534088,6.1356547)"
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3772-1"
+       id="linearGradient4299"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4656319,0,0,0.4656319,77.163825,8.0515159)"
+       x1="-21.915663"
+       y1="3"
+       x2="-21.915663"
+       y2="45.032898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487-5"
+       id="linearGradient4301"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495-3"
+       id="linearGradient4303"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503-4"
+       id="linearGradient4305"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511-1"
+       id="linearGradient4307"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519-7"
+       id="linearGradient4309"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487-5"
+       id="linearGradient4311"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495-3"
+       id="linearGradient4313"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503-4"
+       id="linearGradient4315"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511-1"
+       id="linearGradient4317"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519-7"
+       id="linearGradient4319"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4011-6"
+       id="linearGradient4321"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945944,0,0,0.45945944,31.975226,7.5760596)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-2"
+       id="linearGradient4323"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,-0.2272999,59.399902,24.909181)"
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3428-3"
+       id="linearGradient4325"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4374999,0,0,0.4374999,54.433975,8.7266823)"
+       x1="21.448364"
+       y1="15.5"
+       x2="21.448364"
+       y2="32.509201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3263-8"
+       id="linearGradient4368"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.54545936,-0.54545936,0,77.534088,6.1356547)"
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3772-1"
+       id="linearGradient4370"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4656319,0,0,0.4656319,77.163825,8.0515159)"
+       x1="-21.915663"
+       y1="3"
+       x2="-21.915663"
+       y2="45.032898" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487-5"
+       id="linearGradient4372"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495-3"
+       id="linearGradient4374"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503-4"
+       id="linearGradient4376"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511-1"
+       id="linearGradient4378"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519-7"
+       id="linearGradient4380"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3487-5"
+       id="linearGradient4382"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3495-3"
+       id="linearGradient4384"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3503-4"
+       id="linearGradient4386"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3511-1"
+       id="linearGradient4388"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3519-7"
+       id="linearGradient4390"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4011-6"
+       id="linearGradient4392"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945944,0,0,0.45945944,31.975226,7.5760596)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-2"
+       id="linearGradient4394"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,-0.2272999,59.399902,24.909181)"
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3428-3"
+       id="linearGradient4396"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4374999,0,0,0.4374999,54.433975,8.7266823)"
+       x1="21.448364"
+       y1="15.5"
+       x2="21.448364"
+       y2="32.509201" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3815"
+       id="linearGradient3821"
+       x1="34.439655"
+       y1="18.596245"
+       x2="34.439655"
+       y2="46.218822"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3815">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3817" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3819" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2,0,0,2,-0.99998969,6.94e-4)"
+       y2="46.218822"
+       x2="34.439655"
+       y1="18.596245"
+       x1="34.439655"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3075"
+       xlink:href="#linearGradient3815"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825"
+       id="linearGradient3831"
+       x1="35.094646"
+       y1="19.210447"
+       x2="35.094646"
+       y2="42.529957"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3825">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3827" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3829" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2,0,0,2,-0.99998369,5.48e-4)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient3835"
+       id="linearGradient3841"
+       x1="41.25"
+       y1="19.833317"
+       x2="41.25"
+       y2="40.715191"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3835">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3837" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3839" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2,0,0,2,-0.99998369,5.48e-4)"
+       y2="42.529957"
+       x2="35.094646"
+       y1="19.210447"
+       x1="35.094646"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3097"
+       xlink:href="#linearGradient3825"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205-2"
+       id="linearGradient3035-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3446684,0.49397698,0,1.3408524,0.72796073,-6.5183192)"
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3205-2">
+      <stop
+         id="stop3207-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3209-4"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="24"
+       y1="13.506023"
+       x1="24"
+       gradientTransform="matrix(1.3446684,0.49397698,0,1.3408524,0.7279611,-6.4589719)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3114-6"
+       xlink:href="#linearGradient3205-2"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205-0"
+       id="linearGradient5339-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893368,0.12349424,0,2.6817048,-5.5100612,-2.2303432)"
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45" />
+    <linearGradient
+       id="linearGradient3205-0">
+      <stop
+         id="stop3207-7"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3209-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205-0"
+       id="linearGradient3032-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893368,0.12349424,0,2.6817048,6.4899393,-2.2303432)"
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45" />
+    <linearGradient
+       id="linearGradient3131">
+      <stop
+         id="stop3133"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3135"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205-0"
+       id="linearGradient3035-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3446684,0.49397698,0,1.3408524,0.72796073,-6.5183192)"
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3138">
+      <stop
+         id="stop3140"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3142"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="24"
+       y1="13.506023"
+       x1="24"
+       gradientTransform="matrix(2.6893368,0.98795395,0,2.6817048,0.45593248,-13.036089)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3147"
+       xlink:href="#linearGradient3205-0"
+       inkscape:collect="always" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3355-273"
+       id="linearGradient3665"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1192696,0,0,3.6853228,-9.8623969,-2.200222)"
+       x1="23.999979"
+       y1="9.3726854"
+       x2="23.999979"
+       y2="2.0968478" />
+  </defs>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3060);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.05496335;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path12941"
+     d="M 107,108.0022 C 106.99738,119.04704 87.746392,128 64,128 40.253606,128 21.00262,119.04704 21,108.0022 20.997382,96.95564 40.249904,88 64,88 c 23.750096,0 43.00262,8.95564 43,20.0022 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3047);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3665);stroke-width:1.96777904;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path3164"
+     d="m 102,21.754375 c 0,8.157788 -15.452,14.770978 -36.999996,14.770978 -21.548008,0 -39.016114,-6.61319 -39.016114,-14.770978 0,-8.157786 17.468106,-14.7709762 39.016114,-14.7709762 C 86.548,6.9833988 102,13.596589 102,21.754375 Z"
+     sodipodi:nodetypes="cssscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.3;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98388958;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path3197"
+     d="m 102.65071,21.898195 c 0,7.484754 -16.856798,13.552342 -37.650706,13.552342 -20.793918,0 -37.650716,-6.067588 -37.650716,-13.552342 0,-7.48475 16.856798,-13.5523403 37.650716,-13.5523403 20.793908,0 37.650706,6.0675903 37.650706,13.5523403 l 0,0 z" />
+  <g
+     transform="matrix(2,0,0,2,-52.777039,-6.5442732)"
+     id="g4332">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 74.479429,19.226683 c 0,-5.290958 -4.254498,-9.5454553 -9.545454,-9.5454553 -5.290958,0 -9.545455,4.2544983 -9.545455,9.5454553 -10e-7,5.290957 4.254497,9.545454 9.545455,9.545454 5.290956,-1e-6 9.545454,-4.254497 9.545454,-9.545454 z m -6.045454,0 c 0,1.791874 -1.745436,3.5 -3.5,3.5 -1.792116,0 -3.5,-1.822747 -3.5,-3.5 0,-1.714806 1.648901,-3.5 3.5,-3.5 1.888644,0 3.5,1.670604 3.5,3.5 z"
+       id="path4334"
+       style="fill:url(#linearGradient4368);fill-rule:nonzero;stroke:url(#linearGradient4370);stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 64.933975,15.667683 c -1.964568,0 -3.559,1.594432 -3.559,3.559 0,1.964568 1.594432,3.559 3.559,3.559 1.964568,0 3.559,-1.594432 3.559,-3.559 0,-1.964568 -1.594432,-3.559 -3.559,-3.559 z m 0,1.7795 c 0.982284,0 1.7795,0.797216 1.7795,1.7795 0,0.982284 -0.797216,1.7795 -1.7795,1.7795 -0.982284,0 -1.7795,-0.797216 -1.7795,-1.7795 0,-0.982284 0.797216,-1.7795 1.7795,-1.7795 z"
+       id="path4336"
+       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <g
+       transform="matrix(0.444875,0,0,0.444875,54.256975,8.5496826)"
+       id="g4338">
+      <path
+         inkscape:connector-curvature="0"
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path4340"
+         style="opacity:0.8;fill:url(#linearGradient4372);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path4342"
+         style="opacity:0.8;fill:url(#linearGradient4374);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path4344"
+         style="opacity:0.8;fill:url(#linearGradient4376);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path4346"
+         style="opacity:0.8;fill:url(#linearGradient4378);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 Z"
+         id="path4348"
+         style="opacity:0.8;fill:url(#linearGradient4380);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       transform="matrix(-0.444875,0,0,-0.444875,75.610975,29.899605)"
+       id="g4350">
+      <path
+         inkscape:connector-curvature="0"
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path4352"
+         style="opacity:0.8;fill:url(#linearGradient4382);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path4354"
+         style="opacity:0.8;fill:url(#linearGradient4384);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path4356"
+         style="opacity:0.8;fill:url(#linearGradient4386);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path4358"
+         style="opacity:0.8;fill:url(#linearGradient4388);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 Z"
+         id="path4360"
+         style="opacity:0.8;fill:url(#linearGradient4390);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       d="m 73.433868,19.226382 c 0,4.694572 -3.80586,8.500301 -8.499893,8.500301 -4.694462,0 -8.500108,-3.805772 -8.500108,-8.500301 0,-4.694354 3.805646,-8.499698 8.500108,-8.499698 4.694033,0 8.499893,3.805344 8.499893,8.499698 l 0,0 z"
+       id="path4362"
+       style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient4392);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 64.933975,23.726683 c -2.494286,0 -4.500001,-2.005714 -4.500001,-4.500001 0,-2.494285 2.005715,-4.5 4.500001,-4.5 2.494287,0 4.5,2.005715 4.5,4.5 0,2.494287 -2.005713,4.500001 -4.5,4.500001 l 0,0 0,0 z"
+       id="path4364"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient4394);stroke-width:0.99999976;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       d="m 64.933974,15.726682 c -1.932,0 -3.499999,1.568 -3.499999,3.500001 0,1.932 1.567999,3.499999 3.499999,3.499999 1.932001,0 3.5,-1.567999 3.5,-3.499999 0,-1.932001 -1.567999,-3.500001 -3.5,-3.500001 z m 0,1.750002 c 0.966001,0 1.75,0.783999 1.75,1.749999 0,0.966 -0.783999,1.75 -1.75,1.75 -0.965999,0 -1.749998,-0.784 -1.749998,-1.75 0,-0.965999 0.783999,-1.749999 1.749998,-1.749999 z"
+       id="path4366"
+       style="fill:none;stroke:url(#linearGradient4396);stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <g
+     transform="matrix(2,0,0,2,-97.85484,74.02788)"
+     id="g3942">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3948);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3950);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path3944"
+       d="m 63.927381,-27.905034 0,8.219624 c 4.349294,1.946568 10.163874,2.418326 15,2.0625 l 0,-12.907124 c -3.726256,0 -10.411838,-0.567139 -15,2.625 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient3952);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path3946"
+       d="m 65.427381,-27.030034 0,6.301435 c 3.127993,0.933929 8.686854,3.167848 12.00556,3.130763 l -0.0056,-11.432198 c -5,0 -8,0 -12,2 z"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     id="g3329"
+     transform="matrix(2,0,0,2,-89.854839,81.95134)">
+    <path
+       d="m 63.927381,-27.905034 0,3.257892 c 4.349294,1.946568 10.163874,2.418326 15,2.0625 l 0,-7.945392 c -3.726256,0 -10.411838,-0.567139 -15,2.625 z"
+       id="path3834"
+       style="fill:url(#linearGradient3333);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3335);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 65.427381,-27.030034 0,3.28125 c 3.127993,0.933929 8.686854,1.29821 12.00556,1.261125 0,0 -0.0056,-6.542375 -0.0056,-6.542375 -5,0 -8,0 -12,2 z"
+       id="path3424"
+       style="fill:url(#linearGradient3337);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       inkscape:connector-curvature="0" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.2;fill:url(#linearGradient3038);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3244"
+     d="m 44.506446,35.113651 12.05497,2.273968 0,86.952701 -12.05497,-2.90588 0,-86.320789 0,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3055);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3057);stroke-width:1.99999976;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2230"
+     d="m 26,21.754375 0,85.814545 C 26,115.4435 37.858136,125 65.000004,125 92.14187,125 102,115.4435 102,107.56892 l 0,-85.814545 c 0.14382,20.422202 -75.856182,18.696382 -76,0 z"
+     sodipodi:nodetypes="cssscc" />
+  <path
+     sodipodi:nodetypes="cssscc"
+     d="m 102,21.754375 c 0,8.157788 -15.452,14.770978 -36.999996,14.770978 -21.548008,0 -39.016114,-6.61319 -39.016114,-14.770978 0,-8.157786 17.468106,-14.7709762 39.016114,-14.7709762 C 86.548,6.9833988 102,13.596589 102,21.754375 Z"
+     id="path3172"
+     style="fill:none;stroke:url(#linearGradient3049);stroke-width:1.96777904;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:none;stroke:url(#linearGradient5341);stroke-width:1.99999952;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2206"
+     d="m 28,21.246413 c 0,5.185248 0,82.052247 0,88.026087 0,7.20128 17.032064,13.0458 36.999934,13.0458 C 84.9678,122.3183 100,116.47378 100,109.2725 100,103.74516 99.84582,26.771593 100,21.246413 100.14382,16.092739 86.898428,9.0000007 64.999934,9.0000007 43.10144,9.0000007 28,16.061165 28,21.246413 Z"
+     sodipodi:nodetypes="zsssszz" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.4;fill:url(#radialGradient3052);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path3212"
+     d="m 27.349288,24.436083 0,83.132837 c 0,7.56778 16.867522,16.09024 37.650716,16.09024 20.783194,0 37.650706,-8.52246 37.650706,-16.09024 l 0,-83.132837 c -2.58873,17.11438 -75.33012,16.800208 -75.301422,0 z"
+     sodipodi:nodetypes="cssscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.43290046;fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path3823"
+     d="m 50.000006,41.883865 c 2.234842,0.10264 3,1.979302 3,4.207796 l 0,71.049019 c 0,2.2285 -0.765158,3.93994 -3,3.83732 C 47.765168,120.8754 46.966,118.9987 46.966,116.7702 l 0,-71.049021 c 0,-2.228498 0.799168,-3.93994 3.034006,-3.837314 z m 14,1.999616 C 61.765168,43.986121 61,45.862783 61,48.091276 l 0,71.049024 c 0,2.2285 0.765168,3.93994 3.000006,3.83732 2.23484,-0.1026 3.068,-1.9793 3.068,-4.2078 l 0,-71.049026 c 0,-2.228497 -0.83316,-3.939937 -3.068,-3.837313 z"
+     sodipodi:nodetypes="ssssssssssssss" />
+  <path
+     sodipodi:nodetypes="ssssssssssssss"
+     d="m 50,41.883865 c 2.234842,0.10264 3,1.979302 3,4.207796 l 0,71.049019 c 0,2.2285 -0.765158,3.93994 -3,3.83732 -2.234838,-0.1026 -3.034006,-1.9793 -3.034006,-4.2078 l 0,-71.049021 c 0,-2.228498 0.799168,-3.93994 3.034006,-3.837314 z m 14,1.999616 c -2.234838,0.10264 -3.000006,1.979302 -3.000006,4.207795 l 0,71.049024 c 0,2.2285 0.765168,3.93994 3.000006,3.83732 2.23484,-0.1026 3.068,-1.9793 3.068,-4.2078 l 0,-71.049026 c 0,-2.228497 -0.83316,-3.939937 -3.068,-3.837313 z"
+     id="path5337"
+     style="opacity:0.3;fill:url(#linearGradient5339-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g3116"
+     transform="matrix(2.8571428,0,0,2.8571428,48.347562,-5.0483852)">
+    <path
+       d="m 0.952082,15.046897 7,0 0,13.320038 -3.5237286,-3.5 -3.4762714,3.5 z"
+       id="path3371"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       d="m 1.2783533,14.258345 c 1.6829089,0.183682 4.3423731,0.272755 6.3000002,0.247331 l 0,12.111259 -3.1500001,-3.15 -3.1500001,3.15 z"
+       id="path2472"
+       style="fill:url(#linearGradient3121);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3124);stroke-width:0.69999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       d="m 1.9783533,23.722643 0,-8.695282 c 1.8366717,0.144132 4.9000001,0.197168 4.9000001,0.197168 l 0,8.882368"
+       id="path3475"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3126);stroke-width:0.69999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
+  <path
+     sodipodi:nodetypes="sssssss"
+     d="M 78.000006,41.883865 C 75.765168,41.986505 74.966,43.863167 74.966,46.091661 l 0,71.049019 c 0,2.2285 0.799168,3.93994 3.034006,3.83732 2.23484,-0.1026 3,-1.9793 3,-4.2078 l 0,-71.049021 c 0,-2.228498 -0.76516,-3.93994 -3,-3.837314 z"
+     id="path3833"
+     style="opacity:0.46320346;fill:none;stroke:url(#linearGradient3841);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:nodetypes="ssssssssssssss"
+     d="m 36,37.000693 c 2.23484,0.820988 3,2.795898 3,5.024392 l 0,71.049015 c 0,2.2285 -0.76516,3.36162 -3,2.54064 -2.23484,-0.821 -3,-3.276 -3,-5.5045 l 0,-71.049015 c 0,-2.228498 0.76516,-2.881522 3,-2.060532 z m 56.000006,0 c -2.23484,0.820992 -3,3.171502 -3,5.4 l 0,70.011067 c 0,2.2285 0.76516,3.36162 3,2.54062 2.23484,-0.82098 3,-3.27598 3,-5.50448 l 0,-70.047207 c 0,-2.228498 -0.76516,-3.22099 -3,-2.4 z"
+     id="path3045"
+     style="opacity:0.35064937;fill:none;stroke:url(#linearGradient3075);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:url(#linearGradient3147);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path3287"
+     d="m 36,36.520455 c 2.23484,0.820988 3,3.275992 3,5.504486 l 0,71.049019 c 0,2.2285 -0.76516,3.36162 -3,2.54064 -2.23484,-0.821 -3,-3.276 -3,-5.5045 l 0,-71.049019 c 0,-2.228498 0.76516,-3.361616 3,-2.540626 z m 56,0.480094 c -2.234838,0.820992 -3,3.171502 -3,5.4 l 0,70.011071 c 0,2.2285 0.765162,3.36162 3,2.54062 2.234838,-0.82098 3,-3.276 3,-5.50448 l 0,-70.047211 c 0,-2.228498 -0.765162,-3.22099 -3,-2.4 z"
+     sodipodi:nodetypes="ssssssssssssss" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.3;fill:url(#linearGradient3032-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path3293"
+     d="m 78,41.883865 c -2.234838,0.10264 -3.034006,1.979302 -3.034006,4.207796 l 0,71.049019 c 0,2.2285 0.799168,3.93994 3.034006,3.83732 2.23484,-0.1026 3,-1.9793 3,-4.2078 l 0,-71.049021 c 0,-2.228498 -0.76516,-3.93994 -3,-3.837314 z"
+     sodipodi:nodetypes="sssssss" />
+</svg>

--- a/elementary-xfce/places/128/user-trash.svg
+++ b/elementary-xfce/places/128/user-trash.svg
@@ -1,0 +1,552 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="128"
+   height="128"
+   id="svg3695"
+   inkscape:version="0.48+devel r"
+   sodipodi:docname="user-trash.svg">
+  <metadata
+     id="metadata11265">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1535"
+     inkscape:window-height="876"
+     id="namedview11263"
+     showgrid="true"
+     inkscape:snap-global="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="26.951622"
+     inkscape:cy="59.095872"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3695">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3062"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3697">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3835">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3837" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3839" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3825">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3827" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3829" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3815">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3817" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3819" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="62.71241"
+       cy="108.02493"
+       r="47.38271"
+       fx="62.71241"
+       fy="108.02493"
+       id="radialGradient3269"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3587806,0,0,0.2110472,1.5000008,15.20272)" />
+    <linearGradient
+       id="linearGradient3384">
+      <stop
+         id="stop3386"
+         style="stop-color:#6e6e6e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3388"
+         style="stop-color:#9f9fa1;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="31.048019"
+       y1="45"
+       x2="31.048019"
+       y2="5.5"
+       id="linearGradient3266"
+       xlink:href="#linearGradient3384"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,2)" />
+    <linearGradient
+       id="linearGradient2793-2-0-403">
+      <stop
+         id="stop4645"
+         style="stop-color:#8d909a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4647"
+         style="stop-color:#d9d9d9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.93083"
+       y1="26.410894"
+       x2="21.514704"
+       y2="26.410894"
+       id="linearGradient3264"
+       xlink:href="#linearGradient2793-2-0-403"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2083478,0,0,1.5198788,-1.979478,-15.055094)"
+       spreadMethod="reflect" />
+    <radialGradient
+       cx="19.308081"
+       cy="21.029308"
+       r="14.500172"
+       fx="19.308081"
+       fy="21.029308"
+       id="radialGradient3258"
+       xlink:href="#linearGradient3254-8-457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.679283,-1.6454754,0,48.823182,-18.496093)"
+       spreadMethod="pad" />
+    <linearGradient
+       id="linearGradient3355-273">
+      <stop
+         id="stop4657"
+         style="stop-color:#f0f0f0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3619"
+         style="stop-color:#777779;stop-opacity:1"
+         offset="0.44955608" />
+      <stop
+         id="stop4659"
+         style="stop-color:#6c6c70;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.999979"
+       y1="9.3726854"
+       x2="23.999979"
+       y2="2.0968478"
+       id="linearGradient3255"
+       xlink:href="#linearGradient3355-273"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1598658,0,0,1.3742464,-3.8367541,-0.9326014)" />
+    <linearGradient
+       id="linearGradient3320">
+      <stop
+         id="stop3323"
+         style="stop-color:#4e4e4e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3325"
+         style="stop-color:#b9bac2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="9.0003471"
+       y1="8"
+       x2="24"
+       y2="8"
+       id="linearGradient3253"
+       xlink:href="#linearGradient3320"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3627">
+      <stop
+         id="stop3629"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3190"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0.5" />
+      <stop
+         id="stop3631"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="24"
+       cy="7.7919979"
+       r="14.507708"
+       fx="24"
+       fy="7.7919979"
+       id="radialGradient3250"
+       xlink:href="#linearGradient3627"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.2042761e-8,0.6892888,-3.1574826,0,48.603098,-13.542931)"
+       spreadMethod="pad" />
+    <linearGradient
+       id="linearGradient3254-8-457">
+      <stop
+         id="stop4669"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4671"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574"
+       id="linearGradient3247"
+       xlink:href="#linearGradient3254-8-457"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2227969,0,0,1.9458981,-4.735753,-31.362975)" />
+    <linearGradient
+       id="linearGradient3254-3-182">
+      <stop
+         id="stop4663"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4665"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.25"
+       y1="20.230709"
+       x2="17.125"
+       y2="34.173542"
+       id="linearGradient3261"
+       xlink:href="#linearGradient3254-3-182"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8965013,0,0,1.365896,4.7251825,-8.808688)" />
+    <linearGradient
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43"
+       id="linearGradient3389"
+       xlink:href="#linearGradient3205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0.3684052,0,1,0,-4.9734702)" />
+    <linearGradient
+       id="linearGradient3205">
+      <stop
+         id="stop3207"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3209"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45"
+       id="linearGradient3373"
+       xlink:href="#linearGradient3205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0.04605065,0,1,0,-0.9440383)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205"
+       id="linearGradient3032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893368,0.12349424,0,2.6817048,6.4899354,-2.2308912)"
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205"
+       id="linearGradient3035"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893368,0.98795395,0,2.6817048,0.455929,-13.036637)"
+       x1="24"
+       y1="13.506023"
+       x2="24"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-3-182"
+       id="linearGradient3038"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4109938,0,0,3.5764598,13.163529,-19.835747)"
+       x1="12.25"
+       y1="20.230709"
+       x2="17.125"
+       y2="34.173542" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-8-457"
+       id="linearGradient3041"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6442563,0,0,2.6091619,-6.6400562,-41.902748)"
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3627"
+       id="radialGradient3044"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.5713984,-8.4915335,3.2942488e-7,131.16601,-29.367709)"
+       spreadMethod="pad"
+       cx="23.816956"
+       cy="7.8258715"
+       fx="23.816956"
+       fy="7.8258715"
+       r="14.507708" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3320"
+       id="linearGradient3047"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect"
+       x1="9.0003471"
+       y1="8"
+       x2="24"
+       y2="8"
+       gradientTransform="matrix(2.6893366,0,0,2.6817046,0.455929,0.300738)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3355-273"
+       id="linearGradient3049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1192696,0,0,3.6853228,-9.8623938,-2.200222)"
+       x1="23.999979"
+       y1="9.3726854"
+       x2="23.999979"
+       y2="2.0968478" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-8-457"
+       id="radialGradient3052"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.5033412,-4.4252374,0,131.75789,-49.300319)"
+       spreadMethod="pad"
+       cx="19.308081"
+       cy="21.029308"
+       fx="19.308081"
+       fy="21.029308"
+       r="14.500172" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2793-2-0-403"
+       id="linearGradient3055"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.249654,0,0,4.075866,-4.8675535,-40.072576)"
+       spreadMethod="reflect"
+       x1="11.93083"
+       y1="26.410894"
+       x2="21.514704"
+       y2="26.410894" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3384"
+       id="linearGradient3057"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893366,0,0,2.6817046,0.455929,5.664148)"
+       x1="31.048019"
+       y1="45"
+       x2="31.048019"
+       y2="5.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.90750385,0,0,0.4220944,7.0882462,62.40544)"
+       cx="62.71241"
+       cy="108.02493"
+       fx="62.71241"
+       fy="108.02493"
+       r="47.38271" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3205"
+       id="linearGradient5339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6893368,0.12349424,0,2.6817048,-5.5100648,-2.2308912)"
+       x1="24"
+       y1="15.502284"
+       x2="24"
+       y2="45" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3254-8-457"
+       id="linearGradient5341"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.2885126,0,0,5.2183238,-12.280112,-83.805496)"
+       x1="23.5"
+       y1="10.996204"
+       x2="23.5"
+       y2="39.850574" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3815"
+       id="linearGradient3821"
+       x1="34.439655"
+       y1="18.596245"
+       x2="34.439655"
+       y2="46.218822"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-0.99999323,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825"
+       id="linearGradient3831"
+       x1="35.094646"
+       y1="19.210447"
+       x2="35.094646"
+       y2="42.529957"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-0.99999323,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3835"
+       id="linearGradient3841"
+       x1="41.25"
+       y1="19.833317"
+       x2="41.25"
+       y2="40.715191"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2,0,0,2,-0.99999323,0)" />
+  </defs>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#radialGradient3060);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.05496335;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path12941"
+     d="M 107,108.0022 C 106.99738,119.04704 87.746392,128 64,128 40.253606,128 21.00262,119.04704 21,108.0022 20.997382,96.95564 40.249904,88 64,88 c 23.750096,0 43.00262,8.95564 43,20.0022 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3055);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3057);stroke-width:1.99999976;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2230"
+     d="m 26,21.754375 0,85.814545 C 26,115.4435 37.858136,125 65.000004,125 92.14187,125 102,115.4435 102,107.56892 l 0,-85.814545 z"
+     sodipodi:nodetypes="cssscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.4;fill:url(#radialGradient3052);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path3212"
+     d="m 27.349288,24.436083 0,83.132837 c 0,7.56778 16.867522,16.09024 37.650716,16.09024 20.783194,0 37.650706,-8.52246 37.650706,-16.09024 l 0,-83.132837 c 0,0 -75.301422,0 -75.301422,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3047);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3049);stroke-width:1.96777904;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path3164"
+     d="m 102,21.754375 c 0,8.157788 -15.452,14.770978 -36.999996,14.770978 -21.548008,0 -39.016114,-6.61319 -39.016114,-14.770978 0,-8.157786 17.468106,-14.7709762 39.016114,-14.7709762 C 86.548,6.9833988 102,13.596589 102,21.754375 Z"
+     sodipodi:nodetypes="cssscc" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.3;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98388958;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path3197"
+     d="m 102.65071,21.898195 c 0,7.484754 -16.856798,13.552342 -37.650706,13.552342 -20.793918,0 -37.650716,-6.067588 -37.650716,-13.552342 0,-7.48475 16.856798,-13.5523403 37.650716,-13.5523403 20.793908,0 37.650706,6.0675903 37.650706,13.5523403 l 0,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:none;stroke:url(#linearGradient5341);stroke-width:1.99999952;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2206"
+     d="m 28,21.246413 c 0,5.185248 0,82.052247 0,88.026087 0,7.20128 17.032064,13.0458 36.999934,13.0458 C 84.9678,122.3183 100,116.47378 100,109.2725 100,103.74516 99.84582,26.771593 100,21.246413 100.14382,16.092739 86.898428,9.0000007 64.999934,9.0000007 43.10144,9.0000007 28,16.061165 28,21.246413 Z"
+     sodipodi:nodetypes="zsssszz" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.2;fill:url(#linearGradient3038);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect3244"
+     d="m 44.506446,35.113651 12.05497,2.273968 0,86.952701 -12.05497,-2.90588 0,-86.320789 0,0 z" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.15;fill:url(#linearGradient3035);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path3287"
+     d="m 36,36.519907 c 2.23484,0.820988 3,3.275992 3,5.504486 l 0,71.049027 c 0,2.2285 -0.76516,3.36162 -3,2.54062 -2.23484,-0.821 -3,-3.27598 -3,-5.50448 l 0,-71.049027 c 0,-2.228498 0.76516,-3.361616 3,-2.540626 z m 56,0.480094 c -2.234838,0.820992 -3,3.171502 -3,5.4 l 0,70.011059 c 0,2.2285 0.765162,3.36162 3,2.54064 2.234838,-0.821 3,-3.276 3,-5.5045 l 0,-70.047199 c 0,-2.228498 -0.765162,-3.22099 -3,-2.4 z"
+     sodipodi:nodetypes="ssssssssssssss" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.3;fill:url(#linearGradient3032);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path3293"
+     d="m 78,41.883317 c -2.234838,0.10264 -3.034006,1.979302 -3.034006,4.207796 l 0,71.049027 c 0,2.2285 0.799168,3.93994 3.034006,3.83732 2.23484,-0.1026 3,-1.9793 3,-4.2078 l 0,-71.049029 c 0,-2.228498 -0.76516,-3.93994 -3,-3.837314 z"
+     sodipodi:nodetypes="sssssss" />
+  <path
+     sodipodi:nodetypes="ssssssssssssss"
+     d="m 50,41.883317 c 2.234842,0.10264 3,1.979302 3,4.207796 l 0,71.049027 c 0,2.2285 -0.765158,3.93994 -3,3.83732 -2.234838,-0.1026 -3.034006,-1.9793 -3.034006,-4.2078 l 0,-71.049029 c 0,-2.228498 0.799168,-3.93994 3.034006,-3.837314 z m 14,1.999616 c -2.234838,0.10264 -3.000006,1.979302 -3.000006,4.207795 l 0,71.049032 c 0,2.2285 0.765168,3.93994 3.000006,3.8373 2.23484,-0.1026 3.068,-1.9793 3.068,-4.20778 l 0,-71.049034 c 0,-2.228497 -0.83316,-3.939937 -3.068,-3.837313 z"
+     id="path5337"
+     style="opacity:0.3;fill:url(#linearGradient5339);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     sodipodi:nodetypes="ssssssssssssss"
+     d="m 36,37.000001 c 2.23484,0.820988 3,2.795898 3,5.024392 l 0,71.049027 c 0,2.2285 -0.76516,3.36162 -3,2.54062 -2.23484,-0.821 -3,-3.27598 -3,-5.50448 l 0,-71.049027 c 0,-2.228498 0.76516,-2.881522 3,-2.060532 z m 56,0 c -2.234838,0.820992 -3,3.171502 -3,5.4 l 0,70.011059 c 0,2.2285 0.765162,3.36162 3,2.54064 2.234838,-0.821 3,-3.276 3,-5.5045 l 0,-70.047199 c 0,-2.228498 -0.765162,-3.22099 -3,-2.4 z"
+     id="path3045"
+     style="opacity:0.35064937;fill:none;stroke:url(#linearGradient3821);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="opacity:0.43290046;fill:none;stroke:url(#linearGradient3831);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path3823"
+     d="m 50,41.883317 c 2.234842,0.10264 3,1.979302 3,4.207796 l 0,71.049027 c 0,2.2285 -0.765158,3.93994 -3,3.83732 -2.234838,-0.1026 -3.034006,-1.9793 -3.034006,-4.2078 l 0,-71.049029 c 0,-2.228498 0.799168,-3.93994 3.034006,-3.837314 z m 14,1.999616 c -2.234838,0.10264 -3.000006,1.979302 -3.000006,4.207795 l 0,71.049032 c 0,2.2285 0.765168,3.93994 3.000006,3.8373 2.23484,-0.1026 3.068,-1.9793 3.068,-4.20778 l 0,-71.049034 c 0,-2.228497 -0.83316,-3.939937 -3.068,-3.837313 z"
+     sodipodi:nodetypes="ssssssssssssss" />
+  <path
+     sodipodi:nodetypes="sssssss"
+     d="m 78,41.883317 c -2.234838,0.10264 -3.034006,1.979302 -3.034006,4.207796 l 0,71.049027 c 0,2.2285 0.799168,3.93994 3.034006,3.83732 2.23484,-0.1026 3,-1.9793 3,-4.2078 l 0,-71.049029 c 0,-2.228498 -0.76516,-3.93994 -3,-3.837314 z"
+     id="path3833"
+     style="opacity:0.46320346;fill:none;stroke:url(#linearGradient3841);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce/places/128/xfce-trash_empty.svg
+++ b/elementary-xfce/places/128/xfce-trash_empty.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash.svg

--- a/elementary-xfce/places/128/xfce-trash_full.svg
+++ b/elementary-xfce/places/128/xfce-trash_full.svg
@@ -1,0 +1,1 @@
+/home/sergio/Pictures/elementary-xfce/elementary-xfce/places/128/user-trash-full.svg


### PR DESCRIPTION
Added accessories-calculator, accessories-text-editor, web-browser, xfce4-notes-plugin, camera-photo, user-trash and user-trash-full in 128 px folders.

When you create a desktop shortcut, you can see that some application use the 64 px icons as default.

I'm new in git, need more training :)
