### PR TITLE
Fix issue where xfsm icons don't show in darker

### DIFF
--- a/elementary-xfce-darker/actions/24/xfsm-hibernate.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-hibernate.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/actions/24/system-suspend-hibernate.svg

--- a/elementary-xfce-darker/actions/24/xfsm-lock.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-lock.svg
@@ -1,1 +1,1 @@
-system-lock-screen.svg
+../../../elementary-xfce/actions/24/system-lock-screen.svg

--- a/elementary-xfce-darker/actions/24/xfsm-logout.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-logout.svg
@@ -1,1 +1,1 @@
-system-log-out.svg
+../../../elementary-xfce/actions/24/system-log-out.svg

--- a/elementary-xfce-darker/actions/24/xfsm-reboot.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-reboot.svg
@@ -1,1 +1,1 @@
-system-reboot.svg
+../../../elementary-xfce/actions/24/system-reboot.svg

--- a/elementary-xfce-darker/actions/24/xfsm-shutdown.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-shutdown.svg
@@ -1,1 +1,1 @@
-system-shutdown.svg
+../../../elementary-xfce/actions/24/system-shutdown.svg

--- a/elementary-xfce-darker/actions/24/xfsm-suspend.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-suspend.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/actions/24/system-suspend.svg

--- a/elementary-xfce-darker/actions/24/xfsm-switch-user.svg
+++ b/elementary-xfce-darker/actions/24/xfsm-switch-user.svg
@@ -1,0 +1,1 @@
+../../../elementary-xfce/actions/24/system-switch-user.svg


### PR DESCRIPTION
Resymlinked newer xfsm icons to darker theme to fix
issue where they didn't show in Whisker menu on
darker and darkest themes.