### PR TITLE
Add approved 'monochrome' panel icons for software updater

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,7 @@ Pasi Lallinaho <pasi@shimmerproject.org>
 Sean Davis <smd.seandavis@gmail.com>
 Sérgio Benjamim <sergiobenrocha2@gmail.com>
 spg76
+Maurizio Galli <mauriziogalli@opensuse.org>
+Vinzenz Vietzke <vinz@vinzv.de>
+Stasiek Michalski <hellcp@opensuse.org>
+Noah Davis <noahadvs@gmail.com>

--- a/elementary-xfce-dark/panel/16/software-update-available.svg
+++ b/elementary-xfce-dark/panel/16/software-update-available.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="16"
+   height="16"
+   sodipodi:docname="software-update-available.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#009dff;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce-dark/panel/16/software-update-available.svg
+++ b/elementary-xfce-dark/panel/16/software-update-available.svg
@@ -28,9 +28,9 @@
      inkscape:window-height="1030"
      id="namedview5"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="1.8135593"
-     inkscape:cy="8"
+     inkscape:zoom="31.620488"
+     inkscape:cx="0.88930265"
+     inkscape:cy="9.7384197"
      inkscape:window-x="0"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
@@ -52,9 +52,19 @@
     </rdf:RDF>
   </metadata>
   <path
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="M 8 1 L 8 3 C 4.6862919 3 2 5.1005051 2 8 L 4 8 C 4 6.0667369 5.790556 4.999623 8 5 L 8 7 L 10.240234 5.65625 A 2.5 2.5 0 0 1 9 3.5 A 2.5 2.5 0 0 1 9.5546875 1.9335938 L 8 1 z "
+     id="path816-3" />
+  <path
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="m 12.000781,8 c 0,1.9332633 -1.791337,3.000377 -4.000781,3 V 9 l -5,3 5,3 v -2 c 3.313708,0 6,-2.100505 6,-5 z"
      id="path816"
-     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
-     overflow="visible"
-     style="color:#bebebe;overflow:visible;fill:#009dff;fill-opacity:1;marker:none"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <circle
+     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="12.5"
+     cy="3.5"
+     r="2.5" />
 </svg>

--- a/elementary-xfce-dark/panel/16/software-update-urgent.svg
+++ b/elementary-xfce-dark/panel/16/software-update-urgent.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="16"
+   height="16"
+   sodipodi:docname="software-update-urgent.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#d33636;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce-dark/panel/16/software-update-urgent.svg
+++ b/elementary-xfce-dark/panel/16/software-update-urgent.svg
@@ -28,9 +28,9 @@
      inkscape:window-height="1030"
      id="namedview5"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="1.8135593"
-     inkscape:cy="8"
+     inkscape:zoom="31.620488"
+     inkscape:cx="3.9827497"
+     inkscape:cy="9.7384197"
      inkscape:window-x="0"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
@@ -52,9 +52,19 @@
     </rdf:RDF>
   </metadata>
   <path
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="M 8 1 L 8 3 C 4.6862919 3 2 5.1005051 2 8 L 4 8 C 4 6.0667369 5.790556 4.999623 8 5 L 8 7 L 10.240234 5.65625 A 2.5 2.5 0 0 1 9 3.5 A 2.5 2.5 0 0 1 9.5546875 1.9335938 L 8 1 z "
+     id="path816-3" />
+  <path
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="m 12.000781,8 c 0,1.9332633 -1.791337,3.000377 -4.000781,3 V 9 l -5,3 5,3 v -2 c 3.313708,0 6,-2.100505 6,-5 z"
      id="path816"
-     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
-     overflow="visible"
-     style="color:#bebebe;overflow:visible;fill:#d33636;fill-opacity:1;marker:none"
-     inkscape:connector-curvature="0" />
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccc" />
+  <circle
+     style="opacity:1;fill:#d33636;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="12.5"
+     cy="3.5"
+     r="2.5" />
 </svg>

--- a/elementary-xfce-dark/panel/16/system-software-update.svg
+++ b/elementary-xfce-dark/panel/16/system-software-update.svg
@@ -28,9 +28,9 @@
      inkscape:window-height="1030"
      id="namedview5"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="1.8135593"
-     inkscape:cy="8"
+     inkscape:zoom="31.620488"
+     inkscape:cx="5.4733162"
+     inkscape:cy="9.7384197"
      inkscape:window-x="0"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
@@ -52,9 +52,7 @@
     </rdf:RDF>
   </metadata>
   <path
-     id="path816"
-     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
-     overflow="visible"
-     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;marker:none"
-     inkscape:connector-curvature="0" />
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="M 8 1 L 8 3 C 4.686292 3 2 5.100505 2 8 L 4 8 C 4 6.0667367 5.790556 4.999623 8 5 L 8 7 L 13 4 L 8 1 z M 12 8 C 12 9.9332633 10.209444 11.000377 8 11 L 8 9 L 3 12 L 8 15 L 8 13 C 11.313708 13 14 10.899495 14 8 L 12 8 z "
+     id="path816" />
 </svg>

--- a/elementary-xfce-dark/panel/16/system-software-update.svg
+++ b/elementary-xfce-dark/panel/16/system-software-update.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="16"
+   height="16"
+   sodipodi:docname="system-software-update.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce-dark/panel/22/software-update-available.svg
+++ b/elementary-xfce-dark/panel/22/software-update-available.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="22"
+   height="22"
+   sodipodi:docname="software-update-available.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="15.81"
+     inkscape:cx="4.3731815"
+     inkscape:cy="8.9488981"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4538" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;marker:none"
+     d="M 11 3 L 11 5 A 6 6 0 0 0 5 11 L 7 11 A 4 4 0 0 1 11 7 L 11 9 L 14.164062 7.1015625 A 3.5 3.5 0 0 1 13 4.5 A 3.5 3.5 0 0 1 13.013672 4.2089844 L 11 3 z M 15 11 A 4 4 0 0 1 11 15 L 11 13 L 6 16 L 11 19 L 11 17 A 6 6 0 0 0 17 11 L 15 11 z "
+     id="path816" />
+  <circle
+     style="opacity:1;fill:#da0000;fill-opacity:0;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+  <circle
+     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+</svg>

--- a/elementary-xfce-dark/panel/22/software-update-urgent.svg
+++ b/elementary-xfce-dark/panel/22/software-update-urgent.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="22"
+   height="22"
+   sodipodi:docname="software-update-urgent.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="18.16"
+     inkscape:cx="7.5676037"
+     inkscape:cy="10.653083"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4538" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="color:#bebebe;overflow:visible;fill:#dadada;fill-opacity:1;marker:none"
+     d="M 11 3 L 11 5 A 6 6 0 0 0 5 11 L 7 11 A 4 4 0 0 1 11 7 L 11 9 L 14.164062 7.1015625 A 3.5 3.5 0 0 1 13 4.5 A 3.5 3.5 0 0 1 13.013672 4.2089844 L 11 3 z M 15 11 A 4 4 0 0 1 11 15 L 11 13 L 6 16 L 11 19 L 11 17 A 6 6 0 0 0 17 11 L 15 11 z "
+     id="path816" />
+  <circle
+     style="opacity:1;fill:#da0000;fill-opacity:0;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+  <circle
+     style="opacity:1;fill:#d33636;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+</svg>

--- a/elementary-xfce-dark/panel/22/system-software-update.svg
+++ b/elementary-xfce-dark/panel/22/system-software-update.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="22"
+   height="22"
+   sodipodi:docname="system-software-update.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="m 11,3 v 2 a 6,6 0 0 0 -6,6 h 2 a 4,4 0 0 1 4,-4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#dadada;marker:none;fill-opacity:1"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce/panel/16/software-update-available.svg
+++ b/elementary-xfce/panel/16/software-update-available.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="16"
+   height="16"
+   sodipodi:docname="software-update-available.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#009dff;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce/panel/16/software-update-available.svg
+++ b/elementary-xfce/panel/16/software-update-available.svg
@@ -28,9 +28,9 @@
      inkscape:window-height="1030"
      id="namedview5"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="1.8135593"
-     inkscape:cy="8"
+     inkscape:zoom="20.86"
+     inkscape:cx="1.966443"
+     inkscape:cy="9.7384197"
      inkscape:window-x="0"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
@@ -52,9 +52,13 @@
     </rdf:RDF>
   </metadata>
   <path
-     id="path816"
-     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
-     overflow="visible"
-     style="color:#bebebe;overflow:visible;fill:#009dff;fill-opacity:1;marker:none"
-     inkscape:connector-curvature="0" />
+     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="M 8 1 L 8 3 C 4.6862919 3 2 5.1005051 2 8 L 4 8 C 4 6.0667369 5.790556 4.999623 8 5 L 8 7 L 10.240234 5.65625 A 2.5 2.5 0 0 1 9 3.5 A 2.5 2.5 0 0 1 9.5546875 1.9335938 L 8 1 z M 12 8 C 12 9.9332633 10.209444 11.000377 8 11 L 8 9 L 3 12 L 8 15 L 8 13 C 11.313708 13 14 10.899495 14 8 L 12 8 z "
+     id="path816-3" />
+  <circle
+     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="12.5"
+     cy="3.5"
+     r="2.5" />
 </svg>

--- a/elementary-xfce/panel/16/software-update-urgent.svg
+++ b/elementary-xfce/panel/16/software-update-urgent.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="16"
+   height="16"
+   sodipodi:docname="software-update-urgent.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#d33636;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce/panel/16/software-update-urgent.svg
+++ b/elementary-xfce/panel/16/software-update-urgent.svg
@@ -28,9 +28,9 @@
      inkscape:window-height="1030"
      id="namedview5"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="1.8135593"
-     inkscape:cy="8"
+     inkscape:zoom="20.86"
+     inkscape:cx="0.64374769"
+     inkscape:cy="9.7384197"
      inkscape:window-x="0"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
@@ -52,9 +52,13 @@
     </rdf:RDF>
   </metadata>
   <path
-     id="path816"
-     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
-     overflow="visible"
-     style="color:#bebebe;overflow:visible;fill:#d33636;fill-opacity:1;marker:none"
-     inkscape:connector-curvature="0" />
+     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="M 8 1 L 8 3 C 4.6862919 3 2 5.1005051 2 8 L 4 8 C 4 6.0667369 5.790556 4.999623 8 5 L 8 7 L 10.240234 5.65625 A 2.5 2.5 0 0 1 9 3.5 A 2.5 2.5 0 0 1 9.5546875 1.9335938 L 8 1 z M 12 8 C 12 9.9332633 10.209444 11.000377 8 11 L 8 9 L 3 12 L 8 15 L 8 13 C 11.313708 13 14 10.899495 14 8 L 12 8 z "
+     id="path816-3" />
+  <circle
+     style="opacity:1;fill:#d33636;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="12.5"
+     cy="3.5"
+     r="2.5" />
 </svg>

--- a/elementary-xfce/panel/16/system-software-update.svg
+++ b/elementary-xfce/panel/16/system-software-update.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="16"
+   height="16"
+   sodipodi:docname="system-software-update.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="29.5"
+     inkscape:cx="1.8135593"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/elementary-xfce/panel/16/system-software-update.svg
+++ b/elementary-xfce/panel/16/system-software-update.svg
@@ -28,9 +28,9 @@
      inkscape:window-height="1030"
      id="namedview5"
      showgrid="true"
-     inkscape:zoom="29.5"
-     inkscape:cx="1.8135593"
-     inkscape:cy="8"
+     inkscape:zoom="23.960287"
+     inkscape:cx="5.8525672"
+     inkscape:cy="9.7384197"
      inkscape:window-x="0"
      inkscape:window-y="26"
      inkscape:window-maximized="1"
@@ -52,9 +52,7 @@
     </rdf:RDF>
   </metadata>
   <path
-     id="path816"
-     d="M 8,0 V 2 A 6,6 0 0 0 2,8 H 4 A 4,4 0 0 1 8,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
-     overflow="visible"
-     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;marker:none"
-     inkscape:connector-curvature="0" />
+     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;stroke-width:0.93541437;marker:none"
+     d="M 8 1 L 8 3 C 4.686292 3 2 5.100505 2 8 L 4 8 C 4 6.0667367 5.790556 4.999623 8 5 L 8 7 L 13 4 L 8 1 z M 12 8 C 12 9.9332633 10.209444 11.000377 8 11 L 8 9 L 3 12 L 8 15 L 8 13 C 11.313708 13 14 10.899495 14 8 L 12 8 z "
+     id="path816" />
 </svg>

--- a/elementary-xfce/panel/22/software-update-available.svg
+++ b/elementary-xfce/panel/22/software-update-available.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="22"
+   height="22"
+   sodipodi:docname="software-update-available.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="16.94"
+     inkscape:cx="7.0165289"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4538" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;marker:none"
+     d="M 11 3 L 11 5 A 6 6 0 0 0 5 11 L 7 11 A 4 4 0 0 1 11 7 L 11 9 L 14.164062 7.1015625 A 3.5 3.5 0 0 1 13 4.5 A 3.5 3.5 0 0 1 13.013672 4.2089844 L 11 3 z M 15 11 A 4 4 0 0 1 11 15 L 11 13 L 6 16 L 11 19 L 11 17 A 6 6 0 0 0 17 11 L 15 11 z "
+     id="path816" />
+  <circle
+     style="opacity:1;fill:#da0000;fill-opacity:0;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+  <circle
+     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+</svg>

--- a/elementary-xfce/panel/22/software-update-urgent.svg
+++ b/elementary-xfce/panel/22/software-update-urgent.svg
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="22"
+   height="22"
+   sodipodi:docname="software-update-urgent.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="16.94"
+     inkscape:cx="7.0165289"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4538" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="color:#bebebe;overflow:visible;fill:#5c5c5c;fill-opacity:1;marker:none"
+     d="M 11 3 L 11 5 A 6 6 0 0 0 5 11 L 7 11 A 4 4 0 0 1 11 7 L 11 9 L 14.164062 7.1015625 A 3.5 3.5 0 0 1 13 4.5 A 3.5 3.5 0 0 1 13.013672 4.2089844 L 11 3 z M 15 11 A 4 4 0 0 1 11 15 L 11 13 L 6 16 L 11 19 L 11 17 A 6 6 0 0 0 17 11 L 15 11 z "
+     id="path816" />
+  <circle
+     style="opacity:1;fill:#da0000;fill-opacity:0;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+  <circle
+     style="opacity:1;fill:#d33636;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="17.5"
+     cy="4.5"
+     r="3.5" />
+</svg>

--- a/elementary-xfce/panel/22/system-software-update.svg
+++ b/elementary-xfce/panel/22/system-software-update.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg2"
+   width="22"
+   height="22"
+   sodipodi:docname="system-software-update.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="15.81"
+     inkscape:cx="4.3731815"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="26"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="path816"
+     d="m 11,3 v 2 a 6,6 0 0 0 -6,6 h 2 a 4,4 0 0 1 4,-4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;fill:#666666;marker:none"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
This is the finalized version of software updater monochrome icons for the panel systray/indicator  as discussed in PR #143.

No update:
![software-update-no-update-alternative](https://user-images.githubusercontent.com/44322817/56090078-9c000900-5ecf-11e9-9452-466fdce3b7f2.png)

Update available:
![software-update-available-alternative](https://user-images.githubusercontent.com/44322817/56090083-a15d5380-5ecf-11e9-812a-9c80a1ace46d.png)

Urgent update available:
![software-update-urgent-alternative](https://user-images.githubusercontent.com/44322817/56090085-a6ba9e00-5ecf-11e9-89be-441c8dc19326.png)
