### PR TITLE
use better icon for blueberry tray 16px

### DIFF
--- a/elementary-xfce-dark/panel/16/blueberry-tray-active.svg
+++ b/elementary-xfce-dark/panel/16/blueberry-tray-active.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3201"
+   sodipodi:docname="blueberry-tray-active.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     id="namedview15"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-13.186441"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3201">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3203">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:1;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="11.988697" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.487958,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="20.015596" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="16.498461"
+       x2="11.888327"
+       y2="20.015596" />
+  </defs>
+  <g
+     transform="matrix(1.00507,0,0,1,-294.56663,251)"
+     id="g4-3"
+     style="color:#bebebe;fill:#eeeeec">
+    <path
+       d="m 309,-237 a 2,2 0 1 1 -4,0 2,2 0 1 1 4,0 z"
+       overflow="visible"
+       style="overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#eeeeec;marker:none"
+       id="path6-6"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 300.5,-250 c -0.277,0 -0.5,0.223 -0.5,0.5 v 4.875 l -1.719,-1.5 c -0.312,-0.273 -0.757,-0.22 -1.03,0.094 a 0.753,0.753 0 0 0 0.062,1.062 l 2.25,1.969 -2.25,1.969 a 0.753,0.753 0 0 0 -0.063,1.062 c 0.274,0.313 0.719,0.367 1.031,0.094 l 1.72,-1.5 v 4.875 c 0,0.277 0.222,0.5 0.5,0.5 0.282,0 0.437,-0.02 0.655,-0.188 l 3.532,-3.156 a 0.78,0.78 0 0 0 0.218,-0.375 0.745,0.745 0 0 0 0.032,-0.281 0.723,0.723 0 0 0 -0.032,-0.156 0.78,0.78 0 0 0 -0.218,-0.375 l -2.813,-2.47 2.813,-2.468 a 0.78,0.78 0 0 0 0.218,-0.375 0.712,0.712 0 0 0 0,-0.437 0.78,0.78 0 0 0 -0.218,-0.375 l -3.532,-3.157 c -0.199,-0.16 -0.427,-0.187 -0.656,-0.187 z m 0.5,2.063 2.094,1.875 -2.094,1.812 z m 0,6.187 2.094,1.813 -2.094,1.875 z"
+       overflow="visible"
+       style="overflow:visible;fill:#eeeeec;marker:none"
+       id="path8"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/elementary-xfce-dark/panel/16/blueberry-tray-disabled.svg
+++ b/elementary-xfce-dark/panel/16/blueberry-tray-disabled.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3201"
+   sodipodi:docname="blueberry-tray-disabled.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     id="namedview15"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-12.711864"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3201">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3203">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:1;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="11.988697" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.487958,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="20.015596" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="16.498461"
+       x2="11.888327"
+       y2="20.015596" />
+  </defs>
+  <g
+     style="color:#bebebe;fill:#eeeeec;opacity:0.35"
+     transform="matrix(1.0152513,0,0,1,-277.28607,251)"
+     id="g4">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 280.5,-250 c -0.277,0 -0.5,0.223 -0.5,0.5 v 4.875 l -1.719,-1.5 c -0.312,-0.273 -0.757,-0.22 -1.03,0.094 a 0.753,0.753 0 0 0 0.062,1.062 l 2.25,1.969 -2.25,1.969 a 0.753,0.753 0 0 0 -0.063,1.062 c 0.274,0.313 0.719,0.367 1.031,0.094 l 1.72,-1.5 v 4.875 c 0,0.277 0.222,0.5 0.5,0.5 0.282,0 0.437,-0.02 0.655,-0.188 l 3.532,-3.156 a 0.78,0.78 0 0 0 0.218,-0.375 0.745,0.745 0 0 0 0.032,-0.281 0.723,0.723 0 0 0 -0.032,-0.156 0.78,0.78 0 0 0 -0.218,-0.375 l -2.813,-2.47 2.813,-2.468 a 0.78,0.78 0 0 0 0.218,-0.375 0.712,0.712 0 0 0 0,-0.437 0.78,0.78 0 0 0 -0.218,-0.375 l -3.532,-3.157 c -0.199,-0.16 -0.427,-0.187 -0.656,-0.187 z m 0.5,2.063 2.094,1.875 -2.094,1.812 z m 0,6.187 2.094,1.813 -2.094,1.875 z"
+       overflow="visible"
+       style="overflow:visible;fill:#eeeeec;marker:none"
+       id="path6" />
+  </g>
+</svg>

--- a/elementary-xfce-dark/panel/16/blueberry-tray.svg
+++ b/elementary-xfce-dark/panel/16/blueberry-tray.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3201"
+   sodipodi:docname="blueberry-tray-active.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     id="namedview15"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-0.27118644"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3201">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3203">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:1;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="11.988697" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.487958,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="20.015596" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="16.498461"
+       x2="11.888327"
+       y2="20.015596" />
+  </defs>
+  <g
+     style="color:#bebebe;fill:#eeeeec"
+     transform="matrix(1.0152513,0,0,1,-277.28607,251)"
+     id="g4">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 280.5,-250 c -0.277,0 -0.5,0.223 -0.5,0.5 v 4.875 l -1.719,-1.5 c -0.312,-0.273 -0.757,-0.22 -1.03,0.094 a 0.753,0.753 0 0 0 0.062,1.062 l 2.25,1.969 -2.25,1.969 a 0.753,0.753 0 0 0 -0.063,1.062 c 0.274,0.313 0.719,0.367 1.031,0.094 l 1.72,-1.5 v 4.875 c 0,0.277 0.222,0.5 0.5,0.5 0.282,0 0.437,-0.02 0.655,-0.188 l 3.532,-3.156 a 0.78,0.78 0 0 0 0.218,-0.375 0.745,0.745 0 0 0 0.032,-0.281 0.723,0.723 0 0 0 -0.032,-0.156 0.78,0.78 0 0 0 -0.218,-0.375 l -2.813,-2.47 2.813,-2.468 a 0.78,0.78 0 0 0 0.218,-0.375 0.712,0.712 0 0 0 0,-0.437 0.78,0.78 0 0 0 -0.218,-0.375 l -3.532,-3.157 c -0.199,-0.16 -0.427,-0.187 -0.656,-0.187 z m 0.5,2.063 2.094,1.875 -2.094,1.812 z m 0,6.187 2.094,1.813 -2.094,1.875 z"
+       overflow="visible"
+       style="overflow:visible;fill:#eeeeec;marker:none"
+       id="path6" />
+  </g>
+</svg>

--- a/elementary-xfce/panel/16/blueberry-tray-active.svg
+++ b/elementary-xfce/panel/16/blueberry-tray-active.svg
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3201"
+   sodipodi:docname="blueberry-tray-active.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     id="namedview15"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-26.101695"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3201">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3203">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:1;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="11.988697" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.487958,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="20.015596" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="16.498461"
+       x2="11.888327"
+       y2="20.015596" />
+  </defs>
+  <g
+     transform="matrix(1.00507,0,0,1,-294.56663,251)"
+     id="g4-3"
+     style="color:#bebebe;fill:#666666;fill-opacity:1">
+    <path
+       d="m 309,-237 a 2,2 0 1 1 -4,0 2,2 0 1 1 4,0 z"
+       overflow="visible"
+       style="overflow:visible;isolation:auto;mix-blend-mode:normal;fill:#666666;marker:none;fill-opacity:1"
+       id="path6-6"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 300.5,-250 c -0.277,0 -0.5,0.223 -0.5,0.5 v 4.875 l -1.719,-1.5 c -0.312,-0.273 -0.757,-0.22 -1.03,0.094 a 0.753,0.753 0 0 0 0.062,1.062 l 2.25,1.969 -2.25,1.969 a 0.753,0.753 0 0 0 -0.063,1.062 c 0.274,0.313 0.719,0.367 1.031,0.094 l 1.72,-1.5 v 4.875 c 0,0.277 0.222,0.5 0.5,0.5 0.282,0 0.437,-0.02 0.655,-0.188 l 3.532,-3.156 a 0.78,0.78 0 0 0 0.218,-0.375 0.745,0.745 0 0 0 0.032,-0.281 0.723,0.723 0 0 0 -0.032,-0.156 0.78,0.78 0 0 0 -0.218,-0.375 l -2.813,-2.47 2.813,-2.468 a 0.78,0.78 0 0 0 0.218,-0.375 0.712,0.712 0 0 0 0,-0.437 0.78,0.78 0 0 0 -0.218,-0.375 l -3.532,-3.157 c -0.199,-0.16 -0.427,-0.187 -0.656,-0.187 z m 0.5,2.063 2.094,1.875 -2.094,1.812 z m 0,6.187 2.094,1.813 -2.094,1.875 z"
+       overflow="visible"
+       style="overflow:visible;fill:#666666;marker:none;fill-opacity:1"
+       id="path8"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/elementary-xfce/panel/16/blueberry-tray-disabled.svg
+++ b/elementary-xfce/panel/16/blueberry-tray-disabled.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3201"
+   sodipodi:docname="blueberry-tray-disabled.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     id="namedview15"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-25.627118"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3201">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3203">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:1;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="11.988697" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.487958,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="20.015596" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="16.498461"
+       x2="11.888327"
+       y2="20.015596" />
+  </defs>
+  <g
+     style="color:#bebebe;opacity:0.35;fill:#666666;fill-opacity:1"
+     transform="matrix(1.0152513,0,0,1,-277.28607,251)"
+     id="g4">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 280.5,-250 c -0.277,0 -0.5,0.223 -0.5,0.5 v 4.875 l -1.719,-1.5 c -0.312,-0.273 -0.757,-0.22 -1.03,0.094 a 0.753,0.753 0 0 0 0.062,1.062 l 2.25,1.969 -2.25,1.969 a 0.753,0.753 0 0 0 -0.063,1.062 c 0.274,0.313 0.719,0.367 1.031,0.094 l 1.72,-1.5 v 4.875 c 0,0.277 0.222,0.5 0.5,0.5 0.282,0 0.437,-0.02 0.655,-0.188 l 3.532,-3.156 a 0.78,0.78 0 0 0 0.218,-0.375 0.745,0.745 0 0 0 0.032,-0.281 0.723,0.723 0 0 0 -0.032,-0.156 0.78,0.78 0 0 0 -0.218,-0.375 l -2.813,-2.47 2.813,-2.468 a 0.78,0.78 0 0 0 0.218,-0.375 0.712,0.712 0 0 0 0,-0.437 0.78,0.78 0 0 0 -0.218,-0.375 l -3.532,-3.157 c -0.199,-0.16 -0.427,-0.187 -0.656,-0.187 z m 0.5,2.063 2.094,1.875 -2.094,1.812 z m 0,6.187 2.094,1.813 -2.094,1.875 z"
+       overflow="visible"
+       style="overflow:visible;fill:#666666;marker:none;fill-opacity:1"
+       id="path6" />
+  </g>
+</svg>

--- a/elementary-xfce/panel/16/blueberry-tray.svg
+++ b/elementary-xfce/panel/16/blueberry-tray.svg
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3201"
+   sodipodi:docname="blueberry-tray.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     id="namedview15"
+     showgrid="true"
+     inkscape:zoom="14.75"
+     inkscape:cx="-13.186441"
+     inkscape:cy="8"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3201">
+    <inkscape:grid
+       type="xygrid"
+       id="grid833" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata19">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3203">
+    <linearGradient
+       id="linearGradient3678">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3680" />
+      <stop
+         style="stop-color:#e6e6e6;stop-opacity:1;"
+         offset="1"
+         id="stop3682" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2857"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="11.988697" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2860"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.487958,-2.0355737)"
+       x1="11.888327"
+       y1="2.3846951"
+       x2="11.888327"
+       y2="20.015596" />
+    <linearGradient
+       xlink:href="#linearGradient3678"
+       id="linearGradient2863"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.87523954,0,0,0.85822383,-2.4875775,-2.0355737)"
+       x1="11.888327"
+       y1="16.498461"
+       x2="11.888327"
+       y2="20.015596" />
+  </defs>
+  <g
+     style="color:#bebebe;fill:#666666;fill-opacity:1"
+     transform="matrix(1.0152513,0,0,1,-277.28607,251)"
+     id="g4">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 280.5,-250 c -0.277,0 -0.5,0.223 -0.5,0.5 v 4.875 l -1.719,-1.5 c -0.312,-0.273 -0.757,-0.22 -1.03,0.094 a 0.753,0.753 0 0 0 0.062,1.062 l 2.25,1.969 -2.25,1.969 a 0.753,0.753 0 0 0 -0.063,1.062 c 0.274,0.313 0.719,0.367 1.031,0.094 l 1.72,-1.5 v 4.875 c 0,0.277 0.222,0.5 0.5,0.5 0.282,0 0.437,-0.02 0.655,-0.188 l 3.532,-3.156 a 0.78,0.78 0 0 0 0.218,-0.375 0.745,0.745 0 0 0 0.032,-0.281 0.723,0.723 0 0 0 -0.032,-0.156 0.78,0.78 0 0 0 -0.218,-0.375 l -2.813,-2.47 2.813,-2.468 a 0.78,0.78 0 0 0 0.218,-0.375 0.712,0.712 0 0 0 0,-0.437 0.78,0.78 0 0 0 -0.218,-0.375 l -3.532,-3.157 c -0.199,-0.16 -0.427,-0.187 -0.656,-0.187 z m 0.5,2.063 2.094,1.875 -2.094,1.812 z m 0,6.187 2.094,1.813 -2.094,1.875 z"
+       overflow="visible"
+       style="overflow:visible;fill:#666666;marker:none;fill-opacity:1"
+       id="path6" />
+  </g>
+</svg>


### PR DESCRIPTION
at 16px the blueberry tray icon looks too small and squashed because of the margin and shadow. 
The new icon is based on the symbolic icon already in this theme