### PR TITLE
No longer inherit from the gnome icon theme

### DIFF
--- a/elementary-xfce/index.theme
+++ b/elementary-xfce/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=elementary Xfce
 Comment=Smooth modern theme for Xfce
-Inherits=adwaita,gnome,hicolor
+Inherits=adwaita,hicolor
 
 Example=directory-x-normal
 


### PR DESCRIPTION
gnome-icon-theme has been renamed to adwaita-icon-theme back in 2014
and gnome-icon-theme has been archived.

Since we already inherit adwaita, which in fact is a renamed gnome-icon-theme,
we no longer have to care for the old name.