### PR TITLE
fixed blueman-disabled symbolic icon and added new sofware-updater symbolic icons

### DIFF
--- a/elementary-xfce/status/symbolic/blueman-disabled-symbolic.svg
+++ b/elementary-xfce/status/symbolic/blueman-disabled-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-disabled-symbolic.svg

--- a/elementary-xfce/status/symbolic/software-update-urgent-symbolic.svg
+++ b/elementary-xfce/status/symbolic/software-update-urgent-symbolic.svg
@@ -5,10 +5,72 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   height="16"
-   width="16"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    id="svg2"
-   version="1.1">
+   width="16"
+   height="16"
+   sodipodi:docname="software-update-urgent-symbolic.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <defs
+     id="defs7">
+    <linearGradient
+       x1="159.68553"
+       y1="14.403693"
+       x2="159.68553"
+       y2="38.279892"
+       id="linearGradient2388"
+       xlink:href="#linearGradient3587-6-5-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.32801832,0,0,0.5447147,86.823996,-10.845903)" />
+    <linearGradient
+       id="linearGradient3587-6-5-3">
+      <stop
+         id="stop3589-9-2-2"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3591-7-4-73"
+         style="stop-color:#363636;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3587-6-5-3"
+       id="linearGradient836"
+       x1="7"
+       y1="3"
+       x2="7"
+       y2="19"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-4,-3)" />
+  </defs>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1027"
+     id="namedview5"
+     showgrid="true"
+     inkscape:zoom="15.81"
+     inkscape:cx="-32.29475"
+     inkscape:cy="7.7469956"
+     inkscape:window-x="0"
+     inkscape:window-y="29"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid814" />
+  </sodipodi:namedview>
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -17,21 +79,19 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs10" />
-  <g
-     transform="translate(-773 271)"
-     id="g4">
-    <path
-       class="warning"
-       color="#bebebe"
-       d="M787.969-263a6.963 6.963 0 0 0-6.969-6.969 6.963 6.963 0 0 0-6.969 6.969 6.963 6.963 0 0 0 6.97 6.969 6.963 6.963 0 0 0 6.968-6.969zm-2.938 0l-4.03 5-4-5h3v-4h2v4z"
-       fill="#f9c440"
-       overflow="visible"
-       style="text-indent:0;text-transform:none;marker:none"
-       id="path6" />
-  </g>
+  <path
+     style="color:#bebebe;overflow:visible;opacity:0.99999999;fill:#666666;fill-opacity:1;marker:none"
+     d="M 7 0 L 7 2 A 6 6 0 0 0 1 8 L 3 8 A 4 4 0 0 1 7 4 L 7 6 L 8.4160156 5.1503906 A 3.5 3.5 0 0 1 8 3.5 A 3.5 3.5 0 0 1 8.9140625 1.1484375 L 7 0 z M 11 8 A 4 4 0 0 1 7 12 L 7 10 L 2 13 L 7 16 L 7 14 A 6 6 0 0 0 13 8 L 11 8 z "
+     id="path816" />
+  <circle
+     class="error"
+     style="opacity:1;fill:#ef2929;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     id="path879-5"
+     cx="12.5"
+     cy="3.5"
+     r="3.5" />
 </svg>

--- a/elementary-xfce/status/symbolic/system-software-update-symbolic.svg
+++ b/elementary-xfce/status/symbolic/system-software-update-symbolic.svg
@@ -12,7 +12,7 @@
    id="svg2"
    width="16"
    height="16"
-   sodipodi:docname="software-update-available-symbolic.svg"
+   sodipodi:docname="system-software-update-symbolic.svg"
    inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <defs
      id="defs7">
@@ -36,16 +36,6 @@
          style="stop-color:#363636;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3587-6-5-3"
-       id="linearGradient836"
-       x1="7"
-       y1="3"
-       x2="7"
-       y2="19"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-4,-3)" />
   </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
@@ -61,7 +51,7 @@
      id="namedview5"
      showgrid="true"
      inkscape:zoom="15.81"
-     inkscape:cx="-32.29475"
+     inkscape:cx="-18.8716"
      inkscape:cy="7.7469956"
      inkscape:window-x="0"
      inkscape:window-y="29"
@@ -79,19 +69,14 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     style="color:#bebebe;overflow:visible;opacity:0.99999999;fill:#666666;fill-opacity:1;marker:none"
-     d="M 7 0 L 7 2 A 6 6 0 0 0 1 8 L 3 8 A 4 4 0 0 1 7 4 L 7 6 L 8.4160156 5.1503906 A 3.5 3.5 0 0 1 8 3.5 A 3.5 3.5 0 0 1 8.9140625 1.1484375 L 7 0 z M 11 8 A 4 4 0 0 1 7 12 L 7 10 L 2 13 L 7 16 L 7 14 A 6 6 0 0 0 13 8 L 11 8 z "
-     id="path816" />
-  <circle
-     class="warning"
-     style="opacity:1;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
-     id="path879-5"
-     cx="12.5"
-     cy="3.5"
-     r="3.5" />
+     id="path816"
+     d="M 7,0 V 2 A 6,6 0 0 0 1,8 H 3 A 4,4 0 0 1 7,4 v 2 l 5,-3 z m 4,8 a 4,4 0 0 1 -4,4 v -2 l -5,3 5,3 v -2 a 6,6 0 0 0 6,-6 z"
+     overflow="visible"
+     style="color:#bebebe;overflow:visible;opacity:1;fill:#666666;fill-opacity:1;marker:none"
+     inkscape:connector-curvature="0" />
 </svg>


### PR DESCRIPTION
blueman-disabled icon is displayed as the 22px instead of the symbolic one due to a missing symlink