### PR TITLE
Add symbolic links for xfce 4.16 icon names (#220)

### DIFF
--- a/elementary-xfce-darker/actions/16/xfsm-lock.svg
+++ b/elementary-xfce-darker/actions/16/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce-darker/actions/16/xfsm-reboot.svg
+++ b/elementary-xfce-darker/actions/16/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce-darker/actions/16/xfsm-shutdown.svg
+++ b/elementary-xfce-darker/actions/16/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce-darker/actions/22/xfsm-lock.svg
+++ b/elementary-xfce-darker/actions/22/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce-darker/actions/22/xfsm-reboot.svg
+++ b/elementary-xfce-darker/actions/22/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce-darker/actions/22/xfsm-shutdown.svg
+++ b/elementary-xfce-darker/actions/22/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce-darker/actions/24/xfsm-lock.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce-darker/actions/24/xfsm-reboot.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce-darker/actions/24/xfsm-shutdown.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce-darker/apps/16/org.xfce.about.svg
+++ b/elementary-xfce-darker/apps/16/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/16/help-about.svg

--- a/elementary-xfce-darker/apps/16/org.xfce.appfinder.svg
+++ b/elementary-xfce-darker/apps/16/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/16/edit-find.svg

--- a/elementary-xfce-darker/apps/16/org.xfce.panel.actions.svg
+++ b/elementary-xfce-darker/apps/16/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/16/system-log-out.svg

--- a/elementary-xfce-darker/apps/22/org.xfce.about.svg
+++ b/elementary-xfce-darker/apps/22/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/22/help-about.svg

--- a/elementary-xfce-darker/apps/22/org.xfce.appfinder.svg
+++ b/elementary-xfce-darker/apps/22/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/22/edit-find.svg

--- a/elementary-xfce-darker/apps/22/org.xfce.panel.actions.svg
+++ b/elementary-xfce-darker/apps/22/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/22/system-log-out.svg

--- a/elementary-xfce-darker/apps/24/org.xfce.about.svg
+++ b/elementary-xfce-darker/apps/24/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/24/help-about.svg

--- a/elementary-xfce-darker/apps/24/org.xfce.appfinder.svg
+++ b/elementary-xfce-darker/apps/24/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/24/edit-find.svg

--- a/elementary-xfce-darker/apps/24/org.xfce.panel.actions.svg
+++ b/elementary-xfce-darker/apps/24/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/24/system-log-out.svg

--- a/elementary-xfce/actions/16/xfsm-lock.svg
+++ b/elementary-xfce/actions/16/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce/actions/16/xfsm-reboot.svg
+++ b/elementary-xfce/actions/16/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce/actions/16/xfsm-shutdown.svg
+++ b/elementary-xfce/actions/16/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce/actions/16/xfsm-switch-user.svg
+++ b/elementary-xfce/actions/16/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../apps/16/system-users.svg

--- a/elementary-xfce/actions/22/xfsm-lock.svg
+++ b/elementary-xfce/actions/22/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce/actions/22/xfsm-reboot.svg
+++ b/elementary-xfce/actions/22/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce/actions/22/xfsm-shutdown.svg
+++ b/elementary-xfce/actions/22/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce/actions/22/xfsm-switch-user.svg
+++ b/elementary-xfce/actions/22/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../apps/22/system-users.svg

--- a/elementary-xfce/actions/24/xfsm-lock.svg
+++ b/elementary-xfce/actions/24/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce/actions/24/xfsm-reboot.svg
+++ b/elementary-xfce/actions/24/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce/actions/24/xfsm-shutdown.svg
+++ b/elementary-xfce/actions/24/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce/actions/24/xfsm-switch-user.svg
+++ b/elementary-xfce/actions/24/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../apps/24/system-users.svg

--- a/elementary-xfce/actions/32/xfsm-lock.svg
+++ b/elementary-xfce/actions/32/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce/actions/32/xfsm-reboot.svg
+++ b/elementary-xfce/actions/32/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce/actions/32/xfsm-shutdown.svg
+++ b/elementary-xfce/actions/32/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce/actions/32/xfsm-switch-user.svg
+++ b/elementary-xfce/actions/32/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../apps/32/system-users.svg

--- a/elementary-xfce/actions/48/xfsm-lock.svg
+++ b/elementary-xfce/actions/48/xfsm-lock.svg
@@ -1,0 +1,1 @@
+system-lock-screen.svg

--- a/elementary-xfce/actions/48/xfsm-reboot.svg
+++ b/elementary-xfce/actions/48/xfsm-reboot.svg
@@ -1,0 +1,1 @@
+system-reboot.svg

--- a/elementary-xfce/actions/48/xfsm-shutdown.svg
+++ b/elementary-xfce/actions/48/xfsm-shutdown.svg
@@ -1,0 +1,1 @@
+system-shutdown.svg

--- a/elementary-xfce/actions/48/xfsm-switch-user.svg
+++ b/elementary-xfce/actions/48/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../apps/48/system-users.svg

--- a/elementary-xfce/actions/64/xfsm-switch-user.svg
+++ b/elementary-xfce/actions/64/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../apps/64/system-users.svg

--- a/elementary-xfce/apps/128/org.xfce.about.svg
+++ b/elementary-xfce/apps/128/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/128/help-about.svg

--- a/elementary-xfce/apps/128/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/128/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/128/edit-find.svg

--- a/elementary-xfce/apps/128/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/128/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/128/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/128/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/128/org.xfce.genmon.svg
+++ b/elementary-xfce/apps/128/org.xfce.genmon.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/128/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/128/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/128/gtk-network.svg

--- a/elementary-xfce/apps/128/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/128/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/128/system-log-out.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+x-office-calendar.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/128/folder.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/128/application-x-executable.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/128/user-desktop.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/128/org.xfce.parole.svg
+++ b/elementary-xfce/apps/128/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/128/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/128/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/128/org.xfce.ristretto.png
+++ b/elementary-xfce/apps/128/org.xfce.ristretto.png
@@ -1,0 +1,1 @@
+ristretto.png

--- a/elementary-xfce/apps/128/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/128/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/128/org.xfce.session.svg
+++ b/elementary-xfce/apps/128/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/128/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/128/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/128/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/128/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/128/video-display.svg

--- a/elementary-xfce/apps/128/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/128/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/128/preferences-system.svg

--- a/elementary-xfce/apps/128/org.xfce.settings.manager.svg
+++ b/elementary-xfce/apps/128/org.xfce.settings.manager.svg
@@ -1,0 +1,1 @@
+../../categories/128/preferences-desktop.svg

--- a/elementary-xfce/apps/128/org.xfce.settings.mouse.svg
+++ b/elementary-xfce/apps/128/org.xfce.settings.mouse.svg
@@ -1,0 +1,1 @@
+preferences-desktop-peripherals.svg

--- a/elementary-xfce/apps/128/org.xfce.taskmanager.svg
+++ b/elementary-xfce/apps/128/org.xfce.taskmanager.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/128/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/128/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/128/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/128/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/128/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/128/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/128/org.xfce.webbrowser.svg
+++ b/elementary-xfce/apps/128/org.xfce.webbrowser.svg
@@ -1,0 +1,1 @@
+web-browser.svg

--- a/elementary-xfce/apps/128/org.xfce.xfdesktop.svg
+++ b/elementary-xfce/apps/128/org.xfce.xfdesktop.svg
@@ -1,0 +1,1 @@
+preferences-desktop-wallpaper.svg

--- a/elementary-xfce/apps/128/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/128/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/128/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/128/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/16/org.xfce.Dictionary.svg
+++ b/elementary-xfce/apps/16/org.xfce.Dictionary.svg
@@ -1,0 +1,1 @@
+xfce4-dict.svg

--- a/elementary-xfce/apps/16/org.xfce.ScreenSaver.svg
+++ b/elementary-xfce/apps/16/org.xfce.ScreenSaver.svg
@@ -1,0 +1,1 @@
+preferences-desktop-screensaver.svg

--- a/elementary-xfce/apps/16/org.xfce.about.svg
+++ b/elementary-xfce/apps/16/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/16/help-about.svg

--- a/elementary-xfce/apps/16/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/16/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/16/edit-find.svg

--- a/elementary-xfce/apps/16/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/16/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/16/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/16/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/16/org.xfce.genmon.svg
+++ b/elementary-xfce/apps/16/org.xfce.genmon.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/16/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/16/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/16/gtk-network.svg

--- a/elementary-xfce/apps/16/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/16/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/16/org.xfce.notification.svg
+++ b/elementary-xfce/apps/16/org.xfce.notification.svg
@@ -1,0 +1,1 @@
+xfce4-notifyd.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/16/system-log-out.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+x-office-calendar.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/16/folder.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/16/application-x-executable.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.pager.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.pager.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/16/user-desktop.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.svg
@@ -1,0 +1,1 @@
+xfce4-panel.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/16/org.xfce.parole.svg
+++ b/elementary-xfce/apps/16/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/16/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/16/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/16/org.xfce.ristretto.png
+++ b/elementary-xfce/apps/16/org.xfce.ristretto.png
@@ -1,0 +1,1 @@
+ristretto.png

--- a/elementary-xfce/apps/16/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/16/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/16/org.xfce.session.svg
+++ b/elementary-xfce/apps/16/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.appearance.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.appearance.svg
@@ -1,0 +1,1 @@
+preferences-desktop-theme.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.default-applications.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.default-applications.svg
@@ -1,0 +1,1 @@
+preferences-desktop-default-applications.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/16/video-display.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/16/preferences-system.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.keyboard.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.keyboard.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.manager.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.manager.svg
@@ -1,0 +1,1 @@
+../../categories/16/preferences-desktop.svg

--- a/elementary-xfce/apps/16/org.xfce.settings.mouse.svg
+++ b/elementary-xfce/apps/16/org.xfce.settings.mouse.svg
@@ -1,0 +1,1 @@
+preferences-desktop-peripherals.svg

--- a/elementary-xfce/apps/16/org.xfce.taskmanager.svg
+++ b/elementary-xfce/apps/16/org.xfce.taskmanager.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/16/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/16/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/16/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/16/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/16/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/16/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/16/org.xfce.thunar.svg
+++ b/elementary-xfce/apps/16/org.xfce.thunar.svg
@@ -1,0 +1,1 @@
+Thunar.svg

--- a/elementary-xfce/apps/16/org.xfce.volman.svg
+++ b/elementary-xfce/apps/16/org.xfce.volman.svg
@@ -1,0 +1,1 @@
+../../devices/16/drive-removable-media.svg

--- a/elementary-xfce/apps/16/org.xfce.webbrowser.svg
+++ b/elementary-xfce/apps/16/org.xfce.webbrowser.svg
@@ -1,0 +1,1 @@
+web-browser.svg

--- a/elementary-xfce/apps/16/org.xfce.workspaces.svg
+++ b/elementary-xfce/apps/16/org.xfce.workspaces.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/16/org.xfce.xfdesktop.svg
+++ b/elementary-xfce/apps/16/org.xfce.xfdesktop.svg
@@ -1,0 +1,1 @@
+preferences-desktop-wallpaper.svg

--- a/elementary-xfce/apps/16/org.xfce.xfmpc.svg
+++ b/elementary-xfce/apps/16/org.xfce.xfmpc.svg
@@ -1,0 +1,1 @@
+../../devices/16/multimedia-player.svg

--- a/elementary-xfce/apps/16/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/16/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/16/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/16/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/22/org.xfce.about.svg
+++ b/elementary-xfce/apps/22/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/22/help-about.svg

--- a/elementary-xfce/apps/22/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/22/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/22/edit-find.svg

--- a/elementary-xfce/apps/22/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/22/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/22/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/22/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/22/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/22/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/22/gtk-network.svg

--- a/elementary-xfce/apps/22/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/22/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/22/system-log-out.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+../../mimes/22/x-office-calendar.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/22/folder.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/22/application-x-executable.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/22/user-desktop.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/22/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/22/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/22/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/22/org.xfce.session.svg
+++ b/elementary-xfce/apps/22/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/22/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/22/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/22/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/22/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/22/video-display.svg

--- a/elementary-xfce/apps/22/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/22/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/22/preferences-system.svg

--- a/elementary-xfce/apps/22/org.xfce.settings.keyboard.svg
+++ b/elementary-xfce/apps/22/org.xfce.settings.keyboard.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard.svg

--- a/elementary-xfce/apps/22/org.xfce.settings.mouse.svg
+++ b/elementary-xfce/apps/22/org.xfce.settings.mouse.svg
@@ -1,0 +1,1 @@
+preferences-desktop-peripherals.svg

--- a/elementary-xfce/apps/22/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/22/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/22/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/22/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/22/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/22/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/22/org.xfce.volman.svg
+++ b/elementary-xfce/apps/22/org.xfce.volman.svg
@@ -1,0 +1,1 @@
+../../devices/22/drive-removable-media.svg

--- a/elementary-xfce/apps/22/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/22/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/22/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/22/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/24/org.xfce.ScreenSaver.svg
+++ b/elementary-xfce/apps/24/org.xfce.ScreenSaver.svg
@@ -1,0 +1,1 @@
+preferences-desktop-screensaver.svg

--- a/elementary-xfce/apps/24/org.xfce.about.svg
+++ b/elementary-xfce/apps/24/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/24/help-about.svg

--- a/elementary-xfce/apps/24/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/24/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/24/edit-find.svg

--- a/elementary-xfce/apps/24/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/24/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/24/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/24/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/24/org.xfce.genmon.svg
+++ b/elementary-xfce/apps/24/org.xfce.genmon.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/24/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/24/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/24/gtk-network.svg

--- a/elementary-xfce/apps/24/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/24/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/24/system-log-out.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+x-office-calendar.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/24/folder.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/24/application-x-executable.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.pager.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.pager.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/24/user-desktop.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/24/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/24/org.xfce.parole.svg
+++ b/elementary-xfce/apps/24/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/24/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/24/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/24/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/24/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/24/org.xfce.session.svg
+++ b/elementary-xfce/apps/24/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.appearance.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.appearance.svg
@@ -1,0 +1,1 @@
+preferences-desktop-theme.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.default-applications.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.default-applications.svg
@@ -1,0 +1,1 @@
+preferences-desktop-default-applications.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/24/video-display.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/24/preferences-system.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.keyboard.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.keyboard.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.manager.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.manager.svg
@@ -1,0 +1,1 @@
+../../categories/24/preferences-desktop.svg

--- a/elementary-xfce/apps/24/org.xfce.settings.mouse.svg
+++ b/elementary-xfce/apps/24/org.xfce.settings.mouse.svg
@@ -1,0 +1,1 @@
+preferences-desktop-peripherals.svg

--- a/elementary-xfce/apps/24/org.xfce.taskmanager.svg
+++ b/elementary-xfce/apps/24/org.xfce.taskmanager.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/24/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/24/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/24/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/24/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/24/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/24/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/24/org.xfce.thunar.svg
+++ b/elementary-xfce/apps/24/org.xfce.thunar.svg
@@ -1,0 +1,1 @@
+Thunar.svg

--- a/elementary-xfce/apps/24/org.xfce.volman.svg
+++ b/elementary-xfce/apps/24/org.xfce.volman.svg
@@ -1,0 +1,1 @@
+../../devices/24/drive-removable-media.svg

--- a/elementary-xfce/apps/24/org.xfce.webbrowser.svg
+++ b/elementary-xfce/apps/24/org.xfce.webbrowser.svg
@@ -1,0 +1,1 @@
+web-browser.svg

--- a/elementary-xfce/apps/24/org.xfce.workspaces.svg
+++ b/elementary-xfce/apps/24/org.xfce.workspaces.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/24/org.xfce.xfdesktop.svg
+++ b/elementary-xfce/apps/24/org.xfce.xfdesktop.svg
@@ -1,0 +1,1 @@
+preferences-desktop-wallpaper.svg

--- a/elementary-xfce/apps/24/org.xfce.xfmpc.svg
+++ b/elementary-xfce/apps/24/org.xfce.xfmpc.svg
@@ -1,0 +1,1 @@
+../../devices/24/multimedia-player.svg

--- a/elementary-xfce/apps/24/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/24/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/24/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/24/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/32/org.xfce.Dictionary.svg
+++ b/elementary-xfce/apps/32/org.xfce.Dictionary.svg
@@ -1,0 +1,1 @@
+xfce4-dict.svg

--- a/elementary-xfce/apps/32/org.xfce.ScreenSaver.svg
+++ b/elementary-xfce/apps/32/org.xfce.ScreenSaver.svg
@@ -1,0 +1,1 @@
+preferences-desktop-screensaver.svg

--- a/elementary-xfce/apps/32/org.xfce.about.svg
+++ b/elementary-xfce/apps/32/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/32/help-about.svg

--- a/elementary-xfce/apps/32/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/32/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/32/edit-find.svg

--- a/elementary-xfce/apps/32/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/32/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/32/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/32/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/32/org.xfce.genmon.svg
+++ b/elementary-xfce/apps/32/org.xfce.genmon.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/32/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/32/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/32/gtk-network.svg

--- a/elementary-xfce/apps/32/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/32/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/32/system-log-out.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+x-office-calendar.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/32/folder.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/32/application-x-executable.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.pager.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.pager.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/32/user-desktop.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.svg
@@ -1,0 +1,1 @@
+xfce4-panel.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/32/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/32/org.xfce.parole.svg
+++ b/elementary-xfce/apps/32/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/32/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/32/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/32/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/32/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/32/org.xfce.session.svg
+++ b/elementary-xfce/apps/32/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.color.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.color.svg
@@ -1,0 +1,1 @@
+xfce4-color-settings.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/32/video-display.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/32/preferences-system.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.keyboard.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.keyboard.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.manager.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.manager.svg
@@ -1,0 +1,1 @@
+../../categories/32/preferences-desktop.svg

--- a/elementary-xfce/apps/32/org.xfce.settings.mouse.svg
+++ b/elementary-xfce/apps/32/org.xfce.settings.mouse.svg
@@ -1,0 +1,1 @@
+preferences-desktop-peripherals.svg

--- a/elementary-xfce/apps/32/org.xfce.taskmanager.svg
+++ b/elementary-xfce/apps/32/org.xfce.taskmanager.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/32/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/32/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/32/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/32/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/32/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/32/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/32/org.xfce.thunar.svg
+++ b/elementary-xfce/apps/32/org.xfce.thunar.svg
@@ -1,0 +1,1 @@
+Thunar.svg

--- a/elementary-xfce/apps/32/org.xfce.volman.svg
+++ b/elementary-xfce/apps/32/org.xfce.volman.svg
@@ -1,0 +1,1 @@
+../../devices/32/drive-removable-media.svg

--- a/elementary-xfce/apps/32/org.xfce.workspaces.svg
+++ b/elementary-xfce/apps/32/org.xfce.workspaces.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/32/org.xfce.xfdesktop.svg
+++ b/elementary-xfce/apps/32/org.xfce.xfdesktop.svg
@@ -1,0 +1,1 @@
+preferences-desktop-wallpaper.svg

--- a/elementary-xfce/apps/32/org.xfce.xfmpc.svg
+++ b/elementary-xfce/apps/32/org.xfce.xfmpc.svg
@@ -1,0 +1,1 @@
+../../devices/32/multimedia-player.svg

--- a/elementary-xfce/apps/32/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/32/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/32/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/32/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/32/preferences-system-windows.svg
+++ b/elementary-xfce/apps/32/preferences-system-windows.svg
@@ -1,0 +1,422 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="32px"
+   height="32px"
+   id="svg3351"
+   version="1.1">
+  <defs
+     id="defs3353">
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3189"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
+       x1="16.626165"
+       y1="15.298182"
+       x2="20.054544"
+       y2="24.627615" />
+    <linearGradient
+       id="linearGradient8265-821-176-38-919-66-249-7-7">
+      <stop
+         id="stop2687-1-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2689-5-4"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient3192"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         id="stop3926"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop3928" />
+      <stop
+         id="stop3930"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.95056331" />
+      <stop
+         id="stop3932"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8"
+       id="radialGradient3195"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
+       cx="7.4956832"
+       cy="8.4497671"
+       fx="7.4956832"
+       fy="8.4497671"
+       r="19.99999" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1;"
+         id="stop3750-4" />
+      <stop
+         offset="0.26238"
+         style="stop-color:#55c1ec;stop-opacity:1;"
+         id="stop3752-8" />
+      <stop
+         offset="0.704952"
+         style="stop-color:#3689e6;stop-opacity:1;"
+         id="stop3754-1" />
+      <stop
+         offset="1"
+         style="stop-color:#2b63a0;stop-opacity:1;"
+         id="stop3756-0" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-324-0"
+       id="linearGradient3197"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-0">
+      <stop
+         offset="0"
+         style="stop-color:#185f9a;stop-opacity:1;"
+         id="stop3760-4" />
+      <stop
+         offset="1"
+         style="stop-color:#599ec9;stop-opacity:1;"
+         id="stop3762-4" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3163"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3165"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3167"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient3370-4"
+       gradientUnits="userSpaceOnUse"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403"
+       gradientTransform="matrix(0.6111111,0,0,0.61111111,30.139303,1.7222223)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-1-9-274-0">
+      <stop
+         offset="0"
+         style="stop-color:#365a7c;stop-opacity:1"
+         id="stop3776-3" />
+      <stop
+         offset="1"
+         style="stop-color:#5ea1ca;stop-opacity:1;"
+         id="stop3778-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient136"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55000001,0,0,0.54999992,28.525373,3.0500002)"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403" />
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient138"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59090903,0,0,0.59090902,29.71734,2.2727278)"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403" />
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient194"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59090903,0,0,0.59090902,29.71734,2.2727278)"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403" />
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient196"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55000001,0,0,0.54999992,28.525373,3.0500002)"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403" />
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.59090903,0,0,0.59090902,29.71734,2.2727278)"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403" />
+    <linearGradient
+       xlink:href="#linearGradient3707-319-631-407-1-9-274-0"
+       id="linearGradient243"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55000001,0,0,0.54999992,28.525373,3.0500002)"
+       x1="19.874987"
+       y1="44.520065"
+       x2="19.874987"
+       y2="5.2502403" />
+  </defs>
+  <metadata
+     id="metadata3356">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <g
+       style="display:inline"
+       id="g2036"
+       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
+      <g
+         style="opacity:0.4"
+         id="g3712"
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+        <rect
+           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
+           id="rect2801"
+           y="40"
+           x="38"
+           height="7"
+           width="5" />
+        <rect
+           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
+           id="rect3696"
+           transform="scale(-1,-1)"
+           y="-47"
+           x="-10"
+           height="7"
+           width="5" />
+        <rect
+           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
+           id="rect3700"
+           y="40"
+           x="10"
+           height="7.0000005"
+           width="28" />
+      </g>
+    </g>
+    <rect
+       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="rect5505"
+       y="4.5"
+       x="3.5"
+       ry="2"
+       rx="2"
+       height="25"
+       width="25" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect6741-7"
+       y="5.5"
+       x="4.5"
+       ry="1"
+       rx="1"
+       height="23"
+       width="23" />
+    <path
+       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path3333"
+       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:url(#linearGradient3370-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.61111;marker:none;enable-background:accumulate"
+       id="rect3038-4-1-1"
+       width="14.666667"
+       height="14.666667"
+       x="5"
+       y="6"
+       ry="0.86200625"
+       rx="0.86200625" />
+    <g
+       id="g149">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient138);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.590908;marker:none;enable-background:accumulate"
+         id="rect3038-4-1"
+         width="13"
+         height="13"
+         x="6"
+         y="7"
+         ry="0.76405084"
+         rx="0.7640509" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:url(#linearGradient136);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.549999;marker:none;enable-background:accumulate"
+         id="rect3038-4"
+         width="11"
+         height="11"
+         x="7"
+         y="8"
+         ry="0.64650464"
+         rx="0.6465047" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.521249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect3038"
+         width="9.000001"
+         height="8.999999"
+         x="8"
+         y="9"
+         ry="0.52895826"
+         rx="0.52895832" />
+    </g>
+    <g
+       id="g149-7-9"
+       transform="translate(3.5,3.5)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient241);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.590908;marker:none;enable-background:accumulate"
+         id="rect3038-4-1-5-1"
+         width="13"
+         height="13"
+         x="6"
+         y="7"
+         ry="0.76405084"
+         rx="0.7640509" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:url(#linearGradient243);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.549999;marker:none;enable-background:accumulate"
+         id="rect3038-4-3-2"
+         width="11"
+         height="11"
+         x="7"
+         y="8"
+         ry="0.64650464"
+         rx="0.6465047" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.521249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect3038-5-7"
+         width="9.000001"
+         height="8.999999"
+         x="8"
+         y="9"
+         ry="0.52895826"
+         rx="0.52895832" />
+    </g>
+    <g
+       id="g149-7"
+       transform="translate(7,7)">
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient194);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.590908;marker:none;enable-background:accumulate"
+         id="rect3038-4-1-5"
+         width="13"
+         height="13"
+         x="6"
+         y="7"
+         ry="0.76405084"
+         rx="0.7640509" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:url(#linearGradient196);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.549999;marker:none;enable-background:accumulate"
+         id="rect3038-4-3"
+         width="11"
+         height="11"
+         x="7"
+         y="8"
+         ry="0.64650464"
+         rx="0.6465047" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.521249;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+         id="rect3038-5"
+         width="9.000001"
+         height="8.999999"
+         x="8"
+         y="9"
+         ry="0.52895826"
+         rx="0.52895832" />
+    </g>
+  </g>
+</svg>

--- a/elementary-xfce/apps/32/xfce4-panel.svg
+++ b/elementary-xfce/apps/32/xfce4-panel.svg
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg1325">
+  <metadata
+     id="metadata51">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1327">
+    <linearGradient
+       id="linearGradient3958">
+      <stop
+         id="stop3960"
+         style="stop-color:white;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3962"
+         style="stop-color:black;stop-opacity:1"
+         offset="0.51514298" />
+      <stop
+         id="stop3964"
+         style="stop-color:black;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2270">
+      <stop
+         id="stop2272"
+         style="stop-color:white;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2274"
+         style="stop-color:white;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="31.669502"
+       y1="17"
+       x2="31.653906"
+       y2="47"
+       id="linearGradient2268"
+       xlink:href="#linearGradient2181"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-8)" />
+    <linearGradient
+       x1="23.99696"
+       y1="18.375"
+       x2="23.787659"
+       y2="46"
+       id="linearGradient1341"
+       xlink:href="#linearGradient2270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-8)" />
+    <linearGradient
+       id="linearGradient2181">
+      <stop
+         id="stop2183"
+         style="stop-color:#f0f0f0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2185"
+         style="stop-color:#d3d3d3;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="9.5"
+       cy="24"
+       r="5.5"
+       fx="9.5"
+       fy="24"
+       id="radialGradient3890"
+       xlink:href="#linearGradient2181"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5177196,1.0726872e-7,-1.6705603e-7,2.3636362,-4.9183319,-32.727271)" />
+    <linearGradient
+       x1="9.5"
+       y1="12"
+       x2="9.5"
+       y2="36"
+       id="linearGradient3898"
+       xlink:href="#linearGradient2270"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3976"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3972">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3974"
+         style="fill:url(#linearGradient3976);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3982"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3978">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3980"
+         style="fill:url(#linearGradient3982);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3984">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3986"
+         style="fill:url(#linearGradient3988);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3994"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3990">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3992"
+         style="fill:url(#linearGradient3994);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient4000"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3996">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3998"
+         style="fill:url(#linearGradient4000);fill-opacity:1;stroke:none" />
+    </mask>
+  </defs>
+  <g
+     id="g48"
+     transform="matrix(0.6666595,0,0,0.6666668,-0.33331717,-3.0420059e-6)">
+    <rect
+       style="fill:url(#linearGradient2268);fill-opacity:1;stroke:#969696;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect1333"
+       mask="url(#mask3996)"
+       y="9.5"
+       x="2.5"
+       height="29"
+       width="46" />
+    <rect
+       style="opacity:0.8;fill:none;stroke:url(#linearGradient1341);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect2210"
+       mask="url(#mask3990)"
+       y="10.5"
+       x="3.5"
+       height="27"
+       width="45" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3890);fill-opacity:1;fill-rule:nonzero;stroke:#969696;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect1337"
+       mask="url(#mask3984)"
+       y="11.5"
+       x="4.5"
+       ry="1.625"
+       rx="1.625"
+       height="25"
+       width="10" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:url(#linearGradient3898);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect2212"
+       mask="url(#mask3978)"
+       y="12.5"
+       x="5.5"
+       ry="0.5625"
+       rx="0.5625"
+       height="23"
+       width="8" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path2214"
+       mask="url(#mask3972)"
+       d="M 8,23.5 11,21 v 5 z" />
+    <path
+       id="path1881"
+       d="m 23.244768,31.499084 c -0.0286,-0.08162 0.04173,-0.46111 0.156279,-0.843318 0.22649,-0.755679 0.261925,-1.036342 0.140919,-1.116132 -0.04303,-0.02836 -0.305728,0.02731 -0.583795,0.12372 -0.580038,0.201114 -0.760985,0.16348 -0.75159,-0.15632 0.0069,-0.234784 0.22012,-0.544407 0.730132,-1.060222 l 0.298566,-0.301962 0.04481,-1.481648 c 0.03989,-1.31912 0.07191,-1.55334 0.291901,-2.135226 0.1359,-0.359467 0.373216,-0.84574 0.527369,-1.080608 0.154153,-0.234867 0.28154,-0.469997 0.283082,-0.522512 0.0015,-0.05251 -0.296721,-0.39722 -0.662808,-0.766013 -1.189915,-1.198705 -3.114717,-2.495805 -5.310079,-3.578395 -1.424454,-0.702436 -2.413263,-1.26143 -2.501589,-1.414203 -0.08918,-0.154249 0.111125,-0.08903 0.858816,0.279633 0.403045,0.198728 1.409345,0.606689 2.236221,0.906579 2.213385,0.802743 3.363184,1.483828 5.058618,2.996476 0.476388,0.42503 0.912523,0.80335 0.969187,0.840713 0.05667,0.03737 0.377589,-0.06048 0.713166,-0.21743 0.769311,-0.359806 1.107066,-0.348046 3.535889,0.123118 1.250015,0.242488 2.033964,0.34679 2.583189,0.343687 l 0.788531,-0.0044 0.42795,-0.725912 c 0.393578,-0.66761 0.42103,-0.754 0.341796,-1.075619 -0.204642,-0.83066 -0.0022,-1.769871 0.427596,-1.983905 0.487593,-0.242812 0.822354,0.04779 1.408775,1.22293 0.214367,0.429575 0.441779,0.763936 0.521168,0.766268 0.16675,0.0049 0.165131,-0.09627 -0.01357,-0.847856 -0.184906,-0.777668 -0.07709,-1.420022 0.297657,-1.773379 0.231636,-0.218417 0.331262,-0.25211 0.580667,-0.196384 0.580238,0.129646 0.821202,0.686008 0.906133,2.092159 0.0244,0.403869 0.08245,0.759427 0.129011,0.79013 0.04656,0.03071 0.579605,0.171474 1.184539,0.312826 3.008937,0.703085 4.222975,1.513571 4.185358,2.794129 -0.0085,0.289067 -0.08802,0.407075 -0.54384,0.806964 -0.53503,0.469382 -1.823734,1.195979 -3.477081,1.960448 -1.2504,0.578155 -1.298648,0.839291 -0.365539,1.978435 0.550936,0.672587 0.708029,1.001472 0.574838,1.203466 -0.08763,0.132892 -0.428961,0.07663 -1.474431,-0.243022 -1.061492,-0.324551 -1.171497,-0.241907 -0.625859,0.470193 0.706659,0.922238 0.83902,1.434204 0.402959,1.558635 -0.210947,0.0602 -0.988387,-0.225253 -2.432279,-0.893048 l -1.070143,-0.494935 -0.570196,0.09493 c -0.313609,0.05222 -1.59217,0.08581 -2.841247,0.07467 -2.171096,-0.01938 -2.325853,-0.0328 -3.516295,-0.304845 -1.197177,-0.273595 -1.253659,-0.27839 -1.463204,-0.124207 -0.119877,0.08821 -0.670269,0.518417 -1.223091,0.956026 -0.552823,0.437611 -1.032436,0.795242 -1.065808,0.794737 -0.03337,-4.71e-4 -0.08408,-0.06769 -0.112677,-0.149312 z m 16.374641,-6.046482 c 0.243393,-0.244201 0.188432,-0.553439 -0.07465,-0.420038 -0.302566,0.153422 -0.824417,0.723801 -0.761609,0.832435 0.07201,0.124544 0.522541,-0.09764 0.836261,-0.412397 z m -0.653943,-0.625671 c 0.259274,-0.10262 0.473123,-0.245029 0.475222,-0.316458 0.0051,-0.176797 -0.113762,-0.16726 -0.611296,0.04901 -0.874937,0.380317 -0.753264,0.61946 0.136074,0.26745 z m -0.905562,-1.517956 c 0.0014,-0.04775 -0.12345,-0.11841 -0.277452,-0.157007 -0.154003,-0.03859 -0.35789,-0.175409 -0.45308,-0.304026 -0.313822,-0.424012 -0.392325,-0.273663 -0.112957,0.216342 0.146392,0.256773 0.236623,0.313768 0.509423,0.32178 0.182336,0.0054 0.332666,-0.02933 0.33407,-0.07709 z m 0.387481,-0.957598 c 0.04917,-0.435826 -0.193863,-0.628259 -0.521436,-0.41287 -0.394247,0.259225 -0.217943,0.82062 0.245036,0.780255 0.19894,-0.01735 0.243603,-0.07671 0.2764,-0.367385 z m 3.918278,-0.929279 c 0.0036,-0.220453 0.57091,-1.325971 0.75362,-1.468758 0.282284,-0.220605 0.251432,0.01176 -0.08113,0.611039 -0.431919,0.778323 -0.676355,1.090088 -0.672488,0.857719 z m -0.64777,-0.472425 c 0.01194,-0.341347 0.121247,-0.652554 0.228116,-0.649414 0.05709,0.0016 0.06431,0.140496 0.01843,0.35456 -0.09147,0.426829 -0.258125,0.626143 -0.246546,0.294854 z M 15.311241,16.780107 c 0.0035,-0.120866 0.07034,-0.118905 0.141487,0.0042 0.03054,0.05281 0.01062,0.09472 -0.04437,0.0931 -0.05494,-0.0016 -0.09864,-0.04538 -0.09712,-0.09725 z"
+       style="fill:#030000;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/32/xfwm4.svg
+++ b/elementary-xfce/apps/32/xfwm4.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/48/org.xfce.Dictionary.svg
+++ b/elementary-xfce/apps/48/org.xfce.Dictionary.svg
@@ -1,0 +1,1 @@
+xfce4-dict.svg

--- a/elementary-xfce/apps/48/org.xfce.ScreenSaver.svg
+++ b/elementary-xfce/apps/48/org.xfce.ScreenSaver.svg
@@ -1,0 +1,1 @@
+preferences-desktop-screensaver.svg

--- a/elementary-xfce/apps/48/org.xfce.about.svg
+++ b/elementary-xfce/apps/48/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/48/help-about.svg

--- a/elementary-xfce/apps/48/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/48/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/48/edit-find.svg

--- a/elementary-xfce/apps/48/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/48/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/48/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/48/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/48/org.xfce.genmon.svg
+++ b/elementary-xfce/apps/48/org.xfce.genmon.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/48/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/48/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/48/gtk-network.svg

--- a/elementary-xfce/apps/48/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/48/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/48/org.xfce.notification.svg
+++ b/elementary-xfce/apps/48/org.xfce.notification.svg
@@ -1,0 +1,1 @@
+xfce4-notifyd.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/48/system-log-out.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.applicationsmenu.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.applicationsmenu.svg
@@ -1,0 +1,1 @@
+xfce4-panel-menu.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+x-office-calendar.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/48/folder.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/48/application-x-executable.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.pager.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.pager.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/48/user-desktop.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.svg
@@ -1,0 +1,1 @@
+xfce4-panel.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/48/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/48/org.xfce.parole.svg
+++ b/elementary-xfce/apps/48/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/48/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/48/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/48/org.xfce.ristretto.png
+++ b/elementary-xfce/apps/48/org.xfce.ristretto.png
@@ -1,0 +1,1 @@
+ristretto.png

--- a/elementary-xfce/apps/48/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/48/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/48/org.xfce.session.svg
+++ b/elementary-xfce/apps/48/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.appearance.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.appearance.svg
@@ -1,0 +1,1 @@
+preferences-desktop-theme.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.color.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.color.svg
@@ -1,0 +1,1 @@
+xfce4-color-settings.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.default-applications.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.default-applications.svg
@@ -1,0 +1,1 @@
+preferences-desktop-default-applications.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/48/video-display.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/48/preferences-system.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.keyboard.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.keyboard.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.manager.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.manager.svg
@@ -1,0 +1,1 @@
+../../categories/48/preferences-desktop.svg

--- a/elementary-xfce/apps/48/org.xfce.settings.mouse.svg
+++ b/elementary-xfce/apps/48/org.xfce.settings.mouse.svg
@@ -1,0 +1,1 @@
+preferences-desktop-peripherals.svg

--- a/elementary-xfce/apps/48/org.xfce.taskmanager.svg
+++ b/elementary-xfce/apps/48/org.xfce.taskmanager.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/48/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/48/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/48/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/48/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/48/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/48/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/48/org.xfce.thunar.svg
+++ b/elementary-xfce/apps/48/org.xfce.thunar.svg
@@ -1,0 +1,1 @@
+Thunar.svg

--- a/elementary-xfce/apps/48/org.xfce.volman.svg
+++ b/elementary-xfce/apps/48/org.xfce.volman.svg
@@ -1,0 +1,1 @@
+../../devices/48/drive-removable-media.svg

--- a/elementary-xfce/apps/48/org.xfce.webbrowser.svg
+++ b/elementary-xfce/apps/48/org.xfce.webbrowser.svg
@@ -1,0 +1,1 @@
+web-browser.svg

--- a/elementary-xfce/apps/48/org.xfce.workspaces.svg
+++ b/elementary-xfce/apps/48/org.xfce.workspaces.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/48/org.xfce.xfdesktop.svg
+++ b/elementary-xfce/apps/48/org.xfce.xfdesktop.svg
@@ -1,0 +1,1 @@
+preferences-desktop-wallpaper.svg

--- a/elementary-xfce/apps/48/org.xfce.xfmpc.svg
+++ b/elementary-xfce/apps/48/org.xfce.xfmpc.svg
@@ -1,0 +1,1 @@
+../../devices/48/multimedia-player.svg

--- a/elementary-xfce/apps/48/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/48/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/48/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/48/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/64/org.xfce.Dictionary.svg
+++ b/elementary-xfce/apps/64/org.xfce.Dictionary.svg
@@ -1,0 +1,1 @@
+xfce4-dict.svg

--- a/elementary-xfce/apps/64/org.xfce.ScreenSaver.svg
+++ b/elementary-xfce/apps/64/org.xfce.ScreenSaver.svg
@@ -1,0 +1,1 @@
+preferences-desktop-screensaver.svg

--- a/elementary-xfce/apps/64/org.xfce.about.svg
+++ b/elementary-xfce/apps/64/org.xfce.about.svg
@@ -1,0 +1,1 @@
+../../actions/64/help-about.svg

--- a/elementary-xfce/apps/64/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/64/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/64/edit-find.svg

--- a/elementary-xfce/apps/64/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/64/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/64/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/64/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/64/org.xfce.genmon.svg
+++ b/elementary-xfce/apps/64/org.xfce.genmon.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/64/org.xfce.gigolo.svg
+++ b/elementary-xfce/apps/64/org.xfce.gigolo.svg
@@ -1,0 +1,1 @@
+../../places/64/gtk-network.svg

--- a/elementary-xfce/apps/64/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/64/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/64/org.xfce.notification.svg
+++ b/elementary-xfce/apps/64/org.xfce.notification.svg
@@ -1,0 +1,1 @@
+xfce4-notifyd.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.actions.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.actions.svg
@@ -1,0 +1,1 @@
+../../actions/64/system-log-out.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.clock.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.clock.svg
@@ -1,0 +1,1 @@
+x-office-calendar.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.directorymenu.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.directorymenu.svg
@@ -1,0 +1,1 @@
+../../places/64/folder.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/64/application-x-executable.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.pager.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.pager.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.showdesktop.svg
@@ -1,0 +1,1 @@
+../../places/64/user-desktop.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.svg
@@ -1,0 +1,1 @@
+xfce4-panel.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.tasklist.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.tasklist.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/64/org.xfce.panel.windowmenu.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.windowmenu.svg
@@ -1,0 +1,1 @@
+preferences-system-windows.svg

--- a/elementary-xfce/apps/64/org.xfce.parole.svg
+++ b/elementary-xfce/apps/64/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/64/org.xfce.powermanager.svg
+++ b/elementary-xfce/apps/64/org.xfce.powermanager.svg
@@ -1,0 +1,1 @@
+xfce4-power-manager-settings.svg

--- a/elementary-xfce/apps/64/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/64/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/64/org.xfce.session.svg
+++ b/elementary-xfce/apps/64/org.xfce.session.svg
@@ -1,0 +1,1 @@
+xfce4-session.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.appearance.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.appearance.svg
@@ -1,0 +1,1 @@
+preferences-desktop-theme.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.default-applications.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.default-applications.svg
@@ -1,0 +1,1 @@
+preferences-desktop-default-applications.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.display.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.display.svg
@@ -1,0 +1,1 @@
+../../devices/64/video-display.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.editor.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.editor.svg
@@ -1,0 +1,1 @@
+../../categories/64/preferences-system.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.keyboard.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.keyboard.svg
@@ -1,0 +1,1 @@
+preferences-desktop-keyboard.svg

--- a/elementary-xfce/apps/64/org.xfce.settings.manager.svg
+++ b/elementary-xfce/apps/64/org.xfce.settings.manager.svg
@@ -1,0 +1,1 @@
+../../categories/64/preferences-desktop.svg

--- a/elementary-xfce/apps/64/org.xfce.taskmanager.svg
+++ b/elementary-xfce/apps/64/org.xfce.taskmanager.svg
@@ -1,0 +1,1 @@
+utilities-system-monitor.svg

--- a/elementary-xfce/apps/64/org.xfce.terminal-settings.svg
+++ b/elementary-xfce/apps/64/org.xfce.terminal-settings.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/64/org.xfce.terminal.svg
+++ b/elementary-xfce/apps/64/org.xfce.terminal.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/64/org.xfce.terminalemulator.svg
+++ b/elementary-xfce/apps/64/org.xfce.terminalemulator.svg
@@ -1,0 +1,1 @@
+utilities-terminal.svg

--- a/elementary-xfce/apps/64/org.xfce.thunar.svg
+++ b/elementary-xfce/apps/64/org.xfce.thunar.svg
@@ -1,0 +1,1 @@
+Thunar.svg

--- a/elementary-xfce/apps/64/org.xfce.webbrowser.svg
+++ b/elementary-xfce/apps/64/org.xfce.webbrowser.svg
@@ -1,0 +1,1 @@
+web-browser.svg

--- a/elementary-xfce/apps/64/org.xfce.workspaces.svg
+++ b/elementary-xfce/apps/64/org.xfce.workspaces.svg
@@ -1,0 +1,1 @@
+xfce4-workspaces.svg

--- a/elementary-xfce/apps/64/org.xfce.xfdesktop.svg
+++ b/elementary-xfce/apps/64/org.xfce.xfdesktop.svg
@@ -1,0 +1,1 @@
+preferences-desktop-wallpaper.svg

--- a/elementary-xfce/apps/64/org.xfce.xfmpc.svg
+++ b/elementary-xfce/apps/64/org.xfce.xfmpc.svg
@@ -1,0 +1,1 @@
+../../devices/64/multimedia-player.svg

--- a/elementary-xfce/apps/64/org.xfce.xfwm4-tweaks.svg
+++ b/elementary-xfce/apps/64/org.xfce.xfwm4-tweaks.svg
@@ -1,0 +1,1 @@
+wmtweaks.svg

--- a/elementary-xfce/apps/64/org.xfce.xfwm4.svg
+++ b/elementary-xfce/apps/64/org.xfce.xfwm4.svg
@@ -1,0 +1,1 @@
+xfwm4.svg

--- a/elementary-xfce/apps/96/org.xfce.Dictionary.svg
+++ b/elementary-xfce/apps/96/org.xfce.Dictionary.svg
@@ -1,0 +1,1 @@
+xfce4-dict.svg

--- a/elementary-xfce/apps/96/org.xfce.appfinder.svg
+++ b/elementary-xfce/apps/96/org.xfce.appfinder.svg
@@ -1,0 +1,1 @@
+../../actions/96/edit-find.svg

--- a/elementary-xfce/apps/96/org.xfce.catfish.svg
+++ b/elementary-xfce/apps/96/org.xfce.catfish.svg
@@ -1,0 +1,1 @@
+catfish.svg

--- a/elementary-xfce/apps/96/org.xfce.filemanager.svg
+++ b/elementary-xfce/apps/96/org.xfce.filemanager.svg
@@ -1,0 +1,1 @@
+system-file-manager.svg

--- a/elementary-xfce/apps/96/org.xfce.mousepad.svg
+++ b/elementary-xfce/apps/96/org.xfce.mousepad.svg
@@ -1,0 +1,1 @@
+accessories-text-editor.svg

--- a/elementary-xfce/apps/96/org.xfce.panel.launcher.svg
+++ b/elementary-xfce/apps/96/org.xfce.panel.launcher.svg
@@ -1,0 +1,1 @@
+../../mimes/96/application-x-executable.svg

--- a/elementary-xfce/apps/96/org.xfce.parole.svg
+++ b/elementary-xfce/apps/96/org.xfce.parole.svg
@@ -1,0 +1,1 @@
+parole.svg

--- a/elementary-xfce/apps/96/org.xfce.screenshooter.svg
+++ b/elementary-xfce/apps/96/org.xfce.screenshooter.svg
@@ -1,0 +1,1 @@
+applets-screenshooter.svg

--- a/elementary-xfce/apps/96/org.xfce.settings.accessibility.svg
+++ b/elementary-xfce/apps/96/org.xfce.settings.accessibility.svg
@@ -1,0 +1,1 @@
+preferences-desktop-accessibility.svg

--- a/elementary-xfce/apps/96/org.xfce.thunar.svg
+++ b/elementary-xfce/apps/96/org.xfce.thunar.svg
@@ -1,0 +1,1 @@
+Thunar.svg

--- a/elementary-xfce/apps/96/org.xfce.webbrowser.svg
+++ b/elementary-xfce/apps/96/org.xfce.webbrowser.svg
@@ -1,0 +1,1 @@
+web-browser.svg

--- a/elementary-xfce/apps/symbolic/org.xfce.panel.separator.svg
+++ b/elementary-xfce/apps/symbolic/org.xfce.panel.separator.svg
@@ -1,0 +1,1 @@
+../../actions/symbolic/list-remove-symbolic.svg

--- a/elementary-xfce/devices/32/drive-removable-media.svg
+++ b/elementary-xfce/devices/32/drive-removable-media.svg
@@ -1,0 +1,209 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3786"
+   height="32"
+   width="32"
+   version="1.0">
+  <metadata
+     id="metadata39">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3788">
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient2857"
+       gradientUnits="userSpaceOnUse"
+       cy="42"
+       cx="24"
+       gradientTransform="matrix(0.90476,1.019e-7,-2.6817e-8,0.2381,2.2857,30)"
+       r="21">
+      <stop
+         id="stop6312"
+         style="stop-color:#fff"
+         offset="0" />
+      <stop
+         id="stop6314"
+         style="stop-color:#fff;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient2862"
+       gradientUnits="userSpaceOnUse"
+       cy="12.595"
+       cx="14.237"
+       gradientTransform="matrix(1.1924,0.61996,-0.49419,0.95053,3.4847,-5.4343)"
+       r="23">
+      <stop
+         id="stop7064"
+         style="stop-color:#f0f0f1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#ddddde"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient2864"
+       y2="12.883"
+       gradientUnits="userSpaceOnUse"
+       x2="11.218"
+       gradientTransform="matrix(0.99778,0,0,1.0331,0.053179,-1.3449)"
+       y1="24.049999"
+       x1="17.740999">
+      <stop
+         id="stop3486"
+         style="stop-color:#aaa"
+         offset="0" />
+      <stop
+         id="stop3488"
+         style="stop-color:#c8c8c8"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2868"
+       y2="40.703999"
+       gradientUnits="userSpaceOnUse"
+       x2="28.375"
+       gradientTransform="matrix(1.0002,0,0,0.62554,-5.0044,11.538)"
+       y1="50.296001"
+       x1="28.438">
+      <stop
+         id="stop2223"
+         style="stop-color:#aaa"
+         offset="0" />
+      <stop
+         id="stop2219"
+         style="stop-color:#646464"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient2871"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       cy="486.64999"
+       cx="605.71002"
+       gradientTransform="matrix(-0.044847,0,0,0.020588,32.611,32.451)"
+       r="117.14" />
+    <radialGradient
+       id="radialGradient2874"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       cy="486.64999"
+       cx="605.71002"
+       gradientTransform="matrix(0.044847,0,0,0.020588,15.389,32.451)"
+       r="117.14" />
+    <linearGradient
+       id="linearGradient2877"
+       y2="609.51001"
+       gradientUnits="userSpaceOnUse"
+       x2="302.85999"
+       gradientTransform="matrix(0.076357,0,0,0.020588,-3.5974,32.451)"
+       y1="366.64999"
+       x1="302.85999">
+      <stop
+         id="stop5050"
+         style="stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         offset=".5" />
+      <stop
+         id="stop5052"
+         style="stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g52"
+     transform="scale(0.66666667)">
+    <rect
+       id="rect2723"
+       style="opacity:0.3;fill:url(#linearGradient2877)"
+       height="5"
+       width="36.868999"
+       y="40"
+       x="5.5653" />
+    <path
+       id="path2725"
+       style="opacity:0.3;fill:url(#radialGradient2874)"
+       d="m 42.417,40 v 4.9997 c 2.309,0.009 5.583,-1.12 5.583,-2.5 0,-1.38 -2.577,-2.5 -5.583,-2.5 z" />
+    <path
+       id="path2727"
+       style="opacity:0.3;fill:url(#radialGradient2871)"
+       d="m 5.5833,40 v 4.9997 C 3.2738,45.0087 0,43.8797 0,42.4997 c 0,-1.38 2.5773,-2.5 5.5833,-2.5 z" />
+    <path
+       id="rect6431"
+       style="fill:url(#linearGradient2868);fill-rule:evenodd;stroke:#59595b;stroke-width:0.99986;stroke-linecap:round;stroke-linejoin:round;enable-background:new"
+       d="m 1.4999,37.5 h 45 l -0.89977,5.0001 H 2.49913 L 1.49935,37.5 Z" />
+    <rect
+       id="rect6381"
+       style="fill:#d2d2d3;fill-rule:evenodd;enable-background:new"
+       height="1"
+       width="45"
+       y="37"
+       x="1.5" />
+    <path
+       id="path6345"
+       style="fill:url(#radialGradient2862);stroke:url(#linearGradient2864);stroke-linecap:round;stroke-linejoin:round"
+       d="m 46.5,37.5 -6.795,-27 C 39.545,9.8609 38.659,9.5 38,9.5 H 10 c -0.8098,0 -2.0302,0.2114 -2.214,1 L 1.5,37.474" />
+    <path
+       id="path7046"
+       style="opacity:0.4;fill:none;stroke:#ffffff;stroke-width:0.97705;stroke-linecap:round"
+       d="M 45.511,37.511 2.489,37.489" />
+    <rect
+       id="rect6298"
+       style="opacity:0.5;fill:#ffffff"
+       rx="1"
+       height="2.5"
+       width="40"
+       y="39"
+       x="4" />
+    <rect
+       id="rect6300"
+       style="opacity:0.3;fill:url(#radialGradient2857)"
+       height="4"
+       width="42"
+       y="38"
+       x="3" />
+    <rect
+       id="rect6287"
+       style="fill:#282828"
+       rx="1"
+       height="2"
+       width="40"
+       y="39"
+       x="4" />
+    <path
+       id="path6292"
+       style="fill:none;stroke:#adadad;stroke-width:0.5;stroke-linecap:round"
+       d="M 45.5,33.75 2.5,33.726" />
+    <path
+       id="path6294"
+       style="opacity:0.5;fill:none;stroke:#ffffff;stroke-width:0.47745;stroke-linecap:round"
+       d="M 44.861,34.261 3.039,34.239" />
+  </g>
+</svg>


### PR DESCRIPTION
Uses https://gist.github.com/bluesabre/582d886a02c793285f4e3081df9b2a3c to generate symbolic links for all of the new Xfce 4.16 icons. Closes #220 