### PR TITLE
Remove icon causing cache update error (Fixes #305)

### DIFF
--- a/elementary-xfce/apps/32/mousepad (copy 1).svg
+++ b/elementary-xfce/apps/32/mousepad (copy 1).svg
@@ -1,1 +1,0 @@
-accessories-text-editor.svg


### PR DESCRIPTION
Leftover copy of file with whitespace in file name was preventing gtk-update-icon-cache.

Fixes #305