### PR TITLE
Symbolic media icons: Add at 24px, adjust at 16px

### DIFF
--- a/elementary-xfce/actions/24/media-playback-pause-symbolic.svg
+++ b/elementary-xfce/actions/24/media-playback-pause-symbolic.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   height="16"
-   width="16"
-   id="svg2"
+   height="24"
+   width="24"
    version="1.1"
-   sodipodi:docname="media-skip-forward-symbolic.svg"
+   id="svg6"
+   sodipodi:docname="media-playback-pause-symbolic.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -14,7 +14,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview7"
+     id="namedview6"
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
@@ -22,15 +22,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="15.070213"
-     inkscape:cx="3.6827615"
-     inkscape:cy="7.398701"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="348"
-     inkscape:window-y="140"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g4" />
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -44,23 +44,8 @@
   </metadata>
   <defs
      id="defs10" />
-  <g
-     color="#bebebe"
-     transform="translate(-334,23)"
-     id="g4">
-    <path
-       d="m 335,-20 v 10 l 7,-5 z m 6,5 v 5 l 7,-5 -7,-5 z"
-       fill="#666666"
-       overflow="visible"
-       style="marker:none"
-       id="path6"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 347,-10 h 2 v -10 h -2 z"
-       fill="#666666"
-       overflow="visible"
-       style="marker:none"
-       id="path824"
-       sodipodi:nodetypes="ccccc" />
-  </g>
+  <path
+     id="rect839"
+     style="fill:#666666;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000;fill-opacity:1"
+     d="M 5,2 C 4.446,2 4,2.446 4,3 v 18 c 0,0.554 0.446,1 1,1 h 4 c 0.554,0 1,-0.446 1,-1 V 3 C 10,2.446 9.554,2 9,2 Z m 10,0 c -0.554,0 -1,0.446 -1,1 v 18 c 0,0.554 0.446,1 1,1 h 4 c 0.554,0 1,-0.446 1,-1 V 3 C 20,2.446 19.554,2 19,2 Z" />
 </svg>

--- a/elementary-xfce/actions/24/media-playback-start-symbolic-rtl.svg
+++ b/elementary-xfce/actions/24/media-playback-start-symbolic-rtl.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="24"
+   height="24"
+   sodipodi:docname="media-playback-start-symbolic-rtl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="m 20.00023,2 c 0.552285,0 1,0.4477153 1,1 v 18 c 0,0.552285 -0.447715,1 -1,1 -0.16845,0 -0.319727,-0.05144 -0.458984,-0.125 L 3.5446915,12.876953 C 3.2252665,12.71 2.9997695,12.385392 2.9997695,12 c 0,-0.385392 0.225497,-0.71 0.544922,-0.876953 L 19.541246,2.125 C 19.680503,2.0514361 19.83178,2 20.00023,2 Z"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     id="path980"
+     sodipodi:nodetypes="ssssccsccs" />
+</svg>

--- a/elementary-xfce/actions/24/media-playback-start-symbolic.svg
+++ b/elementary-xfce/actions/24/media-playback-start-symbolic.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="24"
+   height="24"
+   sodipodi:docname="media-playback-start-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="m 3.9997695,2 c -0.5522847,0 -1,0.4477153 -1,1 v 18 c 0,0.552285 0.4477153,1 1,1 0.1684498,0 0.3197269,-0.05144 0.4589844,-0.125 L 20.455308,12.876953 C 20.774733,12.71 21.00023,12.385392 21.00023,12 c 0,-0.385392 -0.225497,-0.71 -0.544922,-0.876953 L 4.4587539,2.125 C 4.3194964,2.0514361 4.1682193,2 3.9997695,2 Z"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     id="path980"
+     sodipodi:nodetypes="ssssccsccs" />
+</svg>

--- a/elementary-xfce/actions/24/media-playback-stop-symbolic.svg
+++ b/elementary-xfce/actions/24/media-playback-stop-symbolic.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   height="16"
-   width="16"
-   id="svg2"
+   height="24"
+   width="24"
    version="1.1"
-   sodipodi:docname="media-skip-forward-symbolic.svg"
+   id="svg6"
+   sodipodi:docname="media-playback-stop-symbolic.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -14,7 +14,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview7"
+     id="namedview6"
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
@@ -22,15 +22,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="15.070213"
-     inkscape:cx="3.6827615"
-     inkscape:cy="7.398701"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="348"
-     inkscape:window-y="140"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g4" />
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.384164"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -44,23 +44,9 @@
   </metadata>
   <defs
      id="defs10" />
-  <g
-     color="#bebebe"
-     transform="translate(-334,23)"
-     id="g4">
-    <path
-       d="m 335,-20 v 10 l 7,-5 z m 6,5 v 5 l 7,-5 -7,-5 z"
-       fill="#666666"
-       overflow="visible"
-       style="marker:none"
-       id="path6"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 347,-10 h 2 v -10 h -2 z"
-       fill="#666666"
-       overflow="visible"
-       style="marker:none"
-       id="path824"
-       sodipodi:nodetypes="ccccc" />
-  </g>
+  <path
+     id="rect839"
+     style="fill:#666666;fill-opacity:1;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 3,2 C 2.446,2 2,2.446 2,3 v 18 c 0,0.554 0.446,1 1,1 h 18 c 0.554,0 1,-0.446 1,-1 V 3 C 22,2.446 21.554,2 21,2 Z"
+     sodipodi:nodetypes="cssccsscc" />
 </svg>

--- a/elementary-xfce/actions/24/media-record-symbolic.svg
+++ b/elementary-xfce/actions/24/media-record-symbolic.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   height="16"
-   width="16"
-   id="svg2"
+   height="24"
+   width="24"
    version="1.1"
-   sodipodi:docname="media-skip-forward-symbolic.svg"
+   id="svg6"
+   sodipodi:docname="media-record-symbolic.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -14,7 +14,7 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview7"
+     id="namedview6"
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
@@ -22,15 +22,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="15.070213"
-     inkscape:cx="3.6827615"
-     inkscape:cy="7.398701"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="348"
-     inkscape:window-y="140"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g4" />
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.384164"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -44,23 +44,10 @@
   </metadata>
   <defs
      id="defs10" />
-  <g
-     color="#bebebe"
-     transform="translate(-334,23)"
-     id="g4">
-    <path
-       d="m 335,-20 v 10 l 7,-5 z m 6,5 v 5 l 7,-5 -7,-5 z"
-       fill="#666666"
-       overflow="visible"
-       style="marker:none"
-       id="path6"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 347,-10 h 2 v -10 h -2 z"
-       fill="#666666"
-       overflow="visible"
-       style="marker:none"
-       id="path824"
-       sodipodi:nodetypes="ccccc" />
-  </g>
+  <circle
+     style="opacity:1;fill:#666666;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;fill-opacity:1"
+     id="path844"
+     cx="12"
+     cy="12"
+     r="10" />
 </svg>

--- a/elementary-xfce/actions/24/media-seek-backward-symbolic-rtl.svg
+++ b/elementary-xfce/actions/24/media-seek-backward-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+media-seek-forward-symbolic.svg

--- a/elementary-xfce/actions/24/media-seek-backward-symbolic.svg
+++ b/elementary-xfce/actions/24/media-seek-backward-symbolic.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="24"
+   height="24"
+   sodipodi:docname="media-seek-backward-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="m 20.000492,6 c 0.552285,0 1,0.4477153 1,1 v 10 c 0,0.552285 -0.447715,1 -1,1 -0.16845,0 -0.319727,-0.05144 -0.458984,-0.125 L 12.000492,13.128906 V 17 c 0,0.552285 -0.447715,1 -1,1 -0.16845,0 -0.319727,-0.05144 -0.458984,-0.125 L 2.544922,12.876953 C 2.225497,12.71 2,12.385392 2,12 2,11.614608 2.225497,11.29 2.544922,11.123047 L 10.541508,6.125 C 10.680765,6.0514361 10.832042,6 11.000492,6 c 0.552285,0 1,0.4477153 1,1 v 3.871094 L 19.541508,6.125 C 19.680765,6.0514361 19.832042,6 20.000492,6 Z"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     id="path980-3" />
+</svg>

--- a/elementary-xfce/actions/24/media-seek-forward-symbolic-rtl.svg
+++ b/elementary-xfce/actions/24/media-seek-forward-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+media-seek-backward-symbolic.svg

--- a/elementary-xfce/actions/24/media-seek-forward-symbolic.svg
+++ b/elementary-xfce/actions/24/media-seek-forward-symbolic.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="media-seek-forward-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     id="path980-3"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     d="M 4,6 C 3.447715,6 3,6.4477153 3,7 v 10 c 0,0.552285 0.447715,1 1,1 0.16845,0 0.319727,-0.05144 0.458984,-0.125 L 12,13.128906 V 17 c 0,0.552285 0.447715,1 1,1 0.16845,0 0.319727,-0.05144 0.458984,-0.125 L 21.45557,12.876953 C 21.774995,12.71 22.000492,12.385392 22.000492,12 c 0,-0.385392 -0.225497,-0.71 -0.544922,-0.876953 L 13.458984,6.125 C 13.319727,6.0514361 13.16845,6 13,6 12.447715,6 12,6.4477153 12,7 v 3.871094 L 4.458984,6.125 C 4.319727,6.0514361 4.16845,6 4,6 Z" />
+</svg>

--- a/elementary-xfce/actions/24/media-skip-backward-symbolic-rtl.svg
+++ b/elementary-xfce/actions/24/media-skip-backward-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+media-skip-forward-symbolic.svg

--- a/elementary-xfce/actions/24/media-skip-backward-symbolic.svg
+++ b/elementary-xfce/actions/24/media-skip-backward-symbolic.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="24"
+   height="24"
+   sodipodi:docname="media-skip-backward-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="M 2,6 C 1.446,6 1,6.446 1,7 v 10 c 0,0.554 0.446,1 1,1 h 1 c 0.554,0 1,-0.446 1,-1 V 13.162109 L 11.541016,17.875 C 11.680273,17.94856 11.83155,18 12,18 c 0.552285,0 1,-0.447715 1,-1 V 13.128906 L 20.541016,17.875 C 20.680273,17.94856 20.83155,18 21,18 c 0.552285,0 1,-0.447715 1,-1 V 7 C 22,6.4477153 21.552285,6 21,6 20.83155,6 20.680273,6.051436 20.541016,6.125 L 13,10.871094 V 7 C 13,6.4477153 12.552285,6 12,6 11.83155,6 11.680273,6.051436 11.541016,6.125 L 4,10.837891 V 7 C 4,6.446 3.554,6 3,6 Z"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     id="path980-3" />
+</svg>

--- a/elementary-xfce/actions/24/media-skip-forward-symbolic-rtl.svg
+++ b/elementary-xfce/actions/24/media-skip-forward-symbolic-rtl.svg
@@ -1,0 +1,1 @@
+media-skip-backward-symbolic.svg

--- a/elementary-xfce/actions/24/media-skip-forward-symbolic.svg
+++ b/elementary-xfce/actions/24/media-skip-forward-symbolic.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg6"
+   version="1.1"
+   width="24"
+   height="24"
+   sodipodi:docname="media-skip-forward-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="12"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1032"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <path
+     d="m 22,6 c 0.554,0 1,0.446 1,1 v 10 c 0,0.554 -0.446,1 -1,1 h -1 c -0.554,0 -1,-0.446 -1,-1 V 13.162109 L 12.458984,17.875 C 12.319727,17.94856 12.16845,18 12,18 11.447715,18 11,17.552285 11,17 V 13.128906 L 3.458984,17.875 C 3.319727,17.94856 3.16845,18 3,18 2.447715,18 2,17.552285 2,17 V 7 C 2,6.4477153 2.447715,6 3,6 3.16845,6 3.319727,6.0514361 3.458984,6.125 L 11,10.871094 V 7 c 0,-0.5522847 0.447715,-1 1,-1 0.16845,0 0.319727,0.051436 0.458984,0.125 L 20,10.837891 V 7 c 0,-0.554 0.446,-1 1,-1 z"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;stop-opacity:1"
+     id="path980-3" />
+</svg>

--- a/elementary-xfce/actions/symbolic/media-skip-backward-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/media-skip-backward-symbolic.svg
@@ -5,7 +5,7 @@
    id="svg2"
    version="1.1"
    sodipodi:docname="media-skip-backward-symbolic.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -23,8 +23,8 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="21.3125"
-     inkscape:cx="2.8387097"
-     inkscape:cy="5.9589443"
+     inkscape:cx="6.5454545"
+     inkscape:cy="5.9824047"
      inkscape:window-width="1317"
      inkscape:window-height="890"
      inkscape:window-x="410"
@@ -49,13 +49,14 @@
      transform="translate(-292,23)"
      id="g4">
     <path
-       d="m 307,-20 v 10 l -7,-5 z m -7,5 v 5 l -7,-5 7,-5 z m -7,0 z"
+       d="m 307,-20 v 10 l -7,-5 z m -6,5 v 5 l -7,-5 7,-5 z"
        fill="#666666"
        overflow="visible"
        style="marker:none"
-       id="path6" />
+       id="path6"
+       sodipodi:nodetypes="ccccccccc" />
     <path
-       d="m 294,-10 h -2 v -10 h 2 z"
+       d="m 295,-10 h -2 v -10 h 2 z"
        fill="#666666"
        overflow="visible"
        style="marker:none"

--- a/elementary-xfce/status/24/media-playlist-repeat-symbolic.svg
+++ b/elementary-xfce/status/24/media-playlist-repeat-symbolic.svg
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="media-playlist-repeat-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.3125"
+     inkscape:cx="10.392962"
+     inkscape:cy="19.002933"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="254"
+     inkscape:window-y="187"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <defs
+     id="defs10" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 19.558547,10 c -0.244716,0 -0.558835,0.226192 -0.558594,0.513672 V 13 c 0,1.662 -1.338,3 -3,3 h -6.996 c 0,0 0,11.044536 0,2 h 6.996 c 2.77,0 5,-2.23 5,-5 V 10.552734 C 20.999953,10.265256 20.686075,10 20.441359,10 Z"
+     id="path1087"
+     sodipodi:nodetypes="scssccsssss" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 14.996047,6 H 8 C 5.23,6 3,8.23 3,11 v 2.447266 C 3,13.734744 3.313878,14 3.558594,14 H 4.441406 C 4.686122,14 5.000241,13.773808 5,13.486328 V 11 C 5,9.338 6.338,8 8,8 h 6.996047 z"
+     id="rect955-6"
+     sodipodi:nodetypes="cssssscsscc" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4.00001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 15.648781,3.5 c -0.359,0 -0.649325,0.2353914 -0.64878,0.5263674 v 5.9472655 c 0,0.2909771 0.28978,0.5263671 0.64878,0.5263671 0.193484,0 0.366824,-0.06716 0.485366,-0.175456 L 19.821951,7.3531898 C 19.931519,7.2591248 20,7.1327388 20,6.9931646 20,6.8535893 19.93152,6.7272066 19.821951,6.6331383 L 16.134147,3.6754562 C 16.015609,3.5671697 15.842265,3.5 15.648781,3.5 Z"
+     id="path1107"
+     sodipodi:nodetypes="sccsccsccs" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4.00001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 8.351219,20.5 c 0.359,0 0.649325,-0.235391 0.64878,-0.526367 V 14.026367 C 8.999999,13.73539 8.710219,13.5 8.351219,13.5 8.157735,13.5 7.984395,13.56716 7.865853,13.675456 L 4.178049,16.64681 C 4.068481,16.74087 4,16.867261 4,17.006836 c 0,0.139575 0.06848,0.265958 0.178049,0.360026 l 3.687804,2.957682 C 7.984391,20.43283 8.157735,20.5 8.351219,20.5 Z"
+     id="path1621"
+     sodipodi:nodetypes="sccsccsccs" />
+</svg>

--- a/elementary-xfce/status/24/media-playlist-shuffle-symbolic.svg
+++ b/elementary-xfce/status/24/media-playlist-shuffle-symbolic.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="24"
+   width="24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="media-playlist-shuffle-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="10.109375"
+     inkscape:cy="10.15625"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="386"
+     inkscape:window-y="48"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
+  <defs
+     id="defs10" />
+  <path
+     id="rect955-6-7-2-1"
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 16.99975,5.999922 C 11.004622,6.003462 10.999114,16 7,16 H 3.5133047 c -0.28748,-2.41e-4 -0.5136719,0.313878 -0.5136719,0.558594 v 0.882812 C 2.9996328,17.686122 3.2648892,18 3.5523672,18 H 7 c 5.998007,0 6.00506,-9.9947678 9.99975,-10.0000779 z m -13.4473828,8.6e-5 c -0.287478,0 -0.5527344,0.3138777 -0.5527344,0.5585938 v 0.8828124 c 0,0.2447161 0.2261919,0.5588348 0.5136719,0.5585939 H 7 c 0.92276,0 1.9446713,0.57773 2.964691,2.3444569 0.259371,-0.66371 0.688612,-1.3811887 1.143671,-2.0487728 C 10.474563,7.6618928 9.2017074,6.000008 7,6.000008 Z M 16.99968,15.999922 c -1.521391,-0.002 -2.79355,-1.515736 -3.248954,-2.170075 -0.25937,0.66371 -0.626653,1.131411 -1.081712,1.798995 0.700424,0.635666 2.972079,2.370277 4.330666,2.37108 z"
+     sodipodi:nodetypes="cscssssccssscsccssccccc" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4.00001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 17.648781,3.5 c -0.359,0 -0.649325,0.2353914 -0.64878,0.5263674 V 9.973633 c 0,0.290977 0.28978,0.526367 0.64878,0.526367 0.193484,0 0.366824,-0.06716 0.485366,-0.175456 L 21.821951,7.3531898 C 21.931519,7.2591248 22,7.1327388 22,6.9931646 22,6.8535893 21.93152,6.7272066 21.821951,6.6331383 L 18.134147,3.6754562 C 18.015609,3.5671697 17.842265,3.5 17.648781,3.5 Z"
+     id="path1107"
+     sodipodi:nodetypes="sccsccsccs" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:#666666;fill-opacity:1;stroke:none;stroke-width:4.00001;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 17.648781,13.5 c -0.359,0 -0.649325,0.235392 -0.64878,0.526368 v 5.947265 c 0,0.290977 0.28978,0.526367 0.64878,0.526367 0.193484,0 0.366824,-0.06716 0.485366,-0.175456 L 21.821951,17.35319 C 21.931519,17.259125 22,17.132739 22,16.993165 22,16.85359 21.93152,16.727207 21.821951,16.633139 L 18.134147,13.675457 C 18.015609,13.56717 17.842265,13.5 17.648781,13.5 Z"
+     id="path3147"
+     sodipodi:nodetypes="sccsccsccs" />
+</svg>


### PR DESCRIPTION
Adds symbolic media icons at 24px.
Adjust spacing for some symbolic media icons at 16px.

Fixes spacing and blurry-icon issues with
Rhythmbox (without alternative toolbar) and
Pulse Audio panel plugin for Xfce Panel.