### PR TITLE
Updated software-updater icons to match symbolic icons color codes

### DIFF
--- a/elementary-xfce-dark/panel/16/software-update-available.svg
+++ b/elementary-xfce-dark/panel/16/software-update-available.svg
@@ -13,7 +13,7 @@
    width="16"
    height="16"
    sodipodi:docname="software-update-available.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <defs
      id="defs7">
     <linearGradient
@@ -47,14 +47,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1149"
+     inkscape:window-height="1023"
      id="namedview5"
      showgrid="true"
      inkscape:zoom="31.620488"
-     inkscape:cx="-4.7083339"
+     inkscape:cx="-10.732909"
      inkscape:cy="9.6119194"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="33"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -110,7 +110,7 @@
        style="color:#bebebe;overflow:visible;fill:url(#linearGradient839);fill-opacity:1.0;stroke-width:0.93541437;marker:none" />
   </g>
   <circle
-     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     style="opacity:1;fill:#f57900;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
      id="path879-5"
      cx="12.5"
      cy="3.5"

--- a/elementary-xfce-dark/panel/22/software-update-available.svg
+++ b/elementary-xfce-dark/panel/22/software-update-available.svg
@@ -13,7 +13,7 @@
    width="22"
    height="22"
    sodipodi:docname="software-update-available.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <defs
      id="defs7">
     <linearGradient
@@ -56,14 +56,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1149"
+     inkscape:window-height="1023"
      id="namedview5"
      showgrid="true"
      inkscape:zoom="18.16"
-     inkscape:cx="22.292607"
+     inkscape:cx="11.802519"
      inkscape:cy="10.432819"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="33"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -78,7 +78,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -98,7 +98,7 @@
      d="M 11 3 L 11 5 A 6 6 0 0 0 5 11 L 7 11 A 4 4 0 0 1 11 7 L 11 9 L 14.164062 7.1015625 A 3.5 3.5 0 0 1 13 4.5 A 3.5 3.5 0 0 1 13.013672 4.2089844 L 11 3 z M 15 11 A 4 4 0 0 1 11 15 L 11 13 L 6 16 L 11 19 L 11 17 A 6 6 0 0 0 17 11 L 15 11 z "
      id="path816" />
   <circle
-     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     style="opacity:1;fill:#f57900;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
      id="path879-5"
      cx="17.5"
      cy="4.5"

--- a/elementary-xfce-dark/panel/24/software-update-available.svg
+++ b/elementary-xfce-dark/panel/24/software-update-available.svg
@@ -88,14 +88,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-height="1023"
      id="namedview5"
      showgrid="true"
      inkscape:zoom="19.69"
-     inkscape:cx="1.2784617"
+     inkscape:cx="-8.3965002"
      inkscape:cy="8.3910694"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="33"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -126,7 +126,7 @@
      cy="6"
      r="4" />
   <circle
-     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:10.30656433;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     style="opacity:1;fill:#f57900;fill-opacity:1;stroke:none;stroke-width:10.30656433;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
      id="path879-5"
      cx="19"
      cy="5"

--- a/elementary-xfce/panel/16/software-update-available.svg
+++ b/elementary-xfce/panel/16/software-update-available.svg
@@ -13,7 +13,7 @@
    width="16"
    height="16"
    sodipodi:docname="software-update-available.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <defs
      id="defs7">
     <linearGradient
@@ -56,14 +56,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1149"
+     inkscape:window-height="1023"
      id="namedview5"
      showgrid="true"
      inkscape:zoom="20.86"
-     inkscape:cx="-6.518696"
+     inkscape:cx="-15.651007"
      inkscape:cy="9.5466651"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="33"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -98,7 +98,7 @@
      d="M 8 1 L 8 3 C 4.6862919 3 2 5.1005051 2 8 L 4 8 C 4 6.0667369 5.790556 4.999623 8 5 L 8 7 L 10.240234 5.65625 A 2.5 2.5 0 0 1 9 3.5 A 2.5 2.5 0 0 1 9.5546875 1.9335938 L 8 1 z M 12 8 C 12 9.9332633 10.209444 11.000377 8 11 L 8 9 L 3 12 L 8 15 L 8 13 C 11.313708 13 14 10.899495 14 8 L 12 8 z "
      id="path816-3" />
   <circle
-     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     style="opacity:1;fill:#f57900;fill-opacity:1;stroke:none;stroke-width:6.44160223;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
      id="path879-5"
      cx="12.5"
      cy="3.5"

--- a/elementary-xfce/panel/22/software-update-available.svg
+++ b/elementary-xfce/panel/22/software-update-available.svg
@@ -13,7 +13,7 @@
    width="22"
    height="22"
    sodipodi:docname="software-update-available.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
   <defs
      id="defs7">
     <linearGradient
@@ -56,14 +56,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1149"
+     inkscape:window-height="1023"
      id="namedview5"
      showgrid="true"
      inkscape:zoom="16.94"
-     inkscape:cx="-3.4321134"
+     inkscape:cx="-14.677686"
      inkscape:cy="7.7638725"
      inkscape:window-x="0"
-     inkscape:window-y="27"
+     inkscape:window-y="33"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -104,7 +104,7 @@
      cy="4.5"
      r="3.5" />
   <circle
-     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     style="opacity:1;fill:#f57900;fill-opacity:1;stroke:none;stroke-width:9.01824379;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
      id="path879-5"
      cx="17.5"
      cy="4.5"

--- a/elementary-xfce/panel/24/software-update-available.svg
+++ b/elementary-xfce/panel/24/software-update-available.svg
@@ -77,14 +77,14 @@
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
      inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-height="1023"
      id="namedview5"
      showgrid="true"
      inkscape:zoom="19.69"
-     inkscape:cx="1.2784617"
+     inkscape:cx="-8.3965002"
      inkscape:cy="8.3910694"
      inkscape:window-x="0"
-     inkscape:window-y="26"
+     inkscape:window-y="33"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
@@ -119,7 +119,7 @@
      d="M 12 3 L 12 5 C 8.0837991 5 5 8.2721 5 12 L 7 12 C 7 9.5147 9.3892 7 12 7 L 12 9 L 14.75 7.625 A 5 5 0 0 1 14 5 A 5 5 0 0 1 14.09375 4.046875 L 12 3 z M 17 12 C 17 14.4853 14.6108 17 12 17 L 12 15 L 6 18 L 12 21 L 12 19 C 15.916201 19 19 15.7279 19 12 L 17 12 z "
      id="path816" />
   <circle
-     style="opacity:1;fill:#009dff;fill-opacity:1;stroke:none;stroke-width:10.30656433;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
+     style="opacity:1;fill:#f57900;fill-opacity:1;stroke:none;stroke-width:10.30656433;stroke-linecap:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0"
      id="path879-5"
      cx="19"
      cy="5"


### PR DESCRIPTION
software-updater non symbolic icons use the same color codes as the symbolic icons, defined by class "warning" for update available and "error" for urgent updates