### PR TITLE
Remove not needed system-software-update.svg from "darker" theme variant

### DIFF
--- a/elementary-xfce-darker/apps/48/system-software-update.svg
+++ b/elementary-xfce-darker/apps/48/system-software-update.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/apps/48/system-software-update.svg

--- a/elementary-xfce-darker/index.theme
+++ b/elementary-xfce-darker/index.theme
@@ -6,8 +6,7 @@ Inherits=elementary-xfce-dark
 Example=directory-x-normal
 
 #Directory list
-Directories=actions/16,actions/22,actions/24,actions/32,actions/48,actions/64,actions/128,actions/symbolic,apps/48,
-
+Directories=actions/16,actions/22,actions/24,actions/32,actions/48,actions/64,actions/128,actions/symbolic,
 [actions/16]
 Size=16
 Context=Actions
@@ -46,9 +45,4 @@ Type=Scalable
 [actions/symbolic]
 Size=16
 Context=Actions
-Type=Scalable
-
-[apps/48]
-Size=48
-Context=Apps
 Type=Scalable


### PR DESCRIPTION
The 48px icon overrides the panel monochrome one. Adding the icons in the Darker variant is not necessary because it already inherits from Dark.