### PR TITLE
Update removable USB device icon (Fixes #213)

### DIFF
--- a/elementary-xfce/devices/128/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/128/drive-removable-media-usb.svg
@@ -1,0 +1,253 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg11300"
+   height="128"
+   width="128"
+   version="1.0"
+   viewBox="0 0 128 128">
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03153139" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.01900466"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(1.2482815,0,0,0.28244155,34.872276,104.84673)"
+       r="22.627001">
+      <stop
+         id="stop23421"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.4795045,0,0,2.1356709,46.78552,-3.8194946)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7339903,0,0,3.0819181,-118.98873,-4.5238907)"
+       x1="118.57409"
+       y1="3.7037382"
+       x2="118.79462"
+       y2="32.292839" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.769231,0,0,3.1538457,-122.7077,3.1651316)"
+       x1="116.83477"
+       y1="-38.101143"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.5999998,0,0,2.6000002,1.6000049,-2.7999916)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     d="m 92.245596,116.60691 a 28.245597,6.3908297 0 1 1 -56.491192,0 28.245597,6.3908297 0 1 1 56.491192,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1.00000012;stroke-opacity:0.29302326"
+     transform="scale(1,-1)"
+     rx="1.0000001"
+     ry="1.0000001"
+     height="39"
+     width="39"
+     y="-118.5"
+     x="44.5" />
+  <path
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 45,95 H 83"
+     id="path4538" />
+  <path
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441861"
+     d="m 50.5,103.5 v 7 h 9 v -7 z"
+     id="rect3450" />
+  <rect
+     id="rect3458"
+     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="37"
+     width="37"
+     y="-117.5"
+     x="45.5" />
+  <rect
+     ry="2.5"
+     id="rect5391"
+     style="opacity:1;fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="2.5000002"
+     height="90"
+     width="54"
+     y="5"
+     x="37" />
+  <rect
+     ry="3"
+     id="rect5391-2"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99992198;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="2.9999998"
+     height="91.000076"
+     width="55.000076"
+     y="4.4999609"
+     x="36.499962" />
+  <rect
+     rx="2.0000002"
+     id="rect5391-2-0"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     ry="2"
+     height="89"
+     width="53"
+     y="5.5"
+     x="37.5" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke-width:1"
+     d="M 63.751369,16.001953 59.132228,24 h 3.294922 v 40.880859 l -8.410156,-7.958984 c -0.543003,-0.677435 -0.924212,-1.56479 -0.945312,-2.476563 0,-3.688487 5.5e-5,-5.879274 -0.002,-6.685546 C 54.626806,47.213247 55.74937,45.745219 55.74937,44 c 0,-2.207818 -1.791383,-3.998047 -4,-3.998047 -2.209577,0 -4,1.790069 -4,3.998047 0,1.745219 1.123888,3.213247 2.679688,3.759766 l -0.002,6.607422 c 0,1.790615 0.983061,3.667104 2.134766,4.861328 v 0.002 c 0.02845,0.02526 8.921875,8.445312 8.921875,8.445312 0.542204,0.675996 0.92162,1.561522 0.943359,2.472657 v 7.029296 A 5,5 0 0 0 58.749416,82 a 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -3.681641,-4.818359 v -6.953125 c 0,-0.01164 6.39e-4,-0.02334 0,-0.03516 V 60.144531 c 0.02317,-0.909374 0.40247,-1.795346 0.945313,-2.470703 0,0 8.893103,-8.417303 8.921875,-8.443359 1.151544,-1.194222 2.134766,-3.072347 2.134765,-4.863281 L 77.067775,38 h 2.681641 v -8 h -8 v 8 h 2.677734 c 0,0 -0.002,1.677211 -0.002,6.445312 -0.02093,0.911933 -0.402309,1.799448 -0.945312,2.476563 l -8.41211,7.960937 V 24 h 3.300782 z"
+     id="path4696" />
+  <path
+     id="path1334"
+     d="M 63.751369,15.001953 59.132228,23 h 3.294922 v 40.880859 l -8.410156,-7.958984 c -0.543003,-0.677435 -0.924212,-1.56479 -0.945312,-2.476563 0,-3.688487 5.5e-5,-5.879274 -0.002,-6.685546 C 54.626806,46.213247 55.74937,44.745219 55.74937,43 c 0,-2.207818 -1.791383,-3.998047 -4,-3.998047 -2.209577,0 -4,1.790069 -4,3.998047 0,1.745219 1.123888,3.213247 2.679688,3.759766 l -0.002,6.607422 c 0,1.790615 0.983061,3.667104 2.134766,4.861328 v 0.002 c 0.02845,0.02526 8.921875,8.445312 8.921875,8.445312 0.542204,0.675996 0.92162,1.561522 0.943359,2.472657 v 7.029296 A 5,5 0 0 0 58.749416,81 a 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -3.681641,-4.818359 v -6.953125 c 0,-0.01164 6.39e-4,-0.02334 0,-0.03516 V 59.144531 c 0.02317,-0.909374 0.40247,-1.795346 0.945313,-2.470703 0,0 8.893103,-8.417303 8.921875,-8.443359 1.151544,-1.194222 2.134766,-3.072347 2.134765,-4.863281 L 77.067775,37 h 2.681641 v -8 h -8 v 8 h 2.677734 c 0,0 -0.002,1.677211 -0.002,6.445312 -0.02093,0.911933 -0.402309,1.799448 -0.945312,2.476563 l -8.41211,7.960937 V 23 h 3.300782 z"
+     style="fill:#aaaaaa;fill-opacity:1;stroke-width:1" />
+  <path
+     id="path4655"
+     d="m 68.5,103.5 v 7 h 9 v -7 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441861" />
+  <path
+     id="path4661"
+     d="M 50,111.5 H 60"
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 68,111.5 H 78"
+     id="path4663" />
+  <rect
+     rx="0.5"
+     ry="0.5"
+     y="99"
+     x="54"
+     height="1"
+     width="2"
+     id="rect4665"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     rx="0.5"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4667"
+     width="2"
+     height="1"
+     x="72"
+     y="99"
+     ry="0.5" />
+  <rect
+     rx="0.5"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4669"
+     width="2"
+     height="1"
+     x="54"
+     y="100"
+     ry="0.5" />
+  <rect
+     ry="0.5"
+     y="100"
+     x="72"
+     height="1"
+     width="2"
+     id="rect4671"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="0.5" />
+</svg>

--- a/elementary-xfce/devices/16/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/16/drive-removable-media-usb.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg11300"
    height="16"
    width="16"
@@ -17,124 +18,161 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient8579"
-       y2="1.25"
-       gradientUnits="userSpaceOnUse"
-       x2="15"
-       gradientTransform="matrix(.33333 0 0 .38235 6.796e-7 -.073530)"
-       y1="36"
-       x1="15">
+       id="linearGradient4614">
       <stop
-         id="stop3823"
-         style="stop-color:gray"
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3825"
-         style="stop-color:#999"
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient8838"
-       y2="35.875"
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730-2"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.163584,0,0,0.38091181,-9.2630881,0.26108203)"
+       x1="118.57409"
+       y1="4.5651455"
+       x2="118.57409"
+       y2="30.817942" />
+    <linearGradient
+       gradientTransform="matrix(0.28675946,0,0,0.301894,6.098381,-0.80358462)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3-0"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14345115,0,0,0.25571722,-7.138462,21.283658)"
+       x1="116.7913"
+       y1="-36.30439"
+       x2="116.7913"
+       y2="-28.483252" />
+    <linearGradient
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763-1"
+       x1="25"
+       y1="-35"
        x2="25"
-       gradientTransform="matrix(.33333 0 0 .38235 6.796e-7 -.073530)"
-       y1="1.125"
-       x1="25">
-      <stop
-         id="stop3145"
-         style="stop-color:#e6e6e6"
-         offset="0" />
-      <stop
-         id="stop3147"
-         style="stop-color:#afafaf"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       id="radialGradient9547"
+       y2="-44.395805"
        gradientUnits="userSpaceOnUse"
-       cy="-36.857"
-       cx="21.333"
-       gradientTransform="matrix(.55152 -1.3105e-7 1.0589e-7 .51140 -4.3596 5.7351)"
-       r="8">
-      <stop
-         id="stop9129"
-         style="stop-color:#f0f0f0"
-         offset="0" />
-      <stop
-         id="stop9131"
-         style="stop-color:#a9a9a9"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient9571"
-       y2="-39.143"
-       gradientUnits="userSpaceOnUse"
-       x2="32.571"
-       gradientTransform="matrix(.29697 0 0 .31818 .87272 -1.3408)"
-       y1="-39.143"
-       x1="15.429">
-      <stop
-         id="stop9575"
-         style="stop-color:#8f8f8f"
-         offset="0" />
-      <stop
-         id="stop9577"
-         style="stop-color:#5f5f5f"
-         offset=".12709" />
-      <stop
-         id="stop9579"
-         style="stop-color:#616161"
-         offset=".87578" />
-      <stop
-         id="stop9581"
-         style="stop-color:#9e9e9e"
-         offset="1" />
-    </linearGradient>
-    <filter
-       id="filter8047"
-       height="1.1309"
-       width="1.36"
-       color-interpolation-filters="sRGB"
-       y="-.065455"
-       x="-0.18">
-      <feGaussianBlur
-         id="feGaussianBlur8049"
-         stdDeviation="0.29999999" />
-    </filter>
+       gradientTransform="matrix(0.33333333,0,0,0.33333333,0,25.333333)" />
   </defs>
   <rect
-     id="rect3448"
-     style="stroke:url(#linearGradient9571);fill:url(#radialGradient9547)"
-     transform="scale(1,-1)"
-     rx=".56471"
-     ry=".56471"
-     height="4.7728"
-     width="4.4545"
-     y="-15.5"
-     x="5.7727" />
+     x="5.5"
+     y="10.5"
+     width="5"
+     height="5"
+     ry="0.5"
+     rx="0.5"
+     style="fill:url(#linearGradient4763-1);fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect3448-7-9" />
   <rect
-     id="rect5391"
-     style="stroke-linejoin:round;stroke:url(#linearGradient8579);stroke-linecap:round;fill:url(#linearGradient8838)"
-     rx="1"
+     x="5.5"
+     y="10.5"
+     width="5"
+     height="5"
+     ry="0.5"
+     rx="0.5"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-opacity:1"
+     id="rect3448-9-2" />
+  <path
+     id="rect3450-0"
+     d="m 6.5,12.499999 v -1 h 1 v 1 z m 2,0 v -1 h 1 v 1 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     x="6.5"
+     y="11.5"
+     width="3"
+     height="3"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458-2" />
+  <rect
+     id="rect5391-3"
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="0.99999994"
      ry="1"
      height="13"
-     width="7"
-     y="0.5"
-     x="4.5" />
+     width="7.0000782"
+     y="0.49999994"
+     x="4.4999609" />
   <rect
-     id="rect8840"
-     style="opacity:.3;filter:url(#filter8047);fill:#fff"
-     rx="1"
-     ry="1"
-     height="11"
-     width="4"
-     y="1"
-     x="6" />
+     x="5"
+     y="0.99999988"
+     width="6"
+     height="12"
+     rx="0.5"
+     style="opacity:1;fill:url(#linearGradient5466-8-3-0);fill-opacity:1;stroke:none;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-5-7"
+     ry="0.5" />
+  <rect
+     x="5.5"
+     y="1.4999908"
+     width="5"
+     height="11.000018"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2-0-5" />
 </svg>

--- a/elementary-xfce/devices/24/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/24/drive-removable-media-usb.svg
@@ -6,209 +6,191 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg11300"
-   height="24"
+   version="1.0"
    width="24"
-   version="1.0">
+   height="24"
+   id="svg2">
   <metadata
-     id="metadata38">
+     id="metadata88">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3">
+     id="defs4">
     <linearGradient
-       id="linearGradient3506">
+       id="linearGradient4075">
       <stop
-         id="stop3508"
-         style="stop-color:#3c3c3c"
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3510"
-         style="stop-color:#3c3c3c;stop-opacity:.22745"
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       id="radialGradient7374"
+    <linearGradient
+       x1="22.553417"
+       y1="6.6305909"
+       x2="22.553417"
+       y2="41.943768"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
        gradientUnits="userSpaceOnUse"
-       cy="41.636"
-       cx="23.335"
-       gradientTransform="matrix(.30936 0 0 .088370 4.7812 18.32)"
-       r="22.627">
+       gradientTransform="matrix(0.21462027,0,0,0.42391297,11.25048,-0.78050762)" />
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.33471938,0,0,0.59667354,-23.328651,0.35638626)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient4614">
       <stop
-         id="stop23421"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
       <stop
-         id="stop23423"
+         offset="0.03140453"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.26516308,0,0,0.06026566,48.916692,28.466026)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
          style="stop-opacity:0"
-         offset="1" />
+         id="stop23423" />
     </radialGradient>
     <linearGradient
-       id="linearGradient7469"
-       y2="9.1187"
-       xlink:href="#linearGradient3506"
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3-0"
+       xlink:href="#linearGradient3600-8"
        gradientUnits="userSpaceOnUse"
-       x2="20.405"
-       gradientTransform="matrix(.64540 0 0 .42550 .098106 -24.059)"
-       y1="6.9878"
-       x1="20.405" />
+       gradientTransform="matrix(0.47793243,0,0,0.42768318,8.8306347,-1.55508)" />
     <linearGradient
-       id="linearGradient7475"
-       y2="9.1187"
-       xlink:href="#linearGradient3506"
-       gradientUnits="userSpaceOnUse"
-       x2="20.405"
-       gradientTransform="matrix(.64540 0 0 .42550 -2.4019 -24.059)"
-       y1="6.9878"
-       x1="20.405" />
-    <linearGradient
-       id="linearGradient8579"
-       y2="1.25"
-       gradientUnits="userSpaceOnUse"
-       x2="15"
-       gradientTransform="matrix(.52381 0 0 .52941 -.57142 -.29397)"
-       y1="36"
-       x1="15">
+       id="linearGradient3600-8">
       <stop
-         id="stop3823"
-         style="stop-color:gray"
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3825"
-         style="stop-color:#999"
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient8838"
-       y2="35.875"
-       gradientUnits="userSpaceOnUse"
-       x2="25"
-       gradientTransform="matrix(.52381 0 0 .52941 -.57142 -.29397)"
-       y1="1.125"
-       x1="25">
-      <stop
-         id="stop3145"
-         style="stop-color:#e6e6e6"
-         offset="0" />
-      <stop
-         id="stop3147"
-         style="stop-color:#afafaf"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       id="radialGradient9547"
-       gradientUnits="userSpaceOnUse"
-       cy="-36.857"
-       cx="21.333"
-       gradientTransform="matrix(.86667 -1.922e-7 1.664e-7 .75005 -7.4222 8.6446)"
-       r="8">
-      <stop
-         id="stop9129"
-         style="stop-color:#f0f0f0"
-         offset="0" />
-      <stop
-         id="stop9131"
-         style="stop-color:#a9a9a9"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient9571"
-       y2="-39.143"
-       gradientUnits="userSpaceOnUse"
-       x2="32.571"
-       gradientTransform="matrix(.46667 0 0 .46667 0.8 -1.7333)"
-       y1="-39.143"
-       x1="15.429">
-      <stop
-         id="stop9575"
-         style="stop-color:#8f8f8f"
-         offset="0" />
-      <stop
-         id="stop9577"
-         style="stop-color:#5f5f5f"
-         offset=".12709" />
-      <stop
-         id="stop9579"
-         style="stop-color:#616161"
-         offset=".87578" />
-      <stop
-         id="stop9581"
-         style="stop-color:#9e9e9e"
-         offset="1" />
-    </linearGradient>
-    <filter
-       id="filter7990"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         id="feGaussianBlur7992"
-         stdDeviation="0.24" />
-    </filter>
   </defs>
-  <path
-     id="path23417"
-     style="opacity:.4;fill-rule:evenodd;fill:url(#radialGradient7374)"
-     d="m19 21.999a7 1.9996 0 1 1 -14 0 7 1.9996 0 1 1 14 0z" />
+  <g
+     id="g4579"
+     transform="translate(-43.104077,-8.3392264)">
+    <path
+       id="path23417"
+       style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:0.99999994"
+       d="m 61.104077,30.975341 a 6.0000001,1.3636364 0 1 1 -12,0 6.0000001,1.3636364 0 1 1 12,0 z" />
+  </g>
   <rect
-     id="rect4383"
-     style="fill:#fff"
-     rx="0.625"
-     ry=".625"
-     height="4.8971"
-     width="6.3732"
-     y="16.653"
-     x="8.8712" />
-  <rect
-     id="rect3448"
-     style="stroke:url(#linearGradient9571);fill:url(#radialGradient9547)"
+     x="7.5"
+     y="-23.5"
+     width="9"
+     height="9"
+     ry="1"
+     rx="1"
      transform="scale(1,-1)"
-     rx=".56471"
-     ry=".56471"
-     height="7"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.30232558"
+     id="rect3448" />
+  <g
+     id="g4576"
+     style="opacity:0.2">
+    <rect
+       y="20"
+       x="9"
+       height="2"
+       width="2"
+       id="rect4570"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+       id="rect4572"
+       width="2"
+       height="2"
+       x="13"
+       y="20" />
+  </g>
+  <rect
+     x="8.4944277"
+     y="-22.472153"
      width="7"
-     y="-22.5"
-     x="8.5" />
-  <rect
-     id="rect3450"
-     style="opacity:.88172;fill:url(#linearGradient7475)"
+     height="7"
      transform="scale(1,-1)"
-     height="1"
-     width="1.5"
-     y="-21"
-     x="10" />
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
   <rect
-     id="rect2874"
-     style="opacity:.88172;fill:url(#linearGradient7469)"
-     transform="scale(1,-1)"
-     height="1"
-     width="1.5"
-     y="-21"
-     x="12.5" />
+     ry="0.5"
+     id="rect5391-5-7"
+     style="opacity:1;fill:url(#linearGradient5466-8-3-0);fill-opacity:1;stroke:none;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="0.5"
+     height="17"
+     width="10"
+     y="0.99999845"
+     x="7" />
   <rect
-     id="rect5391"
-     style="stroke-linejoin:round;stroke:url(#linearGradient8579);stroke-linecap:round;fill:url(#linearGradient8838)"
-     rx="1"
      ry="1"
-     height="18"
-     width="11"
-     y=".50014"
-     x="6.5" />
-  <rect
-     id="rect8840"
-     style="opacity:.3;filter:url(#filter7990);fill:#fff"
      rx="1"
-     ry="1"
-     height="16"
-     width="8"
-     y="1"
-     x="8" />
+     y="0.49995935"
+     x="6.4999609"
+     height="18.000078"
+     width="11.000078"
+     id="rect901"
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <rect
+     y="1.4999593"
+     x="7.5"
+     height="16.000078"
+     width="9"
+     id="rect901-3"
+     style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4161-4);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   <path
-     id="path7988"
-     style="fill:#787878"
-     d="m11.958 4.0008c-0.30556 0.36651-0.4946 0.83505-0.7651 1.2354-0.33743 0.28921-0.1583 0.65957 0.27068 0.51624 0.29511-0.010941 0.12467 0.35608 0.16632 0.53892v5.1232c-0.419-0.38-0.98-0.726-1.184-1.26-0.232-0.4175-0.199-0.8706 0.292-1.0284 0.343-0.2897 0.492-0.8442 0.188-1.2152-0.39-0.6496-1.4923-0.6588-1.8362 0.0422-0.3511 0.6084 0.3005 1.0383 0.4563 1.5468 0.021459 0.49447 0.12196 0.99872 0.44789 1.3896 0.42298 0.5497 1.0284 0.92324 1.5428 1.3675 0.33682 0.40215-0.0972 0.6643-0.36656 0.89786-0.40998 0.47406-0.41161 1.3347 0.19046 1.658 0.60687 0.39313 1.5797 0.13128 1.7663-0.60838 0.13886-0.53965-0.18008-1.1503-0.69222-1.3614v-2.4004c0.59519-0.62344 1.3317-1.1431 1.7527-1.911 0.14039-0.3525 0.08993-0.98464 0.65354-0.8257 0.3359-0.26412 0.07606-0.84628 0.16138-1.2437 0.08802-0.36886-0.10572-0.6677-0.50612-0.54598-0.41633 0.095469-1.1046-0.21048-1.345 0.18277 0.0046 0.49431-0.01182 0.98939 0.008 1.4837 0.11457 0.24072 0.58021-0.00681 0.41452 0.407-0.10818 0.54049-0.5848 0.87872-0.92998 1.2686-0.26105 0.2444-0.21093-0.1388-0.20896-0.30056v-3.1942c0.31475 0.073483 0.84637-0.037056 0.47061-0.41296-0.27675-0.43928-0.56361-0.87231-0.82854-1.3189-0.04488 0.00825-0.07358-0.045475-0.11933-0.030387z" />
+     d="m 10.840723,15.42596 c 0,-0.812844 0.270159,-1.023722 0.601081,-1.307524 0.265666,-0.128245 0.308115,-0.215797 0.304622,-0.628246 -0.0038,-0.455788 -0.04748,-0.403723 -0.892257,-1.137052 C 9.5643341,11.233522 9.3908717,10.963528 9.239426,9.8400295 9.1277128,9.0114045 9.2060698,9.6984184 8.8853869,9.3796815 8.2951367,8.7930329 8.3962618,7.932675 9.098919,7.5629056 9.7319231,7.2298013 10.481784,7.5840826 10.713024,8.325543 10.826996,8.6909666 10.553758,9.3220307 10.186859,9.5407364 9.8511071,9.7408934 9.7118161,9.4071903 9.7885951,10.144998 c 0.04249,0.408357 0.14605,0.373299 0.2301219,0.538935 0.144387,0.284464 1.5583,1.623587 1.712099,1.623587 V 5.9999129 h -0.783763 l 1.06712,-2.5039139 1.11847,2.5041685 h -0.76181 v 4.7546645 c 0.105957,0 1.129458,-1.023679 1.478993,-1.4983148 0.151025,-0.2050753 0.242676,-0.4962648 0.242676,-0.7710368 0,-0.4144014 0.136657,-0.50154 -0.17942,-0.50154 H 13.576338 V 6.0421262 h 1.908216 v 1.9418142 h -0.308681 c -0.275428,0.03225 -0.472288,0.1726354 -0.524283,0.6321332 -0.07755,0.6852601 -0.355742,1.1044272 -1.435848,2.1931844 l -0.844915,0.911155 v 2.24934 l 0.249682,0.149014 c 0.169778,0.08196 0.403596,0.346791 0.519598,0.58852 0.412977,0.862221 -0.161626,1.788713 -1.109116,1.788713 -0.686597,-0.02546 -1.190568,-0.377978 -1.190568,-1.069028 z"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;stroke-width:1;font-variant-east_asian:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path3690-3" />
+  <path
+     d="m 10.840723,14.425792 c 0,-0.812844 0.270159,-1.023722 0.601081,-1.307524 0.265666,-0.128245 0.308115,-0.215797 0.304622,-0.628246 -0.0038,-0.455788 -0.04748,-0.403723 -0.892257,-1.137052 C 9.5643341,10.233354 9.3908717,9.96336 9.239426,8.839862 9.1277128,8.011237 9.2060698,8.6982509 8.8853869,8.379514 8.2951367,7.7928654 8.3962618,6.9325075 9.098919,6.5627381 c 0.6330041,-0.3331043 1.382865,0.021177 1.614105,0.7626374 0.113972,0.3654236 -0.159266,0.9964877 -0.526165,1.2151934 -0.3357519,0.200157 -0.4750429,-0.1335461 -0.3982639,0.604262 0.04249,0.408357 0.14605,0.3732981 0.2301219,0.5389341 0.144387,0.284464 1.5583,1.623587 1.712099,1.623587 V 4.9997454 H 10.947053 L 12.014173,2.4958315 13.132643,5 h -0.76181 v 4.754664 c 0.105957,0 1.129458,-1.0236785 1.478993,-1.4983143 0.151025,-0.2050753 0.242676,-0.4962648 0.242676,-0.7710368 0,-0.4144014 0.136657,-0.50154 -0.17942,-0.50154 H 13.576338 V 5.0419587 h 1.908216 V 6.9837729 H 15.175873 C 14.900445,7.0160229 14.703585,7.1564083 14.65159,7.6159061 14.57404,8.3011662 14.295848,8.7203333 13.215742,9.80909 l -0.844915,0.911155 v 2.24934 l 0.249682,0.149014 c 0.169778,0.08196 0.403596,0.346791 0.519598,0.58852 0.412977,0.862221 -0.161626,1.788713 -1.109116,1.788713 -0.686597,-0.02546 -1.190568,-0.377978 -1.190568,-1.069028 z"
+     style="opacity:0.95;fill:#969696;fill-opacity:1;stroke-width:0.63632655"
+     id="path3690" />
 </svg>

--- a/elementary-xfce/devices/32/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/32/drive-removable-media-usb.svg
@@ -1,0 +1,174 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg2"
+   height="32"
+   width="32"
+   version="1.0">
+  <metadata
+     id="metadata88">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4077" />
+      <stop
+         offset="0.03367912"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4079" />
+      <stop
+         offset="0.99223143"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4081" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4083" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,18.083588,5.1837037)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4075"
+       id="linearGradient4161-4"
+       y2="41.946075"
+       x2="11.11739"
+       y1="-7.4956021"
+       x1="11.11739" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43035349,0,0,0.7671517,-29.42096,-0.1211738)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03140453" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(1)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.996155"
+       x2="16.875002"
+       y1="0"
+       x1="17"
+       id="linearGradient4616"
+       xlink:href="#linearGradient3600-8" />
+    <radialGradient
+       id="radialGradient7374-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.39774462,0,0,0.0903985,6.718924,26.190573)"
+       r="22.627001">
+      <stop
+         id="stop23421-6"
+         offset="0" />
+      <stop
+         id="stop23423-7"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+  </defs>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374-3);fill-rule:evenodd;stroke-width:0.99999988"
+     d="m 25,29.954546 c 0,2.727271 -18,2.727271 -18,0 0,-2.727271 18,-2.727271 18,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.30232562"
+     transform="scale(1,-1)"
+     rx="1"
+     ry="1"
+     height="11"
+     width="11"
+     y="-30.5"
+     x="10.5" />
+  <path
+     style="opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+     d="m 13,27 v 2 h 2 v -2 z m 4,0 v 2 h 2 v -2 z m -3.5,0.5 h 1 v 1 h -1 z m 4,0 h 1 v 1 h -1 z"
+     id="rect4570" />
+  <rect
+     id="rect3458"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="9"
+     width="9"
+     y="-29.472153"
+     x="11.494428" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.99999994;stroke-opacity:0.26511631;marker:none;enable-background:accumulate"
+     id="rect2990"
+     d="m 8.5,2 0.011308,21.5 c -0.033435,1.036496 0.9417175,0.991663 0.9417175,0.991663 H 22.352955 C 23.422887,24.525098 23.488695,23.5 23.488695,23.5 L 23.5,2 C 23.5,2 23.48039,0.5 22,0.5 H 10 C 9.1666667,0.5 8.4995617,1.1666668 8.5,2 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path4034"
+     d="M 10,1.46875 C 10,1.46875 9.4741176,1.508235 9.5,2 v 21.5 h 13 V 2 C 22.473926,1.4516678 22,1.46875 22,1.46875 Z" />
+  <path
+     d="m 14.482844,21.17785 c 0,-1.045085 0.347347,-1.316215 0.772817,-1.681103 0.341572,-0.164886 0.396149,-0.277454 0.391658,-0.807744 -0.0049,-0.586012 -0.06105,-0.519073 -1.147188,-1.461924 -1.658358,-1.439506 -1.881382,-1.786641 -2.076097,-3.231138 -0.143632,-1.065375 -0.04289,-0.83098 -0.455194,-1.240783 -0.758893,-0.754263 -0.628875,-1.860432 0.274541,-2.335847 0.813864,-0.428277 1.77797,0.02723 2.075279,0.980526 0.146537,0.46983 -0.20477,1.281198 -0.676498,1.562391 -0.431681,0.257344 -0.610771,-0.171702 -0.512054,0.776908 0.05464,0.52503 0.187778,1.128862 0.295869,1.341822 0.185643,0.365739 2.00353,2.087469 2.201273,2.087469 V 6.6722424 H 14.619554 C 15.085891,5.8639259 15.539955,5.0421919 15.991565,4.2284756 L 17.4296,6.6725697 H 16.45013 V 13.8864 c 0.136226,0 1.471823,-1.355485 1.921223,-1.965731 0.194177,-0.263668 0.312012,-0.638055 0.312012,-0.991329 0,-0.532798 0.175703,-0.644833 -0.230681,-0.644833 H 18.019728 V 7.7878882 h 2.45342 v 2.4966188 h -0.396876 c -0.354121,0.04146 -0.607227,0.221959 -0.674078,0.812735 -0.0997,0.881048 -0.477046,1.459305 -1.865755,2.859133 l -1.086318,1.171487 v 4.177721 l 0.32102,0.19159 c 0.218286,0.105375 0.518909,0.445875 0.668055,0.756668 0.53097,1.108572 -0.207806,2.299775 -1.426007,2.299775 -0.882767,-0.03272 -1.530729,-0.485972 -1.530729,-1.374466 z"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke-width:1"
+     id="path4625" />
+  <path
+     id="path3690"
+     style="opacity:1;fill:#aaaaaa;stroke-width:1"
+     d="m 14.482844,20.17785 c 0,-1.045085 0.347347,-1.316215 0.772817,-1.681103 0.341572,-0.164886 0.396149,-0.277454 0.391658,-0.807744 -0.0049,-0.586012 -0.06105,-0.519073 -1.147188,-1.461924 -1.658358,-1.439506 -1.881382,-1.786641 -2.076097,-3.231138 -0.143632,-1.065375 -0.04289,-0.83098 -0.455194,-1.240783 -0.758893,-0.754263 -0.628875,-1.860432 0.274541,-2.335847 0.813864,-0.4282774 1.77797,0.02723 2.075279,0.980526 0.146537,0.46983 -0.20477,1.281198 -0.676498,1.562391 -0.431681,0.257344 -0.610771,-0.171702 -0.512054,0.776908 0.05464,0.52503 0.187778,1.128862 0.295869,1.341822 0.185643,0.365739 2.00353,2.087469 2.201273,2.087469 V 5.6722424 H 14.619554 C 15.085891,4.8639259 15.539955,4.0421919 15.991565,3.2284756 L 17.4296,5.6725697 H 16.45013 V 12.8864 c 0.136226,0 1.471823,-1.355485 1.921223,-1.965731 0.194177,-0.263668 0.312012,-0.638055 0.312012,-0.991329 0,-0.532798 0.175703,-0.644833 -0.230681,-0.644833 H 18.019728 V 6.7878882 h 2.45342 V 9.284507 h -0.396876 c -0.354121,0.04146 -0.607227,0.221959 -0.674078,0.812735 -0.0997,0.881048 -0.477046,1.459305 -1.865755,2.859133 l -1.086318,1.171487 v 4.177721 l 0.32102,0.19159 c 0.218286,0.105375 0.518909,0.445875 0.668055,0.756668 0.53097,1.108572 -0.207806,2.299775 -1.426007,2.299775 -0.882767,-0.03272 -1.530729,-0.485972 -1.530729,-1.374466 z" />
+  <g
+     id="g4622"
+     style="opacity:0.2"
+     transform="translate(4,7)">
+    <path
+       id="rect4618"
+       d="m 9.5,20.5 v 1 h 1 v -1 z m 4,0 v 1 h 1 v -1 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
+  </g>
+  <path
+     id="path4666"
+     d="M 11,25 H 21"
+     style="fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;opacity:0.1" />
+</svg>

--- a/elementary-xfce/devices/48/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/48/drive-removable-media-usb.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg11300"
-   height="48"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   version="1.0"
    width="48"
-   version="1.0">
+   height="48"
+   id="svg11300"
+   sodipodi:docname="drive-removable-media-usb.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1013"
+     id="namedview38"
+     showgrid="false"
+     inkscape:zoom="55.625733"
+     inkscape:cx="24"
+     inkscape:cy="10.358427"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata49">
     <rdf:RDF>
@@ -18,255 +43,192 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3">
     <linearGradient
-       id="linearGradient3506">
+       id="linearGradient4614">
       <stop
-         id="stop3508"
-         style="stop-color:#3c3c3c"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
       <stop
-         id="stop3510"
-         style="stop-color:#3c3c3c;stop-opacity:.22745"
-         offset="1" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3494">
+       id="linearGradient3742">
       <stop
-         id="stop3496"
-         style="stop-color:#282828;stop-opacity:.82353"
+         id="stop3734"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3498"
-         style="stop-color:#282828;stop-opacity:0"
+         id="stop3736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.01900466" />
+      <stop
+         id="stop3738"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop3740"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <radialGradient
-       id="radialGradient7374"
+       r="22.627001"
+       gradientTransform="matrix(0.48613231,0,0,0.11048705,12.656462,39.898188)"
+       cx="23.334999"
+       cy="41.636002"
        gradientUnits="userSpaceOnUse"
-       cy="41.636"
-       cx="23.335"
-       gradientTransform="matrix(.57452 0 0 .15462 10.594 37.062)"
-       r="22.627">
+       id="radialGradient7374">
       <stop
-         id="stop23421"
-         offset="0" />
+         offset="0"
+         id="stop23421" />
       <stop
-         id="stop23423"
+         offset="1"
          style="stop-opacity:0"
-         offset="1" />
+         id="stop23423" />
     </radialGradient>
     <linearGradient
-       id="linearGradient7469"
-       y2="9.1187"
-       xlink:href="#linearGradient3494"
-       gradientUnits="userSpaceOnUse"
-       x2="20.405"
-       gradientTransform="matrix(1.3252 0 0 1.3105 -.0052421 -50.962)"
-       y1="6.9878"
-       x1="20.405" />
-    <linearGradient
-       id="linearGradient7471"
-       y2="10.01"
-       xlink:href="#linearGradient3506"
-       gradientUnits="userSpaceOnUse"
-       x2="21.718"
-       gradientTransform="matrix(1.3252 0 0 1.3105 -.0052421 -50.962)"
-       y1="6.1797"
-       x1="21.718" />
-    <linearGradient
-       id="linearGradient7475"
-       y2="9.1187"
-       xlink:href="#linearGradient3494"
-       gradientUnits="userSpaceOnUse"
-       x2="20.405"
-       gradientTransform="matrix(1.3252 0 0 1.3105 -6.0052 -50.962)"
-       y1="6.9878"
-       x1="20.405" />
-    <linearGradient
-       id="linearGradient7477"
-       y2="10.01"
-       xlink:href="#linearGradient3506"
-       gradientUnits="userSpaceOnUse"
-       x2="21.718"
-       gradientTransform="matrix(1.3252 0 0 1.3105 -6.0052 -50.962)"
-       y1="6.1797"
-       x1="21.718" />
-    <linearGradient
-       id="linearGradient8579"
-       y2="1.25"
-       gradientUnits="userSpaceOnUse"
-       x2="15"
-       y1="36"
-       x1="15">
+       id="linearGradient3600-8">
       <stop
-         id="stop3823"
-         style="stop-color:gray"
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3825"
-         style="stop-color:#999"
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient8838"
-       y2="35.875"
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3"
+       xlink:href="#linearGradient3600-8"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95586485,0,0,0.83020854,17.661268,-2.959857)" />
+    <linearGradient
+       y2="31.67935"
+       x2="118.57409"
+       y1="3.7037382"
+       x1="118.57409"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-41.600004,-1.104142)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3730"
+       xlink:href="#linearGradient3742" />
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-41.600004,-1.104142)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-44.395805"
        x2="25"
-       y1="1.125"
-       x1="25">
-      <stop
-         id="stop3145"
-         style="stop-color:#e6e6e6"
-         offset="0" />
-      <stop
-         id="stop3147"
-         style="stop-color:#afafaf"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       id="radialGradient9547"
-       gradientUnits="userSpaceOnUse"
-       cy="-36.857"
-       cx="21.333"
-       gradientTransform="matrix(1.625 -2.2661e-7 1.9175e-7 1.375 -12.667 13.679)"
-       r="8">
-      <stop
-         id="stop9129"
-         style="stop-color:#f0f0f0"
-         offset="0" />
-      <stop
-         id="stop9131"
-         style="stop-color:#a9a9a9"
-         offset="1" />
-    </radialGradient>
-    <linearGradient
-       id="linearGradient9563"
-       y2="-44"
-       gradientUnits="userSpaceOnUse"
-       x2="24"
        y1="-35"
-       x1="24">
-      <stop
-         id="stop9559"
-         style="stop-color:#eeeeec"
-         offset="0" />
-      <stop
-         id="stop9561"
-         style="stop-color:#eeeeec;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient9571"
-       y2="-40"
-       gradientUnits="userSpaceOnUse"
-       x2="32"
-       y1="-40"
-       x1="16">
-      <stop
-         id="stop9575"
-         style="stop-color:#8f8f8f"
-         offset="0" />
-      <stop
-         id="stop9577"
-         style="stop-color:#5f5f5f"
-         offset=".12709" />
-      <stop
-         id="stop9579"
-         style="stop-color:#616161"
-         offset=".87578" />
-      <stop
-         id="stop9581"
-         style="stop-color:#9e9e9e"
-         offset="1" />
-    </linearGradient>
-    <filter
-       id="filter10041"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         id="feGaussianBlur10043"
-         stdDeviation="0.51" />
-    </filter>
+       x1="25"
+       id="linearGradient4763"
+       xlink:href="#linearGradient7056" />
   </defs>
   <path
-     id="path23417"
-     style="opacity:.4;fill-rule:evenodd;fill:url(#radialGradient7374)"
-     d="m37 43.5a13 3.4986 0 1 1 -26 0 13 3.4986 0 1 1 26 0z" />
+     d="m 35,44.4986 a 11,2.5 0 1 1 -22,0 11,2.5 0 1 1 22,0 z"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:0.99999994"
+     id="path23417" />
   <rect
-     id="rect4383"
-     style="fill:#fff"
-     rx="0.625"
-     ry=".625"
-     height="9.5716"
-     width="12.167"
-     y="33.072"
-     x="18.027" />
-  <rect
-     id="rect3448"
-     style="stroke:url(#linearGradient9571);fill:url(#radialGradient9547)"
-     transform="scale(1,-1)"
-     rx=".56471"
-     ry=".56471"
-     height="15"
-     width="15"
+     x="16.5"
      y="-44.5"
-     x="16.5" />
+     width="15"
+     height="15"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:none"
+     id="rect3448" />
   <rect
+     x="16.5"
+     y="-44.5"
+     width="15"
+     height="15"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-opacity:1"
+     id="rect3448-9" />
+  <path
      id="rect3450"
-     style="opacity:.88172;stroke:url(#linearGradient7477);stroke-width:0.92;fill:url(#linearGradient7475)"
-     transform="scale(1,-1)"
-     height="3.08"
-     width="3.08"
-     y="-41.54"
-     x="19.46" />
+     d="m 19.5,38.5 v 3 h 3 v -3 z m 6,0 v 3 h 3 v -3 z"
+     style="opacity:0.4;fill:#000000;fill-opacity:0.33598849;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <rect
-     id="rect3458"
-     style="opacity:.71505;stroke:url(#linearGradient9563);fill:none"
-     transform="scale(1,-1)"
-     height="13"
-     width="13"
+     x="17.5"
      y="-43.5"
-     x="17.5" />
-  <rect
-     id="rect2874"
-     style="opacity:.88172;stroke:url(#linearGradient7471);stroke-width:0.92;fill:url(#linearGradient7469)"
+     width="13"
+     height="13"
      transform="scale(1,-1)"
-     height="3.08"
-     width="3.08"
-     y="-41.54"
-     x="25.46" />
+     style="opacity:0.6;fill:none;stroke:url(#linearGradient4604);font-variant-east_asian:normal;fill-opacity:1;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
   <rect
-     id="rect5391"
-     style="stroke-linejoin:round;stroke:url(#linearGradient8579);stroke-linecap:round;fill:url(#linearGradient8838)"
-     rx="1.625"
-     ry="1.6208"
-     height="34"
-     width="21"
-     y="1.5"
-     x="13.5" />
-  <rect
-     id="rect8840"
-     style="opacity:.3;filter:url(#filter10041);fill:#fff"
-     rx="1.625"
-     ry="1.6208"
-     height="33"
-     width="18"
+     x="14"
      y="2"
-     x="15" />
+     width="20"
+     height="33"
+     ry="1.5"
+     rx="1.5"
+     style="opacity:1;fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391" />
+  <rect
+     x="13.5"
+     y="1.5"
+     width="21"
+     height="34"
+     ry="2"
+     rx="2"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2" />
+  <rect
+     x="14.499961"
+     y="2.4999609"
+     width="19.000078"
+     height="32.000076"
+     ry="1"
+     rx="1"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;font-variant-east_asian:normal"
+     id="rect5391-2-0" />
   <path
-     id="path8593"
-     style="opacity:.95;fill:#fff"
-     d="m22.678 28.32c0-1.2774 0.42456-1.6088 0.94461-2.0548 0.4175-0.20154 0.48421-0.33913 0.47872-0.9873-0.006-0.71628-0.07462-0.63446-1.4022-1.7869-2.027-1.7595-2.2996-2.1838-2.5376-3.9494-0.17556-1.3022-0.05242-1.0157-0.55638-1.5166-0.92759-0.92193-0.76867-2.274 0.33557-2.8551 0.99478-0.52348 2.1732 0.03328 2.5366 1.1985 0.17911 0.57427-0.25029 1.566-0.82688 1.9097-0.52764 0.31455-0.74654-0.20987-0.62588 0.94961 0.06678 0.64174 0.22952 1.3798 0.36164 1.6401 0.22691 0.44704 2.4489 2.5515 2.6906 2.5515v-12.432h-1.2317c0.57-0.9882 1.125-1.9924 1.677-2.987l1.7577 2.9874h-1.1972v8.42c0.16651 0 1.799-1.6568 2.3483-2.4027 0.23734-0.32228 0.38137-0.77989 0.38137-1.2117 0-0.65124 0.21476-0.78818-0.28196-0.78818h-0.5292v-3.0516h2.9988v3.0516h-0.4851c-0.43284 0.05068-0.74221 0.2713-0.82392 0.99341-0.12186 1.0769-0.58309 1.7837-2.2805 3.4947l-1.3278 1.4319v5.1064l0.39238 0.23418c0.26681 0.1288 0.63426 0.54499 0.81656 0.92487 0.649 1.355-0.254 2.811-1.743 2.811-1.079-0.04-1.871-0.594-1.871-1.68z" />
+     d="m 22.678,29.36641 c 0,-1.2774 0.42456,-1.6088 0.94461,-2.0548 0.4175,-0.20154 0.48421,-0.33913 0.47872,-0.9873 -0.006,-0.71628 -0.07462,-0.63446 -1.4022,-1.7869 -2.027,-1.7595 -2.2996,-2.1838 -2.5376,-3.9494 -0.17556,-1.3022 -0.05242,-1.0157 -0.55638,-1.5166 -0.92759,-0.92193 -0.76867,-2.274 0.33557,-2.8551 0.99478,-0.52348 2.1732,0.03328 2.5366,1.1985 0.17911,0.57427 -0.25029,1.566 -0.82688,1.9097 -0.52764,0.31455 -0.74654,-0.20987 -0.62588,0.94961 0.06678,0.64174 0.22952,1.3798 0.36164,1.6401 0.22691,0.44704 2.4489,2.5515 2.6906,2.5515 v -12.432 h -1.2317 c 0.57,-0.988 1.125,-1.9924 1.677,-2.987 l 1.7577,2.9874 h -1.1972 v 8.42 c 0.16651,0 1.799,-1.6568 2.3483,-2.4027 0.23734,-0.32228 0.38137,-0.77989 0.38137,-1.2117 0,-0.65124 0.21476,-0.78818 -0.28196,-0.78818 h -0.5292 v -3.0516 h 2.9988 v 3.0516 h -0.4851 c -0.43284,0.05068 -0.74221,0.2713 -0.82392,0.99341 -0.12186,1.0769 -0.58309,1.7837 -2.2805,3.4947 l -1.3278,1.4319 v 5.1064 l 0.39238,0.23418 c 0.26681,0.1288 0.63426,0.54499 0.81656,0.92487 0.649,1.355 -0.254,2.811 -1.743,2.811 -1.079,-0.04 -1.871,-0.594 -1.871,-1.68 z"
+     style="opacity:0.3;fill:#ffffff"
+     id="path3690-6" />
   <path
-     id="path8591"
-     style="opacity:.95;fill:#464646"
-     d="m22.678 29.32c0-1.2774 0.42456-1.6088 0.94461-2.0548 0.4175-0.20154 0.48421-0.33913 0.47872-0.9873-0.006-0.71628-0.07462-0.63446-1.4022-1.7869-2.027-1.7595-2.2996-2.1838-2.5376-3.9494-0.17556-1.3022-0.05242-1.0157-0.55638-1.5166-0.92759-0.92193-0.76867-2.274 0.33557-2.8551 0.99478-0.52348 2.1732 0.03328 2.5366 1.1985 0.17911 0.57427-0.25029 1.566-0.82688 1.9097-0.52764 0.31455-0.74654-0.20987-0.62588 0.94961 0.06678 0.64174 0.22952 1.3798 0.36164 1.6401 0.22691 0.44704 2.4489 2.5515 2.6906 2.5515v-12.432h-1.2317c0.57-0.988 1.125-1.9924 1.677-2.987l1.7577 2.9874h-1.1972v8.42c0.16651 0 1.799-1.6568 2.3483-2.4027 0.23734-0.32228 0.38137-0.77989 0.38137-1.2117 0-0.65124 0.21476-0.78818-0.28196-0.78818h-0.5292v-3.0516h2.9988v3.0516h-0.4851c-0.43284 0.05068-0.74221 0.2713-0.82392 0.99341-0.12186 1.0769-0.58309 1.7837-2.2805 3.4947l-1.3278 1.4319v5.1064l0.39238 0.23418c0.26681 0.1288 0.63426 0.54499 0.81656 0.92487 0.649 1.355-0.254 2.811-1.743 2.811-1.079-0.04-1.871-0.594-1.871-1.68z" />
-  <path
-     id="path3690"
-     style="opacity:.95;fill:#aaa"
-     d="m22.678 28.82c0-1.2774 0.42456-1.6088 0.94461-2.0548 0.4175-0.20154 0.48421-0.33913 0.47872-0.9873-0.006-0.71628-0.07462-0.63446-1.4022-1.7869-2.027-1.7595-2.2996-2.1838-2.5376-3.9494-0.17556-1.3022-0.05242-1.0157-0.55638-1.5166-0.92759-0.92193-0.76867-2.274 0.33557-2.8551 0.99478-0.52348 2.1732 0.03328 2.5366 1.1985 0.17911 0.57427-0.25029 1.566-0.82688 1.9097-0.52764 0.31455-0.74654-0.20987-0.62588 0.94961 0.06678 0.64174 0.22952 1.3798 0.36164 1.6401 0.22691 0.44704 2.4489 2.5515 2.6906 2.5515v-12.432h-1.2317c0.57-0.988 1.125-1.9924 1.677-2.987l1.7577 2.9874h-1.1972v8.42c0.16651 0 1.799-1.6568 2.3483-2.4027 0.23734-0.32228 0.38137-0.77989 0.38137-1.2117 0-0.65124 0.21476-0.78818-0.28196-0.78818h-0.5292v-3.0516h2.9988v3.0516h-0.4851c-0.43284 0.05068-0.74221 0.2713-0.82392 0.99341-0.12186 1.0769-0.58309 1.7837-2.2805 3.4947l-1.3278 1.4319v5.1064l0.39238 0.23418c0.26681 0.1288 0.63426 0.54499 0.81656 0.92487 0.649 1.355-0.254 2.811-1.743 2.811-1.079-0.04-1.871-0.594-1.871-1.68z" />
+     d="m 22.678,28.36647 c 0,-1.2774 0.42456,-1.6088 0.94461,-2.0548 0.4175,-0.20154 0.48421,-0.33913 0.47872,-0.9873 -0.006,-0.71628 -0.07462,-0.63446 -1.4022,-1.7869 -2.027,-1.7595 -2.2996,-2.1838 -2.5376,-3.9494 -0.17556,-1.3022 -0.05242,-1.0157 -0.55638,-1.5166 -0.92759,-0.92193 -0.76867,-2.274 0.33557,-2.8551 0.99478,-0.52348 2.1732,0.03328 2.5366,1.1985 0.17911,0.57427 -0.25029,1.566 -0.82688,1.9097 -0.52764,0.31455 -0.74654,-0.20987 -0.62588,0.94961 0.06678,0.64174 0.22952,1.3798 0.36164,1.6401 0.22691,0.44704 2.4489,2.5515 2.6906,2.5515 v -12.432 h -1.2317 c 0.57,-0.988 1.125,-1.9924 1.677,-2.987 l 1.7577,2.9874 h -1.1972 v 8.42 c 0.16651,0 1.799,-1.6568 2.3483,-2.4027 0.23734,-0.32228 0.38137,-0.77989 0.38137,-1.2117 0,-0.65124 0.21476,-0.78818 -0.28196,-0.78818 h -0.5292 V 12 h 2.9988 v 3.0516 h -0.4851 c -0.43284,0.05068 -0.74221,0.2713 -0.82392,0.99341 -0.12186,1.0769 -0.58309,1.7837 -2.2805,3.4947 l -1.3278,1.4319 v 5.1064 l 0.39238,0.23418 c 0.26681,0.1288 0.63426,0.54499 0.81656,0.92487 0.649,1.355 -0.254,2.811 -1.743,2.811 -1.079,-0.04 -1.871,-0.594 -1.871,-1.68 z"
+     style="opacity:0.95;fill:#aaaaaa"
+     id="path3690" />
 </svg>

--- a/elementary-xfce/devices/64/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/64/drive-removable-media-usb.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg11300"
+   height="64"
+   width="64"
+   version="1.0"
+   viewBox="0 0 64 64">
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.01900466"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.61871386,0,0,0.14061988,17.56277,53.961714)"
+       r="22.627001">
+      <stop
+         id="stop23421"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2289726,0,0,1.0632918,22.850217,-0.1995066)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81791996,0,0,1.4890166,-55.31544,0.6569973)"
+       x1="118.57409"
+       y1="3.7037382"
+       x2="118.57409"
+       y2="31.67935" />
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81288992,0,0,1.4490643,-54.78462,-4.0592618)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2666667,0,0,1.2666667,0.6,-4.1333342)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     d="m 46,59.816784 a 14.000001,3.1818183 0 1 1 -28.000001,0 14.000001,3.1818183 0 1 1 28.000001,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1.00000012;stroke-opacity:0.29302326"
+     transform="scale(1,-1)"
+     rx="1.0000001"
+     ry="1.0000001"
+     height="19"
+     width="19"
+     y="-60.500004"
+     x="21.5" />
+  <path
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 22,49.5 H 40"
+     id="path4538" />
+  <path
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.67441863"
+     d="m 24.5,53.5 v 4 h 4 v -4 z m 9,0 v 4 h 4 v -4 z"
+     id="rect3450" />
+  <rect
+     id="rect3458"
+     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="17"
+     width="17"
+     y="-59.5"
+     x="22.5" />
+  <rect
+     ry="2.5"
+     id="rect5391"
+     style="opacity:1;fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="2.5"
+     height="44"
+     width="26"
+     y="5"
+     x="18" />
+  <rect
+     ry="3"
+     id="rect5391-2"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="3"
+     height="45.000076"
+     width="27.000078"
+     y="4.4999609"
+     x="17.5" />
+  <rect
+     rx="2.0000002"
+     id="rect5391-2-0"
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     ry="2"
+     height="43"
+     width="25"
+     y="5.5"
+     x="18.5" />
+  <path
+     d="m 27.961933,41.867923 c 0,-1.858009 0.617533,-2.340038 1.373958,-2.988756 0.607264,-0.293144 0.704295,-0.493272 0.69631,-1.436051 -0.0087,-1.041847 -0.108537,-0.922837 -2.039534,-2.599089 -2.94832,-2.559235 -3.344823,-3.176389 -3.691,-5.744497 -0.255356,-1.894081 -0.07625,-1.47736 -0.809268,-2.205931 -1.349202,-1.340969 -1.118049,-3.307588 0.488095,-4.152812 1.446931,-0.761414 3.160971,0.04841 3.689545,1.743247 0.26052,0.83529 -0.364053,2.277785 -1.202717,2.777705 -0.767465,0.45752 -1.08586,-0.305261 -0.910357,1.38123 0.09713,0.933427 0.333842,2.006953 0.526014,2.385565 0.330046,0.650231 3.561984,3.711218 3.913542,3.711218 L 30,17 h -1.791537 c 0.829079,-1.43707 1.63634,-3.425076 2.439237,-4.871745 l 2.556617,4.872327 h -1.741356 l -0.0035,13.904202 c 0.242192,0 2.616688,-2.409856 3.415658,-3.494785 0.345217,-0.468764 0.304712,-1.635494 0.304712,-2.263572 C 35.179831,24.199183 35.492205,24 34.769714,24 H 34 v -5 h 5 v 5 h -1.343763 c -0.629576,0.07372 -1.079562,0.833238 -1.198411,1.883564 -0.177248,1.566377 -0.598118,2.656935 -3.067042,5.145625 l -1.931317,2.082733 v 5.427381 l 0.570726,0.340621 c 0.388082,0.187343 0.922547,0.792701 1.187706,1.345245 0.943986,1.97088 -0.369449,4.088667 -2.535235,4.088667 -1.569431,-0.05818 -2.721414,-0.863987 -2.721414,-2.4436 z"
+     style="opacity:0.2;fill:#ffffff;stroke-width:1;fill-opacity:1"
+     id="path4540" />
+  <path
+     id="path3690"
+     style="opacity:0.95;fill:#aaaaaa;stroke-width:1"
+     d="m 27.961933,40.867923 c 0,-1.858009 0.617533,-2.340038 1.373958,-2.988756 0.607264,-0.293144 0.704295,-0.493272 0.69631,-1.436051 -0.0087,-1.041847 -0.108537,-0.922837 -2.039534,-2.599089 -2.94832,-2.559235 -3.344823,-3.176389 -3.691,-5.744497 -0.255356,-1.894081 -0.07625,-1.47736 -0.809268,-2.205931 -1.349202,-1.340969 -1.118049,-3.307588 0.488095,-4.152812 1.446931,-0.761414 3.160971,0.04841 3.689545,1.743247 0.26052,0.83529 -0.364053,2.277785 -1.202717,2.777705 -0.767465,0.45752 -1.08586,-0.305261 -0.910357,1.38123 0.09713,0.933427 0.333842,2.006953 0.526014,2.385565 0.330046,0.650231 3.561984,3.711218 3.913542,3.711218 L 30,16 h -1.791537 c 0.829079,-1.43707 1.63634,-3.425076 2.439237,-4.871745 l 2.556617,4.872327 h -1.741356 l -0.0035,13.904202 c 0.242192,0 2.616688,-2.409856 3.415658,-3.494785 0.345217,-0.468764 0.304712,-1.635494 0.304712,-2.263572 C 35.179831,23.199183 35.492205,23 34.769714,23 H 34 v -5 h 5 v 5 h -1.343763 c -0.629576,0.07372 -1.079562,0.833238 -1.198411,1.883564 -0.177248,1.566377 -0.598118,2.656935 -3.067042,5.145625 l -1.931317,2.082733 v 5.427381 l 0.570726,0.340621 c 0.388082,0.187343 0.922547,0.792701 1.187706,1.345245 0.943986,1.97088 -0.369449,4.088667 -2.535235,4.088667 -1.569431,-0.05818 -2.721414,-0.863987 -2.721414,-2.4436 z" />
+</svg>

--- a/elementary-xfce/devices/96/drive-removable-media-usb.svg
+++ b/elementary-xfce/devices/96/drive-removable-media-usb.svg
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 96 96"
+   version="1.0"
+   width="96"
+   height="96"
+   id="svg11300"
+   sodipodi:docname="drive-removable-media-usb.svg"
+   inkscape:version="0.92.5 (2060ec1f9f, 2020-04-08)">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1013"
+     id="namedview38"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="24"
+     inkscape:cy="54.354729"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         id="stop3734"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.01900466" />
+      <stop
+         id="stop3738"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop3740"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.97226462,0,0,0.2209741,25.312924,80.797776)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0073162,0,0,1.7107328,34.688663,-7.2203116)" />
+    <linearGradient
+       y2="31.67935"
+       x2="118.57409"
+       y1="3.7037382"
+       x1="118.57409"
+       gradientTransform="matrix(1.3413942,0,0,2.3201011,-93.557906,-4.0467514)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3730"
+       xlink:href="#linearGradient3742" />
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(1.3388775,0,0,2.3866942,-93.292318,2.31416)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-44.395805"
+       x2="25"
+       y1="-35"
+       x1="25"
+       id="linearGradient4763"
+       xlink:href="#linearGradient7056"
+       gradientTransform="matrix(2,0,0,2,0,-1.0014)" />
+  </defs>
+  <path
+     d="m 70,89.9986 a 22,5 0 1 1 -44,0 22,5 0 1 1 44,0 z"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1.99999988"
+     id="path23417"
+     inkscape:connector-curvature="0" />
+  <rect
+     x="33"
+     y="-90.001404"
+     width="30"
+     height="30"
+     ry="2"
+     rx="2"
+     transform="scale(1,-1)"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:none;stroke-width:2"
+     id="rect3448" />
+  <rect
+     x="32.5"
+     y="-90.5"
+     width="30.999998"
+     height="30.999998"
+     ry="2.0666666"
+     rx="2.0666666"
+     transform="scale(1,-1)"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3448-9" />
+  <path
+     id="rect3450"
+     d="m 39,78 v 6 h 6 v -6 z m 12,0 v 6 h 6 v -6 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.33598848;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+  <rect
+     x="34"
+     y="-89"
+     width="28"
+     height="28"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
+  <rect
+     x="27"
+     y="3.0000002"
+     width="42"
+     height="68"
+     ry="2.5"
+     rx="2.5"
+     style="opacity:1;fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:1.99984372;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391" />
+  <rect
+     x="26.5"
+     y="2.5"
+     width="43"
+     height="69"
+     ry="3"
+     rx="3"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="m 29.657896,3.5 c -1.195474,0 -2.157895,0.9338125 -2.157895,2.09375 v 62.8125 c 0,1.159937 0.962421,2.09375 2.157895,2.09375 h 36.684211 c 1.195474,0 2.157895,-0.933813 2.157895,-2.09375 V 5.59375 C 68.500002,4.4338125 67.537581,3.5 66.342107,3.5 Z"
+     id="rect5391-2-0"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 44.356342,57.63682 c 0,-2.5548 0.84912,-3.2176 1.88922,-4.1096 0.835,-0.40308 0.96842,-0.67826 0.95744,-1.9746 -0.012,-1.43256 -0.14924,-1.26892 -2.8044,-3.5738 -4.054,-3.519 -4.5992,-4.3676 -5.0752,-7.8988 -0.35112,-2.6044 -0.10484,-2.0314 -1.11276,-3.0332 -1.85518,-1.84386 -1.53734,-4.548 0.67114,-5.7102 1.98956,-1.04696 4.3464,0.06656 5.0732,2.397 0.35822,1.14854 -0.50058,3.132 -1.65376,3.8194 -1.05528,0.6291 -1.49308,-0.41974 -1.25176,1.89922 0.13356,1.28348 0.45904,2.7596 0.72328,3.2802 0.45382,0.89408 4.8978,5.103 5.3812,5.103 v -24.864 h -2.4634 c 1.14,-1.976 2.25,-3.9848 3.354,-5.974 l 3.5154,5.9748 h -2.3944 v 16.84 c 0.33302,0 3.598,-3.3136 4.6966,-4.8054 0.47468,-0.64456 0.76274,-1.55978 0.76274,-2.4234 0,-1.30248 0.42952,-1.57636 -0.56392,-1.57636 h -1.0584 v -6.1032 h 5.9976 v 6.1032 h -0.9702 c -0.86568,0.10136 -1.48442,0.5426 -1.64784,1.98682 -0.24372,2.1538 -1.16618,3.5674 -4.561,6.9894 l -2.6556,2.8638 v 10.2128 l 0.78476,0.46836 c 0.53362,0.2576 1.26852,1.08998 1.63312,1.84974 1.298,2.71 -0.508,5.622 -3.486,5.622 -2.158,-0.08 -3.742,-1.188 -3.742,-3.36 z"
+     style="opacity:0.3;fill:#ffffff;stroke-width:2"
+     id="path3690-6"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 44.356342,55.63694 c 0,-2.5548 0.84912,-3.2176 1.88922,-4.1096 0.835,-0.40308 0.96842,-0.67826 0.95744,-1.9746 -0.012,-1.43256 -0.14924,-1.26892 -2.8044,-3.5738 -4.054,-3.519 -4.5992,-4.3676 -5.0752,-7.8988 -0.35112,-2.6044 -0.10484,-2.0314 -1.11276,-3.0332 -1.85518,-1.84386 -1.53734,-4.548 0.67114,-5.7102 1.98956,-1.04696 4.3464,0.06656 5.0732,2.397 0.35822,1.14854 -0.50058,3.132 -1.65376,3.8194 -1.05528,0.6291 -1.49308,-0.41974 -1.25176,1.89922 0.13356,1.28348 0.45904,2.7596 0.72328,3.2802 0.45382,0.89408 4.8978,5.103 5.3812,5.103 v -24.864 h -2.4634 c 1.14,-1.976 2.25,-3.9848 3.354,-5.974 l 3.5154,5.9748 h -2.3944 v 16.84 c 0.33302,0 3.598,-3.3136 4.6966,-4.8054 0.47468,-0.64456 0.76274,-1.55978 0.76274,-2.4234 0,-1.30248 0.42952,-1.57636 -0.56392,-1.57636 h -1.0584 V 22.904 h 5.9976 v 6.1032 h -0.9702 c -0.86568,0.10136 -1.48442,0.5426 -1.64784,1.98682 -0.24372,2.1538 -1.16618,3.5674 -4.561,6.9894 l -2.6556,2.8638 v 10.2128 l 0.78476,0.46836 c 0.53362,0.2576 1.26852,1.08998 1.63312,1.84974 1.298,2.71 -0.508,5.622 -3.486,5.622 -2.158,-0.08 -3.742,-1.188 -3.742,-3.36 z"
+     style="opacity:0.95;fill:#aaaaaa;stroke-width:2"
+     id="path3690"
+     inkscape:connector-curvature="0" />
+</svg>


### PR DESCRIPTION
Removable USB device icon was missing above 48px.
This pulls the current icon from upstream for
sizes 16, 24, 32, 48, 64, 128, and from those
creates a new 96px icon.

Fixes #213
