### PR TITLE
remove unnecessary path from media-playback-stop that caused 1px offs…

### DIFF
--- a/elementary-xfce-darker/actions/16/media-playback-stop.svg
+++ b/elementary-xfce-darker/actions/16/media-playback-stop.svg
@@ -318,12 +318,6 @@
     </rdf:RDF>
   </metadata>
   <path
-     sodipodi:nodetypes="cccccccccc"
-     d="m 21.499876,-4.9990459 c 0.263615,-0.00656 0.506881,0.2243277 0.499981,0.474517 l 0,18.9806789 c 0.0069,0.250189 -0.238345,0.505807 -0.499981,0.474517 -0.423518,-0.08764 -18.8019723,0.193024 -18.999298,0 -0.2636156,0.0066 -0.5068913,-0.224328 -0.4999815,-0.474517 l 0,-18.980679 c -0.011872,-0.2143339 0.1548596,-0.4253196 0.3749861,-0.474517 0.020804,-0.00127 0.041694,-0.00127 0.062498,1e-7 0.020804,-0.00127 0.041694,-0.00127 0.062498,0"
-     inkscape:connector-curvature="0"
-     id="path3845"
-     style="opacity:0.35;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
      style="color:#000000;fill:url(#radialGradient3062);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path3797"
      inkscape:connector-curvature="0"


### PR DESCRIPTION
…et when drawn

Before:
![](http://i.imgur.com/BRWQNsi.png)
After:
![](http://i.imgur.com/lJ7S1sR.png)