### PR TITLE
Add lightdm settings, mugshot icons

### DIFF
--- a/elementary-xfce/apps/128/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/128/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="128"
+   height="128"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041667"
+     inkscape:cx="59.753665"
+     inkscape:cy="82.205278"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="231"
+     inkscape:window-y="612"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6216215,0,0,2.6216215,1.0810911,1.0810805)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(2.177881,0,0,2.6488012,11.730865,-4.8688385)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.1606478,0,0,0.0617647,126.81608,80.354101)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060-6">
+      <stop
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.16064786,0,0,0.0617647,1.1839145,80.354101)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.14082841,0,0,0.0617647,13.100591,80.354101)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4826"
+       xlink:href="#linearGradient5048-7" />
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none"
+       id="rect2512"
+       y="103"
+       x="30"
+       height="15"
+       width="68" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none"
+       id="path2514"
+       d="m 98,103.00052 c 0,0 0,14.99917 0,14.99917 8.27297,0.0282 20,-3.36055 20,-7.50056 0,-4.14 -9.232,-7.49861 -20,-7.49861 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;marker:none"
+       id="path2516"
+       d="m 30,103.00052 c 0,0 0,14.99917 0,14.99917 -8.272964,0.0282 -20,-3.36055 -20,-7.50056 0,-4.14 9.232006,-7.49861 20,-7.49861 z" />
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996"
+       id="rect2551"
+       y="15"
+       x="15"
+       ry="7.5"
+       rx="7.5"
+       height="98"
+       width="98" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="15.5"
+       x="15.5"
+       ry="7"
+       rx="7"
+       height="97"
+       width="97" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3"
+       id="rect2551-3"
+       y="14.5"
+       x="14.500004"
+       ry="8"
+       rx="8"
+       height="99"
+       width="98.999992" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.999985;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5"
+       id="rect1590"
+       width="71.000008"
+       height="17.000015"
+       x="28.374998"
+       y="84.499992"
+       rx="4"
+       ry="4" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="path1760"
+       cx="41.5"
+       cy="93"
+       r="5" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2898"
+       cx="56.5"
+       cy="93"
+       r="5" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2900"
+       cx="71.5"
+       cy="93"
+       r="5" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2902"
+       cx="86.5"
+       cy="93"
+       r="5" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="64"
+       cy="50"
+       r="24" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="64"
+       cy="47"
+       r="9" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="M 63.984847,58 A 19.823275,21.155742 0 0 0 49.676766,64.590907 25.858589,25.85859 0 0 0 63.994948,69 25.858589,25.85859 0 0 0 78.323234,64.585859 19.823275,21.155742 0 0 0 63.984847,58 Z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/128/lightdm-settings.svg
+++ b/elementary-xfce/apps/128/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/128/mugshot.svg
+++ b/elementary-xfce/apps/128/mugshot.svg
@@ -1,0 +1,1 @@
+../../status/128/avatar-default.svg

--- a/elementary-xfce/apps/16/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/16/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041667"
+     inkscape:cx="21.043988"
+     inkscape:cy="16.469208"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="657"
+     inkscape:window-y="81"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135147,0,0,0.35135147,-0.43243409,-0.43243545)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(0.31112588,0,0,0.37840017,0.53297991,-1.8384058)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999993"
+       id="rect2551"
+       y="1"
+       x="1"
+       ry="0.5"
+       rx="0.5"
+       height="14"
+       width="14" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="1.4999976"
+       x="1.4999962"
+       height="13.000005"
+       width="13.000005" />
+    <rect
+       style="fill:#ffffff;fill-opacity:0.999905;stroke:none;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;paint-order:stroke fill markers"
+       id="rect7092"
+       width="14"
+       height="4"
+       x="1"
+       y="11" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.35"
+       id="rect2551-3"
+       y="0.50000095"
+       x="0.5"
+       ry="1"
+       rx="1"
+       height="14.999998"
+       width="15" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="8"
+       cy="5.5"
+       r="4.5" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="8"
+       cy="4.5"
+       r="2" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="M 7.9960929,7 A 4.0366532,4.8081244 0 0 0 5.3906239,8.1542969 4.5,4.5 0 0 0 7.9999989,9 4.5,4.5 0 0 0 10.611327,8.1523438 4.0366532,4.8081244 0 0 0 7.9960929,7 Z" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle3343"
+       cx="4"
+       cy="13"
+       r="1.5" />
+    <rect
+       style="fill:#000000;fill-opacity:0.3;stroke:none;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;paint-order:stroke fill markers"
+       id="rect6832"
+       width="14"
+       height="1"
+       x="1"
+       y="10" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle21320"
+       cx="8"
+       cy="13"
+       r="1.5" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999994;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle21322"
+       cx="12"
+       cy="13"
+       r="1.5" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/16/lightdm-settings.svg
+++ b/elementary-xfce/apps/16/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/16/mugshot.svg
+++ b/elementary-xfce/apps/16/mugshot.svg
@@ -1,0 +1,1 @@
+../../status/16/avatar-default.svg

--- a/elementary-xfce/apps/24/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/24/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="24"
+   height="24"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208333"
+     inkscape:cx="10.381232"
+     inkscape:cy="17.73607"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="704"
+     inkscape:window-y="49"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945965,0,0,0.45945965,0.97297032,0.97296825)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(0.400019,0,0,0.48651451,2.3995466,-0.64937893)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03398319,0,0,0.01235294,25.711094,15.482819)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060-6">
+      <stop
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0339832,0,0,0.01235294,-1.711095,15.482819)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.02803824,0,0,0.01235294,1.8661809,15.482819)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4826"
+       xlink:href="#linearGradient5048-7" />
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999991;marker:none"
+       id="rect2512"
+       y="20.011999"
+       x="5.2307692"
+       height="3"
+       width="13.538462" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999991;marker:none"
+       id="path2514"
+       d="m 18.769231,20.012103 c 0,0 0,2.999831 0,2.999831 C 20.519282,23.017559 23,22.339827 23,21.511823 c 0,-0.828 -1.952923,-1.49972 -4.230769,-1.49972 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999991;marker:none"
+       id="path2516"
+       d="m 5.2307692,20.012103 c 0,0 0,2.999831 0,2.999831 C 3.4807191,23.017559 1,22.339827 1,21.511823 c 0,-0.828 1.9529243,-1.49972 4.2307692,-1.49972 z" />
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997"
+       id="rect2551"
+       y="3"
+       x="3"
+       ry="1.5"
+       rx="1.5"
+       height="18"
+       width="18" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="3.4999962"
+       x="3.4999962"
+       ry="1"
+       rx="1"
+       height="17.000008"
+       width="17.000008" />
+    <rect
+       style="fill:#ffffff;fill-opacity:0.99990535;stroke:none;stroke-width:0.999998;stroke-linejoin:round;stroke-opacity:0.3;paint-order:stroke fill markers"
+       id="rect7092"
+       width="18"
+       height="4"
+       x="3"
+       y="17" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3"
+       id="rect2551-3"
+       y="2.500001"
+       x="2.5"
+       ry="2"
+       rx="2"
+       height="18.999998"
+       width="19" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="12"
+       cy="10"
+       r="5.5" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="12"
+       cy="9.3125"
+       r="2.0625" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999991;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="m 11.996605,11.833334 a 4.4403158,5.2889337 0 0 0 -3.2049379,1.647726 5.7921963,6.4646453 0 0 0 3.2072019,1.102274 5.7921963,6.4646453 0 0 0 3.209466,-1.103536 4.4403158,5.2889337 0 0 0 -3.21173,-1.646464 z" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle3343"
+       cx="6.25"
+       cy="19"
+       r="1.25" />
+    <rect
+       style="fill:#000000;fill-opacity:0.3;stroke:none;stroke-width:0.999997;stroke-linejoin:round;stroke-opacity:0.3;paint-order:stroke fill markers"
+       id="rect6832"
+       width="18"
+       height="1"
+       x="3"
+       y="16" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle7804"
+       cx="10.25"
+       cy="19"
+       r="1.25" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle7806"
+       cx="14.25"
+       cy="19"
+       r="1.25" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle7808"
+       cx="18.25"
+       cy="19"
+       r="1.25" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/24/lightdm-settings.svg
+++ b/elementary-xfce/apps/24/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/24/mugshot.svg
+++ b/elementary-xfce/apps/24/mugshot.svg
@@ -1,0 +1,1 @@
+../../status/24/avatar-default.svg

--- a/elementary-xfce/apps/32/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/32/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="32"
+   height="32"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="25.032824"
+     inkscape:cy="12.342227"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="946"
+     inkscape:window-y="304"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162165,0,0,0.62162165,1.0810839,1.0810802)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(0.53335865,0,0,0.64868599,3.1993953,-0.8658385)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.04016195,0,0,0.01647059,32.20402,19.961093)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060-6">
+      <stop
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04016197,0,0,0.01647059,-0.2040213,19.961093)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.0331361,0,0,0.01647059,4.0236684,19.961093)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4826"
+       xlink:href="#linearGradient5048-7" />
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;marker:none"
+       id="rect2512"
+       y="26"
+       x="8"
+       height="4"
+       width="16" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999994;marker:none"
+       id="path2514"
+       d="m 24,26.000138 c 0,0 0,3.999775 0,3.999775 2.068242,0.0075 5,-0.896144 5,-2.000148 0,-1.104 -2.308,-1.999627 -5,-1.999627 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999994;marker:none"
+       id="path2516"
+       d="m 8,26.000138 c 0,0 0,3.999775 0,3.999775 -2.0682411,0.0075 -5,-0.896144 -5,-2.000148 0,-1.104 2.3080014,-1.999627 5,-1.999627 z" />
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1"
+       id="rect2551"
+       y="4"
+       x="4"
+       ry="2"
+       rx="2.0000002"
+       height="24"
+       width="24" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="4.499999"
+       x="4.5"
+       ry="1.735849"
+       rx="1.7358489"
+       height="23.000002"
+       width="23" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3"
+       id="rect2551-3"
+       y="3.5"
+       x="3.499999"
+       ry="2.272727"
+       rx="2.2727275"
+       height="25"
+       width="25.000002" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.999975;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="rect1590"
+       width="19.000025"
+       height="5.0000248"
+       x="6.4999876"
+       y="21.499987"
+       rx="0.97435975"
+       ry="1.0000035" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="16"
+       cy="13"
+       r="7" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="16"
+       cy="12.125"
+       r="2.625" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="m 15.995679,15.333334 a 5.6513111,6.7313703 0 0 0 -4.079012,2.097107 7.3718864,8.2277305 0 0 0 4.081894,1.402893 7.3718864,8.2277305 0 0 0 4.084773,-1.404499 5.6513111,6.7313703 0 0 0 -4.087655,-2.095501 z" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle3343"
+       cx="10"
+       cy="24"
+       r="1.25" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle5249"
+       cx="14"
+       cy="24"
+       r="1.25" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle5251"
+       cx="18"
+       cy="24"
+       r="1.25" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle5253"
+       cx="22"
+       cy="24"
+       r="1.25" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/32/lightdm-settings.svg
+++ b/elementary-xfce/apps/32/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/32/mugshot.svg
+++ b/elementary-xfce/apps/32/mugshot.svg
@@ -1,0 +1,1 @@
+../../status/32/avatar-default.svg

--- a/elementary-xfce/apps/48/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/48/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="48px"
+   height="48px"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.5520834"
+     inkscape:cx="17.876833"
+     inkscape:cy="-19.706745"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="246"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(3.78e-6)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(0.84448446,0,0,1.0270862,3.732376,-2.7042436)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.06553443,0,0,0.02470588,49.672784,30.941636)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060-6">
+      <stop
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06553443,0,0,0.02470588,-1.672999,30.941636)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.05725089,0,0,0.02470588,3.307894,30.941636)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4826"
+       xlink:href="#linearGradient5048-7" />
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none"
+       id="rect2512"
+       y="40"
+       x="10.178"
+       height="6.0000005"
+       width="27.643999" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+       id="path2514"
+       d="m 37.822,40.000203 c 0,0 0,5.999669 0,5.999669 3.374861,0.01129 8.158768,-1.344221 8.158768,-3.000221 0,-1.655999 -3.766089,-2.999448 -8.158768,-2.999448 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+       id="path2516"
+       d="m 10.177771,40.000203 c 0,0 0,5.999669 0,5.999669 C 6.80291,46.011162 2.019,44.655651 2.019,42.999651 c 0,-1.655999 3.766091,-2.999448 8.158771,-2.999448 z" />
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997"
+       id="rect2551"
+       y="5"
+       x="5"
+       ry="2"
+       rx="2"
+       height="38"
+       width="38" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="5.5"
+       x="5.5"
+       ry="2"
+       rx="2"
+       height="37"
+       width="37" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.30000001"
+       id="rect2551-3"
+       y="4.5"
+       x="4.5"
+       ry="3"
+       rx="3"
+       height="39"
+       width="39" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.999997;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5"
+       id="rect1590"
+       width="29"
+       height="7"
+       x="9.5"
+       y="32.5"
+       rx="1.8534217"
+       ry="1.5588621" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="path1760"
+       cx="15"
+       cy="36"
+       r="2" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2898"
+       cx="21"
+       cy="36"
+       r="2" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2900"
+       cx="27"
+       cy="36"
+       r="2" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2902"
+       cx="33"
+       cy="36"
+       r="2" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:0.999998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="24"
+       cy="19.5"
+       r="9.5" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="24"
+       cy="18.5"
+       r="3.5" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="M 23.996094 22.746094 A 7.6660309 8.181321 0 0 0 18.462891 25.294922 A 10 10 0 0 0 24 27 A 10 10 0 0 0 29.541016 25.292969 A 7.6660309 8.181321 0 0 0 23.996094 22.746094 z " />
+  </g>
+</svg>

--- a/elementary-xfce/apps/48/lightdm-settings.svg
+++ b/elementary-xfce/apps/48/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/48/mugshot.svg
+++ b/elementary-xfce/apps/48/mugshot.svg
@@ -1,0 +1,1 @@
+../../status/48/avatar-default.svg

--- a/elementary-xfce/apps/64/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/64/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64"
+   height="64"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208333"
+     inkscape:cx="30.580645"
+     inkscape:cy="49.759531"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="670"
+     inkscape:window-y="69"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324326,0,0,1.4324326,-2.3783745,-2.3783801)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(1.2000569,0,0,1.4595434,3.1986414,-5.9481338)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0803239,0,0,0.02882353,60.40804,44.431914)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060-6">
+      <stop
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08032393,0,0,0.02882353,3.5919574,44.431914)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.08284023,0,0,0.02882353,2.0591709,44.431914)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4826"
+       xlink:href="#linearGradient5048-7" />
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999992;marker:none"
+       id="rect2512"
+       y="55"
+       x="12"
+       height="7"
+       width="40" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999992;marker:none"
+       id="path2514"
+       d="m 52,55.000242 c 0,0 0,6.999608 0,6.999608 4.136485,0.01316 10,-1.568252 10,-3.500261 0,-1.932 -4.616,-3.499347 -10,-3.499347 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999992;marker:none"
+       id="path2516"
+       d="m 12,55.000242 c 0,0 0,6.999608 0,6.999608 -4.1364821,0.01316 -10,-1.568252 -10,-3.500261 0,-1.932 4.6160028,-3.499347 10,-3.499347 z" />
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999998"
+       id="rect2551"
+       y="5.0000019"
+       x="5.0000019"
+       ry="4.5"
+       rx="4.5"
+       height="53.999996"
+       width="53.999996" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="5.4999981"
+       x="5.4999981"
+       ry="4"
+       rx="4"
+       height="53.000004"
+       width="53.000004" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3"
+       id="rect2551-3"
+       y="4.4999962"
+       x="4.5"
+       ry="5"
+       rx="5"
+       height="55.000008"
+       width="55" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.999981;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5"
+       id="rect1590"
+       width="39.000019"
+       height="10.000016"
+       x="12.49999"
+       y="43.499992"
+       rx="2"
+       ry="2" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="32"
+       cy="25"
+       r="13" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="32"
+       cy="23"
+       r="5" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999993;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="m 31.991732,28.999999 a 10.812693,11.539493 0 0 0 -7.804404,3.59504 14.104682,14.104682 0 0 0 7.809916,2.40496 14.104682,14.104682 0 0 0 7.815427,-2.407712 10.812693,11.539493 0 0 0 -7.820939,-3.592288 z" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2842"
+       cx="28"
+       cy="48.5"
+       r="2.75" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle3343"
+       cx="20"
+       cy="48.5"
+       r="2.75" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle3505"
+       cx="36"
+       cy="48.5"
+       r="2.75" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle3507"
+       cx="44"
+       cy="48.5"
+       r="2.75" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/64/lightdm-settings.svg
+++ b/elementary-xfce/apps/64/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/64/mugshot.svg
+++ b/elementary-xfce/apps/64/mugshot.svg
@@ -1,0 +1,1 @@
+../../status/64/avatar-default.svg

--- a/elementary-xfce/apps/96/lightdm-gtk-greeter-settings.svg
+++ b/elementary-xfce/apps/96/lightdm-gtk-greeter-settings.svg
@@ -1,0 +1,246 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="96"
+   height="96"
+   id="svg4828"
+   version="1.1"
+   sodipodi:docname="lightdm-gtk-greeter-settings.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview111"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234044"
+     inkscape:cx="41.903853"
+     inkscape:cy="59.919523"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="1005"
+     inkscape:window-y="254"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4830">
+    <linearGradient
+       xlink:href="#linearGradient4014"
+       id="linearGradient3097"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.081081,0,0,2.081081,-1.945938,-1.945946)"
+       x1="23.99999"
+       y1="5.5018549"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient4014">
+      <stop
+         id="stop4016"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4018"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0312818" />
+      <stop
+         id="stop4020"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95292503" />
+      <stop
+         id="stop4022"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3299-6"
+       id="linearGradient3152"
+       gradientUnits="userSpaceOnUse"
+       x1="29.772825"
+       y1="54.367382"
+       x2="29.772825"
+       y2="4.714005"
+       gradientTransform="matrix(1.7334155,0,0,2.1082296,6.3980351,-6.813974)" />
+    <linearGradient
+       id="linearGradient3299-6">
+      <stop
+         id="stop3301-7"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3303-7"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3157"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.12851824,0,0,0.04970942,98.452867,60.774135)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5060-6">
+      <stop
+         id="stop5062-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient5060-6"
+       id="radialGradient3160"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.12851829,0,0,0.04970942,-2.4528684,60.774135)"
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       r="117.14286" />
+    <linearGradient
+       id="linearGradient5048-7">
+      <stop
+         id="stop5050-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.11183433,0,0,0.04970942,7.5798805,60.774135)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4826"
+       xlink:href="#linearGradient5048-7" />
+  </defs>
+  <metadata
+     id="metadata4833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <rect
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999994;marker:none"
+       id="rect2512"
+       y="79"
+       x="21"
+       height="12.07229"
+       width="54" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;marker:none"
+       id="path2514"
+       d="m 75,79.000409 c 0,0 0,12.071623 0,12.071623 6.618374,0.02272 16,-2.704638 16,-6.036589 0,-3.33195 -7.385603,-6.035034 -16,-6.035034 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;marker:none"
+       id="path2516"
+       d="m 21,79.000409 c 0,0 0,12.071623 0,12.071623 -6.618371,0.02272 -16,-2.704638 -16,-6.036589 0,-3.33195 7.385605,-6.035034 16,-6.035034 z" />
+    <rect
+       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996"
+       id="rect2551"
+       y="9"
+       x="9"
+       ry="5.5"
+       rx="5.5"
+       height="78"
+       width="78" />
+    <rect
+       style="fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="9.5"
+       x="9.5"
+       ry="5"
+       rx="5"
+       height="77"
+       width="77" />
+    <rect
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3"
+       id="rect2551-3"
+       y="8.5"
+       x="8.5"
+       ry="6"
+       rx="6"
+       height="79"
+       width="79" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.999991;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5"
+       id="rect1590"
+       width="57.000004"
+       height="13.000007"
+       x="19.499998"
+       y="65.499992"
+       rx="3"
+       ry="3" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="path1760"
+       cx="30"
+       cy="72"
+       r="4" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2898"
+       cx="42"
+       cy="72"
+       r="4" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2900"
+       cx="54"
+       cy="72"
+       r="4" />
+    <circle
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.501961"
+       id="circle2902"
+       cx="66"
+       cy="72"
+       r="4" />
+    <circle
+       style="fill:#40a0e7;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="path7951"
+       cx="48"
+       cy="38"
+       r="19" />
+    <circle
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       id="circle10768"
+       cx="48"
+       cy="36.000004"
+       r="7" />
+    <path
+       id="circle10842"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.3"
+       d="m 47.992189,44.492192 a 15.332062,16.362642 0 0 0 -11.066406,5.097655 20,20 0 0 0 11.074218,3.410157 20,20 0 0 0 11.082032,-3.414062 15.332062,16.362642 0 0 0 -11.089844,-5.09375 z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/96/lightdm-settings.svg
+++ b/elementary-xfce/apps/96/lightdm-settings.svg
@@ -1,0 +1,1 @@
+lightdm-gtk-greeter-settings.svg

--- a/elementary-xfce/apps/96/mugshot.svg
+++ b/elementary-xfce/apps/96/mugshot.svg
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg5157"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="mugshot.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview28"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.7675533"
+     inkscape:cx="15.925455"
+     inkscape:cy="55.075531"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5157" />
+  <defs
+     id="defs5159">
+    <linearGradient
+       id="linearGradient3820-7-2-8-6">
+      <stop
+         offset="0"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-5-0" />
+      <stop
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-4-1" />
+      <stop
+         offset="1"
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-6-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4806">
+      <stop
+         id="stop4808"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.42447853" />
+      <stop
+         id="stop4812"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.82089913" />
+      <stop
+         id="stop4814"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="39.994175"
+       x2="71.204407"
+       y1="15.761489"
+       x1="71.204407"
+       gradientTransform="matrix(3.0616766,0,0,3.0616771,-172.9799,-37.31945)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient4806" />
+    <radialGradient
+       r="62.769119"
+       fy="186.17059"
+       fx="99.157013"
+       cy="186.17059"
+       cx="99.157013"
+       gradientTransform="matrix(0.50980482,0,0,-0.1592798,-2.5507227,109.6532)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3163"
+       xlink:href="#linearGradient3820-7-2-8-6" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1040"
+       id="linearGradient1044"
+       x1="32"
+       y1="4.4437337"
+       x2="32"
+       y2="59.678059"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3050847,0,0,1.3050847,6.2372872,6.2372921)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1040">
+      <stop
+         style="stop-color:#4eb6e9;stop-opacity:1"
+         offset="0"
+         id="stop1036" />
+      <stop
+         style="stop-color:#328be6;stop-opacity:1"
+         offset="1"
+         id="stop1038" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata5162">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="M 79.999999,79.999998 C 80.00371,74.477492 65.675803,70 47.999999,70 30.324197,70 15.996194,74.477492 16.000001,79.999998 15.996201,85.522505 30.695264,90 48.371067,90 66.04687,90 80.003806,85.522505 79.999999,79.999998 Z"
+     id="path3818-0-5-0"
+     style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none;stroke-width:1" />
+  <g
+     id="g4274"
+     transform="translate(-184.16949,-7.9999975)" />
+  <path
+     d="M 48.000001,9.5000001 C 26.757033,9.5000001 9.5,26.757026 9.5,47.999997 9.5,69.242972 26.757033,86.500008 48.000001,86.5 69.242968,86.5 86.500022,69.242972 86.5,47.999997 86.5,26.757026 69.242968,9.5000001 48.000001,9.5000001 Z"
+     id="path2555-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 47.999998,9.4999996 c 21.242976,0 38.500003,17.2570234 38.500003,38.5000014 0,21.242973 -17.257027,38.500007 -38.500003,38.499999 -21.242974,0 -38.5000139,-17.257026 -38.499999,-38.499999 0,-21.242978 17.257025,-38.5000014 38.499999,-38.5000014 z"
+     id="path2555-7-65-3"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#003651;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     d="m 85.500001,48 c 0,20.710678 -16.78934,37.500001 -37.500021,37.500001 -20.710653,0 -37.499981,-16.789323 -37.499981,-37.500001 0,-20.710679 16.789328,-37.500001 37.499981,-37.500001 20.710681,0 37.500021,16.789322 37.500021,37.500001 z"
+     id="path3019"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3118);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.07;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path4330"
+     d="m 48,27 c -8.90367,0 -16.166767,6.977612 -16.166767,15.600024 0,8.622413 7.263183,15.598562 16.166767,15.598562 8.903584,0 16.166766,-6.976149 16.166766,-15.598562 C 64.166766,33.977612 56.903669,27 48,27 Z m -5.650776,32.182911 c -7.233858,0 -13.493983,4.267822 -16.641315,10.508736 a 0.74990682,0.7511625 0 0 0 0.121192,0.852692 C 31.373683,76.46828 39.256374,80.174058 48,80.174058 c 8.743626,0 16.626317,-3.705778 22.170898,-9.629719 A 0.74990682,0.7511625 0 0 0 70.29209,69.691647 C 67.144759,63.450733 60.884634,59.182911 53.650776,59.182911 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect3049-9"
+     d="m 48,27.751773 c -8.513993,0 -15.415948,6.647608 -15.415948,14.847848 0,8.20024 6.901955,14.847848 15.415948,14.847848 8.513993,0 15.415947,-6.647608 15.415947,-14.847848 0,-8.20024 -6.901955,-14.847848 -15.415947,-14.847848 z m -5.651279,32.18271 c -6.939784,0 -12.942496,4.089637 -15.971813,10.096537 5.408927,5.779007 13.090748,9.391263 21.623092,9.391263 8.532344,0 16.214165,-3.612256 21.623091,-9.391263 -3.029316,-6.0069 -9.032028,-10.096537 -15.971812,-10.096537 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="rect3049"
+     d="m 48,27.002925 c -8.513993,0 -15.415948,6.647608 -15.415948,14.847848 0,8.20024 6.901955,14.847848 15.415948,14.847848 8.513993,0 15.415947,-6.647608 15.415947,-14.847848 0,-8.20024 -6.901955,-14.847848 -15.415947,-14.847848 z m -5.651279,32.18271 c -6.939784,0 -12.942496,4.089637 -15.971813,10.096537 5.408927,5.779007 13.090748,9.391263 21.623092,9.391263 8.532344,0 16.214165,-3.612256 21.623091,-9.391263 -3.029316,-6.0069 -9.032028,-10.096537 -15.971812,-10.096537 z" />
+</svg>

--- a/elementary-xfce/status/16/avatar-default.svg
+++ b/elementary-xfce/status/16/avatar-default.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg4505"
+   sodipodi:docname="avatar-default.svg"
+   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="15.070213"
+     inkscape:cx="10.28519"
+     inkscape:cy="16.224057"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4505" />
+  <defs
+     id="defs4507">
+    <linearGradient
+       id="linearGradient4806-9">
+      <stop
+         id="stop4808-49"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810-05"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.42447853" />
+      <stop
+         id="stop4812-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.82089913" />
+      <stop
+         id="stop4814-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         id="stop3822-2-6-36"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7-6"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2-4"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="15.369057"
+       x2="71.204407"
+       y2="40.495617"
+       id="linearGradient3028"
+       xlink:href="#linearGradient4806-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57010515,0,0,0.57010543,-33.147974,-7.8870696)" />
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3043"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.37681,18.119145)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1040"
+       id="linearGradient1044"
+       x1="32"
+       y1="4.4437337"
+       x2="32"
+       y2="59.678059"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25423729,0,0,0.25423729,-0.13559324,-0.13559262)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1040">
+      <stop
+         style="stop-color:#4eb6e9;stop-opacity:1"
+         offset="0"
+         id="stop1036" />
+      <stop
+         style="stop-color:#328be6;stop-opacity:1"
+         offset="1"
+         id="stop1038" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4510">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 8.0000006,0.49999981 c -4.1382408,0 -7.5000005,3.36175839 -7.5000005,7.49999999 0,4.1382412 3.3617597,7.5000022 7.5000005,7.5000002 C 12.13824,15.5 15.500005,12.138241 15.5,7.9999998 15.5,3.8617582 12.13824,0.49999981 8.0000006,0.49999981 Z"
+     id="path2555"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 8,0.49999992 c -4.1382413,0 -7.5,3.36175808 -7.5,7.49999988 C 0.5,12.138241 3.8617587,15.500002 8,15.5 c 4.138241,0 7.500006,-3.361759 7.5,-7.5000002 C 15.5,3.861758 12.138241,0.49999992 8,0.49999992 Z"
+     id="path2555-7-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#003651;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 14.982759,8.0000002 c 0,3.8564708 -3.126295,6.9827588 -6.982759,6.9827588 -3.8564638,0 -6.9827586,-3.126288 -6.9827586,-6.9827588 0,-3.8564707 3.1262948,-6.9827589 6.9827586,-6.9827589 3.856464,0 6.982759,3.1262882 6.982759,6.9827589 z"
+     id="path3421"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3028);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3840"
+     d="m 8,4.2160218 c -1.7237849,0 -3.1211886,1.3436579 -3.1211886,3.0011434 0,1.6574856 1.3974037,3.0011438 3.1211886,3.0011438 1.723785,0 3.12119,-1.3436582 3.12119,-3.0011438 C 11.12119,5.5596797 9.723785,4.2160218 8,4.2160218 Z M 6.8558146,10.720999 c -1.405063,0 -2.6204018,0.826625 -3.2337324,2.040778 C 4.7172007,13.929867 6.2724997,14.66 8,14.66 c 1.727501,0 3.2828,-0.730133 4.377919,-1.898223 -0.613331,-1.214153 -1.82867,-2.040778 -3.2337329,-2.040778 z" />
+  <path
+     d="m 8,4.0540285 c -1.7237849,0 -3.1211886,1.3436579 -3.1211886,3.0011435 0,1.6574855 1.3974037,3.001143 3.1211886,3.001143 1.723785,0 3.12119,-1.3436575 3.12119,-3.001143 C 11.12119,5.3976864 9.723785,4.0540285 8,4.0540285 Z M 6.8558146,10.559007 c -1.405063,0 -2.6204018,0.826623 -3.2337324,2.040777 1.0951185,1.16809 2.6504175,1.898223 4.3779178,1.898223 1.727501,0 3.2828,-0.730133 4.377919,-1.898223 -0.613331,-1.214154 -1.82867,-2.040777 -3.2337329,-2.040777 z"
+     id="path3070"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="rect3049"
+     d="m 8,3.5367871 c -1.7237849,0 -3.1211886,1.3436579 -3.1211886,3.0011435 0,1.6574856 1.3974037,3.0011435 3.1211886,3.0011435 1.723785,0 3.12119,-1.3436579 3.12119,-3.0011435 C 11.12119,4.880445 9.723785,3.5367871 8,3.5367871 Z M 6.8558146,10.041765 c -1.405063,0 -2.6204018,0.826624 -3.2337324,2.040777 C 4.7172007,13.250633 6.2724997,13.980765 8,13.980765 c 1.727501,0 3.2828,-0.730132 4.377919,-1.898223 -0.613331,-1.214153 -1.82867,-2.040777 -3.2337329,-2.040777 z" />
+</svg>


### PR DESCRIPTION
This adds a new lightdm icon and symlinks mugshot
to the avatar-default icon (both seen in Settings Manager).

Using the avatar icon should add some continuity
between login, profile, user-related actions.

It's uses the same icon that is used in the Whisker Menu, and
the login screen and mugshot placeholder before setting a user image.