### PR TITLE
Add missing icons

### DIFF
--- a/elementary-xfce/actions/16/format-indent-less.svg
+++ b/elementary-xfce/actions/16/format-indent-less.svg
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="svg3495"
+   height="16"
+   width="16"
+   sodipodi:docname="format-indent-less.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="28.416667"
+     inkscape:cx="7.0029325"
+     inkscape:cy="12.844575"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="91"
+     inkscape:window-y="134"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3495" />
+  <defs
+     id="defs3497">
+    <linearGradient
+       id="linearGradient2155">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop2147" />
+      <stop
+         offset="0.5"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop2149" />
+      <stop
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop2153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952">
+      <stop
+         id="stop3954"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,-0.18401958,-0.19761511,0,20.105731,12.519608)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3129"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       gradientTransform="matrix(0.36363758,0,0,-0.36306836,-1.409133,16.837996)"
+       xlink:href="#linearGradient2155"
+       id="linearGradient901"
+       x1="39.372978"
+       y1="29.709902"
+       x2="39.372978"
+       y2="15.765411"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0,0.32595359,-0.35063868,0,31.430831,-1.9682842)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4297-3"
+       id="linearGradient3149-7"
+       y2="49.711662"
+       x2="34.874741"
+       y1="67.730797"
+       x1="34.874741" />
+    <linearGradient
+       id="linearGradient4297-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4299-6" />
+      <stop
+         offset="0.52457154"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4301-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4303-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4305-3" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3500">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="rect4370-8"
+     d="M 8,1 V 3 H 3 V 1 Z m 0,12 v 2 H 3 v -2 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccccc" />
+  <path
+     id="rect4370"
+     d="M 6,5 V 7 H 0 V 5 Z m 0,4 v 2 H 0 V 9 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccccc" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient3129);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+     id="path3501"
+     d="m 12.908362,5.0701527 a -3.0916382,2.8789382 0 1 0 0,5.7578763 -3.0916389,2.8789382 0 0 0 0,-5.7578763 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient901);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.963925;marker:none;enable-background:accumulate"
+     id="path3288-2-2-5"
+     d="M 11.499987,4.4999411 7.4999735,7.9461722 11.499987,11.39824 V 9.4490906 H 15.5 v -3 h -4.000013 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004372;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3288-2-2-7"
+     d="M 11.499987,4.499941 7.4999735,7.9461721 11.499987,11.398241 V 9.4490904 H 15.5 v -3 h -4.000013 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.401;fill:none;stroke:url(#linearGradient3149-7);stroke-width:0.963925;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3288-2-2-8-6"
+     d="m 10.5,6.6496327 -1.5,1.283338 1.5,1.317052 v -0.800931 h 4 v -1 h -4 z" />
+</svg>

--- a/elementary-xfce/actions/16/format-indent-more.svg
+++ b/elementary-xfce/actions/16/format-indent-more.svg
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   id="svg3495"
+   height="16"
+   width="16"
+   sodipodi:docname="format-indent-more.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     width="16px"
+     inkscape:zoom="20.093618"
+     inkscape:cx="4.8771705"
+     inkscape:cy="11.098051"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="91"
+     inkscape:window-y="134"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3495" />
+  <defs
+     id="defs3497">
+    <linearGradient
+       id="linearGradient2155">
+      <stop
+         offset="0"
+         style="stop-color:#90dbec;stop-opacity:1"
+         id="stop2147" />
+      <stop
+         offset="0.5"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop2149" />
+      <stop
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop2153" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3952">
+      <stop
+         id="stop3954"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop3956"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,-0.18401958,0.19761511,0,-4.105731,12.519608)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3952"
+       id="radialGradient3129"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       gradientTransform="matrix(-0.36363758,0,0,-0.36306836,17.409133,16.837996)"
+       xlink:href="#linearGradient2155"
+       id="linearGradient901"
+       x1="39.372978"
+       y1="29.709902"
+       x2="39.372978"
+       y2="15.765411"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0,0.32595359,0.35063868,0,-15.430831,-1.9682842)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4297-3"
+       id="linearGradient3149-7"
+       y2="49.711662"
+       x2="34.874741"
+       y1="67.730797"
+       x1="34.874741" />
+    <linearGradient
+       id="linearGradient4297-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4299-6" />
+      <stop
+         offset="0.52457154"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4301-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4303-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4305-3" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3500">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     id="rect4370-8"
+     d="m 8,1 v 2 h 5 V 1 Z m 0,12 v 2 h 5 v -2 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccccc" />
+  <path
+     id="rect4370"
+     d="m 10,5 v 2 h 6 V 5 Z m 0,4 v 2 h 6 V 9 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccccc" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient3129);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+     id="path3501"
+     d="m 3.091638,5.0701527 a -3.0916382,2.8789382 0 1 1 0,5.7578763 -3.0916389,2.8789382 0 0 1 0,-5.7578763 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient901);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.963925;marker:none;enable-background:accumulate"
+     id="path3288-2-2-5"
+     d="M 4.500013,4.4999411 8.5000265,7.9461722 4.500013,11.39824 V 9.4490906 H 0.5 v -3 h 4.000013 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#004372;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3288-2-2-7"
+     d="M 4.500013,4.499941 8.5000265,7.9461721 4.500013,11.398241 V 9.4490904 H 0.5 v -3 h 4.000013 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.401;fill:none;stroke:url(#linearGradient3149-7);stroke-width:0.963925;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:7;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3288-2-2-8-6"
+     d="M 5.5,6.6496327 7,7.9329707 5.5,9.2500227 v -0.800931 h -4 v -1 h 4 z" />
+</svg>

--- a/elementary-xfce/actions/16/gtk-index.svg
+++ b/elementary-xfce/actions/16/gtk-index.svg
@@ -1,0 +1,219 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3828"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="gtk-index.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview31"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093619"
+     inkscape:cx="11.048284"
+     inkscape:cy="9.9534088"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="428"
+     inkscape:window-y="112"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.23470871,0,0,0.29729793,2.366669,0.86486418)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.27428562,0,0,0.26074053,1.4171648,1.3422324)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.00843401,0,0,0.0082353,8.8671551,10.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.00843401,0,0,0.0082353,7.1328442,10.980565)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.02464497,0,0,0.0082353,-0.9073964,10.980548)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none"
+     id="rect2879"
+     y="14"
+     x="2.0500004"
+     height="1.9999998"
+     width="11.899999" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none"
+     id="path2881"
+     d="m 2.0499999,14.000085 c 0,0 0,1.999891 0,1.999891 C 1.6156692,16.003776 1,15.551902 1,14.999902 c 0,-0.552 0.48468,-0.999817 1.0499999,-0.999817 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none"
+     id="path2883"
+     d="m 13.95,14.000085 c 0,0 0,1.999891 0,1.999891 0.43433,0.0039 1.05,-0.448074 1.05,-1.000074 0,-0.552 -0.484681,-0.999817 -1.05,-0.999817 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none;stroke-width:0.999998"
+     id="path4160-3"
+     d="M 2.0000202,2 C 4.1998717,2 14.000008,2 14.000008,2 l 1.2e-5,12.000014 H 2.0000202 V 2.0000127 Z"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1"
+     d="M 13.50002,13.500014 H 2.5000198 V 2.5 H 13.50002 Z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;opacity:0.3;fill:none;stroke:#000000;stroke-width:0.999921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-3-1"
+     d="m 1.4999802,1.4999569 c 2.41156,0 13.0000648,2.67e-5 13.0000648,2.67e-5 l 1.3e-5,13.0000634 H 1.4999802 V 1.4999707 Z"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7969"
+     width="6"
+     height="1"
+     x="6"
+     y="4" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7971"
+     width="6"
+     height="1"
+     x="6"
+     y="7" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3292"
+     width="1"
+     height="1"
+     x="4"
+     y="4" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3294"
+     width="1"
+     height="1"
+     x="4"
+     y="7" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3726"
+     width="6"
+     height="1"
+     x="6"
+     y="10" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3730"
+     width="1"
+     height="1"
+     x="4"
+     y="10" />
+</svg>

--- a/elementary-xfce/actions/16/view-sort-ascending.svg
+++ b/elementary-xfce/actions/16/view-sort-ascending.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="view-sort-ascending.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview17"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="48.625"
+     inkscape:cx="7.8354756"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <linearGradient
+       xlink:href="#linearGradient78"
+       id="linearGradient72"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.61157583,-0.6008607,0,11.611228,0.9708395)"
+       x1="21.304237"
+       y1="12.667211"
+       x2="1.6827954"
+       y2="12.667211" />
+    <linearGradient
+       id="linearGradient78">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop74" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop76" />
+    </linearGradient>
+    <linearGradient
+       y2="54.037033"
+       x2="34.913044"
+       y1="54.037033"
+       x1="20.443369"
+       gradientTransform="matrix(0,-0.54188661,0.46916342,0,-20.115418,22.918908)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940-5"
+       xlink:href="#linearGradient1597-6" />
+    <linearGradient
+       id="linearGradient1597-6">
+      <stop
+         id="stop1589-2"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.36232007" />
+      <stop
+         id="stop1593-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     d="m 4.9980454,13.499998 c -0.080838,0 -0.1508278,-0.03231 -0.2089844,-0.08789 L 0.60156051,9.072264 c -0.062219,-0.059439 -0.101562,-0.1428761 -0.101562,-0.2421875 0,-0.1845228 0.130217,-0.3222656 0.304688,-0.3222656 H 3.2011704 C 3.3640083,8.5079269 3.4999985,8.3618971 3.4999985,8.1835922 V 2.8066395 c 0,-0.174818 0.1290258,-0.306641 0.3007812,-0.306641 h 2.4023438 c 0.1717556,0 0.3007813,0.131823 0.3007812,0.306641 v 5.4082027 c 0.015028,0.1636803 0.1455949,0.2930775 0.2988282,0.2929687 h 2.3964846 c 0.174469,0 0.300781,0.1377426 0.300781,0.3222656 0,0.1845764 -0.07628,0.1785565 -0.103516,0.2421875 l -4.1874996,4.339843 c -0.054667,0.05559 -0.1295192,0.08789 -0.2109375,0.08789 z"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient72);fill-opacity:1;stroke:#206b00;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     id="path873-5-5" />
+  <path
+     d="M 4.9999985,12.176767 2.4104451,9.4999965 H 3.4030944 C 3.9615922,9.4997884 4.4994068,8.7261201 4.4995326,8.2799208 l 9.318e-4,-4.7799243 h 0.9990681 l 9.32e-4,4.7799243 c 1.09e-4,0.4461993 0.5067412,1.2198527 1.1053156,1.2200757 h 0.9729244 z"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-5);stroke-width:0.999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000;stop-opacity:1"
+     id="path873-5-5-2-3" />
+  <rect
+     style="fill:#81c837;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect856"
+     width="3"
+     height="3"
+     x="12.5"
+     y="1.5" />
+  <rect
+     style="fill:#81c837;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect10630"
+     width="3"
+     height="3"
+     x="12.5"
+     y="6.5" />
+  <rect
+     style="fill:#81c837;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect10632"
+     width="3"
+     height="3"
+     x="12.5"
+     y="11.5" />
+  <rect
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect20652"
+     width="2"
+     height="1"
+     x="13"
+     y="3" />
+  <rect
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect20654"
+     width="2"
+     height="1"
+     x="13"
+     y="8" />
+  <rect
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect20656"
+     width="2"
+     height="1"
+     x="13"
+     y="13" />
+</svg>

--- a/elementary-xfce/actions/16/view-sort-descending.svg
+++ b/elementary-xfce/actions/16/view-sort-descending.svg
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="view-sort-descending.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview17"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="24.3125"
+     inkscape:cx="10.118252"
+     inkscape:cy="12.257069"
+     inkscape:window-width="1920"
+     inkscape:window-height="1026"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10">
+    <linearGradient
+       xlink:href="#linearGradient78"
+       id="linearGradient72"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.61157583,-0.6008607,0,11.611228,15.029161)"
+       x1="21.304237"
+       y1="12.667211"
+       x2="1.6827954"
+       y2="12.667211" />
+    <linearGradient
+       id="linearGradient78">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop74" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop76" />
+    </linearGradient>
+    <linearGradient
+       y2="54.037033"
+       x2="34.913044"
+       y1="54.037033"
+       x1="20.443369"
+       gradientTransform="matrix(0,0.54188661,0.46916342,0,-20.115418,-6.918908)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940-5"
+       xlink:href="#linearGradient1597-6" />
+    <linearGradient
+       id="linearGradient1597-6">
+      <stop
+         id="stop1589-2"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.36232007" />
+      <stop
+         id="stop1593-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     d="m 4.9980454,2.500002 c -0.080838,0 -0.1508278,0.03231 -0.2089844,0.08789 L 0.60156051,6.927736 c -0.062219,0.059439 -0.101562,0.1428761 -0.101562,0.2421875 0,0.1845228 0.130217,0.3222656 0.304688,0.3222656 H 3.2011704 c 0.1628379,-1.16e-4 0.2988281,0.1459138 0.2988281,0.3242187 v 5.3769532 c 0,0.174817 0.1290258,0.306641 0.3007812,0.306641 h 2.4023438 c 0.1717556,0 0.3007813,-0.131824 0.3007812,-0.306641 V 7.7851578 C 6.5189327,7.6214775 6.6494996,7.4920803 6.8027329,7.4921891 h 2.3964846 c 0.174469,0 0.300781,-0.1377426 0.300781,-0.3222656 0,-0.1845764 -0.07628,-0.1785565 -0.103516,-0.2421875 L 5.2089829,2.587893 C 5.1543159,2.532303 5.0794637,2.500003 4.9980454,2.500003 Z"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient72);fill-opacity:1;stroke:#206b00;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     id="path873-5-5" />
+  <path
+     d="M 4.9999985,3.823233 2.4104451,6.5000035 h 0.9926493 c 0.5584978,2.081e-4 1.0963124,0.7738764 1.0964382,1.2200757 l 9.318e-4,4.7799248 h 0.9990681 l 9.32e-4,-4.7799248 C 5.5005735,7.2738799 6.0072057,6.5002265 6.6057801,6.5000035 h 0.9729244 z"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-5);stroke-width:0.999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000;stop-opacity:1"
+     id="path873-5-5-2-3" />
+  <rect
+     style="fill:#81c837;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect856"
+     width="3"
+     height="3"
+     x="12.5"
+     y="-14.5"
+     transform="scale(1,-1)" />
+  <rect
+     style="fill:#81c837;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect10630"
+     width="3"
+     height="3"
+     x="12.5"
+     y="-9.5"
+     transform="scale(1,-1)" />
+  <rect
+     style="fill:#81c837;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect10632"
+     width="3"
+     height="3"
+     x="12.5"
+     y="-4.5"
+     transform="scale(1,-1)" />
+  <rect
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect20652"
+     width="2"
+     height="1"
+     x="13"
+     y="-13"
+     transform="scale(1,-1)" />
+  <rect
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect20654"
+     width="2"
+     height="1"
+     x="13"
+     y="-8"
+     transform="scale(1,-1)" />
+  <rect
+     style="opacity:0.5;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961;paint-order:normal"
+     id="rect20656"
+     width="2"
+     height="1"
+     x="13"
+     y="-3"
+     transform="scale(1,-1)" />
+</svg>

--- a/elementary-xfce/actions/24/gtk-index.svg
+++ b/elementary-xfce/actions/24/gtk-index.svg
@@ -1,0 +1,233 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1"
+   sodipodi:docname="gtk-index.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview31"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="12.889665"
+     inkscape:cy="16.423125"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="500"
+     inkscape:window-y="137"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="M 2.0000202,2 C 5.6664319,2 21.99996,2 21.99996,2 l 2e-5,19.999983 H 2.0000202 V 2.0000212 Z"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1"
+     d="M 21.49998,21.499983 H 2.5000198 V 2.5 H 21.49998 Z"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="display:inline;opacity:0.3;fill:none;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-3-1"
+     d="M 1.4999802,1.4999569 C 5.3955611,1.4999569 22.499999,1.5 22.499999,1.5 l 2.1e-5,21.000016 H 1.4999802 V 1.4999792 Z"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7969"
+     width="9"
+     height="1"
+     x="9"
+     y="7" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7971"
+     width="9"
+     height="1"
+     x="9"
+     y="10" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3292"
+     width="1"
+     height="1"
+     x="6"
+     y="7" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3294"
+     width="1"
+     height="1"
+     x="6"
+     y="10" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3726"
+     width="9"
+     height="1"
+     x="9"
+     y="13" />
+  <rect
+     style="fill:#a6a6a6;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3728"
+     width="9"
+     height="1"
+     x="9"
+     y="16" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3730"
+     width="1"
+     height="1"
+     x="6"
+     y="13" />
+  <rect
+     style="fill:#737373;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect3732"
+     width="1"
+     height="1"
+     x="6"
+     y="16" />
+</svg>

--- a/elementary-xfce/actions/24/view-page-continuous.svg
+++ b/elementary-xfce/actions/24/view-page-continuous.svg
@@ -1,0 +1,200 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1"
+   sodipodi:docname="view-page-continuous.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview31"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208333"
+     inkscape:cx="12.457478"
+     inkscape:cy="14.076246"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="597"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
+  <path
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-3-1"
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+  <rect
+     style="fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7967"
+     width="10"
+     height="1"
+     x="7"
+     y="6" />
+  <rect
+     style="fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7969"
+     width="10"
+     height="1"
+     x="7"
+     y="9" />
+  <rect
+     style="fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7971"
+     width="10"
+     height="1"
+     x="7"
+     y="12" />
+</svg>

--- a/elementary-xfce/actions/24/view-page-facing.svg
+++ b/elementary-xfce/actions/24/view-page-facing.svg
@@ -1,0 +1,511 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1"
+   sodipodi:docname="view-page-facing.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview31"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208333"
+     inkscape:cx="12.457478"
+     inkscape:cy="3.8005865"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="633"
+     inkscape:window-y="128"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,15.238793,15.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,8.761206,15.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.04349113,0,0,0.0082353,-3.7189366,15.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient973"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977"
+       id="linearGradient975"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient1105"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977"
+       id="linearGradient1107"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient1109"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient1111"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977"
+       id="linearGradient1113"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient1115"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient1117"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,55.954701,15.980564)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5060"
+       id="radialGradient1119"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,49.477114,15.980564)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5048"
+       id="linearGradient1121"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04349113,0,0,0.0082353,36.996971,15.980547)"
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient1979"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977"
+       id="linearGradient1981"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient1983"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient6313"
+       x1="11.499999"
+       y1="18.499987"
+       x2="11.499999"
+       y2="5.4999871"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient6732"
+       gradientUnits="userSpaceOnUse"
+       x1="11.499999"
+       y1="18.499987"
+       x2="11.499999"
+       y2="5.4999871"
+       gradientTransform="matrix(-1,0,0,1,24,0)" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879"
+     y="19"
+     x="1.5"
+     height="2"
+     width="21" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 1.4999999,19.000085 c 0,0 0,1.999891 0,1.999891 C 0.8795275,21.003776 0,20.551901 0,19.999901 0,19.447902 0.6924,19.000085 1.4999999,19.000085 Z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 22.5,19.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <g
+     id="g971"
+     transform="translate(7.9999991,3.999987)">
+    <path
+       d="m 4.000001,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 14.000001,15 h -10 z"
+       id="path965"
+       style="display:inline;fill:url(#linearGradient973);fill-opacity:1;stroke:none"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="M 13.500001,14.5 H 4.5000009 v -13 h 9.0000001 z"
+       id="path967"
+       style="fill:none;stroke:url(#linearGradient975);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="color:#000000;fill:url(#linearGradient977);stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 4.000002,16 h 10.499999 c 0.27614,-6e-6 0.499994,-0.22386 0.5,-0.5 v -15 c -6e-6,-0.27613986 -0.22386,-0.4999939361683 -0.5,-0.5 H 4.000002 Z m -1e-6,-15 c 2.7567582,7.53e-5 9.326338,-7.526e-5 10,0 v 14 h -10 z"
+       id="path969"
+       sodipodi:nodetypes="cccccccccccc" />
+  </g>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient1121);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect1083"
+     y="19"
+     x="42.215908"
+     height="2"
+     width="21" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient1119);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path1085"
+     d="m 42.215908,19.000085 c 0,0 0,1.999891 0,1.999891 -0.620473,0.0038 -1.5,-0.448075 -1.5,-1.000075 0,-0.551999 0.6924,-0.999816 1.5,-0.999816 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient1117);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path1087"
+     d="m 63.215908,19.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <g
+     id="g1095"
+     transform="translate(38.715907,3.999987)">
+    <path
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+       id="path1089"
+       style="display:inline;fill:url(#linearGradient1111);fill-opacity:1;stroke:none" />
+    <path
+       d="M 12.5,14.5 H 3.4999999 V 1.5 H 12.5 Z"
+       id="path1091"
+       style="fill:none;stroke:url(#linearGradient1113);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 10e-8,-15.00005204 z"
+       id="path1093"
+       style="display:inline;fill:none;stroke:url(#linearGradient1115);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     id="g1103"
+     transform="translate(50.715907,3.999987)">
+    <path
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
+       id="path1097"
+       style="display:inline;fill:url(#linearGradient1105);fill-opacity:1;stroke:none" />
+    <path
+       d="M 12.5,14.5 H 3.4999999 V 1.5 H 12.5 Z"
+       id="path1099"
+       style="fill:none;stroke:url(#linearGradient1107);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 10e-8,-15.00005204 z"
+       id="path1101"
+       style="display:inline;fill:none;stroke:url(#linearGradient1109);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  </g>
+  <g
+     id="g1977"
+     transform="matrix(-1,0,0,1,16,3.999987)">
+    <path
+       d="m 4.000001,1 c 2.2915074,0 9.999987,8.904e-4 9.999987,8.904e-4 L 14,15 H 4.000001 Z"
+       id="path1971"
+       style="display:inline;fill:url(#linearGradient1979);fill-opacity:1;stroke:none"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="M 13.5,14.5 H 4.5000009 V 1.5 H 13.5 Z"
+       id="path1973"
+       style="fill:none;stroke:url(#linearGradient1981);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="color:#000000;fill:url(#linearGradient1983);stroke-linejoin:round;-inkscape-stroke:none"
+       d="M 4.000002,16 H 14.5 c 0.27614,-6e-6 0.499994,-0.22386 0.5,-0.5 V 0.5 C 14.999994,0.22386014 14.77614,6.0638317e-6 14.5,0 H 4.000002 Z m -1e-6,-15 C 6.7567592,1.0000753 13.326338,0.99992474 14,1 V 15 H 4.000001 Z"
+       id="path1975"
+       sodipodi:nodetypes="cccccccccccc" />
+  </g>
+  <path
+     id="rect6018"
+     style="fill-opacity:1;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;fill:url(#linearGradient6313)"
+     d="m 11.999999,17.999987 h 1 v 1 h -1 z m -0.999999,-1 h 1 v 1 h -1 z m 1,-1 h 1 v 1 h -1 z m -1,-1 h 1 v 1 h -1 z m 1,-1 h 1 v 1 h -1 z m -1,-1 h 1 v 1 h -1 z m 1,-1 h 1 v 1 h -1 z m -1,-1 h 1 v 1 h -1 z m 1,-1.0000004 h 1 v 1.0000004 h -1 z m -1,-1 h 1 v 1 h -1 z m 1,-0.9999995 h 1 v 1 h -1 z m -1,-1 h 1 v 1 h -1 z m 1,-1 h 1 v 1 h -1 z m -1,-1 h 1 v 1 h -1 z" />
+  <path
+     id="path6730"
+     style="fill:url(#linearGradient6732);fill-opacity:1;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;opacity:0.3"
+     d="m 12.000001,17.999987 h -1 v 1 h 1 z m 0.999999,-1 h -1 v 1 h 1 z m -1,-1 h -1 v 1 h 1 z m 1,-1 h -1 v 1 h 1 z m -1,-1 h -1 v 1 h 1 z m 1,-1 h -1 v 1 h 1 z m -1,-1 h -1 v 1 h 1 z m 1,-1 h -1 v 1 h 1 z M 12,9.9999866 h -1 v 1.0000004 h 1 z m 1,-1 h -1 v 1 h 1 z M 12,7.9999871 h -1 v 1 h 1 z m 1,-1 h -1 v 1 h 1 z m -1,-1 h -1 v 1 h 1 z m 1,-1 h -1 v 1 h 1 z" />
+  <rect
+     style="opacity:1;fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7346"
+     width="7"
+     height="1"
+     x="3"
+     y="8" />
+  <rect
+     style="opacity:1;fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7428"
+     width="7"
+     height="1"
+     x="3"
+     y="10" />
+  <rect
+     style="opacity:1;fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7430"
+     width="7"
+     height="1"
+     x="3"
+     y="12" />
+  <rect
+     style="opacity:1;fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7967"
+     width="7"
+     height="1"
+     x="14"
+     y="8" />
+  <rect
+     style="opacity:1;fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7969"
+     width="7"
+     height="1"
+     x="14"
+     y="10" />
+  <rect
+     style="opacity:1;fill:#c2c2c2;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round"
+     id="rect7971"
+     width="7"
+     height="1"
+     x="14"
+     y="12" />
+</svg>

--- a/elementary-xfce/actions/symbolic/sidebar-hide-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/sidebar-hide-symbolic.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="sidebar-hide-symbolic.svg">
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="854"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="7.0802174"
+     inkscape:cx="18.648472"
+     inkscape:cy="14.473081"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="false" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.87082839;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.1715737,8 10.12132,3.0502532 10.828426,3.7573602 5.8786797,8.7071073 Z"
+     id="path834"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path883"
+     d="M 5.1715737,8 10.12132,12.949747 10.828426,12.24264 5.8786797,7.2928926 Z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.87082839;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/elementary-xfce/actions/symbolic/sidebar-places-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/sidebar-places-symbolic.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.92.3 (unknown)"
+   sodipodi:docname="sidebar-places-symbolic.svg">
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="854"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="40.051758"
+     inkscape:cx="5.8994152"
+     inkscape:cy="8.3223228"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="false" />
+  <metadata
+     id="metadata90">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1 3 L 1 4 L 1 5 L 1 14 L 15 14 L 15 5 L 10 5 L 10 4 L 10 3 L 1 3 z M 2 4 L 9 4 L 9 5 L 2 5 L 2 4 z M 2 6 L 14 6 L 14 13 L 2 13 L 2 6 z "
+     id="rect6206" />
+</svg>

--- a/elementary-xfce/actions/symbolic/sidebar-show-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/sidebar-show-symbolic.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="sidebar-show-symbolic.svg">
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="854"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="-8.494195"
+     inkscape:cy="16.678098"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="false" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.87082839;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 10.828426,8.0000002 5.8786799,12.949747 5.1715739,12.24264 10.12132,7.2928928 Z"
+     id="path834"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path883"
+     d="M 10.828426,8.0000002 5.8786799,3.050253 5.1715739,3.75736 10.12132,8.7071076 Z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.87082839;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/elementary-xfce/actions/symbolic/sidebar-tree-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/sidebar-tree-symbolic.svg
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg7384"
+   height="16"
+   width="16"
+   version="1.1"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="sidebar-tree-symbolic.svg">
+  <metadata
+     id="metadata39">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1440"
+     inkscape:window-height="854"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="20.025879"
+     inkscape:cx="-6.7879092"
+     inkscape:cy="13.928896"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7384"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="false" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path830"
+     d="M 5,4 V 15 H 6 V 4 Z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:2.34520793;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:0.70710671;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 8,8 H 7 v 1 h 1 z"
+     id="path823"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path825"
+     d="M 8,11 H 7 v 1 h 1 z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:0.70710671;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:0.70710671;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 8,14 H 7 v 1 h 1 z"
+     id="path827"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path866"
+     d="M 8,5 H 7 v 1 h 1 z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:0.70710671;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.58113873;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 1,2 H 6 V 1 H 1 Z"
+     id="path868"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path870"
+     d="M 1,5 H 6 V 4 H 1 Z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.58113873;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path872"
+     d="M 1,1 V 5 H 2 V 1 Z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.41421342;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.41421342;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5,1 V 5 H 6 V 1 Z"
+     id="path874"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path876"
+     d="M 15,8 H 9 v 1 h 6 z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.73205066;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.73205066;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 15,11 H 9 v 1 h 6 z"
+     id="path878"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path880"
+     d="M 15,14 H 9 v 1 h 6 z"
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.73205066;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="fill:#8c8c8c;fill-opacity:1;stroke:none;stroke-width:1.73205066;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 15,5 H 9 v 1 h 6 z"
+     id="path882"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+</svg>

--- a/elementary-xfce/apps/128/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/128/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg

--- a/elementary-xfce/apps/128/org.xfce.panel.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.svg
@@ -1,0 +1,1 @@
+xfce4-panel.svg

--- a/elementary-xfce/apps/128/xfce4-panel.svg
+++ b/elementary-xfce/apps/128/xfce4-panel.svg
@@ -1,0 +1,265 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg1325"
+   sodipodi:docname="xfce4-panel.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     width="128px"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-center="true"
+     inkscape:zoom="7.5351066"
+     inkscape:cx="27.869546"
+     inkscape:cy="65.228009"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1325" />
+  <metadata
+     id="metadata51">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs1327">
+    <linearGradient
+       id="linearGradient3958">
+      <stop
+         id="stop3960"
+         style="stop-color:white;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3962"
+         style="stop-color:black;stop-opacity:1"
+         offset="0.51514298" />
+      <stop
+         id="stop3964"
+         style="stop-color:black;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2270">
+      <stop
+         id="stop2272"
+         style="stop-color:white;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2274"
+         style="stop-color:white;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="31.669502"
+       y1="17"
+       x2="31.653906"
+       y2="47"
+       id="linearGradient2268"
+       xlink:href="#linearGradient2181"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-8)" />
+    <linearGradient
+       x1="23.99696"
+       y1="18.375"
+       x2="23.787659"
+       y2="46"
+       id="linearGradient1341"
+       xlink:href="#linearGradient2270"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-8)" />
+    <linearGradient
+       id="linearGradient2181">
+      <stop
+         id="stop2183"
+         style="stop-color:#f0f0f0;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2185"
+         style="stop-color:#d3d3d3;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="9.5"
+       cy="24"
+       r="5.5"
+       fx="9.5"
+       fy="24"
+       id="radialGradient3890"
+       xlink:href="#linearGradient2181"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5177196,1.0726872e-7,-1.6705603e-7,2.3636362,-4.9183319,-32.727271)" />
+    <linearGradient
+       x1="9.5"
+       y1="12"
+       x2="9.5"
+       y2="36"
+       id="linearGradient3898"
+       xlink:href="#linearGradient2270"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3976"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3972">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3974"
+         style="fill:url(#linearGradient3976);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3982"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3978">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3980"
+         style="fill:url(#linearGradient3982);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3984">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3986"
+         style="fill:url(#linearGradient3988);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient3994"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3990">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3992"
+         style="fill:url(#linearGradient3994);fill-opacity:1;stroke:none" />
+    </mask>
+    <linearGradient
+       x1="44"
+       y1="24"
+       x2="50"
+       y2="24"
+       id="linearGradient4000"
+       xlink:href="#linearGradient3958"
+       gradientUnits="userSpaceOnUse" />
+    <mask
+       id="mask3996">
+      <rect
+         width="49"
+         height="32"
+         x="1"
+         y="8"
+         id="rect3998"
+         style="fill:url(#linearGradient4000);fill-opacity:1;stroke:none" />
+    </mask>
+  </defs>
+  <rect
+     style="fill:url(#linearGradient2268);fill-opacity:1;stroke:#969696;stroke-width:0.383226;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect1333"
+     mask="url(#mask3996)"
+     y="9.5"
+     x="2.5"
+     height="29"
+     width="46"
+     transform="matrix(2.5009044,0,0,2.7226415,-1.7725472,-1.3439533)" />
+  <rect
+     style="opacity:0.8;fill:none;stroke:url(#linearGradient1341);stroke-width:0.373739;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect2210"
+     mask="url(#mask3990)"
+     y="10.5"
+     x="3.5"
+     height="27"
+     width="45"
+     transform="matrix(2.5124662,0,0,2.8494506,-3.3241284,-4.3867559)" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3890);fill-opacity:1;fill-rule:nonzero;stroke:#969696;stroke-width:0.411556;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect1337"
+     mask="url(#mask3984)"
+     y="11.5"
+     x="4.5"
+     ry="1.0614461"
+     rx="1.4874753"
+     height="25"
+     width="9.9997997"
+     transform="matrix(2.1130652,0,0,2.7940136,-1.0739711,-2.5562099)" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:url(#linearGradient3898);stroke-width:0.379542;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect2212"
+     mask="url(#mask3978)"
+     y="12.5"
+     x="5.5"
+     ry="0.68763298"
+     rx="0.8379612"
+     height="23"
+     width="8"
+     transform="matrix(2.3867453,0,0,2.9085283,-3.6741641,-5.8046494)" />
+  <path
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.45291"
+     id="path2214"
+     mask="url(#mask3972)"
+     d="M 8,23.5 11,21 v 5 z"
+     transform="matrix(3,0,0,2.6,-10,2.9)" />
+  <path
+     id="path1881"
+     d="m 51.782054,79.142294 c -0.05768,-0.164775 0.08416,-0.930893 0.31519,-1.702498 0.456794,-1.525572 0.528261,-2.092177 0.284211,-2.253257 -0.08678,-0.05725 -0.616604,0.05513 -1.177421,0.249767 -1.169844,0.40601 -1.534785,0.330035 -1.515837,-0.315581 0.01392,-0.473984 0.443947,-1.099054 1.47256,-2.140386 l 0.60216,-0.609603 0.09037,-2.991165 c 0.08045,-2.663052 0.145031,-3.135897 0.588718,-4.310614 0.274089,-0.725696 0.752717,-1.707388 1.063619,-2.181542 0.310902,-0.474151 0.567821,-0.948834 0.570931,-1.054852 0.003,-0.106007 -0.598439,-0.801911 -1.336778,-1.546434 -2.399868,-2.419957 -6.281886,-5.038554 -10.709581,-7.224097 -2.872896,-1.418084 -4.867166,-2.546587 -5.045305,-2.855006 -0.179862,-0.3114 0.224121,-0.179735 1.732094,0.564525 0.812878,0.401194 2.842424,1.22479 4.510101,1.830211 4.464044,1.620585 6.783005,2.995565 10.202425,6.049313 0.960798,0.858055 1.840413,1.621811 1.954695,1.697239 0.114294,0.07544 0.761537,-0.122097 1.438342,-0.438949 1.551577,-0.72638 2.232775,-0.702639 7.131323,0.248552 2.521081,0.489537 4.102181,0.700102 5.20988,0.693838 l 1.590341,-0.0089 0.863107,-1.465478 c 0.793784,-1.347777 0.84915,-1.522182 0.689348,-2.171469 -0.41273,-1.676944 -0.0044,-3.573032 0.862393,-4.005126 0.983397,-0.490191 1.658556,0.09648 2.841274,2.468862 0.432344,0.86723 0.890998,1.542241 1.051112,1.546949 0.336309,0.0099 0.333043,-0.19435 -0.02737,-1.711659 -0.372926,-1.569964 -0.155478,-2.866754 0.600327,-3.580114 0.467172,-0.440943 0.668102,-0.508962 1.171112,-0.396462 1.170248,0.26173 1.656233,1.384919 1.827526,4.22367 0.04921,0.815334 0.166288,1.533138 0.260194,1.595122 0.0939,0.062 1.168971,0.346173 2.389026,0.631536 6.068546,1.419394 8.517066,3.055611 8.441199,5.640813 -0.01714,0.583571 -0.177522,0.821807 -1.096838,1.629107 -1.07907,0.947592 -3.678181,2.414453 -7.012718,3.95777 -2.521857,1.167185 -2.619165,1.694369 -0.737233,3.994083 1.11115,1.357825 1.427981,2.021781 1.159356,2.429569 -0.176736,0.268283 -0.865146,0.154701 -2.973692,-0.490615 -2.14086,-0.655207 -2.362722,-0.488364 -1.262257,0.94923 1.425218,1.861822 1.692169,2.895384 0.812704,3.146586 -0.425447,0.121533 -1.993419,-0.454742 -4.905519,-1.802893 l -2.158307,-0.999179 -1.149995,0.191645 c -0.632499,0.105422 -3.211152,0.173234 -5.730341,0.150745 -4.378754,-0.03913 -4.690874,-0.06622 -7.091805,-0.615424 -2.414515,-0.552336 -2.52843,-0.562017 -2.951049,-0.250751 -0.241773,0.17808 -1.351826,1.046585 -2.466779,1.930035 -1.114956,0.883453 -2.082259,1.605442 -2.149565,1.604422 -0.0673,-9.51e-4 -0.169576,-0.136653 -0.227251,-0.301432 z M 84.80709,66.9356 c 0.490885,-0.492995 0.380038,-1.117287 -0.150557,-0.847976 -0.610227,0.30973 -1.662717,1.461216 -1.536043,1.680527 0.145232,0.251431 1.053881,-0.197116 1.686604,-0.832551 z m -1.318898,-1.26311 c 0.522914,-0.20717 0.954213,-0.494667 0.958447,-0.638868 0.01029,-0.35692 -0.22944,-0.337666 -1.232887,0.09894 -1.764608,0.767788 -1.519213,1.250572 0.27444,0.539931 z m -1.826374,-3.064464 c 0.0028,-0.0964 -0.248979,-0.239047 -0.559577,-0.316967 -0.310599,-0.07791 -0.721807,-0.354117 -0.91379,-0.61377 -0.632928,-0.856 -0.791256,-0.552474 -0.227816,0.436753 0.29525,0.518375 0.477231,0.633438 1.027425,0.649612 0.367743,0.0109 0.670934,-0.05921 0.673766,-0.15563 z m 0.781487,-1.933208 c 0.09917,-0.879849 -0.390991,-1.268335 -1.051653,-0.833505 -0.795133,0.523326 -0.439556,1.656675 0.494198,1.575186 0.401231,-0.03503 0.491309,-0.154863 0.557455,-0.741681 z m 7.902541,-1.876037 c 0.0073,-0.445052 1.151434,-2.676882 1.519931,-2.965142 0.569322,-0.445359 0.507098,0.02374 -0.163626,1.233571 -0.871112,1.571286 -1.3641,2.20068 -1.356301,1.731571 z m -1.306449,-0.953736 c 0.02408,-0.689114 0.244536,-1.317382 0.460074,-1.311043 0.115141,0.0032 0.129703,0.283635 0.03717,0.715789 -0.18448,0.861687 -0.520597,1.264064 -0.497244,0.595254 z M 35.781398,49.427487 c 0.0071,-0.244006 0.141864,-0.240047 0.285356,0.0085 0.0616,0.106613 0.02142,0.191221 -0.08949,0.187951 -0.110805,-0.0032 -0.198941,-0.09161 -0.195876,-0.196329 z"
+     style="fill:#030000;fill-opacity:1;stroke:none;stroke-width:0.999999" />
+</svg>

--- a/elementary-xfce/apps/16/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/16/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg

--- a/elementary-xfce/apps/22/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/22/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg

--- a/elementary-xfce/apps/24/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/24/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg

--- a/elementary-xfce/apps/32/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/32/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg

--- a/elementary-xfce/apps/48/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/48/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg

--- a/elementary-xfce/apps/64/org.xfce.mailreader.svg
+++ b/elementary-xfce/apps/64/org.xfce.mailreader.svg
@@ -1,0 +1,1 @@
+internet-mail.svg


### PR DESCRIPTION
Adds a few missing icons used by some apps.


Whisker Menu and Applications Menu
- org.xfce.mailreader

Mousepad
- format-indent-more
- format-indent-less

Atril and Xarchiver
- gtk-index
- view-page-continuous
- view-page-facing

Xfdesktop (and other apps)
- view-sort-ascending
- view-sort-descending

Sidebar icons
- Used for some app's sidebars

Xfce Panel icon at 128px
- For Panel > About

Fixes #250 