### PR TITLE
Added nm-applet wired symbolic icon

### DIFF
--- a/elementary-xfce/status/symbolic/nm-device-wired-symbolic.svg
+++ b/elementary-xfce/status/symbolic/nm-device-wired-symbolic.svg
@@ -1,0 +1,1 @@
+network-wired-symbolic.svg


### PR DESCRIPTION
The icon is a symlink of the existing network-wired-symbolic.svg 