### PR TITLE
Deprecate elementary-xfce-darkest

### DIFF
--- a/elementary-xfce-darkest/actions
+++ b/elementary-xfce-darkest/actions
@@ -1,1 +1,0 @@
-../elementary-xfce-darker/actions

--- a/elementary-xfce-darkest/index.theme
+++ b/elementary-xfce-darkest/index.theme
@@ -1,49 +1,9 @@
 [Icon Theme]
 Name=elementary Xfce darkest
-Comment=Addon for dark toolbar and panel icons
+Comment=Deprecated, please use elementary Xfce
 Inherits=elementary-xfce
 
 Example=directory-x-normal
 
 #Directory list
-Directories=actions/16,actions/22,actions/24,actions/32,actions/48,actions/64,actions/128,actions/symbolic,
-
-[actions/16]
-Size=16
-Context=Actions
-Type=Fixed
-
-[actions/22]
-Size=22
-Context=Actions
-Type=Fixed
-
-[actions/24]
-Size=24
-Context=Actions
-Type=Fixed
-
-[actions/32]
-Size=32
-Context=Actions
-Type=Fixed
-
-[actions/48]
-Size=48
-Context=Actions
-Type=Scalable
-
-[actions/64]
-Size=64
-Context=Actions
-Type=Scalable
-
-[actions/128]
-Size=128
-Context=Actions
-Type=Scalable
-
-[actions/symbolic]
-Size=16
-Context=Actions
-Type=Scalable
+Directories=


### PR DESCRIPTION
This variant used elementary-xfce as a fallback and
symlinked the faux symbolic toolbar icons from xfce-darker.

It now falls back entirely to elementary-xfce and
its description is changed to indicate this.