### PR TITLE
Add new desktop places icon

### DIFF
--- a/elementary-xfce/places/128/user-desktop.svg
+++ b/elementary-xfce/places/128/user-desktop.svg
@@ -6,10 +6,35 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="128"
    height="128"
-   id="svg9481">
+   id="svg9481"
+   sodipodi:docname="user-desktopc.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4.1676258"
+     inkscape:cx="67.566792"
+     inkscape:cy="109.64962"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="572"
+     inkscape:window-y="124"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
      id="metadata54">
     <rdf:RDF>
@@ -18,11 +43,89 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs9483">
+    <linearGradient
+       id="linearGradient3813">
+      <stop
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3807">
+      <stop
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient54135">
+      <stop
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop54133"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient53089">
+      <stop
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient132442">
+      <stop
+         id="stop132438"
+         style="stop-color:#353a3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop132440"
+         style="stop-color:#5e6669;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient5048-7">
       <stop
@@ -50,36 +153,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
-      <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729">
-      <stop
-         id="stop8022"
-         style="stop-color:#85c2cf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8024"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop8026"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop8028"
-         style="stop-color:#2c5889;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient3282">
       <stop
          id="stop3284"
@@ -91,71 +164,32 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2238">
-      <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2242"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        x1="12.578789"
        y1="2.9137428"
        x2="12.578789"
        y2="43.810863"
        id="linearGradient3308"
-       xlink:href="#linearGradient2238"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6420597,0,0,2.4848291,0.5873493,11.863829)" />
-    <linearGradient
-       x1="33.579403"
-       y1="5.7086449"
-       x2="33.579403"
-       y2="16.323294"
-       id="linearGradient3311"
-       xlink:href="#linearGradient2446-733-45-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1910236,0,0,1.7591838,-6.608807,8.1210008)" />
-    <linearGradient
-       x1="16.91585"
-       y1="7.0006418"
-       x2="16.91585"
-       y2="14"
-       id="linearGradient3313"
-       xlink:href="#linearGradient3958-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6888891,0,0,2.6669522,-0.5333398,-0.5038536)" />
+       gradientTransform="matrix(2.5532544,0,0,2.2286507,2.718924,21.754337)" />
     <linearGradient
        x1="24.682861"
        y1="9.2416716"
        x2="24.682861"
        y2="13.523027"
        id="linearGradient3316"
-       xlink:href="#linearGradient3282"
+       xlink:href="#linearGradient132442"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6081214,0,0,0.9360169,1.4228412,27.349641)" />
-    <radialGradient
-       cx="26.616697"
-       cy="-2.0644982"
-       r="23"
-       fx="26.616697"
-       fy="-2.0644982"
-       id="radialGradient3322"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-4.8906066e-8,-2.8514561,3.7557195,0,96.173997,156.12002)" />
+       gradientTransform="matrix(2.5646527,0,0,0.9360169,2.4657939,31.34964)" />
     <linearGradient
        x1="10.014208"
        y1="44.960102"
        x2="10.014208"
-       y2="2.8764627"
+       y2="3.7234669"
        id="linearGradient3324"
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
+       xlink:href="#linearGradient24734"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.5745574,0,0,2.4174817,2.2106631,10.950807)" />
+       gradientTransform="matrix(2.4894438,0,0,2.1488667,4.2533212,20.90086)" />
     <radialGradient
        cx="605.71429"
        cy="486.64789"
@@ -165,7 +199,7 @@
        id="radialGradient3327"
        xlink:href="#linearGradient5060-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.144583,0,0,5.3529403e-2,105.13447,91.373542)" />
+       gradientTransform="matrix(-0.144583,0,0,0.0535294,107.13447,89.373543)" />
     <radialGradient
        cx="605.71429"
        cy="486.64789"
@@ -175,7 +209,7 @@
        id="radialGradient3330"
        xlink:href="#linearGradient5060-6"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.1445831,0,0,5.3529403e-2,22.86553,91.373542)" />
+       gradientTransform="matrix(0.1445831,0,0,0.0535294,20.86553,89.373543)" />
     <linearGradient
        x1="302.85715"
        y1="366.64789"
@@ -184,87 +218,243 @@
        id="linearGradient3333"
        xlink:href="#linearGradient5048-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.1905325,0,0,5.3529403e-2,-4.8639063,91.373542)" />
+       gradientTransform="matrix(0.18224848,0,0,0.0535294,-1.8698234,89.373543)" />
     <linearGradient
-       id="linearGradient2446-733-45-2">
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96694049,0,0,0.88888648,2.1157415,11.166835)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6840099,0,0,1.7591838,9.7304295,89.121019)"
+       x1="33.579403"
+       y1="7.8211875"
+       x2="33.579403"
+       y2="16.323294" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0666669,0,0,2.6669522,14.4,80.496159)"
+       x1="16.91585"
+       y1="8.3539181"
+       x2="16.91585"
+       y2="14" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3282"
+       id="linearGradient6880"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6083415,0,0,0.70201266,25.410751,-108.48777)"
+       x1="24.682861"
+       y1="9.2416716"
+       x2="24.682861"
+       y2="13.523027" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient78920"
+       x1="41.935978"
+       y1="19.562904"
+       x2="41.935978"
+       y2="29.11515"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99181182,0,0,0.9333336,0.52453471,10.766658)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient79052"
+       x1="71.851761"
+       y1="20.362186"
+       x2="71.851761"
+       y2="29.421877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0000086,0,0,1,-5.5949194e-5,8.9999997)" />
+    <linearGradient
+       id="linearGradient119256-6">
       <stop
-         id="stop3793-7"
-         style="stop-color:#333333;stop-opacity:1;"
+         id="stop119252-7"
+         style="stop-color:#8bd1ee;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3795-3"
-         style="stop-color:#242424;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3958-1">
-      <stop
-         id="stop3960-6"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962-7"
-         style="stop-color:#000000;stop-opacity:1;"
+         id="stop119254-5"
+         style="stop-color:#b7e9fa;stop-opacity:1"
          offset="1" />
     </linearGradient>
   </defs>
   <rect
-     width="92"
+     width="88"
      height="13"
-     x="18"
-     y="111"
+     x="20"
+     y="109"
      id="rect2512"
-     style="opacity:0.3;fill:url(#linearGradient3333);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient3333);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none" />
   <path
-     d="M 110,111.00044 C 110,111.00044 110,123.9997 110,123.9997 C 117.44567,124.02417 128.00001,121.08723 128,117.49923 C 128,113.91123 119.69119,111.00044 110,111.00044 z"
+     d="m 108,109.00044 c 0,0 0,12.99926 0,12.99926 7.44567,0.0245 18.00001,-2.91247 18,-6.50047 0,-3.588 -8.30881,-6.49879 -18,-6.49879 z"
      id="path2514"
-     style="opacity:0.3;fill:url(#radialGradient3330);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3330);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="M 18,111.00044 C 18,111.00044 18,123.9997 18,123.9997 C 10.554331,124.02417 0,121.08723 0,117.49923 C 0,113.91123 8.3088039,111.00044 18,111.00044 z"
+     d="m 20,109.00044 c 0,0 0,12.99926 0,12.99926 -7.445669,0.0245 -18,-2.91247 -18,-6.50047 0,-3.588 8.308804,-6.49879 18,-6.49879 z"
      id="path2516"
-     style="opacity:0.3;fill:url(#radialGradient3327);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3327);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <rect
-     width="120.99786"
-     height="98.997864"
-     rx="7"
-     ry="7"
-     x="3.5010662"
-     y="19.501066"
+     width="116.998"
+     height="87.997871"
+     rx="5"
+     ry="5"
+     x="5.5010643"
+     y="28.501064"
      id="rect2573"
-     style="fill:url(#radialGradient3322);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 27.5,102.50001 h 73 l 8.00001,14 H 19.5 Z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
   <rect
-     width="120"
+     width="118"
      height="4"
      rx="0"
      ry="0"
-     x="4"
-     y="36"
+     x="5"
+     y="40"
      id="rect1436"
-     style="opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
   <path
-     d="M 11.566661,19.500001 C 11.566661,19.500001 117.33743,19.522905 117.33743,19.522905 C 121.54533,19.522905 124.5,22.886432 124.5,26.608412 C 124.5,26.608412 124.5,35.500001 124.5,35.500001 C 124.5,35.500001 3.4999941,35.500001 3.4999941,35.500001 C 3.4999941,35.500001 3.4999938,26.608412 3.4999938,26.608412 C 3.4999938,22.641264 6.7502832,19.500001 11.566661,19.500001 z"
-     id="rect2311"
-     style="fill:url(#linearGradient3311);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient3313);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
+     id="rect78551"
+     style="fill:url(#linearGradient79052);stroke:url(#linearGradient78920);stroke-width:0.999992"
+     d="m 10.45953,28.499996 h 107.08194 c 2.74731,0 4.95906,2.081334 4.95906,4.666668 V 39.5 H 5.5004745 l -4.1e-6,-6.333336 c 0,-2.585334 2.2117403,-4.666668 4.9590596,-4.666668 z"
+     sodipodi:nodetypes="ssccccs" />
   <rect
-     width="118.99626"
-     height="96.996246"
-     rx="6"
-     ry="6"
-     x="4.5018659"
-     y="20.501919"
+     width="114.996"
+     height="86.996269"
+     rx="4"
+     ry="4"
+     x="6.5018654"
+     y="29.501863"
      id="rect2601"
-     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373137;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <rect
-     width="83"
-     height="19"
+     width="74"
+     height="3"
      rx="0"
      ry="0"
-     x="22.5"
-     y="99.499985"
-     id="rect9439"
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 21.5,119 C 21.5,119 21.5,98.499985 21.5,98.499985 C 21.5,98.499985 106.5,98.499985 106.5,98.499985 C 106.5,98.499985 106.5,119 106.5,119"
-     id="rect2429" />
+     x="27"
+     y="-102"
+     id="rect6872"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient6880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     transform="scale(1,-1)" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect3766"
+     width="7.9999995"
+     height="7.9999995"
+     x="33"
+     y="107.00001"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect36659"
+     width="7.9999995"
+     height="7.9999995"
+     x="32"
+     y="105"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect3768"
+     width="7.9999995"
+     height="7.9999995"
+     x="47"
+     y="107.00001"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38158"
+     width="7.9999995"
+     height="7.9999995"
+     x="46"
+     y="105"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect3770"
+     width="7.9999995"
+     height="7.9999995"
+     x="61"
+     y="107.00001"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38242"
+     width="7.9999995"
+     height="7.9999995"
+     x="60"
+     y="105"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect3772"
+     width="7.9999995"
+     height="7.9999995"
+     x="75"
+     y="107.00001"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38326"
+     width="7.9999995"
+     height="7.9999995"
+     x="74"
+     y="105"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect3774"
+     width="7.9999995"
+     height="7.9999995"
+     x="89"
+     y="107.00001"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38328"
+     width="7.9999995"
+     height="7.9999995"
+     x="88"
+     y="105"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:1"
+     id="rect48112"
+     width="113.99999"
+     height="1"
+     x="7.0000038"
+     y="39" />
+  <rect
+     style="fill:#505a63;fill-opacity:1;stroke-width:0.999999"
+     id="rect49649"
+     width="92.000008"
+     height="1"
+     x="17.999996"
+     y="116" />
 </svg>

--- a/elementary-xfce/places/16/user-desktop.svg
+++ b/elementary-xfce/places/16/user-desktop.svg
@@ -6,12 +6,37 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="16"
    height="16"
-   id="svg3342">
+   id="svg9481"
+   sodipodi:docname="user-desktop.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="19.041821"
+     inkscape:cy="18.487426"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="576"
+     inkscape:window-y="14"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
-     id="metadata37">
+     id="metadata54">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -23,192 +48,207 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3344">
+     id="defs9483">
     <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
+       id="linearGradient3813">
       <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3321">
+       id="linearGradient3807">
       <stop
-         id="stop3323"
-         style="stop-color:#6faebc;stop-opacity:1"
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3325"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3327"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3329"
-         style="stop-color:#2c5889;stop-opacity:1"
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2238">
+       id="linearGradient54135">
       <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2242"
+         id="stop54133"
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3282">
+       id="linearGradient53089">
       <stop
-         id="stop3284"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3286"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient2446-733-45-1"
-       id="linearGradient2414"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2716144,0,0,0.2198978,-0.7524457,0.0776258)"
-       x1="33.579403"
-       y1="5.7086449"
-       x2="33.579403"
-       y2="16.323294" />
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3958-6"
-       id="linearGradient2416"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3333333,0,0,0.3333689,7.1074495e-4,-1.0004803)"
-       x1="16.91585"
-       y1="7.0006418"
-       x2="16.91585"
-       y2="14" />
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3282"
-       id="linearGradient2419"
+       x1="12.578789"
+       y1="2.9137428"
+       x2="12.578789"
+       y2="43.810863"
+       id="linearGradient3308"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3042808,0,0,0.2340042,0.6993307,2.8374077)"
-       x1="24.682861"
-       y1="9.2416716"
-       x2="24.682861"
-       y2="13.523027" />
+       gradientTransform="matrix(0.28855602,0,0,0.28169996,1.0743358,1.5225827)" />
     <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient2422"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2885901,0,0,0.281741,1.0734846,1.5216393)"
-       x1="24.675762"
-       y1="1.6925697"
-       x2="24.675762"
-       y2="44.295784" />
-    <radialGradient
-       xlink:href="#linearGradient3321"
-       id="radialGradient2425"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.3743803,0.4655272,0,11.988014,19.393247)"
-       cx="26.616697"
-       cy="-2.0644982"
-       fx="26.616697"
-       fy="-2.0644982"
-       r="23" />
-    <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
-       id="linearGradient2427"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3191203,0,0,0.3174019,0.3411154,0.3333387)"
        x1="10.014208"
        y1="44.960102"
        x2="10.014208"
-       y2="-11.86743" />
-    <linearGradient
-       id="linearGradient2446-733-45-1">
-      <stop
-         id="stop3793-0"
-         style="stop-color:#333333;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3795-9"
-         style="stop-color:#242424;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3958-6">
-      <stop
-         id="stop3960-8"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962-3"
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient3798"
+       y2="3.7234669"
+       id="linearGradient3324"
+       xlink:href="#linearGradient24734"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2885901,0,0,0.281741,1.0734846,1.5216393)"
-       x1="24.675762"
-       y1="1.6925697"
-       x2="24.675762"
-       y2="44.295784" />
+       gradientTransform="matrix(0.31911961,0,0,0.31740194,0.31236776,0.3784636)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12395125,0,0,0.13129444,0.0383533,-1.059317)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22139228,0,0,0.22563944,0.86636494,10.968275)"
+       x1="33.579403"
+       y1="6.7119455"
+       x2="33.579403"
+       y2="14.193644" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27169916,0,0,0.34207318,1.4802609,9.862018)"
+       x1="16.082123"
+       y1="8.1919737"
+       x2="16.082123"
+       y2="12.680706" />
+    <linearGradient
+       id="linearGradient119256-6">
+      <stop
+         id="stop119252-7"
+         style="stop-color:#70bde6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop119254-5"
+         style="stop-color:#add7ef;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient943"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50205013,0,0,0.51925156,-0.54997169,-3.0186676)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="12.263648" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient945"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50205013,0,0,0.51925156,-0.54997169,-3.0186676)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="12.237682" />
   </defs>
   <rect
-     style="fill:url(#radialGradient2425);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2427);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect1316"
-     y="1.5010664"
-     x="0.50106621"
-     ry="1.5617938"
-     rx="1.5284374"
-     height="12.997867"
-     width="14.997868" />
+     width="14.99787"
+     height="12.99787"
+     rx="0.5"
+     ry="0.5"
+     x="0.47231486"
+     y="1.501065"
+     id="rect2573"
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <rect
-     style="opacity:0.2;fill:url(#linearGradient2419);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect1436"
-     y="5"
-     x="1"
-     ry="0"
-     rx="0"
+     width="12.99627"
+     height="10.99627"
+     rx="0.49999994"
+     ry="0.5"
+     x="1.5018649"
+     y="2.5018649"
+     id="rect2601"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 3,11.5 h 10 l 1,2.999944 -12,1.12e-4 z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999996"
+     id="rect36659"
+     width="2"
+     height="2"
+     x="4"
+     y="12" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999996"
+     id="rect38242"
+     width="2"
+     height="2"
+     x="10"
+     y="12" />
+  <path
+     id="rect900"
+     style="fill:url(#linearGradient945);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient943);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 1,1.5 h 14 c 0.277,0 0.5,0.223 0.5,0.5 V 3.5 H 0.5 V 2 C 0.5,1.723 0.723,1.5 1,1.5 Z"
+     sodipodi:nodetypes="sssccss" />
+  <rect
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:0.999999"
+     id="rect48112"
+     width="12"
      height="1"
-     width="14" />
+     x="2"
+     y="3" />
   <rect
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient2422);stroke-width:1.00213301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect2232"
-     y="2.5010664"
-     x="1.5010662"
-     ry="0.53651923"
-     rx="0.53651923"
-     height="10.997867"
-     width="12.997868" />
-  <path
-     style="fill:url(#linearGradient2414);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient2416);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect2311"
-     d="M 1.500711,1.5000001 C 1.500711,1.5000001 14.612789,1.5028629 14.612789,1.5028629 C 15.13443,1.5028629 15.500711,1.9233048 15.500711,2.3885518 C 15.500711,2.3885518 15.500711,4.5 15.500711,4.5 C 15.500711,4.5 0.50071114,4.5 0.50071114,4.5 C 0.50071114,4.5 0.50071114,2.3885518 0.50071114,2.3885518 C 0.50071114,1.8926584 0.90363933,1.5000001 1.500711,1.5000001 z" />
-  <rect
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect9439"
-     y="11.5"
-     x="3.5"
-     ry="0"
-     rx="0"
-     height="2.9999998"
-     width="9" />
-  <path
-     style="opacity:0.2;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 2.5,15 C 2.5,15 2.5,10.500001 2.5,10.500001 C 2.5,10.500001 13.5,10.500001 13.5,10.500001 C 13.5,10.500001 13.5,15 13.5,15"
-     id="rect2429" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.2;color:#000000;fill:url(#linearGradient3798);fill-opacity:1;stroke:none;stroke-width:1.00213301;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="M 2.03125,2 C 1.4650946,2 1,2.4650946 1,3.03125 L 1,4 15,4 15,3.03125 C 15,2.4650946 14.534905,2 13.96875,2 z m 0,1 11.9375,0 C 13.997058,3 14,3.0029421 14,3.03125 L 14,4 2,4 C 2,4 2,3.3463945 2,3.03125 2,3.0029421 2.0029421,3 2.03125,3 z"
-     id="rect3792" />
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999996"
+     id="rect918"
+     width="2"
+     height="2"
+     x="7"
+     y="12" />
 </svg>

--- a/elementary-xfce/places/22/user-desktop.svg
+++ b/elementary-xfce/places/22/user-desktop.svg
@@ -6,62 +6,124 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="22"
    height="22"
-   id="svg2639">
+   id="svg9481"
+   sodipodi:docname="user-desktop.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="45.114277"
+     inkscape:cy="43.06168"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="589"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
-     id="metadata42">
+     id="metadata54">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs2641">
+     id="defs9483">
     <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
+       id="linearGradient3813">
       <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729">
+       id="linearGradient3807">
       <stop
-         id="stop8022"
-         style="stop-color:#85c2cf;stop-opacity:1"
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop8024"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop8026"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop8028"
-         style="stop-color:#2c5889;stop-opacity:1"
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2238">
+       id="linearGradient54135">
       <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2242"
+         id="stop54133"
          style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient53089">
+      <stop
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient132442">
+      <stop
+         id="stop132438"
+         style="stop-color:#353a3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop132440"
+         style="stop-color:#5e6669;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -76,125 +138,191 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient2446-733-45-9"
-       id="linearGradient2419"
+       x1="12.578789"
+       y1="2.9137428"
+       x2="12.578789"
+       y2="43.810863"
+       id="linearGradient3308"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3802462,0,0,0.329847,-1.2543548,0.3664358)"
+       gradientTransform="matrix(0.42177392,0,0,0.35855329,0.87695835,2.9825314)" />
+    <linearGradient
+       x1="24.682861"
+       y1="9.2416716"
+       x2="24.682861"
+       y2="13.523027"
+       id="linearGradient3316"
+       xlink:href="#linearGradient132442"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47815556,0,0,0.23400423,-0.47247937,4.8374086)" />
+    <linearGradient
+       x1="10.014208"
+       y1="44.960102"
+       x2="10.014208"
+       y2="3.7234669"
+       id="linearGradient3324"
+       xlink:href="#linearGradient24734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44678557,0,0,0.39066049,0.27712995,2.1193593)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17353879,0,0,0.16159811,-0.10650587,0.34972906)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30873513,0,0,0.31472916,1.0505743,14.417341)"
        x1="33.579403"
-       y1="5.7086449"
+       y1="4.9473233"
        x2="33.579403"
-       y2="16.323294" />
+       y2="14.193644" />
     <linearGradient
-       xlink:href="#linearGradient3958-7"
-       id="linearGradient2421"
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4666493,0,0,0.5000537,-0.1999749,-1.2507234)"
-       x1="16.91585"
-       y1="7.0006418"
-       x2="16.91585"
-       y2="14" />
+       gradientTransform="matrix(0.37888889,0,0,0.4771347,1.9066622,12.874299)"
+       x1="16.082123"
+       y1="6.5509825"
+       x2="16.082123"
+       y2="12.680706" />
     <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient3282"
-       id="linearGradient2424"
+       id="linearGradient6880"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4346869,0,0,0.2340043,0.5704707,3.8374098)"
+       gradientTransform="matrix(0.31514798,0,0,0.23400423,3.4385926,-18.16259)"
        x1="24.682861"
        y1="9.2416716"
        x2="24.682861"
        y2="13.523027" />
     <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient2427"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4218075,0,0,0.3842123,0.8761112,2.165418)"
-       x1="22.762604"
-       y1="-4.8771"
-       x2="22.762604"
-       y2="43.84375" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729"
-       id="radialGradient2433"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.4895932,0.6517645,0,16.583449,25.946788)"
-       cx="26.616697"
-       cy="-2.0644982"
-       fx="26.616697"
-       fy="-2.0644982"
-       r="23" />
-    <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
-       id="linearGradient2435"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4467866,0,0,0.41508,0.2771291,1.0213291)"
-       x1="10.014208"
-       y1="44.960102"
-       x2="10.014208"
-       y2="2.8764627" />
-    <linearGradient
-       id="linearGradient2446-733-45-9">
+       id="linearGradient119256-6">
       <stop
-         id="stop3793-1"
-         style="stop-color:#333333;stop-opacity:1;"
+         id="stop119252-7"
+         style="stop-color:#70c3e6;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3795-0"
-         style="stop-color:#242424;stop-opacity:1;"
+         id="stop119254-5"
+         style="stop-color:#9de1f6;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3958-7">
-      <stop
-         id="stop3960-1"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962-2"
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient908"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71179547,0,0,0.37756196,-1.1219604,0.21485126)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="15.322867" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71179547,0,0,0.37756196,-1.1219604,0.21485126)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="14.6669" />
   </defs>
   <rect
-     style="fill:url(#radialGradient2433);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2435);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect1316"
-     y="2.5008497"
-     x="0.50108719"
-     ry="1.4241893"
-     rx="1.4532951"
-     height="16.998301"
-     width="20.997826" />
+     width="20.997869"
+     height="15.997869"
+     rx="0.5"
+     ry="0.5"
+     x="0.50106502"
+     y="3.501065"
+     id="rect2573"
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <rect
-     style="opacity:0.2;fill:url(#linearGradient2424);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect1436"
-     y="6"
-     x="1"
-     ry="0"
-     rx="0"
+     width="14.5"
      height="1"
-     width="20" />
-  <path
-     style="fill:url(#linearGradient2419);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient2421);stroke-width:0.99999987999999995;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect2311"
-     d="M 1.8999478,2.4999998 C 1.8999478,2.4999998 20.256173,2.5042948 20.256173,2.5042948 C 20.986443,2.5042948 21.499219,3.1349549 21.499219,3.8328263 C 21.499219,3.8328263 21.499219,5.4999999 21.499219,5.4999999 C 21.499219,5.4999999 0.49999995,5.4999999 0.49999995,5.4999999 C 0.49999995,5.4999999 0.49999995,3.8328263 0.49999995,3.8328263 C 0.49999995,3.0889863 1.0640786,2.4999998 1.8999478,2.4999998 z" />
-  <rect
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient2427);stroke-width:1.00213313;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect2232"
-     y="3.5010633"
-     x="1.5010666"
-     ry="0.54499364"
-     rx="0.55883807"
-     height="14.997867"
-     width="18.997868" />
-  <rect
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect9439"
-     y="15.500003"
-     x="4.5000005"
-     ry="0"
      rx="0"
-     height="4"
-     width="12.999999" />
+     ry="0"
+     x="3.7499998"
+     y="-16"
+     id="rect6872"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient6880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     transform="scale(1,-1)" />
+  <rect
+     width="18.996269"
+     height="13.99627"
+     rx="0.5"
+     ry="0.5"
+     x="1.5018651"
+     y="4.228982"
+     id="rect2601"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="opacity:0.2;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 3.5,20 C 3.5,20 3.5,14.500003 3.5,14.500003 C 3.5,14.500003 18.5,14.500003 18.5,14.500003 C 18.5,14.500003 18.5,20 18.5,20"
-     id="rect2437" />
+     id="rect906"
+     style="fill:url(#linearGradient908);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient910);stroke-width:0.999997;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 0.96299975,3.5004978 H 21.034 c 0.203133,0 0.466333,0.2620877 0.466333,0.4635018 v 2.536 H 0.49666645 v -2.536 c 0,-0.2014141 0.2632,-0.4635018 0.4663333,-0.4635018 z"
+     sodipodi:nodetypes="sssccss" />
+  <rect
+     width="22"
+     height="1"
+     rx="0"
+     ry="0"
+     x="-2.475e-07"
+     y="7"
+     id="rect1436"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:0.999998"
+     id="rect48112"
+     width="18"
+     height="1"
+     x="1.9999998"
+     y="6" />
+  <path
+     d="M 3.9999998,15.5 H 18 l 1.5,3.999922 -17.0000002,1.56e-4 z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     style="fill:#505a63;fill-opacity:1;stroke-width:0.999997"
+     id="rect49649"
+     width="17.599998"
+     height="1"
+     x="2.1999996"
+     y="19" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="rect36659"
+     width="2"
+     height="2"
+     x="3.9999998"
+     y="16" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect38158"
+     width="2"
+     height="2"
+     x="7.9999995"
+     y="16" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="rect38242"
+     width="2"
+     height="2"
+     x="12"
+     y="16" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="rect1107"
+     width="2"
+     height="2"
+     x="16"
+     y="16" />
 </svg>

--- a/elementary-xfce/places/24/user-desktop.svg
+++ b/elementary-xfce/places/24/user-desktop.svg
@@ -6,106 +6,150 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="24"
    height="24"
-   id="svg2638">
+   id="svg9481"
+   sodipodi:docname="user-desktop8.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="9.5699384"
+     inkscape:cy="15.153495"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="774"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
-     id="metadata56">
+     id="metadata54">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs2640">
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3931"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)" />
+     id="defs9483">
     <linearGradient
-       id="linearGradient5060">
+       id="linearGradient3813">
       <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2662"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)" />
     <linearGradient
-       id="linearGradient5048">
+       id="linearGradient3807">
       <stop
-         id="stop5050"
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient54135">
+      <stop
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop54133"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient53089">
+      <stop
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient132442">
+      <stop
+         id="stop132438"
+         style="stop-color:#353a3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop132440"
+         style="stop-color:#5e6669;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
          style="stop-color:#000000;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop5056"
+         id="stop5056-9"
          style="stop-color:#000000;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop5052"
+         id="stop5052-6"
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient2660"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)" />
-    <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
+       id="linearGradient5060-6">
       <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729">
-      <stop
-         id="stop8022"
-         style="stop-color:#85c2cf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8024"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop8026"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop8028"
-         style="stop-color:#2c5889;stop-opacity:1"
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -120,155 +164,333 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2238">
-      <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2242"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient2432"
+       x1="12.578789"
+       y1="2.9137428"
+       x2="12.578789"
+       y2="43.810863"
+       id="linearGradient3308"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4662133,0,0,0.4354479,0.8103191,1.987307)"
-       x1="22.762604"
-       y1="-4.8771"
-       x2="22.762604"
-       y2="43.84375" />
+       gradientTransform="matrix(0.42177392,0,0,0.35855329,1.8769586,4.9825316)" />
     <linearGradient
-       xlink:href="#linearGradient2446-733-45-7"
-       id="linearGradient2436"
+       x1="24.682861"
+       y1="9.2416716"
+       x2="24.682861"
+       y2="13.523027"
+       id="linearGradient3316"
+       xlink:href="#linearGradient132442"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4164756,0,0,0.3298469,-1.4211487,0.3664383)"
+       gradientTransform="matrix(0.47815556,0,0,0.23400423,0.52752088,6.8374088)" />
+    <linearGradient
+       x1="10.014208"
+       y1="44.960102"
+       x2="10.014208"
+       y2="3.7234669"
+       id="linearGradient3324"
+       xlink:href="#linearGradient24734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44678557,0,0,0.39066049,1.2771302,4.1193595)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3327"
+       xlink:href="#linearGradient5060-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0722915,0,0,0.02662157,53.567235,39.274275)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3330"
+       xlink:href="#linearGradient5060-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07229155,0,0,0.02662157,10.432765,39.274275)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3333"
+       xlink:href="#linearGradient5048-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09112424,0,0,0.02662157,-0.9349117,39.274275)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17353879,0,0,0.16159811,0.89349438,2.3497293)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30873513,0,0,0.31472916,2.0505745,16.417341)"
        x1="33.579403"
-       y1="5.7086449"
+       y1="4.9473233"
        x2="33.579403"
-       y2="16.323294" />
+       y2="14.193644" />
     <linearGradient
-       xlink:href="#linearGradient3958-6"
-       id="linearGradient2438"
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5111111,0,0,0.5000534,-0.2663078,-1.2507216)"
-       x1="16.91585"
-       y1="7.0006418"
-       x2="16.91585"
-       y2="14" />
+       gradientTransform="matrix(0.37888889,0,0,0.4771347,2.9066624,14.874299)"
+       x1="16.082123"
+       y1="6.5509825"
+       x2="16.082123"
+       y2="12.680706" />
     <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient3282"
-       id="linearGradient2441"
+       id="linearGradient6880"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4781556,0,0,0.2340043,0.5275254,3.8374089)"
+       gradientTransform="matrix(0.31514798,0,0,0.23400423,4.4385928,-20.16259)"
        x1="24.682861"
        y1="9.2416716"
        x2="24.682861"
        y2="13.523027" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient78920"
+       x1="41.935978"
+       y1="19.562904"
+       x2="41.935978"
+       y2="29.11515"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.49590591,0,0,0.46417127,-6.968847,-7.6067131)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient79052"
+       x1="71.851761"
+       y1="20.362186"
+       x2="71.851761"
+       y2="29.421877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5000043,0,0,0.49732622,-7.2311423,-8.4853181)" />
+    <linearGradient
+       id="linearGradient119256-6">
+      <stop
+         id="stop119252-7"
+         style="stop-color:#70c3e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop119254-5"
+         style="stop-color:#9de1f6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient922"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="13.839313"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9747305,0,0,1.0385031,-1.6298876,-0.53733491)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient930"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="13.723811"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9747305,0,0,1.0385031,-1.6298876,-0.53733491)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9747305,0,0,1.0385031,-16.305772,-28.654344)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="13.839313" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient979"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9747305,0,0,1.0385031,-16.305772,-28.654344)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="13.723811" />
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729"
-       id="radialGradient2447"
+       gradientTransform="matrix(0.01554655,0,0,0.01235337,12.695219,15.470559)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-0.5472088,0.7138538,0,18.230214,28.71861)"
-       cx="26.616697"
-       cy="-2.0644982"
-       fx="26.616697"
-       fy="-2.0644982"
-       r="23" />
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient5942"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
-       id="linearGradient2449"
+       gradientTransform="matrix(0.04168734,0,0,0.01235283,-3.0669985,15.470886)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.489349,0,0,0.463927,0.3705005,0.8599059)"
-       x1="10.014208"
-       y1="44.960102"
-       x2="10.014208"
-       y2="2.8764627" />
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient5946"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.01554655,0,0,0.01235337,11.304779,15.470559)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient5950"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       id="linearGradient2446-733-45-7">
-      <stop
-         id="stop3793-1"
-         style="stop-color:#333333;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3795-3"
-         style="stop-color:#242424;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient908"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71179547,0,0,0.37756196,-0.12196019,2.2148515)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="15.322867" />
     <linearGradient
-       id="linearGradient3958-6">
-      <stop
-         id="stop3960-5"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962-3"
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.71179547,0,0,0.37756196,-0.12196019,2.2148515)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="14.6669" />
   </defs>
-  <g
-     id="g5022"
-     transform="matrix(1.182016e-2,0,0,9.90682e-3,22.513267,19.753927)">
-    <rect
-       style="opacity:0.40206185;fill:url(#linearGradient2660);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2969"
-       y="-150.69685"
-       x="-1559.2523"
-       height="478.35718"
-       width="1339.6335" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient2662);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2971"
-       d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 L -219.61876,-150.68038 z" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3931);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2973"
-       d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 L -1559.2523,-150.68038 z" />
-  </g>
+  <path
+     d="m 22.064517,20 c 0,0 0,2.999941 0,2.999941 C 22.865126,23.005641 24,22.327803 24,21.499777 24,20.671746 23.106581,20 22.064517,20 Z"
+     id="path3411"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none" />
   <rect
-     style="fill:url(#radialGradient2447);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2449);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect1316"
-     y="2.5010662"
-     x="0.5010668"
-     ry="1.5917214"
-     rx="1.5917214"
-     height="18.997868"
-     width="22.997868" />
+     width="20.129032"
+     height="2.9999747"
+     x="1.9354856"
+     y="20.000025"
+     id="rect4173-14"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient5946);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none" />
+  <path
+     d="m 1.9354843,20 c 0,0 0,2.999941 0,2.999941 C 1.1348714,23.005641 4.95e-7,22.327803 4.95e-7,21.499777 4.95e-7,20.671746 0.8934198,20 1.9354843,20 Z"
+     id="path5018-7"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5950);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none" />
   <rect
-     style="opacity:0.2;fill:url(#linearGradient2441);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect1436"
-     y="6"
-     x="1"
-     ry="0"
-     rx="0"
+     width="20.997869"
+     height="15.997869"
+     rx="0.5"
+     ry="0.5"
+     x="1.5010653"
+     y="5.5010653"
+     id="rect2573"
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="fill:url(#linearGradient977);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient979);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     id="rect914-3"
+     width="59"
+     height="6"
+     x="-12.175884"
+     y="-19.617008"
+     rx="2"
+     ry="2" />
+  <rect
+     width="14.5"
      height="1"
-     width="22" />
-  <path
-     style="fill:url(#linearGradient2436);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient2438);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect2311"
-     d="M 2.0336918,2.5 C 2.0336918,2.5 22.138876,2.5042946 22.138876,2.5042946 C 22.938726,2.5042946 23.500357,3.1349562 23.500357,3.8328274 C 23.500357,3.8328274 23.500357,5.5 23.500357,5.5 C 23.500357,5.5 0.50035808,5.5 0.50035808,5.5 C 0.50035808,5.5 0.50035808,3.8328274 0.50035808,3.8328274 C 0.50035808,3.0889868 1.1181823,2.5 2.0336918,2.5 z" />
-  <rect
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect9439"
-     y="17.5"
-     x="4.5000005"
-     ry="0"
      rx="0"
-     height="3.9999998"
-     width="14.999999" />
+     ry="0"
+     x="4.75"
+     y="-18"
+     id="rect6872"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient6880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     transform="scale(1,-1)" />
   <rect
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient2432);stroke-width:1.00213301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect2232"
-     y="3.5010662"
-     x="1.5010667"
-     ry="0.61766976"
-     rx="0.61766976"
-     height="16.997868"
-     width="20.997868" />
+     width="18.996269"
+     height="13.99627"
+     rx="0.5"
+     ry="0.5"
+     x="2.5018654"
+     y="6.228982"
+     id="rect2601"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 3.5,22 C 3.5,22 3.5,16.5 3.5,16.5 C 3.5,16.5 20.5,16.5 20.5,16.5 C 20.5,16.5 20.5,22 20.5,22"
-     id="rect2455" />
+     id="rect906"
+     style="fill:url(#linearGradient908);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient910);stroke-width:0.999997;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 1.963,5.500498 h 20.071 c 0.203133,0 0.466333,0.2620877 0.466333,0.4635018 v 2.536 H 1.4966667 v -2.536 c 0,-0.2014141 0.2632,-0.4635018 0.4663333,-0.4635018 z"
+     sodipodi:nodetypes="sssccss" />
+  <rect
+     width="22"
+     height="1"
+     rx="0"
+     ry="0"
+     x="1"
+     y="9"
+     id="rect1436"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:0.999998"
+     id="rect48112"
+     width="18"
+     height="1"
+     x="3"
+     y="8" />
+  <path
+     d="m 5,17.5 h 14 l 1.5,3.999922 -17,1.56e-4 z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     style="fill:#505a63;fill-opacity:1;stroke-width:0.999997"
+     id="rect49649"
+     width="17.599998"
+     height="1"
+     x="3.1999998"
+     y="21" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="rect36659"
+     width="2"
+     height="2"
+     x="5"
+     y="18" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect38158"
+     width="2"
+     height="2"
+     x="9"
+     y="18" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="rect38242"
+     width="2"
+     height="2"
+     x="13"
+     y="18" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="rect1107"
+     width="2"
+     height="2"
+     x="17"
+     y="18" />
 </svg>

--- a/elementary-xfce/places/32/user-desktop.svg
+++ b/elementary-xfce/places/32/user-desktop.svg
@@ -6,117 +6,150 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="32"
    height="32"
-   id="svg2639">
+   id="svg9481"
+   sodipodi:docname="user-desktop.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="35.308734"
+     inkscape:cy="20.934827"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="589"
+     inkscape:window-y="40"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
-     id="metadata56">
+     id="metadata54">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs2641">
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3932"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)" />
+     id="defs9483">
     <linearGradient
-       id="linearGradient5060">
+       id="linearGradient3813">
       <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3407"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)" />
     <linearGradient
-       id="linearGradient5048">
+       id="linearGradient3807">
       <stop
-         id="stop5050"
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient54135">
+      <stop
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop54133"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient53089">
+      <stop
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient132442">
+      <stop
+         id="stop132438"
+         style="stop-color:#353a3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop132440"
+         style="stop-color:#5e6669;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
          style="stop-color:#000000;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop5056"
+         id="stop5056-9"
          style="stop-color:#000000;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop5052"
+         id="stop5052-6"
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient3405"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)" />
-    <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
+       id="linearGradient5060-6">
       <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729">
-      <stop
-         id="stop8022"
-         style="stop-color:#85c2cf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8024"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop8026"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop8028"
-         style="stop-color:#2c5889;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2238">
-      <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2242"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -131,144 +164,243 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient2446-733-45-3"
-       id="linearGradient2433"
+       x1="12.578789"
+       y1="2.9137428"
+       x2="12.578789"
+       y2="43.810863"
+       id="linearGradient3308"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5613326,0,0,0.439796,-2.0897298,1.6552502)"
+       gradientTransform="matrix(0.59939777,0,0,0.48664217,1.6137884,7.8104225)" />
+    <linearGradient
+       x1="24.682861"
+       y1="9.2416716"
+       x2="24.682861"
+       y2="13.523027"
+       id="linearGradient3316"
+       xlink:href="#linearGradient132442"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.65203035,0,0,0.23400423,0.3557103,9.8376961)" />
+    <linearGradient
+       x1="10.014208"
+       y1="44.960102"
+       x2="10.014208"
+       y2="3.7234669"
+       id="linearGradient3324"
+       xlink:href="#linearGradient24734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.61700683,0,0,0.51275814,1.191813,6.6875198)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2396555,0,0,0.21210425,0.6620154,4.3648065)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42100248,0,0,0.43283945,2.4326017,23.513958)"
        x1="33.579403"
-       y1="5.7086449"
+       y1="7.8211875"
        x2="33.579403"
        y2="16.323294" />
     <linearGradient
-       xlink:href="#linearGradient3958-9"
-       id="linearGradient2435"
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.688884,0,0,0.6667381,-0.5332158,-0.5009634)"
+       gradientTransform="matrix(0.5166667,0,0,0.6561919,3.5999943,21.391849)"
        x1="16.91585"
-       y1="7.0006418"
+       y1="8.3539181"
        x2="16.91585"
        y2="14" />
     <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient3282"
-       id="linearGradient2438"
+       id="linearGradient6880"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6520304,0,0,0.2340042,0.3557106,6.8374098)"
+       gradientTransform="matrix(0.41295254,0,0,0.23400423,6.0919497,-26.162878)"
        x1="24.682861"
        y1="9.2416716"
        x2="24.682861"
        y2="13.523027" />
     <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient2444"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6438835,0,0,0.5892091,0.546013,3.4517154)"
-       x1="12.578789"
-       y1="-7.8073711"
-       x2="12.578789"
-       y2="41.827358" />
+       id="linearGradient119256-6">
+      <stop
+         id="stop119252-7"
+         style="stop-color:#70c3e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop119254-5"
+         style="stop-color:#9de1f6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729"
-       id="radialGradient2447"
+       gradientTransform="matrix(0.02008097,0,0,0.01647116,16.89799,21.960748)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.2529193e-8,-0.720032,0.9621739,0,24.242624,38.998777)"
-       cx="26.616697"
-       cy="-2.0644982"
-       fx="26.616697"
-       fy="-2.0644982"
-       r="23" />
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient5942"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
-       id="linearGradient2449"
+       gradientTransform="matrix(0.05384615,0,0,0.01647044,-3.4615405,21.961183)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6595732,0,0,0.6104475,0.1702567,2.3415483)"
-       x1="10.014208"
-       y1="44.960102"
-       x2="10.014208"
-       y2="2.8764627" />
+       xlink:href="#linearGradient5048-7"
+       id="linearGradient5946"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.02008097,0,0,0.01647116,15.102006,21.960748)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient5950"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       id="linearGradient2446-733-45-3">
-      <stop
-         id="stop3793-1"
-         style="stop-color:#333333;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3795-9"
-         style="stop-color:#242424;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient908"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97063024,0,0,0.5192519,-0.52994581,3.981615)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="13.839313" />
     <linearGradient
-       id="linearGradient3958-9">
-      <stop
-         id="stop3960-3"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962-6"
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97063024,0,0,0.5192519,-0.52994581,3.981615)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="13.723811" />
   </defs>
-  <g
-     id="g2583"
-     transform="matrix(1.576018e-2,0,0,1.254293e-2,30.017663,26.89018)">
-    <rect
-       style="opacity:0.40206185;fill:url(#linearGradient3405);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2585"
-       y="-150.69685"
-       x="-1559.2523"
-       height="478.35718"
-       width="1339.6335" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3407);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2587"
-       d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 L -219.61876,-150.68038 z" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2589"
-       d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 L -1559.2523,-150.68038 z" />
-  </g>
+  <path
+     d="m 29,28 c 0,0 0,3.99992 0,3.99992 1.03412,0.0076 2.5,-0.896183 2.5,-2.000218 C 31.5,28.895662 30.346,28 29,28 Z"
+     id="path3411"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <rect
-     style="fill:url(#radialGradient2447);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2449);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect2591"
-     y="4.5"
-     x="0.50000024"
-     ry="1.8014445"
-     rx="1.8366539"
-     height="25"
-     width="30.999998" />
+     width="26"
+     height="3.999965"
+     x="3.0000019"
+     y="28.000034"
+     id="rect4173-14"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient5946);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 3,28 c 0,0 0,3.99992 0,3.99992 C 1.965875,32.00752 0.5,31.103737 0.5,29.999702 0.5,28.895662 1.654,28 3,28 Z"
+     id="path5018-7"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5950);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <rect
-     style="opacity:0.2;fill:url(#linearGradient2438);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect1436"
-     y="9"
-     x="1"
-     ry="0"
-     rx="0"
+     width="28.997869"
+     height="20.997869"
+     rx="0.5"
+     ry="0.5"
+     x="1.5010653"
+     y="8.5010653"
+     id="rect2573"
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="26.996269"
+     height="18.996269"
+     rx="2"
+     ry="2"
+     x="2.5018654"
+     y="9.5021515"
+     id="rect2601"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 6.5,24.500287 h 19 l 2,4.999893 -23,2.15e-4 z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     width="19"
      height="1"
-     width="30" />
-  <path
-     style="fill:url(#linearGradient2433);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient2435);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect2311"
-     d="M 2.5667621,4.5000001 C 2.5667621,4.5000001 29.664862,4.5057263 29.664862,4.5057263 C 30.742914,4.5057263 31.49989,5.3466079 31.49989,6.2771031 C 31.49989,6.2771031 31.49989,8.5 31.49989,8.5 C 31.49989,8.5 0.50011015,8.5 0.50011015,8.5 C 0.50011015,8.5 0.50011015,6.2771031 0.50011015,6.2771031 C 0.50011015,5.2853162 1.3328221,4.5000001 2.5667621,4.5000001 z" />
-  <rect
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient2444);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect2645"
-     y="5.5"
-     x="1.5000002"
-     ry="1.1146195"
-     rx="1.1438993"
-     height="23"
-     width="29" />
-  <rect
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect9439"
-     y="24.499998"
-     x="5.5"
-     ry="0"
      rx="0"
-     height="4.9999995"
-     width="21" />
+     ry="0"
+     x="6.5"
+     y="-24.000286"
+     id="rect6872"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient6880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     transform="scale(1,-1)" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect36659"
+     width="3"
+     height="2.9999998"
+     x="7"
+     y="25.000286"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38158"
+     width="3"
+     height="3"
+     x="12"
+     y="25.000286"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38242"
+     width="3"
+     height="3"
+     x="17"
+     y="25.000286"
+     rx="0.5"
+     ry="0.5" />
   <path
-     style="opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 4.5,30 C 4.5,30 4.5,23.499998 4.5,23.499998 C 4.5,23.499998 27.5,23.499998 27.5,23.499998 C 27.5,23.499998 27.5,30 27.5,30"
-     id="rect2455" />
+     id="rect906"
+     style="fill:url(#linearGradient908);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient910);stroke-width:0.999998;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 1.999999,8.5002858 h 28 c 0.277,0 0.5,0.223 0.5,0.5 v 2.5000012 h -29 V 9.0002858 c 0,-0.277 0.223,-0.5 0.5,-0.5 z"
+     sodipodi:nodetypes="sssccss" />
+  <rect
+     width="30.000002"
+     height="1"
+     rx="0"
+     ry="0"
+     x="1"
+     y="12.000287"
+     id="rect1436"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+  <rect
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:1"
+     id="rect48112"
+     width="28"
+     height="1"
+     x="2"
+     y="11.000287" />
+  <rect
+     style="fill:#505a63;fill-opacity:1;stroke-width:1"
+     id="rect49649"
+     width="24"
+     height="1"
+     x="4"
+     y="29.000286" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect1107"
+     width="3"
+     height="3"
+     x="22"
+     y="25.000286"
+     rx="0.5"
+     ry="0.5" />
 </svg>

--- a/elementary-xfce/places/48/user-desktop.svg
+++ b/elementary-xfce/places/48/user-desktop.svg
@@ -6,12 +6,37 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="48"
    height="48"
-   id="svg9481">
+   id="svg9481"
+   sodipodi:docname="user-desktop.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="42.273283"
+     inkscape:cy="27.669898"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="841"
+     inkscape:window-y="63"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
-     id="metadata55">
+     id="metadata54">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -24,6 +49,83 @@
   </metadata>
   <defs
      id="defs9483">
+    <linearGradient
+       id="linearGradient3813">
+      <stop
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3807">
+      <stop
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient54135">
+      <stop
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop54133"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient53089">
+      <stop
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient132442">
+      <stop
+         id="stop132438"
+         style="stop-color:#353a3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop132440"
+         style="stop-color:#5e6669;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient5048-7">
       <stop
@@ -51,36 +153,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
-      <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729">
-      <stop
-         id="stop8022"
-         style="stop-color:#85c2cf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8024"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop8026"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop8028"
-         style="stop-color:#2c5889;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient3282">
       <stop
          id="stop3284"
@@ -92,193 +164,279 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3958">
-      <stop
-         id="stop3960"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962"
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2446-733-45">
-      <stop
-         id="stop3793"
-         style="stop-color:#333333;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3795"
-         style="stop-color:#242424;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2238">
-      <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2242"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient2434"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9546411,0,0,0.8965269,1.0874564,5.385244)"
        x1="12.578789"
        y1="2.9137428"
        x2="12.578789"
-       y2="43.810863" />
-    <linearGradient
-       xlink:href="#linearGradient2446-733-45"
-       id="linearGradient2437"
+       y2="43.810863"
+       id="linearGradient3308"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8148434,0,0,0.6596233,-2.2594711,3.2339741)"
+       gradientTransform="matrix(0.9102396,0,0,0.79405539,2.15324,9.7416258)" />
+    <linearGradient
+       x1="24.682861"
+       y1="9.2416716"
+       x2="24.682861"
+       y2="13.523027"
+       id="linearGradient3316"
+       xlink:href="#linearGradient132442"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95631109,0,0,0.35100634,1.0550418,13.756274)" />
+    <linearGradient
+       x1="10.014208"
+       y1="44.960102"
+       x2="10.014208"
+       y2="3.7234669"
+       id="linearGradient3324"
+       xlink:href="#linearGradient24734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.91489407,0,0,0.8057926,2.0425069,8.6511024)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35535976,0,0,0.33331901,1.2569262,5.0009901)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.63150371,0,0,0.65386383,3.6488926,34.180115)"
        x1="33.579403"
-       y1="5.7086449"
+       y1="7.8211875"
        x2="33.579403"
        y2="16.323294" />
     <linearGradient
-       xlink:href="#linearGradient3958"
-       id="linearGradient2439"
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77500005,0,0,0.99126859,5.3999815,30.974375)"
        x1="16.91585"
-       y1="7.0006418"
+       y1="8.3539181"
        x2="16.91585"
        y2="14" />
     <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient3282"
-       id="linearGradient2442"
+       id="linearGradient6880"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9563112,0,0,0.4680085,1.0550418,9.674819)"
+       gradientTransform="matrix(0.55422579,0,0,0.23400424,10.702354,-39.16275)"
        x1="24.682861"
        y1="9.2416716"
        x2="24.682861"
        y2="13.523027" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729"
-       id="radialGradient2448"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.8187668e-8,-1.0656573,1.3967139,0,35.965186,58.558833)"
-       cx="26.616697"
-       cy="-2.0644982"
-       fx="26.616697"
-       fy="-2.0644982"
-       r="23" />
     <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
-       id="linearGradient2450"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9574517,0,0,0.9034707,1.0211784,4.30563)"
-       x1="10.014208"
-       y1="44.960102"
-       x2="10.014208"
-       y2="2.8764627" />
+       id="linearGradient119256-6">
+      <stop
+         id="stop119252-7"
+         style="stop-color:#70c3e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop119254-5"
+         style="stop-color:#9de1f6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5060-6"
-       id="radialGradient2453"
+       gradientTransform="matrix(0.03012146,0,0,0.02462026,25.346986,31.972828)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-6.5587303e-2,0,0,1.6470586e-2,47.692226,36.961094)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
        xlink:href="#linearGradient5060-6"
-       id="radialGradient2456"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(6.5587303e-2,0,0,1.6470586e-2,0.3077845,36.961094)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
+       id="radialGradient5942"
        fy="486.64789"
-       r="117.14286" />
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
+       gradientTransform="matrix(0.08076923,0,0,0.02461919,-5.1923112,31.973478)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5048-7"
-       id="linearGradient2459"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(6.5587303e-2,0,0,1.6470586e-2,0.2948769,36.961094)"
-       x1="302.85715"
-       y1="366.64789"
+       id="linearGradient5946"
+       y2="609.50507"
        x2="302.85715"
-       y2="609.50507" />
-    <filter
-       id="filter3803"
-       x="-0.061395349"
-       width="1.1227907"
-       y="-2.64"
-       height="6.28">
-      <feGaussianBlur
-         stdDeviation="1.1"
-         id="feGaussianBlur3805" />
-    </filter>
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.03012146,0,0,0.02462026,22.653007,31.972828)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient5950"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient1014"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4810479,0,0,0.77614442,-1.2224162,4.7460494)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="13.839313" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient1016"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4810479,0,0,0.77614442,-1.2224162,4.7460494)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="13.723811" />
   </defs>
-  <rect
-     style="opacity:0.3;fill:url(#linearGradient2459);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2512"
-     y="43"
-     x="8.1653528"
-     height="4"
-     width="31.669294" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient2456);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2514"
-     d="M 39.834649,43.000138 C 39.834649,43.000138 39.834649,46.999917 39.834649,46.999917 C 43.212232,47.007443 48.000002,46.10377 48,44.99977 C 48,43.89577 44.230872,43.000138 39.834649,43.000138 z" />
-  <path
-     style="opacity:0.3;fill:url(#radialGradient2453);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2516"
-     d="M 8.1653532,43.000138 C 8.1653532,43.000138 8.1653532,46.999917 8.1653532,46.999917 C 4.7877688,47.007443 0,46.10377 0,44.99977 C 0,43.89577 3.7691287,43.000138 8.1653532,43.000138 z" />
+     d="m 43.5,41 c 0,0 0,5.97888 0,5.97888 1.55118,0.01129 3.75,-1.339569 3.75,-2.989825 C 47.25,42.338791 45.519,41 43.5,41 Z"
+     id="path3411"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <rect
-     style="fill:url(#radialGradient2448);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2450);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     width="39"
+     height="5.9789472"
+     x="4.5000024"
+     y="41.00005"
+     id="rect4173-14"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient5946);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 4.4999995,41 c 0,0 0,5.97888 0,5.97888 -1.5511875,0.01129 -3.75,-1.339569 -3.75,-2.989825 0,-1.650264 1.731,-2.989055 3.75,-2.989055 z"
+     id="path5018-7"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5950);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <rect
+     width="42.997871"
+     height="32.997871"
+     rx="1.5"
+     ry="1.5000001"
+     x="2.5010643"
+     y="11.501065"
      id="rect2573"
-     y="7.5010657"
-     x="1.5010662"
-     ry="2.6659844"
-     rx="2.6659844"
-     height="36.997868"
-     width="44.997868" />
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="fill:#000000;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;filter:url(#filter3803);opacity:0.7"
-     d="m 2,14 43,0 0,1 -43,0 z"
-     id="path3801" />
+     id="rect914"
+     style="opacity:1;fill:url(#linearGradient1014);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1016);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 4,11.500268 h 40 c 0.831,0 1.49536,0.666666 1.5,1.494737 v 3.505154 h -43 v -3.505154 c 0,-0.828084 0.669,-1.494737 1.5,-1.494737 z"
+     sodipodi:nodetypes="sssccss" />
   <rect
-     style="opacity:0.2;fill:url(#linearGradient2442);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect1436"
-     y="14"
+     width="44"
+     height="1.5"
+     rx="0"
+     ry="0"
      x="2"
-     ry="0"
-     rx="0"
-     height="2"
-     width="44" />
-  <path
-     style="fill:url(#linearGradient2437);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2439);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect2311"
-     d="M 4.5,7.500642 C 4.5,7.500642 43.836231,7.5092304 43.836231,7.5092304 C 45.401156,7.5092304 46.5,8.7704177 46.5,10.166011 C 46.5,10.166011 46.5,13.5 46.5,13.5 C 46.5,13.5 1.5000001,13.5 1.5000001,13.5 C 1.5000001,13.5 1.5,10.166011 1.5,10.166011 C 1.5,8.67849 2.7087852,7.500642 4.5,7.500642 z" />
+     y="17.000158"
+     id="rect1436"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
   <rect
-     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2434);stroke-width:1.00373149;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:1"
+     id="rect48112"
+     width="40"
+     height="1"
+     x="4"
+     y="16.000158" />
+  <rect
+     width="40.996269"
+     height="30.996269"
+     rx="0.5"
+     ry="0.5"
+     x="3.5018649"
+     y="12.502024"
      id="rect2601"
-     y="8.5018673"
-     x="2.5018673"
-     ry="1.6959794"
-     rx="1.6959794"
-     height="34.996269"
-     width="42.996269" />
-  <rect
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect9439"
-     y="37.5"
-     x="8.499999"
-     ry="0"
-     rx="0"
-     height="7"
-     width="31.000002" />
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 7.5000003,45.000002 C 7.5000003,42.384617 7.5000003,36.500002 7.5000003,36.500002 C 7.5000003,36.500002 40.500001,36.500002 40.500001,36.500002 C 40.500001,36.500002 40.500001,45.000002 40.500001,45.000002"
-     id="rect2461" />
+     d="m 11.500005,37.500159 h 24.999998 l 3.499994,6.999837 -32.000002,3.25e-4 z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     width="25.5"
+     height="1"
+     rx="0"
+     ry="0"
+     x="11.25"
+     y="-37.00016"
+     id="rect6872"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient6880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     transform="scale(1,-1)" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect1156"
+     width="4"
+     height="4"
+     x="14"
+     y="40.00016"
+     rx="0.50001109"
+     ry="0.49995548" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect36659"
+     width="4"
+     height="4"
+     x="13"
+     y="39.00016"
+     rx="0.50001109"
+     ry="0.49995548" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect1158"
+     width="4"
+     height="4"
+     x="20"
+     y="40.00016"
+     rx="0.49995556"
+     ry="0.49995556" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect38158"
+     width="4"
+     height="4"
+     x="19"
+     y="39.00016"
+     rx="0.49995556"
+     ry="0.49995556" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect1160"
+     width="4"
+     height="4"
+     x="26"
+     y="40.00016"
+     rx="0.50001109"
+     ry="0.49995556" />
+  <rect
+     style="fill:#505a63;fill-opacity:1;stroke-width:0.999999"
+     id="rect49649"
+     width="34"
+     height="1"
+     x="7"
+     y="44.00016" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect1162"
+     width="4"
+     height="4"
+     x="32"
+     y="40.00016"
+     rx="0.50001109"
+     ry="0.49995556" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect1050"
+     width="4"
+     height="4"
+     x="25"
+     y="39.00016"
+     rx="0.50001109"
+     ry="0.49995556" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999997"
+     id="rect1054"
+     width="4"
+     height="4"
+     x="31"
+     y="39.00016"
+     rx="0.50001109"
+     ry="0.49995556" />
 </svg>

--- a/elementary-xfce/places/64/user-desktop.svg
+++ b/elementary-xfce/places/64/user-desktop.svg
@@ -6,23 +6,126 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.0"
    width="64"
    height="64"
-   id="svg9481">
+   id="svg9481"
+   sodipodi:docname="user-desktop.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="47.048425"
+     inkscape:cy="49.257602"
+     inkscape:window-width="1319"
+     inkscape:window-height="980"
+     inkscape:window-x="302"
+     inkscape:window-y="40"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9481"
+     showguides="false"
+     inkscape:snap-object-midpoints="true"
+     inkscape:document-rotation="0" />
   <metadata
-     id="metadata55">
+     id="metadata54">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs9483">
+    <linearGradient
+       id="linearGradient3813">
+      <stop
+         id="stop3809"
+         style="stop-color:#4d5865;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3811"
+         style="stop-color:#596169;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3807">
+      <stop
+         id="stop3803"
+         style="stop-color:#6e7073;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3805"
+         style="stop-color:#53565a;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient54135">
+      <stop
+         id="stop54131"
+         style="stop-color:#e5e5e5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop54133"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient53089">
+      <stop
+         id="stop53085"
+         style="stop-color:#262b31;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop53087"
+         style="stop-color:#32383e;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient48050">
+      <stop
+         id="stop48046"
+         style="stop-color:#434343;stop-opacity:0.25020409"
+         offset="0" />
+      <stop
+         id="stop48048"
+         style="stop-color:#3c3c3c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient24734">
+      <stop
+         id="stop24730"
+         style="stop-color:#2b3035;stop-opacity:0.53676158"
+         offset="0" />
+      <stop
+         id="stop24732"
+         style="stop-color:#434343;stop-opacity:0.42771575"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient132442">
+      <stop
+         id="stop132438"
+         style="stop-color:#353a3b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop132440"
+         style="stop-color:#5e6669;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient5048-7">
       <stop
@@ -50,36 +153,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3332-412-419-652-471-761-410-156-661-505">
-      <stop
-         id="stop8032"
-         style="stop-color:#1a426c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8034"
-         style="stop-color:#78959c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729">
-      <stop
-         id="stop8022"
-         style="stop-color:#85c2cf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8024"
-         style="stop-color:#74a4be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop8026"
-         style="stop-color:#5177a0;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop8028"
-         style="stop-color:#2c5889;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient3282">
       <stop
          id="stop3284"
@@ -91,180 +164,297 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2238">
-      <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2242"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient2432"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3099701,0,0,1.2296538,0.5591281,6.2253163)"
        x1="12.578789"
        y1="2.9137428"
        x2="12.578789"
-       y2="43.810863" />
-    <linearGradient
-       xlink:href="#linearGradient2446-733-45-3"
-       id="linearGradient2435"
+       y2="43.810863"
+       id="linearGradient3308"
+       xlink:href="#linearGradient54135"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1045659,0,0,0.8795917,-3.5961863,3.8105009)"
+       gradientTransform="matrix(1.2654873,0,0,1.0758509,1.6268994,10.761852)" />
+    <linearGradient
+       x1="24.682861"
+       y1="9.2416716"
+       x2="24.682861"
+       y2="13.523027"
+       id="linearGradient3316"
+       xlink:href="#linearGradient132442"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3040607,0,0,0.46550575,0.71142061,15.697949)" />
+    <linearGradient
+       x1="10.014208"
+       y1="44.960102"
+       x2="10.014208"
+       y2="3.7234669"
+       id="linearGradient3324"
+       xlink:href="#linearGradient24734"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2553366,0,0,1.0744074,1.8718744,9.7010547)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient119256-6"
+       id="linearGradient889"
+       x1="69.693268"
+       y1="118.11372"
+       x2="69.693268"
+       y2="36.079391"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48759319,0,0,0.44443249,0.79397006,4.8341597)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3813"
+       id="linearGradient6876"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.84200495,0,0,0.87488823,4.8652034,43.846274)"
        x1="33.579403"
-       y1="5.7086449"
+       y1="7.8211875"
        x2="33.579403"
        y2="16.323294" />
     <linearGradient
-       xlink:href="#linearGradient3958-9"
-       id="linearGradient2437"
+       inkscape:collect="always"
+       xlink:href="#linearGradient53089"
+       id="linearGradient6878"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3555561,0,0,1.3334759,-0.5333464,-0.5019254)"
+       gradientTransform="matrix(1.0333334,0,0,1.3263453,7.1999887,39.556904)"
        x1="16.91585"
-       y1="7.0006418"
+       y1="8.3539181"
        x2="16.91585"
        y2="14" />
     <linearGradient
+       inkscape:collect="always"
        xlink:href="#linearGradient3282"
-       id="linearGradient2440"
+       id="linearGradient6880"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3040608,0,0,0.7020128,0.7114208,11.512229)"
+       gradientTransform="matrix(0.80417075,0,0,0.46800846,12.705376,-54.325184)"
        x1="24.682861"
        y1="9.2416716"
        x2="24.682861"
        y2="13.523027" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-895-534-212-357-729"
-       id="radialGradient2446"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.4654702e-8,-1.4400882,1.893347,0,48.219679,78.498576)"
-       cx="26.616697"
-       cy="-2.0644982"
-       fx="26.616697"
-       fy="-2.0644982"
-       r="23" />
     <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471-761-410-156-661-505"
-       id="linearGradient2448"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2978952,0,0,1.2209155,0.8505437,5.1828923)"
-       x1="10.014208"
-       y1="44.960102"
-       x2="10.014208"
-       y2="2.8764627" />
+       id="linearGradient119256-6">
+      <stop
+         id="stop119252-7"
+         style="stop-color:#70c3e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop119254-5"
+         style="stop-color:#9de1f6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5060-6"
-       id="radialGradient2451"
+       gradientTransform="matrix(0.04016195,0,0,0.0329426,33.795981,40.92139)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-8.7449735e-2,0,0,2.470588e-2,63.589633,47.94164)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
        xlink:href="#linearGradient5060-6"
-       id="radialGradient2454"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(8.7449735e-2,0,0,2.470588e-2,0.4103793,47.94164)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
+       id="radialGradient5942"
        fy="486.64789"
-       r="117.14286" />
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
+       gradientTransform="matrix(0.1076923,0,0,0.03294117,-6.923081,40.92226)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5048-7"
-       id="linearGradient2457"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(8.7449735e-2,0,0,2.470588e-2,0.3931692,47.94164)"
-       x1="302.85715"
-       y1="366.64789"
+       id="linearGradient5946"
+       y2="609.50507"
        x2="302.85715"
-       y2="609.50507" />
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04016195,0,0,0.0329426,30.204011,40.92139)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient5950"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
     <linearGradient
-       id="linearGradient2446-733-45-3">
-      <stop
-         id="stop3793-3"
-         style="stop-color:#333333;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3795-7"
-         style="stop-color:#242424;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient3807"
+       id="linearGradient1014"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9747305,0,0,1.0385031,-1.6298876,4.4626649)"
+       x1="17.798742"
+       y1="9.1200294"
+       x2="17.798742"
+       y2="13.839313" />
     <linearGradient
-       id="linearGradient3958-9">
-      <stop
-         id="stop3960-5"
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3962-5"
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient48050"
+       id="linearGradient1016"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9747305,0,0,1.0385031,-1.6298876,4.4626649)"
+       x1="12.753998"
+       y1="8.9392328"
+       x2="12.753998"
+       y2="13.723811" />
   </defs>
-  <rect
-     style="opacity:0.3;fill:url(#linearGradient2457);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2512"
-     y="57"
-     x="10.887136"
-     height="6"
-     width="42.225723" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient2454);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2514"
-     d="M 53.112864,57.000208 C 53.112864,57.000208 53.112864,62.999875 53.112864,62.999875 C 57.616308,63.011165 64.000001,61.655656 63.999998,59.999656 C 63.999998,58.343656 58.974495,57.000208 53.112864,57.000208 z" />
-  <path
-     style="opacity:0.3;fill:url(#radialGradient2451);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2516"
-     d="M 10.887137,57.000208 C 10.887137,57.000208 10.887137,62.999875 10.887137,62.999875 C 6.3836916,63.011165 0,61.655656 0,59.999656 C 0,58.343656 5.0255048,57.000208 10.887137,57.000208 z" />
+     d="m 58.000001,53 c 0,0 0,7.99991 0,7.99991 2.06824,0.0151 5,-1.79238 5,-4.00047 0,-2.2081 -2.308,-3.99944 -5,-3.99944 z"
+     id="path3411"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5942);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <rect
-     style="fill:url(#radialGradient2446);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2448);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     width="52"
+     height="8"
+     x="6.0000038"
+     y="53.000069"
+     id="rect4173-14"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient5946);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 6,53 c 0,0 0,7.99991 0,7.99991 C 3.93175,61.01501 1,59.20753 1,56.99944 1,54.79134 3.308,53 6,53 Z"
+     id="path5018-7"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient5950);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <rect
+     width="58.997868"
+     height="43.997871"
+     rx="2"
+     ry="2"
+     x="2.5010662"
+     y="13.501065"
      id="rect2573"
-     y="9.5010815"
-     x="1.5010662"
-     ry="3"
-     rx="3"
-     height="49.99749"
-     width="60.997868" />
+     style="fill:url(#linearGradient889);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3324);stroke-width:1.00213;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     id="rect914"
+     style="opacity:1;fill:url(#linearGradient1014);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1016);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 4.5,13.5 h 55 c 1.108,0 2,0.892 2,2 v 4 h -59 v -4 c 0,-1.108 0.892,-2 2,-2 z"
+     sodipodi:nodetypes="sssccss" />
   <rect
-     style="opacity:0.2;fill:url(#linearGradient2440);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.00000012;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect1436"
-     y="18"
+     width="60.000004"
+     height="1.9893049"
+     rx="0"
+     ry="0"
      x="2"
-     ry="0"
-     rx="0"
-     height="3"
-     width="60" />
-  <path
-     style="fill:url(#linearGradient2435);fill-opacity:1.0;fill-rule:evenodd;stroke:url(#linearGradient2437);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible"
-     id="rect2311"
-     d="M 5.0829535,9.4999999 C 5.0829535,9.4999999 59.262894,9.5114522 59.262894,9.5114522 C 61.384237,9.5114522 62.500012,10.819445 62.500012,12.680435 C 62.500012,12.680435 62.500012,17.5 62.500012,17.5 C 62.500012,17.5 1.4999879,17.5 1.4999879,17.5 C 1.4999879,17.5 1.4999878,12.592489 1.4999878,12.592489 C 1.4999878,10.608916 2.6548613,9.4999999 5.0829535,9.4999999 z" />
+     y="20"
+     id="rect1436"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
   <rect
-     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2432);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect2601"
-     y="10.5"
-     x="2.5"
+     style="fill:#1f1f1f;fill-opacity:1;stroke-width:0.999999"
+     id="rect48112"
+     width="56"
+     height="1"
+     x="4"
+     y="19" />
+  <rect
+     width="56.996269"
+     height="41.996269"
+     rx="2"
      ry="1.9999999"
-     rx="1.9999999"
-     height="48"
-     width="58.999996" />
-  <rect
-     style="opacity:0.5;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect9439"
-     y="50.500015"
-     x="11.500002"
-     ry="0"
-     rx="0"
-     height="9"
-     width="40.999996" />
+     x="3.5018649"
+     y="14.501865"
+     id="rect2601"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3308);stroke-width:1.00373;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="M 10.5,60 C 10.5,60 10.5,49.500015 10.5,49.500015 C 10.5,49.500015 53.5,49.500015 53.5,49.500015 C 53.5,49.500015 53.5,60 53.5,60"
-     id="rect2459" />
+     d="m 13.749989,50.499997 h 36.5 l 4.000005,6.999785 -44.5000053,4.36e-4 z"
+     id="path6874"
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient6876);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6878);stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     width="37"
+     height="2"
+     rx="0"
+     ry="0"
+     x="13.5"
+     y="-50"
+     id="rect6872"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:url(#linearGradient6880);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none"
+     transform="scale(1,-1)" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999994"
+     id="rect932"
+     width="4"
+     height="3.9786096"
+     x="16.5"
+     y="53"
+     rx="1"
+     ry="0.99999988" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999994"
+     id="rect36659"
+     width="4"
+     height="3.9786096"
+     x="16"
+     y="52"
+     rx="1"
+     ry="0.99999988" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999994"
+     id="rect934"
+     width="4"
+     height="3.9786096"
+     x="23.5"
+     y="53"
+     rx="1"
+     ry="0.99999988" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999994"
+     id="rect38158"
+     width="4"
+     height="3.9786096"
+     x="23"
+     y="52"
+     rx="1"
+     ry="0.99999988" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999994"
+     id="rect936"
+     width="4"
+     height="4"
+     x="30.5"
+     y="53"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999994"
+     id="rect38242"
+     width="4"
+     height="4"
+     x="30"
+     y="52"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect938"
+     width="4"
+     height="4"
+     x="37.5"
+     y="53"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38326"
+     width="4"
+     height="4"
+     x="37"
+     y="52"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#2a2d31;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect940"
+     width="4"
+     height="4"
+     x="44.5"
+     y="53"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#8ad1ea;fill-opacity:1;stroke:none;stroke-width:0.999995"
+     id="rect38328"
+     width="4"
+     height="4"
+     x="44"
+     y="52"
+     rx="1"
+     ry="0.99999994" />
+  <rect
+     style="fill:#505a63;fill-opacity:1;stroke-width:1"
+     id="rect49649"
+     width="46.000004"
+     height="1"
+     x="8.9999981"
+     y="57" />
 </svg>


### PR DESCRIPTION
The desktop icon is one of the few places icons
that has not seen a refresh, leaving the current
desktop icon looking a little bit dated.

This one is  brighter, cleaner, and better matches
the folder colors, gradients, outlines, and curves.
The sizing has also been adjusted to match the width
and height of the folders. This should also blend in
better with the newly designed Xfce app icons.

New:

![elementary-xfce-desktop-up](https://user-images.githubusercontent.com/1984060/146443882-6727f984-04f0-4f4d-8d88-2f3587cb27e7.png)

Current:
![elementary-xfce-desktop-up-current](https://user-images.githubusercontent.com/1984060/146446451-96c4fb9d-dd30-4b31-a30f-c9e1213933a5.png)

