### PR TITLE
Make window-close visible in dark and light themes

### DIFF
--- a/elementary-xfce/actions/16/window-close.svg
+++ b/elementary-xfce/actions/16/window-close.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.0"
    width="16"
    height="16"
-   id="svg3167">
+   id="svg3167"
+   sodipodi:docname="window-close.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.3125"
+     inkscape:cx="2.9325513"
+     inkscape:cy="5.2551319"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="265"
+     inkscape:window-y="194"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     showguides="false" />
   <metadata
      id="metadata10">
     <rdf:RDF>
@@ -21,21 +45,49 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3169" />
+     id="defs3169">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient1071">
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:0.69999999"
+         offset="0"
+         id="stop1067" />
+      <stop
+         style="stop-color:#1a1a1a;stop-opacity:0.5"
+         offset="1"
+         id="stop1069" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1071"
+       id="linearGradient1073"
+       x1="7.0854278"
+       y1="13.921408"
+       x2="7.0854278"
+       y2="2.1204123"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <g
      id="layer1">
-    <g
-       transform="matrix(0.9900134,0,0,0.9900134,0.0798928,0.3091806)"
-       id="g3163"
-       style="opacity:0.6">
-      <path
-         d="m 4.778787,4.5502097 6.442426,6.4363783"
-         id="path3173"
-         style="fill:none;stroke:#000000;stroke-width:1.63881421;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="M 11.218188,4.5471855 4.7818113,10.989613"
-         id="path3175"
-         style="fill:none;stroke:#000000;stroke-width:1.63881421;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    </g>
+    <rect
+       style="opacity:1;fill:url(#linearGradient1073);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5"
+       id="rect8368"
+       width="12"
+       height="12"
+       x="2"
+       y="2"
+       rx="2.1818182"
+       ry="2.1818182" />
+    <path
+       style="fill:none;stroke:#fefefe;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 5.5251263,5.5251261 10.474874,10.474874"
+       id="path2338"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;stroke:#fefefe;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 10.474874,5.5251262 5.5251262,10.474874"
+       id="path4591"
+       sodipodi:nodetypes="cc" />
   </g>
 </svg>


### PR DESCRIPTION
Trying to ditch the monochrome close icon and make it more visible in light and dark themes.

Let me know what you think about the shape/design and color. If the red is too loud or anything else. And also if I should do the other sizes in the same style.