### PR TITLE
Fix xfce4-terminal and blueman icons used in help dialogs

### DIFF
--- a/elementary-xfce-dark/apps/128/blueman.svg
+++ b/elementary-xfce-dark/apps/128/blueman.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/apps/128/blueman.svg

--- a/elementary-xfce-dark/apps/128/utilities-terminal.svg
+++ b/elementary-xfce-dark/apps/128/utilities-terminal.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/apps/128/utilities-terminal.svg

--- a/elementary-xfce/apps/128/blueman.svg
+++ b/elementary-xfce/apps/128/blueman.svg
@@ -1,0 +1,1 @@
+bluetooth.svg

--- a/elementary-xfce/apps/128/bluetooth.svg
+++ b/elementary-xfce/apps/128/bluetooth.svg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg4103"
+   sodipodi:docname="bluetooth.svg"
+   inkscape:version="0.92.4 (5da689c313, 2019-01-14)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1019"
+     id="namedview30"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="3.2796268"
+     inkscape:cx="31.627635"
+     inkscape:cy="29.830508"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4103">
+    <sodipodi:guide
+       position="231.05085,-37.423729"
+       orientation="0,1"
+       id="guide844"
+       inkscape:locked="false" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid846" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4105">
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 64 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="128 : 64 : 1"
+       inkscape:persp3d-origin="64 : 42.666667 : 1"
+       id="perspective842" />
+    <radialGradient
+       cx="27"
+       cy="45.047001"
+       r="17.625"
+       id="radialGradient3904"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91545,0,6.5816e-6,0.20922,-0.71745,35.213)">
+      <stop
+         id="stop8694"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8696"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       cx="27"
+       cy="45.047001"
+       r="17.625"
+       id="radialGradient4099"
+       xlink:href="#radialGradient3904"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9686719,0,1.4153707e-5,0.65887591,10.42515,85.947299)" />
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         id="stop943"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop945"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="43.432285"
+       x2="27.583231"
+       y1="7.4575353"
+       x1="27.583231"
+       gradientTransform="matrix(2.7643163,0,0,2.9952559,-12.672823,-11.146544)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1295"
+       xlink:href="#linearGradient954" />
+    <linearGradient
+       id="linearGradient954">
+      <stop
+         id="stop946"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop948"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.33333334" />
+      <stop
+         id="stop950"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.73809522" />
+      <stop
+         id="stop952"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.5219455,0,0,2.5375851,124.10663,4.164209)"
+       gradientUnits="userSpaceOnUse"
+       y2="46.525425"
+       x2="-24"
+       y1="2"
+       x1="-24"
+       id="linearGradient880-3"
+       xlink:href="#linearGradient947" />
+  </defs>
+  <metadata
+     id="metadata4108">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g859"
+     transform="matrix(0.91668081,0,0,0.91668081,4.7497033,2.581533)">
+    <path
+       inkscape:connector-curvature="0"
+       d="m 102.28887,115.38919 a 38.708936,11.612681 0 0 1 -77.417871,0 38.708936,11.612681 0 1 1 77.417871,0 z"
+       id="path3361"
+       style="opacity:0.4;fill:url(#radialGradient4099);stroke-width:1.93544662" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#linearGradient880-3);fill-opacity:1;stroke-width:1.93544686"
+       d="m 49.805909,121.02993 c -13.35715,-3.75124 -21.46096,-13.08823 -25.51826,-29.401479 -2.20428,-8.862778 -3.06357,-32.612144 -1.57945,-43.653167 3.34764,-24.904441 13.55984,-36.941811 33.48777,-39.4728694 5.56845,-0.7072509 9.27603,-0.7088302 14.8073,-0.00639 20.08243,2.5506784 30.199501,14.7291094 33.605041,40.4520914 1.17781,8.896316 0.4678,33.069446 -1.18719,40.419305 -3.69731,16.419889 -10.687121,25.938699 -22.414871,30.524819 -6.17425,2.41443 -24.30061,3.07535 -31.20034,1.1376 z"
+       id="path855-0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:1.93544686"
+       d="m 49.810569,121.0278 c -13.35028,-3.75128 -21.44993,-13.08841 -25.50515,-29.401845 -2.20314,-8.862914 -3.06199,-32.612592 -1.57863,-43.653763 3.34592,-24.904771 13.55287,-36.942305 33.47056,-39.4733947 5.56559,-0.7072625 9.27125,-0.7088419 14.79969,-0.00639 20.0721,2.5507107 30.183971,14.7293067 33.587761,40.4526297 1.1772,8.896433 0.46756,33.069893 -1.18658,40.419848 -3.69541,16.420105 -10.681631,25.939025 -22.403351,30.525225 -6.17106,2.41445 -24.28811,3.07539 -31.1843,1.13762 z"
+       id="path855-3-63" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1295);stroke-width:1.93544662;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="path855-3-6-0"
+       d="m 70.729829,10.421698 c -5.41061,-0.6924445 -8.77697,-0.6923865 -14.22593,0.0048 -9.55546,1.222972 -16.38303,4.608502 -21.42295,10.595142 -5.03992,5.986644 -8.33896,14.812745 -9.97991,27.114347 -1.40693,10.547157 -0.45786,35.10393 1.53233,43.167446 3.93342,15.936757 11.21744,24.308157 23.82524,27.876177 2.83423,0.80208 9.11727,1.20475 15.15522,0.98231 6.03797,-0.22242 12.16409,-1.11383 14.55218,-2.05486 10.97935,-4.32648 17.324091,-12.90286 20.928661,-29.03392 1.42991,-6.399129 2.23638,-31.70401 1.15171,-39.959828 C 100.5742,36.3859 97.2762,27.306686 92.231869,21.18716 87.187539,15.067637 80.360039,11.654159 70.729829,10.421611 Z" />
+    <g
+       transform="matrix(1.9354467,0,0,1.9354467,21.307569,-10.405354)"
+       id="g842">
+      <g
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.3888889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="layer1-4-1-2"
+         transform="matrix(2.5714286,0,0,2.5714286,0.6842857,19.428572)">
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.3888889;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect6885-0-7"
+           d="m 7.5097742,1 c -0.277,0 -0.4422236,0.2230174 -0.4453298,0.5 v 4.875 l -1.7734202,-1.5 c -0.31288,-0.27345 -0.75785,-0.21912 -1.03125,0.09375 -0.2734,0.31288 -0.25038,0.78909 0.0625,1.0625 l 2.25,1.96875 -2.25,1.96875 c -0.31288,0.273401 -0.3359,0.749622 -0.0625,1.0625 0.2734,0.312878 0.71837,0.367151 1.03125,0.09375 l 1.7734202,-1.5 V 14.5 c 0,0.277 0.1683298,0.5 0.4453298,0.5 0.28242,0 0.4375,-0.01953 0.65625,-0.1875 l 3.5312498,-3.15625 c 0.11231,-0.09991 0.18145,-0.24072 0.21875,-0.375 0.0142,-0.05132 0.0283,-0.10335 0.0312,-0.15625 0.004,-0.042 0.003,-0.083 0,-0.125 -0.006,-0.05361 -0.0136,-0.10455 -0.0312,-0.15625 -0.0385,-0.13396 -0.10556,-0.2761 -0.21875,-0.375 L 8.8847742,8 11.697274,5.53125 c 0.11319,-0.098907 0.18028,-0.2410493 0.21875,-0.375 0.0176,-0.051747 0.0254,-0.102645 0.0312,-0.15625 0.003,-0.041989 0.004,-0.083009 0,-0.125 -0.003,-0.052913 -0.017,-0.1049375 -0.0312,-0.15625 -0.0373,-0.1342859 -0.10644,-0.2750953 -0.21875,-0.375 L 8.1660242,1.1875 C 7.9667342,1.0265176 7.7385742,1 7.5097742,1 Z M 7.8422222,2.9444435 10.103524,4.9375 7.8422222,6.8333323 Z m 0,6.2222221 2.2613018,1.8958344 -2.2613018,1.993054 z" />
+      </g>
+      <g
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.3886719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         id="layer1-4-1-2-5"
+         transform="matrix(2.5728642,0,0,2.5728642,1.6684039,18.411506)">
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.3886719;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="path3499"
+           d="m 7.5097656,0.2265625 c -0.3462601,0 -0.7031901,0.16787958 -0.9160156,0.41992188 C 6.3809245,0.89852667 6.2942683,1.2021411 6.2910156,1.4921875 a 0.77422636,0.77422636 0 0 0 0,0.00781 V 4.7070287 L 5.8007812,4.2929688 C 5.1758032,3.7467522 4.1957771,3.8661533 3.6777344,4.4589844 3.1340658,5.0811608 3.1783982,6.0591718 3.8125,6.6132812 L 5.3964844,8 3.8125,9.3867188 C 3.1783763,9.9408291 3.134057,10.918833 3.6777344,11.541016 c 0.5180697,0.592877 1.4980854,0.712119 2.1230468,0.166015 L 6.2910156,11.292969 V 14.5 c 0,0.295298 0.088534,0.603088 0.3027344,0.855469 0.2142005,0.25238 0.5697717,0.417969 0.9160156,0.417969 0.3181095,0 0.7910133,-0.0897 1.1269532,-0.347657 a 0.77422636,0.77422636 0 0 0 0.044922,-0.03516 l 3.5292972,-3.15625 c 0.264304,-0.235123 0.385197,-0.508585 0.451171,-0.746094 0.01436,-0.0519 0.04653,-0.156353 0.05664,-0.310547 0.0069,-0.09053 0.0043,-0.172447 0,-0.232422 a 0.77422636,0.77422636 0 0 0 -0.002,-0.03125 c -0.0074,-0.06587 -0.02558,-0.173879 -0.0625,-0.292968 -0.06471,-0.222105 -0.175011,-0.496492 -0.447266,-0.7343752 L 10.056641,8 12.207031,6.1132812 c 0.272187,-0.2378402 0.382543,-0.5120683 0.447266,-0.734375 0.03654,-0.1178211 0.055,-0.2255822 0.0625,-0.2949218 a 0.77422636,0.77422636 0 0 0 0.002,-0.029297 c 0.0043,-0.059994 0.0069,-0.1418696 0,-0.2324219 C 12.70849,4.66988 12.676713,4.5644913 12.662109,4.5117188 12.596135,4.2742012 12.475258,4.0007499 12.210938,3.765625 L 8.6816406,0.609375 A 0.77422636,0.77422636 0 0 0 8.6523438,0.5859375 C 8.2607006,0.26957617 7.7983808,0.2265625 7.5097656,0.2265625 Z M 8.6152344,4.6582031 8.9160156,4.921875 8.6152344,5.1738281 Z m 0,6.1679689 0.3007812,0.251953 -0.3007812,0.263672 z" />
+      </g>
+      <g
+         style="fill:#ffffff;stroke-width:0.5"
+         id="layer1-4-1"
+         transform="matrix(2.5714286,0,0,2.5714286,0.6842857,18.428573)">
+        <path
+           inkscape:connector-curvature="0"
+           style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.91155374;marker:none;enable-background:accumulate"
+           id="rect6885-0"
+           d="m 7.5097742,1 c -0.277,0 -0.4422236,0.2230174 -0.4453298,0.5 v 4.875 l -1.7734202,-1.5 c -0.31288,-0.27345 -0.75785,-0.21912 -1.03125,0.09375 -0.2734,0.31288 -0.25038,0.78909 0.0625,1.0625 l 2.25,1.96875 -2.25,1.96875 c -0.31288,0.273401 -0.3359,0.749622 -0.0625,1.0625 0.2734,0.312878 0.71837,0.367151 1.03125,0.09375 l 1.7734202,-1.5 V 14.5 c 0,0.277 0.1683298,0.5 0.4453298,0.5 0.28242,0 0.4375,-0.01953 0.65625,-0.1875 l 3.5312498,-3.15625 c 0.11231,-0.09991 0.18145,-0.24072 0.21875,-0.375 0.0142,-0.05132 0.0283,-0.10335 0.0312,-0.15625 0.004,-0.042 0.003,-0.083 0,-0.125 -0.006,-0.05361 -0.0136,-0.10455 -0.0312,-0.15625 -0.0385,-0.13396 -0.10556,-0.2761 -0.21875,-0.375 L 8.8847742,8 11.697274,5.53125 c 0.11319,-0.098907 0.18028,-0.2410493 0.21875,-0.375 0.0176,-0.051747 0.0254,-0.102645 0.0312,-0.15625 0.003,-0.041989 0.004,-0.083009 0,-0.125 -0.003,-0.052913 -0.017,-0.1049375 -0.0312,-0.15625 -0.0373,-0.1342859 -0.10644,-0.2750953 -0.21875,-0.375 L 8.1660242,1.1875 C 7.9667342,1.0265176 7.7385742,1 7.5097742,1 Z M 7.8422222,2.9444435 10.103524,4.9375 7.8422222,6.8333323 Z m 0,6.2222221 2.2613018,1.8958344 -2.2613018,1.993054 z" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Because of missing 128px icons in Dark and Darker, they don't scale right in help dialogs.