### PR TITLE
Remove stock icon symlinks from actions

### DIFF
--- a/elementary-xfce-darker/actions/16/stock_about.svg
+++ b/elementary-xfce-darker/actions/16/stock_about.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_about.svg

--- a/elementary-xfce-darker/actions/16/stock_add-bookmark.svg
+++ b/elementary-xfce-darker/actions/16/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_add-bookmark.svg

--- a/elementary-xfce-darker/actions/16/stock_bottom.svg
+++ b/elementary-xfce-darker/actions/16/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce-darker/actions/16/stock_calc-accept.svg
+++ b/elementary-xfce-darker/actions/16/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_calc-accept.svg

--- a/elementary-xfce-darker/actions/16/stock_calc-cancel.svg
+++ b/elementary-xfce-darker/actions/16/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce-darker/actions/16/stock_close.svg
+++ b/elementary-xfce-darker/actions/16/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce-darker/actions/16/stock_cut.svg
+++ b/elementary-xfce-darker/actions/16/stock_cut.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_cut.svg

--- a/elementary-xfce-darker/actions/16/stock_delete.svg
+++ b/elementary-xfce-darker/actions/16/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce-darker/actions/16/stock_down.svg
+++ b/elementary-xfce-darker/actions/16/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce-darker/actions/16/stock_edit.svg
+++ b/elementary-xfce-darker/actions/16/stock_edit.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_edit.svg

--- a/elementary-xfce-darker/actions/16/stock_exit.svg
+++ b/elementary-xfce-darker/actions/16/stock_exit.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_exit.svg

--- a/elementary-xfce-darker/actions/16/stock_file-properites.svg
+++ b/elementary-xfce-darker/actions/16/stock_file-properites.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_file-properites.svg

--- a/elementary-xfce-darker/actions/16/stock_file-properties.svg
+++ b/elementary-xfce-darker/actions/16/stock_file-properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_file-properties.svg

--- a/elementary-xfce-darker/actions/16/stock_filters-invert.svg
+++ b/elementary-xfce-darker/actions/16/stock_filters-invert.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_filters-invert.svg

--- a/elementary-xfce-darker/actions/16/stock_first.svg
+++ b/elementary-xfce-darker/actions/16/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce-darker/actions/16/stock_folder_properties.svg
+++ b/elementary-xfce-darker/actions/16/stock_folder_properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_folder_properties.svg

--- a/elementary-xfce-darker/actions/16/stock_fullscreen.svg
+++ b/elementary-xfce-darker/actions/16/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce-darker/actions/16/stock_help-add-bookmark.svg
+++ b/elementary-xfce-darker/actions/16/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_help-add-bookmark.svg

--- a/elementary-xfce-darker/actions/16/stock_help.svg
+++ b/elementary-xfce-darker/actions/16/stock_help.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_help.svg

--- a/elementary-xfce-darker/actions/16/stock_home.svg
+++ b/elementary-xfce-darker/actions/16/stock_home.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_home.svg

--- a/elementary-xfce-darker/actions/16/stock_last.svg
+++ b/elementary-xfce-darker/actions/16/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce-darker/actions/16/stock_leave-fullscreen.svg
+++ b/elementary-xfce-darker/actions/16/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-view-restore.svg

--- a/elementary-xfce-darker/actions/16/stock_left.svg
+++ b/elementary-xfce-darker/actions/16/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce-darker/actions/16/stock_mail-filters-apply.svg
+++ b/elementary-xfce-darker/actions/16/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_mail-filters-apply.svg

--- a/elementary-xfce-darker/actions/16/stock_mailto.svg
+++ b/elementary-xfce-darker/actions/16/stock_mailto.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_mailto.svg

--- a/elementary-xfce-darker/actions/16/stock_mark.svg
+++ b/elementary-xfce-darker/actions/16/stock_mark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_mark.svg

--- a/elementary-xfce-darker/actions/16/stock_media-fwd.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-fwd.svg
@@ -1,1 +1,0 @@
-media-seek-forward.svg

--- a/elementary-xfce-darker/actions/16/stock_media-next.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-next.svg
@@ -1,1 +1,0 @@
-media-skip-forward.svg

--- a/elementary-xfce-darker/actions/16/stock_media-pause.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-pause.svg
@@ -1,1 +1,0 @@
-media-playback-pause.svg

--- a/elementary-xfce-darker/actions/16/stock_media-play.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce-darker/actions/16/stock_media-prev.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-prev.svg
@@ -1,1 +1,0 @@
-media-skip-backward.svg

--- a/elementary-xfce-darker/actions/16/stock_media-rec.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-rec.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_media-rec.svg

--- a/elementary-xfce-darker/actions/16/stock_media-rew.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-rew.svg
@@ -1,1 +1,0 @@
-media-seek-backward.svg

--- a/elementary-xfce-darker/actions/16/stock_media-stop.svg
+++ b/elementary-xfce-darker/actions/16/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce-darker/actions/16/stock_navigator.svg
+++ b/elementary-xfce-darker/actions/16/stock_navigator.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_navigator.svg

--- a/elementary-xfce-darker/actions/16/stock_new-address-book.svg
+++ b/elementary-xfce-darker/actions/16/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_new-address-book.svg

--- a/elementary-xfce-darker/actions/16/stock_new-appointment.svg
+++ b/elementary-xfce-darker/actions/16/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_new-appointment.svg

--- a/elementary-xfce-darker/actions/16/stock_new-dir.svg
+++ b/elementary-xfce-darker/actions/16/stock_new-dir.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_new-dir.svg

--- a/elementary-xfce-darker/actions/16/stock_new-tab.svg
+++ b/elementary-xfce-darker/actions/16/stock_new-tab.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_new-tab.svg

--- a/elementary-xfce-darker/actions/16/stock_new-text.svg
+++ b/elementary-xfce-darker/actions/16/stock_new-text.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_new-text.svg

--- a/elementary-xfce-darker/actions/16/stock_new-window.svg
+++ b/elementary-xfce-darker/actions/16/stock_new-window.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_new-window.svg

--- a/elementary-xfce-darker/actions/16/stock_no.svg
+++ b/elementary-xfce-darker/actions/16/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce-darker/actions/16/stock_not.svg
+++ b/elementary-xfce-darker/actions/16/stock_not.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_not.svg

--- a/elementary-xfce-darker/actions/16/stock_paste.svg
+++ b/elementary-xfce-darker/actions/16/stock_paste.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_paste.svg

--- a/elementary-xfce-darker/actions/16/stock_print.svg
+++ b/elementary-xfce-darker/actions/16/stock_print.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_print.svg

--- a/elementary-xfce-darker/actions/16/stock_properties.svg
+++ b/elementary-xfce-darker/actions/16/stock_properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_properties.svg

--- a/elementary-xfce-darker/actions/16/stock_redo.svg
+++ b/elementary-xfce-darker/actions/16/stock_redo.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_redo.svg

--- a/elementary-xfce-darker/actions/16/stock_refresh.svg
+++ b/elementary-xfce-darker/actions/16/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce-darker/actions/16/stock_right.svg
+++ b/elementary-xfce-darker/actions/16/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce-darker/actions/16/stock_save-as.svg
+++ b/elementary-xfce-darker/actions/16/stock_save-as.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_save-as.svg

--- a/elementary-xfce-darker/actions/16/stock_save.svg
+++ b/elementary-xfce-darker/actions/16/stock_save.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_save.svg

--- a/elementary-xfce-darker/actions/16/stock_scores.svg
+++ b/elementary-xfce-darker/actions/16/stock_scores.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_scores.svg

--- a/elementary-xfce-darker/actions/16/stock_select-all.svg
+++ b/elementary-xfce-darker/actions/16/stock_select-all.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_select-all.svg

--- a/elementary-xfce-darker/actions/16/stock_stop.svg
+++ b/elementary-xfce-darker/actions/16/stock_stop.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_stop.svg

--- a/elementary-xfce-darker/actions/16/stock_top.svg
+++ b/elementary-xfce-darker/actions/16/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce-darker/actions/16/stock_undo.svg
+++ b/elementary-xfce-darker/actions/16/stock_undo.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_undo.svg

--- a/elementary-xfce-darker/actions/16/stock_up.svg
+++ b/elementary-xfce-darker/actions/16/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce-darker/actions/16/stock_view-details.svg
+++ b/elementary-xfce-darker/actions/16/stock_view-details.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_view-details.svg

--- a/elementary-xfce-darker/actions/16/stock_yes.svg
+++ b/elementary-xfce-darker/actions/16/stock_yes.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/16/stock_yes.svg

--- a/elementary-xfce-darker/actions/16/stock_zoom-1.svg
+++ b/elementary-xfce-darker/actions/16/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce-darker/actions/16/stock_zoom-in.svg
+++ b/elementary-xfce-darker/actions/16/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce-darker/actions/16/stock_zoom-out.svg
+++ b/elementary-xfce-darker/actions/16/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce-darker/actions/16/stock_zoom-page.svg
+++ b/elementary-xfce-darker/actions/16/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit.svg

--- a/elementary-xfce-darker/actions/22/stock_about.svg
+++ b/elementary-xfce-darker/actions/22/stock_about.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_about.svg

--- a/elementary-xfce-darker/actions/22/stock_add-bookmark.svg
+++ b/elementary-xfce-darker/actions/22/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_add-bookmark.svg

--- a/elementary-xfce-darker/actions/22/stock_bottom.svg
+++ b/elementary-xfce-darker/actions/22/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce-darker/actions/22/stock_calc-accept.svg
+++ b/elementary-xfce-darker/actions/22/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_calc-accept.svg

--- a/elementary-xfce-darker/actions/22/stock_calc-cancel.svg
+++ b/elementary-xfce-darker/actions/22/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce-darker/actions/22/stock_close.svg
+++ b/elementary-xfce-darker/actions/22/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce-darker/actions/22/stock_cut.svg
+++ b/elementary-xfce-darker/actions/22/stock_cut.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_cut.svg

--- a/elementary-xfce-darker/actions/22/stock_delete.svg
+++ b/elementary-xfce-darker/actions/22/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce-darker/actions/22/stock_down.svg
+++ b/elementary-xfce-darker/actions/22/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce-darker/actions/22/stock_edit.svg
+++ b/elementary-xfce-darker/actions/22/stock_edit.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_edit.svg

--- a/elementary-xfce-darker/actions/22/stock_exit.svg
+++ b/elementary-xfce-darker/actions/22/stock_exit.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_exit.svg

--- a/elementary-xfce-darker/actions/22/stock_file-properites.svg
+++ b/elementary-xfce-darker/actions/22/stock_file-properites.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_file-properites.svg

--- a/elementary-xfce-darker/actions/22/stock_file-properties.svg
+++ b/elementary-xfce-darker/actions/22/stock_file-properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_file-properties.svg

--- a/elementary-xfce-darker/actions/22/stock_filters-invert.svg
+++ b/elementary-xfce-darker/actions/22/stock_filters-invert.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_filters-invert.svg

--- a/elementary-xfce-darker/actions/22/stock_first.svg
+++ b/elementary-xfce-darker/actions/22/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce-darker/actions/22/stock_fullscreen.svg
+++ b/elementary-xfce-darker/actions/22/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce-darker/actions/22/stock_help-add-bookmark.svg
+++ b/elementary-xfce-darker/actions/22/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_help-add-bookmark.svg

--- a/elementary-xfce-darker/actions/22/stock_help.svg
+++ b/elementary-xfce-darker/actions/22/stock_help.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_help.svg

--- a/elementary-xfce-darker/actions/22/stock_last.svg
+++ b/elementary-xfce-darker/actions/22/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce-darker/actions/22/stock_leave-fullscreen.svg
+++ b/elementary-xfce-darker/actions/22/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_leave-fullscreen.svg

--- a/elementary-xfce-darker/actions/22/stock_left.svg
+++ b/elementary-xfce-darker/actions/22/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce-darker/actions/22/stock_mail-compose.svg
+++ b/elementary-xfce-darker/actions/22/stock_mail-compose.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_mail-compose.svg

--- a/elementary-xfce-darker/actions/22/stock_mail-filters-apply.svg
+++ b/elementary-xfce-darker/actions/22/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_mail-filters-apply.svg

--- a/elementary-xfce-darker/actions/22/stock_mail-forward.svg
+++ b/elementary-xfce-darker/actions/22/stock_mail-forward.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_mail-forward.svg

--- a/elementary-xfce-darker/actions/22/stock_mail-reply-to-all.svg
+++ b/elementary-xfce-darker/actions/22/stock_mail-reply-to-all.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_mail-reply-to-all.svg

--- a/elementary-xfce-darker/actions/22/stock_mail-reply.svg
+++ b/elementary-xfce-darker/actions/22/stock_mail-reply.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_mail-reply.svg

--- a/elementary-xfce-darker/actions/22/stock_mark.svg
+++ b/elementary-xfce-darker/actions/22/stock_mark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_mark.svg

--- a/elementary-xfce-darker/actions/22/stock_media-play.svg
+++ b/elementary-xfce-darker/actions/22/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce-darker/actions/22/stock_media-rec.svg
+++ b/elementary-xfce-darker/actions/22/stock_media-rec.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_media-rec.svg

--- a/elementary-xfce-darker/actions/22/stock_media-stop.svg
+++ b/elementary-xfce-darker/actions/22/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce-darker/actions/22/stock_navigator.svg
+++ b/elementary-xfce-darker/actions/22/stock_navigator.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_navigator.svg

--- a/elementary-xfce-darker/actions/22/stock_new-address-book.svg
+++ b/elementary-xfce-darker/actions/22/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_new-address-book.svg

--- a/elementary-xfce-darker/actions/22/stock_new-appointment.svg
+++ b/elementary-xfce-darker/actions/22/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_new-appointment.svg

--- a/elementary-xfce-darker/actions/22/stock_new-bcard.svg
+++ b/elementary-xfce-darker/actions/22/stock_new-bcard.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_new-bcard.svg

--- a/elementary-xfce-darker/actions/22/stock_new-tab.svg
+++ b/elementary-xfce-darker/actions/22/stock_new-tab.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_new-tab.svg

--- a/elementary-xfce-darker/actions/22/stock_new-text.svg
+++ b/elementary-xfce-darker/actions/22/stock_new-text.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_new-text.svg

--- a/elementary-xfce-darker/actions/22/stock_new-window.svg
+++ b/elementary-xfce-darker/actions/22/stock_new-window.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_new-window.svg

--- a/elementary-xfce-darker/actions/22/stock_no.svg
+++ b/elementary-xfce-darker/actions/22/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce-darker/actions/22/stock_not.svg
+++ b/elementary-xfce-darker/actions/22/stock_not.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_not.svg

--- a/elementary-xfce-darker/actions/22/stock_print-setup.svg
+++ b/elementary-xfce-darker/actions/22/stock_print-setup.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_print-setup.svg

--- a/elementary-xfce-darker/actions/22/stock_print.svg
+++ b/elementary-xfce-darker/actions/22/stock_print.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_print.svg

--- a/elementary-xfce-darker/actions/22/stock_properties.svg
+++ b/elementary-xfce-darker/actions/22/stock_properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_properties.svg

--- a/elementary-xfce-darker/actions/22/stock_redo.svg
+++ b/elementary-xfce-darker/actions/22/stock_redo.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_redo.svg

--- a/elementary-xfce-darker/actions/22/stock_refresh.svg
+++ b/elementary-xfce-darker/actions/22/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce-darker/actions/22/stock_right.svg
+++ b/elementary-xfce-darker/actions/22/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce-darker/actions/22/stock_save-as.svg
+++ b/elementary-xfce-darker/actions/22/stock_save-as.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_save-as.svg

--- a/elementary-xfce-darker/actions/22/stock_save.svg
+++ b/elementary-xfce-darker/actions/22/stock_save.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_save.svg

--- a/elementary-xfce-darker/actions/22/stock_scores.svg
+++ b/elementary-xfce-darker/actions/22/stock_scores.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_scores.svg

--- a/elementary-xfce-darker/actions/22/stock_select-all.svg
+++ b/elementary-xfce-darker/actions/22/stock_select-all.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_select-all.svg

--- a/elementary-xfce-darker/actions/22/stock_stop.svg
+++ b/elementary-xfce-darker/actions/22/stock_stop.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_stop.svg

--- a/elementary-xfce-darker/actions/22/stock_top.svg
+++ b/elementary-xfce-darker/actions/22/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce-darker/actions/22/stock_undo.svg
+++ b/elementary-xfce-darker/actions/22/stock_undo.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_undo.svg

--- a/elementary-xfce-darker/actions/22/stock_up.svg
+++ b/elementary-xfce-darker/actions/22/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce-darker/actions/22/stock_view-details.svg
+++ b/elementary-xfce-darker/actions/22/stock_view-details.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_view-details.svg

--- a/elementary-xfce-darker/actions/22/stock_yes.svg
+++ b/elementary-xfce-darker/actions/22/stock_yes.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/22/stock_yes.svg

--- a/elementary-xfce-darker/actions/22/stock_zoom-1.svg
+++ b/elementary-xfce-darker/actions/22/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce-darker/actions/22/stock_zoom-in.svg
+++ b/elementary-xfce-darker/actions/22/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce-darker/actions/22/stock_zoom-out.svg
+++ b/elementary-xfce-darker/actions/22/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce-darker/actions/22/stock_zoom-page.svg
+++ b/elementary-xfce-darker/actions/22/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit-best.svg

--- a/elementary-xfce-darker/actions/24/stock_about.svg
+++ b/elementary-xfce-darker/actions/24/stock_about.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_about.svg

--- a/elementary-xfce-darker/actions/24/stock_add-bookmark.svg
+++ b/elementary-xfce-darker/actions/24/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_add-bookmark.svg

--- a/elementary-xfce-darker/actions/24/stock_bottom.svg
+++ b/elementary-xfce-darker/actions/24/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce-darker/actions/24/stock_calc-accept.svg
+++ b/elementary-xfce-darker/actions/24/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_calc-accept.svg

--- a/elementary-xfce-darker/actions/24/stock_calc-cancel.svg
+++ b/elementary-xfce-darker/actions/24/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce-darker/actions/24/stock_close.svg
+++ b/elementary-xfce-darker/actions/24/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce-darker/actions/24/stock_cut.svg
+++ b/elementary-xfce-darker/actions/24/stock_cut.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_cut.svg

--- a/elementary-xfce-darker/actions/24/stock_delete.svg
+++ b/elementary-xfce-darker/actions/24/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce-darker/actions/24/stock_down.svg
+++ b/elementary-xfce-darker/actions/24/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce-darker/actions/24/stock_edit.svg
+++ b/elementary-xfce-darker/actions/24/stock_edit.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_edit.svg

--- a/elementary-xfce-darker/actions/24/stock_exit.svg
+++ b/elementary-xfce-darker/actions/24/stock_exit.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_exit.svg

--- a/elementary-xfce-darker/actions/24/stock_file-properites.svg
+++ b/elementary-xfce-darker/actions/24/stock_file-properites.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_file-properites.svg

--- a/elementary-xfce-darker/actions/24/stock_file-properties.svg
+++ b/elementary-xfce-darker/actions/24/stock_file-properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_file-properties.svg

--- a/elementary-xfce-darker/actions/24/stock_filters-invert.svg
+++ b/elementary-xfce-darker/actions/24/stock_filters-invert.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_filters-invert.svg

--- a/elementary-xfce-darker/actions/24/stock_first.svg
+++ b/elementary-xfce-darker/actions/24/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce-darker/actions/24/stock_folder-properties.svg
+++ b/elementary-xfce-darker/actions/24/stock_folder-properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_folder-properties.svg

--- a/elementary-xfce-darker/actions/24/stock_folder_properties.svg
+++ b/elementary-xfce-darker/actions/24/stock_folder_properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_folder_properties.svg

--- a/elementary-xfce-darker/actions/24/stock_fullscreen.svg
+++ b/elementary-xfce-darker/actions/24/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce-darker/actions/24/stock_help-add-bookmark.svg
+++ b/elementary-xfce-darker/actions/24/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_help-add-bookmark.svg

--- a/elementary-xfce-darker/actions/24/stock_help.svg
+++ b/elementary-xfce-darker/actions/24/stock_help.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_help.svg

--- a/elementary-xfce-darker/actions/24/stock_home.svg
+++ b/elementary-xfce-darker/actions/24/stock_home.svg
@@ -1,1 +1,0 @@
-go-home.svg

--- a/elementary-xfce-darker/actions/24/stock_last.svg
+++ b/elementary-xfce-darker/actions/24/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce-darker/actions/24/stock_leave-fullscreen.svg
+++ b/elementary-xfce-darker/actions/24/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_leave-fullscreen.svg

--- a/elementary-xfce-darker/actions/24/stock_left.svg
+++ b/elementary-xfce-darker/actions/24/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce-darker/actions/24/stock_mail-compose.svg
+++ b/elementary-xfce-darker/actions/24/stock_mail-compose.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_mail-compose.svg

--- a/elementary-xfce-darker/actions/24/stock_mail-filters-apply.svg
+++ b/elementary-xfce-darker/actions/24/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_mail-filters-apply.svg

--- a/elementary-xfce-darker/actions/24/stock_mail-forward.svg
+++ b/elementary-xfce-darker/actions/24/stock_mail-forward.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_mail-forward.svg

--- a/elementary-xfce-darker/actions/24/stock_mail-reply-to-all.svg
+++ b/elementary-xfce-darker/actions/24/stock_mail-reply-to-all.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_mail-reply-to-all.svg

--- a/elementary-xfce-darker/actions/24/stock_mail-reply.svg
+++ b/elementary-xfce-darker/actions/24/stock_mail-reply.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_mail-reply.svg

--- a/elementary-xfce-darker/actions/24/stock_mark.svg
+++ b/elementary-xfce-darker/actions/24/stock_mark.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_mark.svg

--- a/elementary-xfce-darker/actions/24/stock_media-fwd.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-fwd.svg
@@ -1,1 +1,0 @@
-media-seek-forward.svg

--- a/elementary-xfce-darker/actions/24/stock_media-next.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-next.svg
@@ -1,1 +1,0 @@
-media-skip-forward.svg

--- a/elementary-xfce-darker/actions/24/stock_media-pause.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-pause.svg
@@ -1,1 +1,0 @@
-media-playback-pause.svg

--- a/elementary-xfce-darker/actions/24/stock_media-play.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce-darker/actions/24/stock_media-prev.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-prev.svg
@@ -1,1 +1,0 @@
-media-skip-backward.svg

--- a/elementary-xfce-darker/actions/24/stock_media-rec.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-rec.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_media-rec.svg

--- a/elementary-xfce-darker/actions/24/stock_media-rew.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-rew.svg
@@ -1,1 +1,0 @@
-media-seek-backward.svg

--- a/elementary-xfce-darker/actions/24/stock_media-stop.svg
+++ b/elementary-xfce-darker/actions/24/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce-darker/actions/24/stock_navigator.svg
+++ b/elementary-xfce-darker/actions/24/stock_navigator.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_navigator.svg

--- a/elementary-xfce-darker/actions/24/stock_new-address-book.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-address-book.svg

--- a/elementary-xfce-darker/actions/24/stock_new-appointment.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-appointment.svg

--- a/elementary-xfce-darker/actions/24/stock_new-bcard.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-bcard.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-bcard.svg

--- a/elementary-xfce-darker/actions/24/stock_new-dir.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-dir.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-dir.svg

--- a/elementary-xfce-darker/actions/24/stock_new-tab.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-tab.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-tab.svg

--- a/elementary-xfce-darker/actions/24/stock_new-text.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-text.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-text.svg

--- a/elementary-xfce-darker/actions/24/stock_new-window.svg
+++ b/elementary-xfce-darker/actions/24/stock_new-window.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_new-window.svg

--- a/elementary-xfce-darker/actions/24/stock_no.svg
+++ b/elementary-xfce-darker/actions/24/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce-darker/actions/24/stock_not.svg
+++ b/elementary-xfce-darker/actions/24/stock_not.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_not.svg

--- a/elementary-xfce-darker/actions/24/stock_paste.svg
+++ b/elementary-xfce-darker/actions/24/stock_paste.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_paste.svg

--- a/elementary-xfce-darker/actions/24/stock_print-setup.svg
+++ b/elementary-xfce-darker/actions/24/stock_print-setup.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_print-setup.svg

--- a/elementary-xfce-darker/actions/24/stock_print.svg
+++ b/elementary-xfce-darker/actions/24/stock_print.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_print.svg

--- a/elementary-xfce-darker/actions/24/stock_properties.svg
+++ b/elementary-xfce-darker/actions/24/stock_properties.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_properties.svg

--- a/elementary-xfce-darker/actions/24/stock_redo.svg
+++ b/elementary-xfce-darker/actions/24/stock_redo.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_redo.svg

--- a/elementary-xfce-darker/actions/24/stock_refresh.svg
+++ b/elementary-xfce-darker/actions/24/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce-darker/actions/24/stock_right.svg
+++ b/elementary-xfce-darker/actions/24/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce-darker/actions/24/stock_save-as.svg
+++ b/elementary-xfce-darker/actions/24/stock_save-as.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_save-as.svg

--- a/elementary-xfce-darker/actions/24/stock_save.svg
+++ b/elementary-xfce-darker/actions/24/stock_save.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_save.svg

--- a/elementary-xfce-darker/actions/24/stock_scores.svg
+++ b/elementary-xfce-darker/actions/24/stock_scores.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_scores.svg

--- a/elementary-xfce-darker/actions/24/stock_select-all.svg
+++ b/elementary-xfce-darker/actions/24/stock_select-all.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_select-all.svg

--- a/elementary-xfce-darker/actions/24/stock_stop.svg
+++ b/elementary-xfce-darker/actions/24/stock_stop.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_stop.svg

--- a/elementary-xfce-darker/actions/24/stock_top.svg
+++ b/elementary-xfce-darker/actions/24/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce-darker/actions/24/stock_undo.svg
+++ b/elementary-xfce-darker/actions/24/stock_undo.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_undo.svg

--- a/elementary-xfce-darker/actions/24/stock_up.svg
+++ b/elementary-xfce-darker/actions/24/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce-darker/actions/24/stock_view-details.svg
+++ b/elementary-xfce-darker/actions/24/stock_view-details.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_view-details.svg

--- a/elementary-xfce-darker/actions/24/stock_yes.svg
+++ b/elementary-xfce-darker/actions/24/stock_yes.svg
@@ -1,1 +1,0 @@
-../../../elementary-xfce/actions/24/stock_yes.svg

--- a/elementary-xfce-darker/actions/24/stock_zoom-1.svg
+++ b/elementary-xfce-darker/actions/24/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce-darker/actions/24/stock_zoom-in.svg
+++ b/elementary-xfce-darker/actions/24/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce-darker/actions/24/stock_zoom-out.svg
+++ b/elementary-xfce-darker/actions/24/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce-darker/actions/24/stock_zoom-page.svg
+++ b/elementary-xfce-darker/actions/24/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit-best.svg

--- a/elementary-xfce/actions/128/stock_about.svg
+++ b/elementary-xfce/actions/128/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/128/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/128/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/128/stock_delete.svg
+++ b/elementary-xfce/actions/128/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/128/stock_file-properites.svg
+++ b/elementary-xfce/actions/128/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/128/stock_file-properties.svg
+++ b/elementary-xfce/actions/128/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/128/stock_folder-properties.svg
+++ b/elementary-xfce/actions/128/stock_folder-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/128/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/128/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/128/stock_help.svg
+++ b/elementary-xfce/actions/128/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/128/stock_media-rec.svg
+++ b/elementary-xfce/actions/128/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/128/stock_media-stop.svg
+++ b/elementary-xfce/actions/128/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/128/stock_navigator.svg
+++ b/elementary-xfce/actions/128/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/128/stock_new-text.svg
+++ b/elementary-xfce/actions/128/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/128/stock_not.svg
+++ b/elementary-xfce/actions/128/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/128/stock_paste.svg
+++ b/elementary-xfce/actions/128/stock_paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/128/stock_properties.svg
+++ b/elementary-xfce/actions/128/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/128/stock_scores.svg
+++ b/elementary-xfce/actions/128/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/128/stock_stop.svg
+++ b/elementary-xfce/actions/128/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/128/stock_view-details.svg
+++ b/elementary-xfce/actions/128/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/16/stock_about.svg
+++ b/elementary-xfce/actions/16/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/16/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/16/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/16/stock_bottom.svg
+++ b/elementary-xfce/actions/16/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce/actions/16/stock_calc-accept.svg
+++ b/elementary-xfce/actions/16/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/16/stock_calc-cancel.svg
+++ b/elementary-xfce/actions/16/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce/actions/16/stock_close.svg
+++ b/elementary-xfce/actions/16/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/16/stock_cut.svg
+++ b/elementary-xfce/actions/16/stock_cut.svg
@@ -1,1 +1,0 @@
-edit-cut.svg

--- a/elementary-xfce/actions/16/stock_delete.svg
+++ b/elementary-xfce/actions/16/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/16/stock_down.svg
+++ b/elementary-xfce/actions/16/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce/actions/16/stock_edit.svg
+++ b/elementary-xfce/actions/16/stock_edit.svg
@@ -1,1 +1,0 @@
-gtk-edit.svg

--- a/elementary-xfce/actions/16/stock_exit.svg
+++ b/elementary-xfce/actions/16/stock_exit.svg
@@ -1,1 +1,0 @@
-system-shutdown.svg

--- a/elementary-xfce/actions/16/stock_file-properites.svg
+++ b/elementary-xfce/actions/16/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/16/stock_file-properties.svg
+++ b/elementary-xfce/actions/16/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/16/stock_filters-invert.svg
+++ b/elementary-xfce/actions/16/stock_filters-invert.svg
@@ -1,1 +1,0 @@
-object-inverse.svg

--- a/elementary-xfce/actions/16/stock_first.svg
+++ b/elementary-xfce/actions/16/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce/actions/16/stock_folder_properties.svg
+++ b/elementary-xfce/actions/16/stock_folder_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/16/stock_fullscreen.svg
+++ b/elementary-xfce/actions/16/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce/actions/16/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/16/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/16/stock_help.svg
+++ b/elementary-xfce/actions/16/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/16/stock_home.svg
+++ b/elementary-xfce/actions/16/stock_home.svg
@@ -1,1 +1,0 @@
-go-home.svg

--- a/elementary-xfce/actions/16/stock_last.svg
+++ b/elementary-xfce/actions/16/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce/actions/16/stock_leave-fullscreen.svg
+++ b/elementary-xfce/actions/16/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-view-restore.svg

--- a/elementary-xfce/actions/16/stock_left.svg
+++ b/elementary-xfce/actions/16/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce/actions/16/stock_mail-filters-apply.svg
+++ b/elementary-xfce/actions/16/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/16/stock_mailto.svg
+++ b/elementary-xfce/actions/16/stock_mailto.svg
@@ -1,1 +1,0 @@
-mail-forward.svg

--- a/elementary-xfce/actions/16/stock_mark.svg
+++ b/elementary-xfce/actions/16/stock_mark.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/16/stock_media-fwd.svg
+++ b/elementary-xfce/actions/16/stock_media-fwd.svg
@@ -1,1 +1,0 @@
-media-seek-forward.svg

--- a/elementary-xfce/actions/16/stock_media-next.svg
+++ b/elementary-xfce/actions/16/stock_media-next.svg
@@ -1,1 +1,0 @@
-media-skip-forward.svg

--- a/elementary-xfce/actions/16/stock_media-pause.svg
+++ b/elementary-xfce/actions/16/stock_media-pause.svg
@@ -1,1 +1,0 @@
-media-playback-pause.svg

--- a/elementary-xfce/actions/16/stock_media-play.svg
+++ b/elementary-xfce/actions/16/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce/actions/16/stock_media-prev.svg
+++ b/elementary-xfce/actions/16/stock_media-prev.svg
@@ -1,1 +1,0 @@
-media-skip-backward.svg

--- a/elementary-xfce/actions/16/stock_media-rec.svg
+++ b/elementary-xfce/actions/16/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/16/stock_media-rew.svg
+++ b/elementary-xfce/actions/16/stock_media-rew.svg
@@ -1,1 +1,0 @@
-media-seek-backward.svg

--- a/elementary-xfce/actions/16/stock_media-stop.svg
+++ b/elementary-xfce/actions/16/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/16/stock_navigator.svg
+++ b/elementary-xfce/actions/16/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/16/stock_new-address-book.svg
+++ b/elementary-xfce/actions/16/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-address-book-new.svg

--- a/elementary-xfce/actions/16/stock_new-appointment.svg
+++ b/elementary-xfce/actions/16/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-appointment-new.svg

--- a/elementary-xfce/actions/16/stock_new-dir.svg
+++ b/elementary-xfce/actions/16/stock_new-dir.svg
@@ -1,1 +1,0 @@
-folder-new.svg

--- a/elementary-xfce/actions/16/stock_new-tab.svg
+++ b/elementary-xfce/actions/16/stock_new-tab.svg
@@ -1,1 +1,0 @@
-tab-new.svg

--- a/elementary-xfce/actions/16/stock_new-text.svg
+++ b/elementary-xfce/actions/16/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/16/stock_new-window.svg
+++ b/elementary-xfce/actions/16/stock_new-window.svg
@@ -1,1 +1,0 @@
-window-new.svg

--- a/elementary-xfce/actions/16/stock_no.svg
+++ b/elementary-xfce/actions/16/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/16/stock_not.svg
+++ b/elementary-xfce/actions/16/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/16/stock_paste.svg
+++ b/elementary-xfce/actions/16/stock_paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/16/stock_print.svg
+++ b/elementary-xfce/actions/16/stock_print.svg
@@ -1,1 +1,0 @@
-document-print.svg

--- a/elementary-xfce/actions/16/stock_properties.svg
+++ b/elementary-xfce/actions/16/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/16/stock_redo.svg
+++ b/elementary-xfce/actions/16/stock_redo.svg
@@ -1,1 +1,0 @@
-edit-redo.svg

--- a/elementary-xfce/actions/16/stock_refresh.svg
+++ b/elementary-xfce/actions/16/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce/actions/16/stock_right.svg
+++ b/elementary-xfce/actions/16/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce/actions/16/stock_save-as.svg
+++ b/elementary-xfce/actions/16/stock_save-as.svg
@@ -1,1 +1,0 @@
-document-save-as.svg

--- a/elementary-xfce/actions/16/stock_save.svg
+++ b/elementary-xfce/actions/16/stock_save.svg
@@ -1,1 +1,0 @@
-document-save.svg

--- a/elementary-xfce/actions/16/stock_scores.svg
+++ b/elementary-xfce/actions/16/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/16/stock_select-all.svg
+++ b/elementary-xfce/actions/16/stock_select-all.svg
@@ -1,1 +1,0 @@
-edit-select-all.svg

--- a/elementary-xfce/actions/16/stock_stop.svg
+++ b/elementary-xfce/actions/16/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/16/stock_top.svg
+++ b/elementary-xfce/actions/16/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce/actions/16/stock_undo.svg
+++ b/elementary-xfce/actions/16/stock_undo.svg
@@ -1,1 +1,0 @@
-edit-undo.svg

--- a/elementary-xfce/actions/16/stock_up.svg
+++ b/elementary-xfce/actions/16/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce/actions/16/stock_view-details.svg
+++ b/elementary-xfce/actions/16/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/16/stock_yes.svg
+++ b/elementary-xfce/actions/16/stock_yes.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/16/stock_zoom-1.svg
+++ b/elementary-xfce/actions/16/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce/actions/16/stock_zoom-in.svg
+++ b/elementary-xfce/actions/16/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce/actions/16/stock_zoom-out.svg
+++ b/elementary-xfce/actions/16/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce/actions/16/stock_zoom-page.svg
+++ b/elementary-xfce/actions/16/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit-best.svg

--- a/elementary-xfce/actions/22/stock_about.svg
+++ b/elementary-xfce/actions/22/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/22/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/22/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/22/stock_bottom.svg
+++ b/elementary-xfce/actions/22/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce/actions/22/stock_calc-accept.svg
+++ b/elementary-xfce/actions/22/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/22/stock_calc-cancel.svg
+++ b/elementary-xfce/actions/22/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce/actions/22/stock_close.svg
+++ b/elementary-xfce/actions/22/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/22/stock_cut.svg
+++ b/elementary-xfce/actions/22/stock_cut.svg
@@ -1,1 +1,0 @@
-edit-cut.svg

--- a/elementary-xfce/actions/22/stock_delete.svg
+++ b/elementary-xfce/actions/22/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/22/stock_down.svg
+++ b/elementary-xfce/actions/22/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce/actions/22/stock_edit.svg
+++ b/elementary-xfce/actions/22/stock_edit.svg
@@ -1,1 +1,0 @@
-gtk-edit.svg

--- a/elementary-xfce/actions/22/stock_exit.svg
+++ b/elementary-xfce/actions/22/stock_exit.svg
@@ -1,1 +1,0 @@
-system-shutdown.svg

--- a/elementary-xfce/actions/22/stock_file-properites.svg
+++ b/elementary-xfce/actions/22/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/22/stock_file-properties.svg
+++ b/elementary-xfce/actions/22/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/22/stock_filters-invert.svg
+++ b/elementary-xfce/actions/22/stock_filters-invert.svg
@@ -1,1 +1,0 @@
-object-inverse.svg

--- a/elementary-xfce/actions/22/stock_first.svg
+++ b/elementary-xfce/actions/22/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce/actions/22/stock_fullscreen.svg
+++ b/elementary-xfce/actions/22/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce/actions/22/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/22/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/22/stock_help.svg
+++ b/elementary-xfce/actions/22/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/22/stock_last.svg
+++ b/elementary-xfce/actions/22/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce/actions/22/stock_leave-fullscreen.svg
+++ b/elementary-xfce/actions/22/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-view-restore.svg

--- a/elementary-xfce/actions/22/stock_left.svg
+++ b/elementary-xfce/actions/22/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce/actions/22/stock_mail-compose.svg
+++ b/elementary-xfce/actions/22/stock_mail-compose.svg
@@ -1,1 +1,0 @@
-mail-message-new.svg

--- a/elementary-xfce/actions/22/stock_mail-filters-apply.svg
+++ b/elementary-xfce/actions/22/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/22/stock_mail-forward.svg
+++ b/elementary-xfce/actions/22/stock_mail-forward.svg
@@ -1,1 +1,0 @@
-mail-forward.svg

--- a/elementary-xfce/actions/22/stock_mail-reply-to-all.svg
+++ b/elementary-xfce/actions/22/stock_mail-reply-to-all.svg
@@ -1,1 +1,0 @@
-mail-reply-all.svg

--- a/elementary-xfce/actions/22/stock_mail-reply.svg
+++ b/elementary-xfce/actions/22/stock_mail-reply.svg
@@ -1,1 +1,0 @@
-mail-reply-sender.svg

--- a/elementary-xfce/actions/22/stock_mark.svg
+++ b/elementary-xfce/actions/22/stock_mark.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/22/stock_media-play.svg
+++ b/elementary-xfce/actions/22/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce/actions/22/stock_media-rec.svg
+++ b/elementary-xfce/actions/22/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/22/stock_media-stop.svg
+++ b/elementary-xfce/actions/22/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/22/stock_navigator.svg
+++ b/elementary-xfce/actions/22/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/22/stock_new-address-book.svg
+++ b/elementary-xfce/actions/22/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-address-book-new.svg

--- a/elementary-xfce/actions/22/stock_new-appointment.svg
+++ b/elementary-xfce/actions/22/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-appointment-new.svg

--- a/elementary-xfce/actions/22/stock_new-bcard.svg
+++ b/elementary-xfce/actions/22/stock_new-bcard.svg
@@ -1,1 +1,0 @@
-contact-new.svg

--- a/elementary-xfce/actions/22/stock_new-tab.svg
+++ b/elementary-xfce/actions/22/stock_new-tab.svg
@@ -1,1 +1,0 @@
-tab-new.svg

--- a/elementary-xfce/actions/22/stock_new-text.svg
+++ b/elementary-xfce/actions/22/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/22/stock_new-window.svg
+++ b/elementary-xfce/actions/22/stock_new-window.svg
@@ -1,1 +1,0 @@
-window-new.svg

--- a/elementary-xfce/actions/22/stock_no.svg
+++ b/elementary-xfce/actions/22/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/22/stock_not.svg
+++ b/elementary-xfce/actions/22/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/22/stock_print-setup.svg
+++ b/elementary-xfce/actions/22/stock_print-setup.svg
@@ -1,1 +1,0 @@
-document-page-setup.svg

--- a/elementary-xfce/actions/22/stock_print.svg
+++ b/elementary-xfce/actions/22/stock_print.svg
@@ -1,1 +1,0 @@
-document-print.svg

--- a/elementary-xfce/actions/22/stock_properties.svg
+++ b/elementary-xfce/actions/22/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/22/stock_redo.svg
+++ b/elementary-xfce/actions/22/stock_redo.svg
@@ -1,1 +1,0 @@
-edit-redo.svg

--- a/elementary-xfce/actions/22/stock_refresh.svg
+++ b/elementary-xfce/actions/22/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce/actions/22/stock_right.svg
+++ b/elementary-xfce/actions/22/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce/actions/22/stock_save-as.svg
+++ b/elementary-xfce/actions/22/stock_save-as.svg
@@ -1,1 +1,0 @@
-document-save-as.svg

--- a/elementary-xfce/actions/22/stock_save.svg
+++ b/elementary-xfce/actions/22/stock_save.svg
@@ -1,1 +1,0 @@
-document-save.svg

--- a/elementary-xfce/actions/22/stock_scores.svg
+++ b/elementary-xfce/actions/22/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/22/stock_select-all.svg
+++ b/elementary-xfce/actions/22/stock_select-all.svg
@@ -1,1 +1,0 @@
-edit-select-all.svg

--- a/elementary-xfce/actions/22/stock_stop.svg
+++ b/elementary-xfce/actions/22/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/22/stock_top.svg
+++ b/elementary-xfce/actions/22/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce/actions/22/stock_undo.svg
+++ b/elementary-xfce/actions/22/stock_undo.svg
@@ -1,1 +1,0 @@
-edit-undo.svg

--- a/elementary-xfce/actions/22/stock_up.svg
+++ b/elementary-xfce/actions/22/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce/actions/22/stock_view-details.svg
+++ b/elementary-xfce/actions/22/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/22/stock_yes.svg
+++ b/elementary-xfce/actions/22/stock_yes.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/22/stock_zoom-1.svg
+++ b/elementary-xfce/actions/22/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce/actions/22/stock_zoom-in.svg
+++ b/elementary-xfce/actions/22/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce/actions/22/stock_zoom-out.svg
+++ b/elementary-xfce/actions/22/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce/actions/22/stock_zoom-page.svg
+++ b/elementary-xfce/actions/22/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit-best.svg

--- a/elementary-xfce/actions/24/stock_about.svg
+++ b/elementary-xfce/actions/24/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/24/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/24/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/24/stock_bottom.svg
+++ b/elementary-xfce/actions/24/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce/actions/24/stock_calc-accept.svg
+++ b/elementary-xfce/actions/24/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/24/stock_calc-cancel.svg
+++ b/elementary-xfce/actions/24/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce/actions/24/stock_close.svg
+++ b/elementary-xfce/actions/24/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/24/stock_cut.svg
+++ b/elementary-xfce/actions/24/stock_cut.svg
@@ -1,1 +1,0 @@
-edit-cut.svg

--- a/elementary-xfce/actions/24/stock_delete.svg
+++ b/elementary-xfce/actions/24/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/24/stock_down.svg
+++ b/elementary-xfce/actions/24/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce/actions/24/stock_edit.svg
+++ b/elementary-xfce/actions/24/stock_edit.svg
@@ -1,1 +1,0 @@
-gtk-edit.svg

--- a/elementary-xfce/actions/24/stock_exit.svg
+++ b/elementary-xfce/actions/24/stock_exit.svg
@@ -1,1 +1,0 @@
-system-shutdown.svg

--- a/elementary-xfce/actions/24/stock_file-properites.svg
+++ b/elementary-xfce/actions/24/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/24/stock_file-properties.svg
+++ b/elementary-xfce/actions/24/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/24/stock_filters-invert.svg
+++ b/elementary-xfce/actions/24/stock_filters-invert.svg
@@ -1,1 +1,0 @@
-object-inverse.svg

--- a/elementary-xfce/actions/24/stock_first.svg
+++ b/elementary-xfce/actions/24/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce/actions/24/stock_folder-properties.svg
+++ b/elementary-xfce/actions/24/stock_folder-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/24/stock_folder_properties.svg
+++ b/elementary-xfce/actions/24/stock_folder_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/24/stock_fullscreen.svg
+++ b/elementary-xfce/actions/24/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce/actions/24/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/24/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/24/stock_help.svg
+++ b/elementary-xfce/actions/24/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/24/stock_home.svg
+++ b/elementary-xfce/actions/24/stock_home.svg
@@ -1,1 +1,0 @@
-go-home.svg

--- a/elementary-xfce/actions/24/stock_last.svg
+++ b/elementary-xfce/actions/24/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce/actions/24/stock_leave-fullscreen.svg
+++ b/elementary-xfce/actions/24/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-view-restore.svg

--- a/elementary-xfce/actions/24/stock_left.svg
+++ b/elementary-xfce/actions/24/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce/actions/24/stock_mail-compose.svg
+++ b/elementary-xfce/actions/24/stock_mail-compose.svg
@@ -1,1 +1,0 @@
-mail-message-new.svg

--- a/elementary-xfce/actions/24/stock_mail-filters-apply.svg
+++ b/elementary-xfce/actions/24/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/24/stock_mail-forward.svg
+++ b/elementary-xfce/actions/24/stock_mail-forward.svg
@@ -1,1 +1,0 @@
-mail-forward.svg

--- a/elementary-xfce/actions/24/stock_mail-reply-to-all.svg
+++ b/elementary-xfce/actions/24/stock_mail-reply-to-all.svg
@@ -1,1 +1,0 @@
-mail-reply-all.svg

--- a/elementary-xfce/actions/24/stock_mail-reply.svg
+++ b/elementary-xfce/actions/24/stock_mail-reply.svg
@@ -1,1 +1,0 @@
-mail-reply-sender.svg

--- a/elementary-xfce/actions/24/stock_mark.svg
+++ b/elementary-xfce/actions/24/stock_mark.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/24/stock_media-fwd.svg
+++ b/elementary-xfce/actions/24/stock_media-fwd.svg
@@ -1,1 +1,0 @@
-media-seek-forward.svg

--- a/elementary-xfce/actions/24/stock_media-next.svg
+++ b/elementary-xfce/actions/24/stock_media-next.svg
@@ -1,1 +1,0 @@
-media-skip-forward.svg

--- a/elementary-xfce/actions/24/stock_media-pause.svg
+++ b/elementary-xfce/actions/24/stock_media-pause.svg
@@ -1,1 +1,0 @@
-media-playback-pause.svg

--- a/elementary-xfce/actions/24/stock_media-play.svg
+++ b/elementary-xfce/actions/24/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce/actions/24/stock_media-prev.svg
+++ b/elementary-xfce/actions/24/stock_media-prev.svg
@@ -1,1 +1,0 @@
-media-skip-backward.svg

--- a/elementary-xfce/actions/24/stock_media-rec.svg
+++ b/elementary-xfce/actions/24/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/24/stock_media-rew.svg
+++ b/elementary-xfce/actions/24/stock_media-rew.svg
@@ -1,1 +1,0 @@
-media-seek-backward.svg

--- a/elementary-xfce/actions/24/stock_media-stop.svg
+++ b/elementary-xfce/actions/24/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/24/stock_navigator.svg
+++ b/elementary-xfce/actions/24/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/24/stock_new-address-book.svg
+++ b/elementary-xfce/actions/24/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-address-book-new.svg

--- a/elementary-xfce/actions/24/stock_new-appointment.svg
+++ b/elementary-xfce/actions/24/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-appointment-new.svg

--- a/elementary-xfce/actions/24/stock_new-bcard.svg
+++ b/elementary-xfce/actions/24/stock_new-bcard.svg
@@ -1,1 +1,0 @@
-contact-new.svg

--- a/elementary-xfce/actions/24/stock_new-dir.svg
+++ b/elementary-xfce/actions/24/stock_new-dir.svg
@@ -1,1 +1,0 @@
-folder-new.svg

--- a/elementary-xfce/actions/24/stock_new-tab.svg
+++ b/elementary-xfce/actions/24/stock_new-tab.svg
@@ -1,1 +1,0 @@
-tab-new.svg

--- a/elementary-xfce/actions/24/stock_new-text.svg
+++ b/elementary-xfce/actions/24/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/24/stock_new-window.svg
+++ b/elementary-xfce/actions/24/stock_new-window.svg
@@ -1,1 +1,0 @@
-window-new.svg

--- a/elementary-xfce/actions/24/stock_no.svg
+++ b/elementary-xfce/actions/24/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/24/stock_not.svg
+++ b/elementary-xfce/actions/24/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/24/stock_paste.svg
+++ b/elementary-xfce/actions/24/stock_paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/24/stock_print-setup.svg
+++ b/elementary-xfce/actions/24/stock_print-setup.svg
@@ -1,1 +1,0 @@
-document-page-setup.svg

--- a/elementary-xfce/actions/24/stock_print.svg
+++ b/elementary-xfce/actions/24/stock_print.svg
@@ -1,1 +1,0 @@
-document-print.svg

--- a/elementary-xfce/actions/24/stock_properties.svg
+++ b/elementary-xfce/actions/24/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/24/stock_redo.svg
+++ b/elementary-xfce/actions/24/stock_redo.svg
@@ -1,1 +1,0 @@
-edit-redo.svg

--- a/elementary-xfce/actions/24/stock_refresh.svg
+++ b/elementary-xfce/actions/24/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce/actions/24/stock_right.svg
+++ b/elementary-xfce/actions/24/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce/actions/24/stock_save-as.svg
+++ b/elementary-xfce/actions/24/stock_save-as.svg
@@ -1,1 +1,0 @@
-document-save-as.svg

--- a/elementary-xfce/actions/24/stock_save.svg
+++ b/elementary-xfce/actions/24/stock_save.svg
@@ -1,1 +1,0 @@
-document-save.svg

--- a/elementary-xfce/actions/24/stock_scores.svg
+++ b/elementary-xfce/actions/24/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/24/stock_select-all.svg
+++ b/elementary-xfce/actions/24/stock_select-all.svg
@@ -1,1 +1,0 @@
-edit-select-all.svg

--- a/elementary-xfce/actions/24/stock_stop.svg
+++ b/elementary-xfce/actions/24/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/24/stock_top.svg
+++ b/elementary-xfce/actions/24/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce/actions/24/stock_undo.svg
+++ b/elementary-xfce/actions/24/stock_undo.svg
@@ -1,1 +1,0 @@
-edit-undo.svg

--- a/elementary-xfce/actions/24/stock_up.svg
+++ b/elementary-xfce/actions/24/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce/actions/24/stock_view-details.svg
+++ b/elementary-xfce/actions/24/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/24/stock_yes.svg
+++ b/elementary-xfce/actions/24/stock_yes.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/24/stock_zoom-1.svg
+++ b/elementary-xfce/actions/24/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce/actions/24/stock_zoom-in.svg
+++ b/elementary-xfce/actions/24/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce/actions/24/stock_zoom-out.svg
+++ b/elementary-xfce/actions/24/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce/actions/24/stock_zoom-page.svg
+++ b/elementary-xfce/actions/24/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit-best.svg

--- a/elementary-xfce/actions/32/stock_about.svg
+++ b/elementary-xfce/actions/32/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/32/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/32/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/32/stock_cut.svg
+++ b/elementary-xfce/actions/32/stock_cut.svg
@@ -1,1 +1,0 @@
-edit-cut.svg

--- a/elementary-xfce/actions/32/stock_delete.svg
+++ b/elementary-xfce/actions/32/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/32/stock_exit.svg
+++ b/elementary-xfce/actions/32/stock_exit.svg
@@ -1,1 +1,0 @@
-system-shutdown.svg

--- a/elementary-xfce/actions/32/stock_file-properites.svg
+++ b/elementary-xfce/actions/32/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/32/stock_file-properties.svg
+++ b/elementary-xfce/actions/32/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/32/stock_fullscreen.svg
+++ b/elementary-xfce/actions/32/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce/actions/32/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/32/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/32/stock_help.svg
+++ b/elementary-xfce/actions/32/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/32/stock_leave-fullscreen.svg
+++ b/elementary-xfce/actions/32/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-view-restore.svg

--- a/elementary-xfce/actions/32/stock_left.svg
+++ b/elementary-xfce/actions/32/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce/actions/32/stock_media-rec.svg
+++ b/elementary-xfce/actions/32/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/32/stock_media-stop.svg
+++ b/elementary-xfce/actions/32/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/32/stock_navigator.svg
+++ b/elementary-xfce/actions/32/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/32/stock_new-address-book.svg
+++ b/elementary-xfce/actions/32/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-address-book-new.svg

--- a/elementary-xfce/actions/32/stock_new-text.svg
+++ b/elementary-xfce/actions/32/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/32/stock_not.svg
+++ b/elementary-xfce/actions/32/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/32/stock_paste.svg
+++ b/elementary-xfce/actions/32/stock_paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/32/stock_properties.svg
+++ b/elementary-xfce/actions/32/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/32/stock_refresh.svg
+++ b/elementary-xfce/actions/32/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce/actions/32/stock_right.svg
+++ b/elementary-xfce/actions/32/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce/actions/32/stock_scores.svg
+++ b/elementary-xfce/actions/32/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/32/stock_select-all.svg
+++ b/elementary-xfce/actions/32/stock_select-all.svg
@@ -1,1 +1,0 @@
-edit-select-all.svg

--- a/elementary-xfce/actions/32/stock_stop.svg
+++ b/elementary-xfce/actions/32/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/32/stock_view-details.svg
+++ b/elementary-xfce/actions/32/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/32/stock_zoom-1.svg
+++ b/elementary-xfce/actions/32/stock_zoom-1.svg
@@ -1,1 +1,0 @@
-zoom-original.svg

--- a/elementary-xfce/actions/32/stock_zoom-in.svg
+++ b/elementary-xfce/actions/32/stock_zoom-in.svg
@@ -1,1 +1,0 @@
-zoom-in.svg

--- a/elementary-xfce/actions/32/stock_zoom-out.svg
+++ b/elementary-xfce/actions/32/stock_zoom-out.svg
@@ -1,1 +1,0 @@
-zoom-out.svg

--- a/elementary-xfce/actions/32/stock_zoom-page.svg
+++ b/elementary-xfce/actions/32/stock_zoom-page.svg
@@ -1,1 +1,0 @@
-zoom-fit-best.svg

--- a/elementary-xfce/actions/48/stock_about.svg
+++ b/elementary-xfce/actions/48/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/48/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/48/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/48/stock_bookmark.svg
+++ b/elementary-xfce/actions/48/stock_bookmark.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/48/stock_bottom.svg
+++ b/elementary-xfce/actions/48/stock_bottom.svg
@@ -1,1 +1,0 @@
-go-bottom.svg

--- a/elementary-xfce/actions/48/stock_calc-accept.svg
+++ b/elementary-xfce/actions/48/stock_calc-accept.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/48/stock_calc-cancel.svg
+++ b/elementary-xfce/actions/48/stock_calc-cancel.svg
@@ -1,1 +1,0 @@
-dialog-cancel.svg

--- a/elementary-xfce/actions/48/stock_close.svg
+++ b/elementary-xfce/actions/48/stock_close.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/48/stock_cut.svg
+++ b/elementary-xfce/actions/48/stock_cut.svg
@@ -1,1 +1,0 @@
-edit-cut.svg

--- a/elementary-xfce/actions/48/stock_delete.svg
+++ b/elementary-xfce/actions/48/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/48/stock_down.svg
+++ b/elementary-xfce/actions/48/stock_down.svg
@@ -1,1 +1,0 @@
-go-down.svg

--- a/elementary-xfce/actions/48/stock_edit.svg
+++ b/elementary-xfce/actions/48/stock_edit.svg
@@ -1,1 +1,0 @@
-gtk-edit.svg

--- a/elementary-xfce/actions/48/stock_exit.svg
+++ b/elementary-xfce/actions/48/stock_exit.svg
@@ -1,1 +1,0 @@
-system-shutdown.svg

--- a/elementary-xfce/actions/48/stock_file-properites.svg
+++ b/elementary-xfce/actions/48/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/48/stock_file-properties.svg
+++ b/elementary-xfce/actions/48/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/48/stock_first.svg
+++ b/elementary-xfce/actions/48/stock_first.svg
@@ -1,1 +1,0 @@
-go-first.svg

--- a/elementary-xfce/actions/48/stock_folder-properties.svg
+++ b/elementary-xfce/actions/48/stock_folder-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/48/stock_fullscreen.svg
+++ b/elementary-xfce/actions/48/stock_fullscreen.svg
@@ -1,1 +1,0 @@
-view-fullscreen.svg

--- a/elementary-xfce/actions/48/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/48/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/48/stock_help.svg
+++ b/elementary-xfce/actions/48/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/48/stock_home.svg
+++ b/elementary-xfce/actions/48/stock_home.svg
@@ -1,1 +1,0 @@
-go-home.svg

--- a/elementary-xfce/actions/48/stock_last.svg
+++ b/elementary-xfce/actions/48/stock_last.svg
@@ -1,1 +1,0 @@
-go-last.svg

--- a/elementary-xfce/actions/48/stock_leave-fullscreen.svg
+++ b/elementary-xfce/actions/48/stock_leave-fullscreen.svg
@@ -1,1 +1,0 @@
-view-restore.svg

--- a/elementary-xfce/actions/48/stock_left.svg
+++ b/elementary-xfce/actions/48/stock_left.svg
@@ -1,1 +1,0 @@
-go-previous.svg

--- a/elementary-xfce/actions/48/stock_mail-filters-apply.svg
+++ b/elementary-xfce/actions/48/stock_mail-filters-apply.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/48/stock_mark.svg
+++ b/elementary-xfce/actions/48/stock_mark.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/48/stock_media-fwd.svg
+++ b/elementary-xfce/actions/48/stock_media-fwd.svg
@@ -1,1 +1,0 @@
-media-seek-forward.svg

--- a/elementary-xfce/actions/48/stock_media-next.svg
+++ b/elementary-xfce/actions/48/stock_media-next.svg
@@ -1,1 +1,0 @@
-media-skip-forward.svg

--- a/elementary-xfce/actions/48/stock_media-pause.svg
+++ b/elementary-xfce/actions/48/stock_media-pause.svg
@@ -1,1 +1,0 @@
-media-playback-pause.svg

--- a/elementary-xfce/actions/48/stock_media-play.svg
+++ b/elementary-xfce/actions/48/stock_media-play.svg
@@ -1,1 +1,0 @@
-media-playback-start.svg

--- a/elementary-xfce/actions/48/stock_media-prev.svg
+++ b/elementary-xfce/actions/48/stock_media-prev.svg
@@ -1,1 +1,0 @@
-media-skip-backward.svg

--- a/elementary-xfce/actions/48/stock_media-rec.svg
+++ b/elementary-xfce/actions/48/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/48/stock_media-rew.svg
+++ b/elementary-xfce/actions/48/stock_media-rew.svg
@@ -1,1 +1,0 @@
-media-seek-backward.svg

--- a/elementary-xfce/actions/48/stock_media-stop.svg
+++ b/elementary-xfce/actions/48/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/48/stock_navigator.svg
+++ b/elementary-xfce/actions/48/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/48/stock_new-address-book.svg
+++ b/elementary-xfce/actions/48/stock_new-address-book.svg
@@ -1,1 +1,0 @@
-address-book-new.svg

--- a/elementary-xfce/actions/48/stock_new-appointment.svg
+++ b/elementary-xfce/actions/48/stock_new-appointment.svg
@@ -1,1 +1,0 @@
-appointment-new.svg

--- a/elementary-xfce/actions/48/stock_new-dir.svg
+++ b/elementary-xfce/actions/48/stock_new-dir.svg
@@ -1,1 +1,0 @@
-folder-new.svg

--- a/elementary-xfce/actions/48/stock_new-tab.svg
+++ b/elementary-xfce/actions/48/stock_new-tab.svg
@@ -1,1 +1,0 @@
-tab-new.svg

--- a/elementary-xfce/actions/48/stock_new-text.svg
+++ b/elementary-xfce/actions/48/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/48/stock_new-vcard.svg
+++ b/elementary-xfce/actions/48/stock_new-vcard.svg
@@ -1,1 +1,0 @@
-contact-new.svg

--- a/elementary-xfce/actions/48/stock_new-window.svg
+++ b/elementary-xfce/actions/48/stock_new-window.svg
@@ -1,1 +1,0 @@
-window-new.svg

--- a/elementary-xfce/actions/48/stock_no.svg
+++ b/elementary-xfce/actions/48/stock_no.svg
@@ -1,1 +1,0 @@
-window-close.svg

--- a/elementary-xfce/actions/48/stock_not.svg
+++ b/elementary-xfce/actions/48/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/48/stock_paste.svg
+++ b/elementary-xfce/actions/48/stock_paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/48/stock_print-setup.svg
+++ b/elementary-xfce/actions/48/stock_print-setup.svg
@@ -1,1 +1,0 @@
-document-page-setup.svg

--- a/elementary-xfce/actions/48/stock_print.svg
+++ b/elementary-xfce/actions/48/stock_print.svg
@@ -1,1 +1,0 @@
-document-print.svg

--- a/elementary-xfce/actions/48/stock_properties.svg
+++ b/elementary-xfce/actions/48/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/48/stock_redo.svg
+++ b/elementary-xfce/actions/48/stock_redo.svg
@@ -1,1 +1,0 @@
-edit-redo.svg

--- a/elementary-xfce/actions/48/stock_refresh.svg
+++ b/elementary-xfce/actions/48/stock_refresh.svg
@@ -1,1 +1,0 @@
-view-refresh.svg

--- a/elementary-xfce/actions/48/stock_right.svg
+++ b/elementary-xfce/actions/48/stock_right.svg
@@ -1,1 +1,0 @@
-go-next.svg

--- a/elementary-xfce/actions/48/stock_save-as.svg
+++ b/elementary-xfce/actions/48/stock_save-as.svg
@@ -1,1 +1,0 @@
-document-save-as.svg

--- a/elementary-xfce/actions/48/stock_save.svg
+++ b/elementary-xfce/actions/48/stock_save.svg
@@ -1,1 +1,0 @@
-document-save.svg

--- a/elementary-xfce/actions/48/stock_scores.svg
+++ b/elementary-xfce/actions/48/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/48/stock_select-all.svg
+++ b/elementary-xfce/actions/48/stock_select-all.svg
@@ -1,1 +1,0 @@
-edit-select-all.svg

--- a/elementary-xfce/actions/48/stock_stop.svg
+++ b/elementary-xfce/actions/48/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/48/stock_top.svg
+++ b/elementary-xfce/actions/48/stock_top.svg
@@ -1,1 +1,0 @@
-go-top.svg

--- a/elementary-xfce/actions/48/stock_undo.svg
+++ b/elementary-xfce/actions/48/stock_undo.svg
@@ -1,1 +1,0 @@
-edit-undo.svg

--- a/elementary-xfce/actions/48/stock_up.svg
+++ b/elementary-xfce/actions/48/stock_up.svg
@@ -1,1 +1,0 @@
-go-up.svg

--- a/elementary-xfce/actions/48/stock_view-details.svg
+++ b/elementary-xfce/actions/48/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/48/stock_yes.svg
+++ b/elementary-xfce/actions/48/stock_yes.svg
@@ -1,1 +1,0 @@
-dialog-apply.svg

--- a/elementary-xfce/actions/48/stock_zoom-1.png
+++ b/elementary-xfce/actions/48/stock_zoom-1.png
@@ -1,1 +1,0 @@
-zoom-original.png

--- a/elementary-xfce/actions/48/stock_zoom-in.png
+++ b/elementary-xfce/actions/48/stock_zoom-in.png
@@ -1,1 +1,0 @@
-zoom-in.png

--- a/elementary-xfce/actions/48/stock_zoom-out.png
+++ b/elementary-xfce/actions/48/stock_zoom-out.png
@@ -1,1 +1,0 @@
-zoom-out.png

--- a/elementary-xfce/actions/48/stock_zoom-page.png
+++ b/elementary-xfce/actions/48/stock_zoom-page.png
@@ -1,1 +1,0 @@
-zoom-fit-best.png

--- a/elementary-xfce/actions/64/stock_about.svg
+++ b/elementary-xfce/actions/64/stock_about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/64/stock_add-bookmark.svg
+++ b/elementary-xfce/actions/64/stock_add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/64/stock_delete.svg
+++ b/elementary-xfce/actions/64/stock_delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/64/stock_file-properites.svg
+++ b/elementary-xfce/actions/64/stock_file-properites.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/64/stock_file-properties.svg
+++ b/elementary-xfce/actions/64/stock_file-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/64/stock_folder-properties.svg
+++ b/elementary-xfce/actions/64/stock_folder-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/64/stock_help-add-bookmark.svg
+++ b/elementary-xfce/actions/64/stock_help-add-bookmark.svg
@@ -1,1 +1,0 @@
-bookmark-new.svg

--- a/elementary-xfce/actions/64/stock_help.svg
+++ b/elementary-xfce/actions/64/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/64/stock_media-rec.svg
+++ b/elementary-xfce/actions/64/stock_media-rec.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/64/stock_media-stop.svg
+++ b/elementary-xfce/actions/64/stock_media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/64/stock_navigator.svg
+++ b/elementary-xfce/actions/64/stock_navigator.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/64/stock_new-text.svg
+++ b/elementary-xfce/actions/64/stock_new-text.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/64/stock_not.svg
+++ b/elementary-xfce/actions/64/stock_not.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/64/stock_paste.svg
+++ b/elementary-xfce/actions/64/stock_paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/64/stock_properties.svg
+++ b/elementary-xfce/actions/64/stock_properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/64/stock_scores.svg
+++ b/elementary-xfce/actions/64/stock_scores.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/64/stock_stop.svg
+++ b/elementary-xfce/actions/64/stock_stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/64/stock_view-details.svg
+++ b/elementary-xfce/actions/64/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/96/stock_help.svg
+++ b/elementary-xfce/actions/96/stock_help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/96/stock_view-details.svg
+++ b/elementary-xfce/actions/96/stock_view-details.svg
@@ -1,1 +1,0 @@
-help-info.svg


### PR DESCRIPTION
These were deprecated around 2013 in favor of the
freedesktop icon naming spec. They should be safe
for removal.

A few remaining are still necessary
- stock_folder* for Thunar
- stock_xfburn* for Xfburn