### PR TITLE
Added support for vsd, vsdx and vstx

### DIFF
--- a/elementary-xfce/mimes/16/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/16/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/16/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/16/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/16/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/16/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/22/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/22/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/22/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/22/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/22/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/22/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/24/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/24/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/24/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/24/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/24/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/24/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/32/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/32/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/32/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/32/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/32/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/32/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/48/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/48/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/48/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/48/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/48/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/48/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/64/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/64/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/64/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/64/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/64/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/64/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/96/application-vnd.ms-visio.drawing.main+xml.svg
+++ b/elementary-xfce/mimes/96/application-vnd.ms-visio.drawing.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg

--- a/elementary-xfce/mimes/96/application-vnd.ms-visio.template.main+xml.svg
+++ b/elementary-xfce/mimes/96/application-vnd.ms-visio.template.main+xml.svg
@@ -1,0 +1,1 @@
+x-office-drawing-template.svg

--- a/elementary-xfce/mimes/96/application-vnd.visio.svg
+++ b/elementary-xfce/mimes/96/application-vnd.visio.svg
@@ -1,0 +1,1 @@
+x-office-drawing.svg


### PR DESCRIPTION
Currently elementary theme do not support visio icons. This PR fixes it.
Also I've added (http://cgit.freedesktop.org/xdg/shared-mime-info/commit/?id=d1022b00c120f477060714d0b5c0cbe6211e4b23) vsdx and vstx file-type support to share-mime-info project, so to test it you should build latest shared-mime-info.
To verify my symlinks use mime-type database http://cgit.freedesktop.org/xdg/shared-mime-info/tree/freedesktop.org.xml.in
More info about this filetypes http://fileinfo.com/software/microsoft/visio