### PR TITLE
adding symlink to appropriate update icon for gpk

### DIFF
--- a/elementary-xfce-dark/apps/48/system-software-update.svg
+++ b/elementary-xfce-dark/apps/48/system-software-update.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/apps/48/system-software-update.svg

--- a/elementary-xfce-darker/apps/48/system-software-update.svg
+++ b/elementary-xfce-darker/apps/48/system-software-update.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/apps/48/system-software-update.svg

--- a/elementary-xfce-darker/index.theme
+++ b/elementary-xfce-darker/index.theme
@@ -6,7 +6,7 @@ Inherits=elementary-xfce-dark
 Example=directory-x-normal
 
 #Directory list
-Directories=actions/16,actions/22,actions/24,actions/32,actions/48,actions/64,actions/128,actions/symbolic,
+Directories=actions/16,actions/22,actions/24,actions/32,actions/48,actions/64,actions/128,actions/symbolic,apps/48,
 
 [actions/16]
 Size=16
@@ -46,4 +46,9 @@ Type=Scalable
 [actions/symbolic]
 Size=16
 Context=Actions
+Type=Scalable
+
+[apps/48]
+Size=48
+Context=Apps
 Type=Scalable


### PR DESCRIPTION
![screen-pkupdate-icon](https://user-images.githubusercontent.com/74432/56120697-f9976280-5f6e-11e9-9857-f7791f16c8d0.png)
As shown in the screenshot this commit changes the header icon for gnome-packagekit appropriately.