### PR TITLE
Add symbolic links for some Mate Disk Usage Analyzer

### DIFF
--- a/elementary-xfce/apps/24/mate-disk-usage-analyzer.svg
+++ b/elementary-xfce/apps/24/mate-disk-usage-analyzer.svg
@@ -1,0 +1,1 @@
+baobab.svg

--- a/elementary-xfce/apps/48/mate-disk-usage-analyzer.svg
+++ b/elementary-xfce/apps/48/mate-disk-usage-analyzer.svg
@@ -1,0 +1,1 @@
+baobab.svg

--- a/elementary-xfce/apps/64/mate-disk-usage-analyzer.svg
+++ b/elementary-xfce/apps/64/mate-disk-usage-analyzer.svg
@@ -1,0 +1,1 @@
+baobab.svg


### PR DESCRIPTION
At least in Arch Linux mate-disk-usage-analyzer.desktop is looking for them.