### PR TITLE
Add some missing symbolic icons for blueman and blueberry

### DIFF
--- a/elementary-xfce/status/symbolic/blueberry-tray-active-symbolic.svg
+++ b/elementary-xfce/status/symbolic/blueberry-tray-active-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-paired-symbolic.svg

--- a/elementary-xfce/status/symbolic/blueberry-tray-disabled-symbolic.svg
+++ b/elementary-xfce/status/symbolic/blueberry-tray-disabled-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-disabled-symbolic.svg

--- a/elementary-xfce/status/symbolic/blueberry-tray-symbolic.svg
+++ b/elementary-xfce/status/symbolic/blueberry-tray-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-active-symbolic.svg

--- a/elementary-xfce/status/symbolic/blueman-active-symbolic.svg
+++ b/elementary-xfce/status/symbolic/blueman-active-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-paired-symbolic.svg

--- a/elementary-xfce/status/symbolic/blueman-symbolic.svg
+++ b/elementary-xfce/status/symbolic/blueman-symbolic.svg
@@ -1,0 +1,1 @@
+bluetooth-active-symbolic.svg


### PR DESCRIPTION
Apparently appindicators don't use the *-tray-symbolic.svg icons. Created symlinks with correct icon name for blueman. Also added missing blueberry symbolic icons