### PR TITLE
New multimedia category icon

### DIFF
--- a/elementary-xfce/categories/128/applications-multimedia.svg
+++ b/elementary-xfce/categories/128/applications-multimedia.svg
@@ -1,488 +1,135 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
+   version="1.1"
    width="128"
    height="128"
-   id="svg3645">
+   id="svg9767"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2"
+     inkscape:cx="79.25"
+     inkscape:cy="84.5"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="97"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9767"
+     inkscape:snap-global="false" />
+  <defs
+     id="defs9769">
+    <linearGradient
+       id="linearGradient1258">
+      <stop
+         id="stop1250"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1252"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.09999999" />
+      <stop
+         id="stop1254"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1256"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient864">
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop860" />
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="1"
+         id="stop862" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient864"
+       id="linearGradient866-3"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.8421045,0,0,5.8421045,-52.842093,-6.1052503)" />
+    <linearGradient
+       gradientTransform="matrix(2.9459461,0,0,2.9459459,-6.7027256,-6.7026811)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient1258"
+       id="linearGradient5397-6"
+       y2="40.078964"
+       x2="30.526697"
+       y1="5.7253451"
+       x1="30.526697" />
+  </defs>
   <metadata
-     id="metadata201261">
+     id="metadata9772">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs3647">
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2704"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.1303396,0,0,0.0665175,-5.1301159,59.93959)" />
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient2738"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.11761996,0,0,0.06651459,2.5123608,59.941205)" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2735"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.1303396,0,0,0.0665175,95.177268,59.93959)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#2e4a5a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#6e8796;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="53.623615"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2761"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7458681,0,0,1.8151292,122.49509,-0.76713992)" />
-    <linearGradient
-       id="linearGradient3993">
-      <stop
-         id="stop3995"
-         style="stop-color:#a3c0d0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4001"
-         style="stop-color:#427da1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="14.76559"
-       cy="10.898237"
-       r="18.000002"
-       fx="14.76559"
-       fy="10.898237"
-       id="radialGradient2759"
-       xlink:href="#linearGradient3993"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-4.9085881e-8,4.3322336,-7.6972789,-7.6766615e-8,112.13959,-44.293239)" />
-    <linearGradient
-       x1="16.745687"
-       y1="46.132927"
-       x2="16.745687"
-       y2="1.4097958"
-       id="linearGradient2799"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0090242,0,0,1.9588252,-21.363767,4.1249799)" />
-    <linearGradient
-       x1="-22.539846"
-       y1="11.109024"
-       x2="-22.539846"
-       y2="46.263954"
-       id="linearGradient2797"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.878607,0,0,2.0327737,72.086475,2.2612535)" />
-    <linearGradient
-       id="linearGradient3582">
-      <stop
-         id="stop3584"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3586"
-         style="stop-color:#5a5a5a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.745687"
-       y1="46.132927"
-       x2="16.745687"
-       y2="1.4097958"
-       id="linearGradient2803"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0167306,0,0,1.9560617,-28.020049,4.0863811)" />
-    <linearGradient
-       id="linearGradient3932">
-      <stop
-         id="stop3934"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3936"
-         style="stop-color:#434343;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-22.539846"
-       y1="11.109024"
-       x2="-22.539846"
-       y2="46.263954"
-       id="linearGradient2801"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8858135,0,0,2.0299057,65.788672,2.2252845)" />
-    <linearGradient
-       id="linearGradient3461">
-      <stop
-         id="stop3463"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3465"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.722891"
-       y1="3"
-       x2="16.722891"
-       y2="35.055153"
-       id="linearGradient2711"
-       xlink:href="#linearGradient3461"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7778266,0,0,2.8064942,-4.0008776,-2.3233863)" />
-    <linearGradient
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient2698"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2021932,0,0,0.87099613,89.946749,-91.535292)" />
-    <linearGradient
-       id="linearGradient2372">
-      <stop
-         id="stop2374"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2376"
-         style="stop-color:#ffffff;stop-opacity:0.34482759"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="28.503141"
-       y1="137.53885"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient3642"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.87099971,0,0,0.87099613,46.1281,-79.57637)" />
-    <linearGradient
-       id="linearGradient3668">
-      <stop
-         id="stop3670"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3672"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.757765"
-       fy="37.841019"
-       id="radialGradient3634"
-       xlink:href="#linearGradient3668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.9141006,-0.4703676,0.06360573,2.7115901,53.145778,-6.5647694)" />
-    <linearGradient
-       id="linearGradient7067">
-      <stop
-         id="stop7069"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7071"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.68769"
-       fy="37.45607"
-       id="radialGradient3622"
-       xlink:href="#linearGradient7067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.9768774,-0.55644236,0.15755836,2.6279504,-1.3612994,9.5074172)" />
-    <linearGradient
-       xlink:href="#linearGradient2372"
-       id="linearGradient3025"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1319245,0,0,0.84699866,88.694739,-85.384908)"
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074" />
-  </defs>
-  <g
-     id="g4239">
-    <path
-       d="m 73.420382,84.328649 c 0,0 0,16.153301 0,16.153301 6.712165,0.0303 16.226757,-3.61909 16.226753,-8.077664 0,-4.458566 -7.490274,-8.075637 -16.226753,-8.075637 l 0,0 0,0 z"
-       id="path5058"
-       style="opacity:0.40206185;fill:url(#radialGradient2704);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       width="56.793621"
-       height="16.153547"
-       x="16.626755"
-       y="84.328659"
-       id="rect4173"
-       style="opacity:0.40206185;fill:url(#linearGradient2738);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="m 16.626752,84.328649 c 0,0 0,16.153301 0,16.153301 C 9.914584,100.51236 0.4,96.86286 0.4,92.404286 0.4,87.94572 7.8902721,84.328649 16.626752,84.328649 l 0,0 0,0 z"
-       id="path5018"
-       style="opacity:0.40206185;fill:url(#radialGradient2735);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       width="49.00008"
-       height="89.000084"
-       rx="0"
-       ry="0"
-       x="21.49996"
-       y="6.4999552"
-       id="rect3457"
-       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2759);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2761);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       d="m 23.501398,51.5 45.9972,0"
-       id="path3460"
-       style="fill:none;stroke:#333333;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="m 23.501639,52.5 c 15.332243,0 30.664482,0 45.996722,0"
-       id="path3360"
-       style="display:block;overflow:visible;visibility:visible;opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-    <path
-       d="m 22.499997,6.4866831 0.01333,89.0266409 -15.019978,0 0,-4.639982 -0.00667,-84.3866589 z"
-       id="path3385"
-       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2797);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2799);stroke-width:0.97335809;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="9.9999924"
-       id="rect3464"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <path
-       d="m 69.486679,95.452639 0,-88.9659594 15.021739,0 0.0049,88.4547524 c -1.210442,1.071274 -3.613644,0.256663 -5.327259,0.511207 l -9.699423,0 z"
-       id="rect15391"
-       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2801);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2803);stroke-width:0.97335809;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <rect
-       width="6"
-       height="4"
-       x="73"
-       y="50"
-       id="rect3766"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4"
-       x="73"
-       y="10"
-       id="rect3760"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.0000005"
-       x="73"
-       y="60.000004"
-       id="rect3772"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="75.001312"
-       height="87.001312"
-       rx="0"
-       ry="0"
-       x="8.4993439"
-       y="7.4993377"
-       id="rect2689"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient2711);stroke-width:0.99868685;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <rect
-       width="6"
-       height="4.0000005"
-       x="73"
-       y="80.000023"
-       id="rect3774"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.0000005"
-       x="73"
-       y="70.000008"
-       id="rect3768"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4"
-       x="73"
-       y="19.999996"
-       id="rect3762"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.0000005"
-       x="73"
-       y="90"
-       id="rect3776"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4"
-       x="73"
-       y="39.999992"
-       id="rect3770"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4"
-       x="73"
-       y="30"
-       id="rect3764"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="19.999992"
-       id="rect3744"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="30"
-       id="rect3746"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="50"
-       id="rect3748"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="70"
-       id="rect3750"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="40"
-       id="rect3752"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4.000001"
-       x="13"
-       y="60"
-       id="rect3754"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4"
-       x="13"
-       y="80"
-       id="rect3756"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="6"
-       height="4"
-       x="13"
-       y="90"
-       id="rect3758"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-  </g>
-  <g
-     id="g4270"
-     transform="translate(2.0004921,0)">
-    <path
-       d="m 117.88508,80.591857 0.16024,-44.369839 c 1.68854,-0.218496 -0.32704,-0.03525 1.94986,-0.36245 0.0313,8.287841 0,13.869992 0,45.170946 0,0.232915 -0.35432,-0.11691 -2.1101,-0.438657 l 0,0 0,0 z"
-       id="path3996"
-       style="opacity:0.4;fill:url(#linearGradient2698);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 117.96423,17.527357 -49.229621,11.6087 c -4.45096,2.207213 -2.85822,7.812992 -3.14501,11.767332 l 0,51.32606 C 52.835934,88.917097 39.402713,97.197229 38.509508,109.96085 37.994988,117.64654 46.55067,124.2449 54.1,123.541 c 11.504857,-0.20021 19.855229,-9.92232 19.31,-20.47396 l 0.09998,-53.998106 40.96924,-10.013201 0,42.23638 c -10.95063,-3.117479 -24.12587,4.028966 -25.94045,15.453364 -1.51727,6.732503 3.24365,13.499343 9.74676,15.423493 12.17311,3.94311 25.78941,-7.68675 24.3537,-20.123258 -0.034,-23.327471 0.10251,-46.655016 0,-69.982418 -0.28606,-2.318709 -2.11923,-4.653183 -4.675,-4.535937 z"
-       id="path3406"
-       style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="M 66,92.548721 66,34.369 c -0.132493,6.8e-5 0.306555,-4.430713 3.794005,-4.834823 1.121571,-0.445809 47.547175,-11.442781 47.547175,-11.442781 0,0 1.01149,1.392037 -19.056033,6.386285 -24.340123,6.057579 -30.193513,7.34105 -30.195952,10.372089 l -0.04794,59.571749 c -0.634234,-0.538772 -0.897438,-0.846246 -2.041233,-1.468734 z"
-       id="path2720"
-       style="opacity:0.4;fill:url(#linearGradient3642);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 122.191,93.912482 c 0,8.465018 -7.48702,16.596078 -16.72252,18.161088 -9.235565,1.56487 -16.72248,-4.02875 -16.72248,-12.49384 0,-8.465115 7.486915,-16.596107 16.72248,-18.161071 9.2355,-1.564982 16.72252,4.028699 16.72252,12.493823 l 0,0 z"
-       id="path2716"
-       style="opacity:0.6;fill:url(#radialGradient3634);fill-opacity:1;stroke:none" />
-    <path
-       d="m 72.878116,105.16643 c 0,8.21328 -7.605877,16.10239 -16.988214,17.62076 -9.382325,1.51843 -16.886394,-5.47961 -16.886394,-12.12209 0,-8.6496 7.773211,-16.801447 16.886394,-18.232589 9.604751,-2.144182 17.175244,3.994537 16.988214,12.733919 z"
-       id="path2712"
-       style="opacity:0.6;fill:url(#radialGradient3622);fill-opacity:1;stroke:none" />
-    <path
-       d="M 115.00005,81.999837 115,38.476 l 2,-0.35223 c 0.0297,8.059496 0,14.637673 0,45.07623 0,0.226498 -0.618,-0.717782 -1.99998,-1.200163 l 0,0 z"
-       id="path3996-1"
-       style="opacity:0.4;fill:url(#linearGradient3025);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-  </g>
+  <rect
+     width="111"
+     height="111"
+     rx="7"
+     ry="7"
+     x="8.5"
+     y="8.5"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate" />
+  <rect
+     width="109"
+     height="109"
+     x="9.499999"
+     y="9.499999"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397-6);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="6"
+     ry="6" />
+  <rect
+     width="111"
+     height="111"
+     rx="7"
+     ry="7"
+     x="8.5"
+     y="8.5"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path835"
+     d="m 93.152812,23 c 2.211252,0.372184 3.847972,2.750908 3.847972,5.39674 V 86.349188 C 96.271944,91.483884 91.509656,96.353236 84.8799,98.074168 76.569752,100.23132 68.383384,96.633956 66.602032,90.193444 64.820708,83.752936 70.028204,76.78136 78.338352,74.624212 82.943532,73.428804 87.542008,74.16038 91.000676,75.9697 V 45.119252 L 51.000394,55.451508 v 42.19938 c -0.72884,5.134692 -5.333944,10.004042 -11.9637,11.724982 -8.310148,2.15715 -15.87296,-1.83944 -17.654284,-8.27995 -1.78132,-6.440504 2.80318,-13.012856 11.113332,-15.170008 4.605176,-1.195408 9.046,-0.463832 12.504664,1.345492 V 41.996616 c 0,-3.527736 2.746524,-7.159912 6.157388,-8.072936 L 93.153032,23 h 2.2e-4"
+     sodipodi:nodetypes="cscsssccccssscsccc" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#fffdfd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path16590-0"
+     d="m 93.152812,21.999916 c 2.211252,0.372184 3.847972,2.750908 3.847972,5.39674 V 85.349104 C 96.271944,90.4838 91.509656,95.353152 84.8799,97.074084 76.569752,99.231236 68.383384,95.633872 66.602032,89.19336 c -1.781324,-6.440508 3.426172,-13.412084 11.73632,-15.569232 4.60518,-1.195408 9.203656,-0.463832 12.662324,1.345488 V 44.119168 L 51.000394,54.451424 v 42.19938 c -0.72884,5.134696 -5.333944,10.004046 -11.9637,11.724986 -8.310148,2.15715 -15.87296,-1.83944 -17.654284,-8.27995 -1.78132,-6.440508 2.80318,-13.01286 11.113332,-15.170012 4.605176,-1.195408 9.046,-0.463832 12.504664,1.345492 V 40.996532 c 0,-3.527736 2.746524,-7.159912 6.157388,-8.072936 l 41.995238,-10.92368 h 2.2e-4"
+     sodipodi:nodetypes="cscsssccccssscsccc" />
 </svg>

--- a/elementary-xfce/categories/16/applications-multimedia.svg
+++ b/elementary-xfce/categories/16/applications-multimedia.svg
@@ -1,343 +1,131 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
+   version="1.1"
    width="16"
    height="16"
-   id="svg2">
+   id="svg9767"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="8.1206794"
+     inkscape:cy="10.871767"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9767"
+     inkscape:snap-global="false" />
+  <defs
+     id="defs9769">
+    <linearGradient
+       id="linearGradient1258">
+      <stop
+         id="stop1250"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1252"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop1254"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1256"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient864">
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop860" />
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="1"
+         id="stop862" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient864"
+       id="linearGradient866-3"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.7894736,0,0,0.7894736,-7.7894721,-1.4736825)" />
+    <linearGradient
+       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.43118381,-0.43368178)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient1258"
+       id="linearGradient5397-6"
+       y2="41.414486"
+       x2="30.526697"
+       y1="6.5909567"
+       x1="30.526697" />
+  </defs>
   <metadata
-     id="metadata191584">
+     id="metadata9772">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient3522">
-      <stop
-         id="stop3524"
-         style="stop-color:#a3c0d0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3526"
-         style="stop-color:#5a8caa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3582">
-      <stop
-         id="stop3584"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3586"
-         style="stop-color:#5a5a5a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3932">
-      <stop
-         id="stop3934"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3936"
-         style="stop-color:#434343;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7067-814-120-245-5">
-      <stop
-         offset="0"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         id="stop3877-0" />
-      <stop
-         offset="1"
-         style="stop-color:#4d4d4d;stop-opacity:1"
-         id="stop3879-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2372">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2374" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.37931034"
-         id="stop2376" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3932"
-       id="linearGradient3533"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.91442446,0,0,0.84900545,0.26374818,-1.6011742)"
-       x1="5.0678191"
-       y1="4.5037227"
-       x2="5.0678191"
-       y2="18.154421" />
-    <linearGradient
-       xlink:href="#linearGradient3582"
-       id="linearGradient3535"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.91442446,0,0,0.84900545,0.26374818,-1.6011742)"
-       x1="2.6708329"
-       y1="18.300243"
-       x2="2.6708329"
-       y2="0.7810511" />
-    <linearGradient
-       xlink:href="#linearGradient3522"
-       id="linearGradient3537"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72669445,0,0,0.66036406,0.04724189,-1.1308998)"
-       x1="12.872127"
-       y1="5.0561161"
-       x2="12.872127"
-       y2="21.467987" />
-    <linearGradient
-       xlink:href="#linearGradient3582"
-       id="linearGradient3539"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.92470776,0,0,0.84782219,0.14587305,-1.5903585)"
-       x1="5.6597543"
-       y1="18.299864"
-       x2="5.6597543"
-       y2="1" />
-    <radialGradient
-       xlink:href="#linearGradient7067-814-120-245-5"
-       id="radialGradient4342"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.37667571,-0.06311262,0,0.36451394,-25.447611,-4.771394)"
-       cx="17.058823"
-       cy="41.058823"
-       fx="15.544384"
-       fy="39.027378"
-       r="5.7384715" />
-    <linearGradient
-       xlink:href="#linearGradient2372"
-       id="linearGradient4344"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12649532,0,0,0.12875595,-20.887365,-18.137667)"
-       x1="28.739122"
-       y1="144.11652"
-       x2="27.008177"
-       y2="134.08141" />
-    <linearGradient
-       xlink:href="#linearGradient2372"
-       id="linearGradient4347"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.12649532,0,0,0.12875595,5.114,-14.056928)"
-       x1="28.739122"
-       y1="144.11652"
-       x2="25.400293"
-       y2="119.86452" />
-    <radialGradient
-       xlink:href="#linearGradient7067-814-120-245-5"
-       id="radialGradient4350"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.37667571,-0.06311262,0,0.36451394,0.553754,-0.6906547)"
-       cx="17.058823"
-       cy="41.058823"
-       fx="15.544384"
-       fy="39.027378"
-       r="5.7384715" />
-  </defs>
-  <g
-     id="g3506"
-     transform="translate(-2.0000001,1.000003)">
-    <path
-       d="m 4.8554401,13.511138 c -0.7562743,0 -1.5125489,0 -2.2688232,0 -0.1838207,-0.16603 -0.044041,-0.49567 -0.087717,-0.73072 0,-4.403659 0,-8.807322 0,-13.2109825 l 0.025635,-0.057025 0.062082,-0.023548 0,0 c 0.7871277,0 1.4508426,0 2.2379702,0 m 8.3428529,-1.922e-4 c 0.755691,0 1.508149,0 2.254961,0 0.106015,0 0.08772,0.4401992 0.08772,0.7302494 0,4.4008333 2e-6,8.8016663 2e-6,13.2024993 -0.180768,0.168738 -0.539659,0.04042 -0.795571,0.08052 -0.509378,0 -1.018755,0 -1.528132,0"
-       id="path3385"
-       style="fill:url(#linearGradient3533);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3535);stroke-width:0.97734213;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <rect
-       width="9.002285"
-       height="14.002285"
-       rx="0"
-       ry="0"
-       x="4.4985867"
-       y="-0.50161695"
-       id="rect3457"
-       style="fill:url(#linearGradient3537);fill-opacity:1;stroke:url(#linearGradient3539);stroke-width:0.99771518;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-    <path
-       d="m 5.4270232,0.5134093 c 2.3786509,0 4.7573018,0 7.1359538,0"
-       id="rect15660"
-       style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:0.97318149;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <g
-       id="g3495">
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="-0.27648115"
-         id="rect3466"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="1.2634621"
-         id="rect3468"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="2.8034048"
-         id="rect3470"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="4.3433475"
-         id="rect3472"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="5.8832903"
-         id="rect3474"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="7.423233"
-         id="rect3476"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="8.9631767"
-         id="rect3478"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="10.503119"
-         id="rect3480"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.98464245"
-         height="0.69195426"
-         x="2.9997289"
-         y="12.043062"
-         id="rect3482"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    </g>
-    <path
-       d="m 5.4317521,7.513409 c 2.3786509,0 4.7573019,0 7.1359539,0"
-       id="path4318"
-       style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:0.97318149;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <path
-       d="m 5.4317521,6.513409 c 2.3786509,0 4.7573019,0 7.1359539,0"
-       id="path4320"
-       style="fill:none;stroke:#464646;stroke-width:0.97318149;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <g
-       transform="translate(-0.99972916,0)"
-       id="g3484">
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3175"
-         y="-0.27648115"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3177"
-         y="1.2634621"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3179"
-         y="2.8034048"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3181"
-         y="4.3433475"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3183"
-         y="5.8832903"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3185"
-         y="7.423233"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3187"
-         y="8.9631767"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3189"
-         y="10.503119"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-      <rect
-         style="fill:#ffffff;fill-opacity:1;stroke:none"
-         id="rect3191"
-         y="12.043062"
-         x="14.999729"
-         height="0.69195426"
-         width="0.98464245" />
-    </g>
-  </g>
+  <rect
+     width="15"
+     height="15"
+     rx="1"
+     ry="1"
+     x="0.5"
+     y="0.5"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="13"
+     height="13"
+     x="1.5012512"
+     y="1.4987478"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397-6);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="15"
+     height="15"
+     rx="1"
+     ry="1"
+     x="0.5"
+     y="0.5"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-     d="M 8,2.5 C 7.5,3 7.527538,3.7450793 7.5,4.3125 l 0,6.625 C 6.188274,10.690892 4.569378,11.7526 4.5,13.46875 4.386748,14.537188 5.344725,15.474992 6.375,15.5 8.219664,15.54478 9.479991,14.32903 9.5,12.78125 9.532839,12.80769 9.5,6 9.5,6 l 3.875,-0.5 c 0,0 0.125,3.5792324 0.125,4.4375 -1.311726,-0.246608 -2.930622,0.8151 -3,2.53125 -0.113252,1.068438 0.844725,2.006242 1.875,2.03125 1.844664,0.04478 3.104991,-1.17097 3.125,-2.71875 C 15.54422,11.81686 15.5,1.5 15.5,1.5 z"
-     id="path4031-3" />
+     id="path4382"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1.00225;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 11.556641,3.5060344 c -0.03619,3.375e-4 -0.07474,0.00308 -0.113282,0.013672 L 6.5546875,4.8927531 C 6.2463391,4.9774575 6,5.3179054 6,5.656425 v 0.6875 0.3457031 4.8710939 A 1.9016424,1.6019228 13.68287 0 0 5.5722656,11.3908 a 1.9016424,1.6019228 13.68287 0 0 -2.28125,1.03125 1.9016424,1.6019228 13.68287 0 0 1.3828125,2.046875 1.9016424,1.6019228 13.68287 0 0 2.28125,-1.03125 A 1.9016424,1.6019228 13.68287 0 0 7,12.894706 V 6.9630656 L 11,5.9591594 V 10.371269 A 1.9016424,1.6019228 13.68287 0 0 10.570312,10.201347 1.9016424,1.6019228 13.68287 0 0 8.2890625,11.230644 1.9016424,1.6019228 13.68287 0 0 9.671875,13.277519 1.9016424,1.6019228 13.68287 0 0 11.953125,12.248222 1.9016424,1.6019228 13.68287 0 0 12,11.716972 V 5.0118938 3.9786906 C 12,3.724801 11.865516,3.5079875 11.662109,3.5079875 h -0.002 c -0.0339,0 -0.06732,-0.00229 -0.103515,-0.00195 z" />
   <path
-     style="fill:url(#radialGradient4350);fill-opacity:1;stroke:none"
-     id="path2937-5"
-     d="m 8.973564,12.865116 a 1.7166647,2.0994822 57.095252 0 1 -3.988331,0.66825 1.7166647,2.0994822 57.095252 0 1 3.988331,-0.66825 z" />
-  <path
-     style="opacity:0.4;fill:url(#linearGradient4347);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path2945-6"
-     d="m 8.053687,11.476373 0.054174,-8.5026634 c 0,0 6.2220963,-0.8778388 6.6580393,-0.8798621 0.113284,0.048252 0.140038,0.2567924 0.140038,0.2567924 L 8.5433745,3.5664023 c 0,0 0.020487,3.389173 0.020487,8.2014757 0,0.03443 -0.325438,-0.243938 -0.5101745,-0.291505 z" />
-  <g
-     transform="translate(32.001365,3.0807393)"
-     id="g4334">
-    <path
-       style="fill:url(#radialGradient4342);fill-opacity:1;stroke:none"
-       id="path4338"
-       d="m -17.027801,8.784377 a 1.7166647,2.0994822 57.095252 0 1 -3.988331,0.66825 1.7166647,2.0994822 57.095252 0 1 3.988331,-0.66825 z" />
-    <path
-       style="opacity:0.4;fill:url(#linearGradient4344);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path4340"
-       d="m -17.947678,7.395634 -0.05369,-5.1592162 c 0,0 0.831779,-0.7200801 0.594225,0.3656859 l -0.03036,5.0850353 c -2.06e-4,0.034429 -0.325438,-0.243938 -0.510175,-0.291505 z" />
-  </g>
+     id="path4192"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#fffdfd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00225;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 11.556641 2.5058594 C 11.520451 2.5061969 11.481901 2.5089392 11.443359 2.5195312 L 6.5546875 3.8925781 C 6.2463391 3.9772825 6 4.3177304 6 4.65625 L 6 5.34375 L 6 5.6894531 L 6 10.560547 A 1.9016424 1.6019228 13.68287 0 0 5.5722656 10.390625 A 1.9016424 1.6019228 13.68287 0 0 3.2910156 11.421875 A 1.9016424 1.6019228 13.68287 0 0 4.6738281 13.46875 A 1.9016424 1.6019228 13.68287 0 0 6.9550781 12.4375 A 1.9016424 1.6019228 13.68287 0 0 7 11.894531 L 7 5.9628906 L 11 4.9589844 L 11 9.3710938 A 1.9016424 1.6019228 13.68287 0 0 10.570312 9.2011719 A 1.9016424 1.6019228 13.68287 0 0 8.2890625 10.230469 A 1.9016424 1.6019228 13.68287 0 0 9.671875 12.277344 A 1.9016424 1.6019228 13.68287 0 0 11.953125 11.248047 A 1.9016424 1.6019228 13.68287 0 0 12 10.716797 L 12 4.0117188 L 12 2.9785156 C 12 2.724626 11.865516 2.5078125 11.662109 2.5078125 L 11.660156 2.5078125 C 11.626256 2.5078125 11.592836 2.5055194 11.556641 2.5058594 z " />
 </svg>

--- a/elementary-xfce/categories/24/applications-multimedia.svg
+++ b/elementary-xfce/categories/24/applications-multimedia.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="24"
    height="24"
-   id="svg2">
+   id="svg2"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview80"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="32.000001"
+     inkscape:cx="10.421875"
+     inkscape:cy="14.781249"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="434"
+     inkscape:window-y="115"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer14" />
   <metadata
      id="metadata191584">
     <rdf:RDF>
@@ -24,403 +46,99 @@
   <defs
      id="defs4">
     <linearGradient
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient3905"
-       xlink:href="#linearGradient2372-378"
+       xlink:href="#linearGradient864"
+       id="linearGradient866"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33892707,0,0,0.16641626,14.123506,-16.768028)" />
+       gradientTransform="translate(-8)" />
     <linearGradient
-       id="linearGradient2372-378">
+       id="linearGradient864">
       <stop
-         id="stop3245"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop860" />
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="1"
+         id="stop862" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.97421989,0.97172349)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient878"
+       id="linearGradient5397"
+       y2="41.414486"
+       x2="30.526697"
+       y1="6.5909567"
+       x1="30.526697" />
+    <linearGradient
+       id="linearGradient878">
+      <stop
+         id="stop870"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3247"
-         style="stop-color:#ffffff;stop-opacity:0.37931034"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="28.739122"
-       y1="144.11652"
-       x2="25.400293"
-       y2="119.86452"
-       id="linearGradient3908"
-       xlink:href="#linearGradient2372-270"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.16844268,0,0,0.16641626,9.1569719,-15.590696)" />
-    <linearGradient
-       id="linearGradient2372-270">
-      <stop
-         id="stop3239"
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop872"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0" />
       <stop
-         id="stop3241"
-         style="stop-color:#ffffff;stop-opacity:0.37931034"
+         id="stop874"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop876"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.109128"
-       fy="38.980988"
-       id="radialGradient3911"
-       xlink:href="#linearGradient7067-561-456-275"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.50449452,0,-0.08259045,0.47423109,14.688834,-0.9890424)" />
-    <linearGradient
-       id="linearGradient7067-561-456-275">
-      <stop
-         id="stop3871"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3873"
-         style="stop-color:#4d4d4d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.638257"
-       fy="38.175381"
-       id="radialGradient3914"
-       xlink:href="#linearGradient7067-814-120-245"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.50575523,0,-0.08279685,0.47541618,5.7349922,0.27552075)" />
-    <linearGradient
-       id="linearGradient7067-814-120-245">
-      <stop
-         id="stop3877"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3879"
-         style="stop-color:#4d4d4d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="22.90196"
-       cy="45.866665"
-       r="7.9058824"
-       fx="22.90196"
-       fy="45.866665"
-       id="radialGradient3918"
-       xlink:href="#linearGradient5670-612"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.57706668,0,0,0.24304281,-2.6541892,10.931456)" />
-    <linearGradient
-       id="linearGradient5670-612">
-      <stop
-         id="stop3203"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3205"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="22.90196"
-       cy="45.866665"
-       r="7.9058824"
-       fx="22.90196"
-       fy="45.866665"
-       id="radialGradient3921"
-       xlink:href="#linearGradient5670-725"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53060292,0,0,0.2234737,7.4709011,10.491967)" />
-    <linearGradient
-       id="linearGradient5670-725">
-      <stop
-         id="stop3197"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3199"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.872127"
-       y1="5.0561161"
-       x2="12.872127"
-       y2="21.467987"
-       id="linearGradient2926"
-       xlink:href="#linearGradient3522"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8074178,0,0,0.7546417,-0.4469554,0.78020858)" />
-    <linearGradient
-       id="linearGradient3522">
-      <stop
-         id="stop3524"
-         style="stop-color:#a3c0d0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3526"
-         style="stop-color:#5a8caa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="5.6597543"
-       y1="18.299864"
-       x2="5.6597543"
-       y2="1"
-       id="linearGradient2928"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.027427,0,0,0.9688625,-0.337368,0.25515478)" />
-    <linearGradient
-       id="linearGradient3582">
-      <stop
-         id="stop3584"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3586"
-         style="stop-color:#5a5a5a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="5.0678191"
-       y1="4.5037227"
-       x2="5.0678191"
-       y2="18.154421"
-       id="linearGradient2931"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9846423,0,0,0.9700961,0.09316947,0.24338418)" />
-    <linearGradient
-       id="linearGradient3932">
-      <stop
-         id="stop3934"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3936"
-         style="stop-color:#434343;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="2.6708329"
-       y1="18.300243"
-       x2="2.6708329"
-       y2="0.7810511"
-       id="linearGradient2933"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9846423,0,0,0.9700961,0.09316947,0.24338418)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient4327"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02428835,0,0,0.01181249,0.3129068,11.79412)" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient4329"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02274695,0,0,0.01180411,1.286836,11.799198)" />
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient4021"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.02422947,0,0,0.01180411,18.618613,11.799198)" />
   </defs>
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="1"
+     ry="1"
+     x="2.499999"
+     y="2.499999"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="17"
+     height="17"
+     x="3.5012503"
+     y="3.4987469"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="1"
+     ry="1"
+     x="2.499999"
+     y="2.499999"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <g
-     id="layer1">
-    <g
-       transform="translate(0.01283355,-1.0582085e-7)"
-       id="g4322"
-       style="display:inline">
-      <path
-         d="m 14.950532,16.125243 c 0,0 0,2.868588 0,2.868588 1.25079,0.0054 3.023802,-0.642705 3.023801,-1.434478 0,-0.791774 -1.395788,-1.43411 -3.023801,-1.43411 z"
-         id="path5058"
-         style="opacity:0.40206185;fill:url(#radialGradient4327);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.75;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <rect
-         width="10.98353"
-         height="2.8667126"
-         x="4.0164704"
-         y="16.127151"
-         id="rect4173"
-         style="opacity:0.40206185;fill:url(#linearGradient4329);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.75;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="m 4.0164708,16.127249 c 0,0 0,2.866554 0,2.866554 -1.2477579,0.0054 -3.01647085,-0.642249 -3.01647085,-1.433461 0,-0.791212 1.39240355,-1.433093 3.01647085,-1.433093 z"
-         id="path5018"
-         style="opacity:0.40206185;fill:url(#radialGradient4021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.75;marker:none;visibility:visible;display:inline;overflow:visible" />
-    </g>
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="g838"
+     transform="translate(-689.0002,483.192)">
     <path
-       d="m 5.0374533,17.511112 c -0.8143479,0 -1.6286962,0 -2.4430441,0 -0.1979362,-0.189711 -0.047423,-0.566366 -0.094453,-0.83494 0,-5.031738 0,-10.0634785 0,-15.0952182 l 0.027604,-0.065158 0.066849,-0.026906 0,0 c 0.8475705,0 1.5622515,0 2.4098219,0 m 8.9834929,-2.197e-4 c 0.81372,0 1.623958,0 2.428118,0 0.114155,0 0.09446,0.5029833 0.09446,0.8344023 0,5.0285085 2e-6,10.0570166 2e-6,15.0855256 -0.194649,0.192804 -0.581099,0.04619 -0.856662,0.09201 -0.548493,0 -1.096984,0 -1.645476,0"
-       id="path3385"
-       style="fill:url(#linearGradient2931);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2933);stroke-width:0.97734219;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <rect
-       width="10.002285"
-       height="16.001337"
-       rx="0"
-       ry="0"
-       x="4.4988575"
-       y="1.4993321"
-       id="rect3457"
-       style="fill:url(#linearGradient2926);fill-opacity:1;stroke:url(#linearGradient2928);stroke-width:0.99771523;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       inkscape:connector-curvature="0"
+       d="m 698.99439,-475.39289 c -0.554,0.14844 -1,0.73897 -1,1.3125 v 7.0933 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07146 1.9375,-1.90625 l 0.0312,-7.09369 5.99963,-1.62463 v 5.53094 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34975,0.35071 -2.19557,1.48415 -1.90625,2.53125 0.28933,1.0471 1.619,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-9.43651 c 0,-0.43016 -0.2677,-0.88338 -0.625,-0.81269 -2.15319,0.426 -4.24977,1.10385 -6.37453,1.65578 z"
+       id="path836"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       sodipodi:nodetypes="cscsssccccsssccsc" />
+  </g>
+  <g
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="layer14"
+     transform="translate(-689.0002,482.192)">
     <path
-       d="m 5.4813648,2.5081265 c 2.6790905,0 5.3581812,0 8.0372722,0"
-       id="rect15660"
-       style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:0.97318149;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <g
-       transform="matrix(1.2528457,0,0,0.9903337,0.16027982,0.01504957)"
-       id="g2693"
-       style="display:inline">
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="2.189693"
-         id="rect3464"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="3.7446673"
-         id="rect3466"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="5.2996411"
-         id="rect3468"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="6.8546152"
-         id="rect3470"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="8.4095888"
-         id="rect3472"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="9.9645624"
-         id="rect3474"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="11.519536"
-         id="rect3476"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="13.074511"
-         id="rect3478"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="14.629483"
-         id="rect3480"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-      <rect
-         width="0.78592473"
-         height="0.69870818"
-         x="2.2666161"
-         y="16.184458"
-         id="rect3482"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    </g>
-    <path
-       d="m 5.4865907,10.513409 c 2.6790905,0 5.3581813,0 8.0372723,0"
-       id="path4318"
-       style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:0.97318149;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <path
-       d="m 5.4865907,9.5134092 c 2.6790905,0 5.3581813,0 8.0372723,0"
-       id="path4320"
-       style="fill:none;stroke:#464646;stroke-width:0.97318149;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    <path
-       d="m 23.817631,20.741968 a 4.1948844,1.7667586 0 0 1 -8.389766,0 4.1948844,1.7667586 0 1 1 8.389766,0 z"
-       id="path2704"
-       style="opacity:0.3;fill:url(#radialGradient3921);fill-opacity:1;stroke:none" />
-    <path
-       d="m 15.123991,22.079026 a 4.5622215,1.9214699 0 0 1 -9.124443,0 4.5622215,1.9214699 0 1 1 9.124443,0 z"
-       id="path4121"
-       style="opacity:0.3;fill:url(#radialGradient3918);fill-opacity:1;stroke:none" />
-    <path
-       d="m 22.650673,3.491309 c -3.138748,0.4909342 -6.260348,0.9963132 -9.390368,1.5146659 -0.828847,0.3925189 -0.64251,1.4032624 -0.67918,2.1366501 0,3.272519 0,6.545039 0,9.817558 -2.130196,-0.478261 -4.9558026,1.082171 -5.0481871,3.300286 -0.1508079,1.380949 1.1108399,2.582986 2.4827661,2.61531 2.456378,0.05787 4.457652,-1.523949 4.484297,-3.524446 -0.02683,-3.359718 0.0075,-6.720758 0,-10.0809914 0.380277,-0.027337 6.482042,-1.0941006 6.999998,-1.1651275 0,2.5166759 0,5.0333509 0,7.5500269 -1.964811,-0.567663 -4.218153,0.618744 -4.702024,2.607288 -0.358022,1.151945 0.181761,2.513682 1.346986,2.985639 2.27471,1.014525 5.474278,-1.040504 5.347325,-3.452335 -0.03523,-4.480006 0.02888,-8.9618453 0,-13.4423296 C 23.432545,3.9324622 23.138601,3.4609169 22.650673,3.491309 z"
-       id="path4031"
-       style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       d="M 13.92608,19.299245 A 2.550196,3.1192601 57.133119 0 1 8,20.291883 2.550196,3.1192601 57.133119 1 1 13.92608,19.299245 z"
-       id="path2937"
-       style="fill:url(#radialGradient3914);fill-opacity:1;stroke:none" />
-    <path
-       d="m 22.866887,17.986024 a 2.5501954,3.1192593 57.133119 1 1 -5.926076,0.992638 2.5501954,3.1192593 57.133119 0 1 5.926076,-0.992638 z"
-       id="path2941"
-       style="fill:url(#radialGradient3911);fill-opacity:1;stroke:none" />
-    <path
-       d="M 13.071493,17.410934 13.000001,6.1889409 c 0,0 0.07826,-0.8579116 0.658769,-0.8605267 0.205885,-0.03496 9.230353,-1.4948304 9.230353,-1.4948304 0,0 1.165235,0.5429398 -8.37771,2.0643986 -0.978908,0.1845618 -0.760562,0.5451979 -0.760562,1.1785273 0,1.7082183 2e-6,4.4913233 2e-6,10.7111933 0,0.0445 -0.433358,-0.315288 -0.679363,-0.376769 z"
-       id="path2945"
-       style="opacity:0.3;fill:url(#linearGradient3908);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 21.999999,16.11932 0.04518,-8.4774936 c 0.476042,-0.041747 0.07309,-0.00671 0.715009,-0.069248 0.0088,1.5835093 3.65e-4,2.8978946 3.65e-4,8.8783896 0,0.0445 -0.265557,-0.270168 -0.760551,-0.331648 z"
-       id="path2947"
-       style="opacity:0.3;fill:url(#linearGradient3905);fill-opacity:1;fill-rule:evenodd;stroke:none" />
+       inkscape:connector-curvature="0"
+       d="m 699.00039,-475.39289 c -0.554,0.14844 -1,0.73897 -1,1.3125 v 7.0933 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07146 1.9375,-1.90625 l 0.0312,-7.09369 5.99963,-1.62463 v 5.53094 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34975,0.35071 -2.19557,1.48415 -1.90625,2.53125 0.28933,1.0471 1.619,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-9.43651 c 0,-0.43016 -0.2677,-0.88338 -0.625,-0.81269 -2.15319,0.426 -4.24977,1.10385 -6.37453,1.65578 z"
+       id="path16590"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       sodipodi:nodetypes="cscsssccccsssccsc" />
   </g>
 </svg>

--- a/elementary-xfce/categories/32/applications-multimedia.svg
+++ b/elementary-xfce/categories/32/applications-multimedia.svg
@@ -1,435 +1,134 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg9767"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg4185"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="15.180699"
+     inkscape:cy="7.2478445"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="19"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9767"
+     inkscape:snap-global="false" />
   <defs
-     id="defs4187">
+     id="defs9769">
     <linearGradient
-       xlink:href="#linearGradient2372"
-       id="linearGradient4076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.29552794,0,0,0.21508208,23.132091,-21.359919)"
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074" />
-    <linearGradient
-       id="linearGradient2372">
+       id="linearGradient1258">
       <stop
-         id="stop2374"
+         id="stop1250"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2376"
-         style="stop-color:#ffffff;stop-opacity:0.34482759"
+         id="stop1252"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02015998" />
+      <stop
+         id="stop1254"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3668"
-       id="radialGradient4078"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.66923599,-0.10851154,0.01460734,0.62555068,15.262386,0.80826963)"
-       cx="17.058823"
-       cy="41.058823"
-       fx="14.757765"
-       fy="37.841019"
-       r="5.7384715" />
-    <linearGradient
-       id="linearGradient3668">
       <stop
-         id="stop3670"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3672"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop1256"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient2372"
-       id="linearGradient4080"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2141126,0,0,0.21508208,13.115004,-19.583025)"
-       x1="28.503141"
-       y1="137.53885"
-       x2="26.256771"
-       y2="125.39074" />
-    <radialGradient
-       xlink:href="#linearGradient7067"
-       id="radialGradient4082"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.63560012,-0.11375924,0.02231595,0.60479102,3.8661654,3.5772567)"
-       cx="17.058823"
-       cy="41.058823"
-       fx="14.68769"
-       fy="37.45607"
-       r="5.7384715" />
-    <linearGradient
-       id="linearGradient7067">
+       id="linearGradient864">
       <stop
-         id="stop7069"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7071"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2543"
-       xlink:href="#linearGradient5048-7" />
-    <linearGradient
-       id="linearGradient5048-7">
-      <stop
-         style="stop-color:black;stop-opacity:0;"
+         style="stop-color:#ffa154;stop-opacity:1"
          offset="0"
-         id="stop5050-7" />
+         id="stop860" />
       <stop
-         id="stop5056-6"
-         offset="0.5"
-         style="stop-color:black;stop-opacity:1;" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
+         style="stop-color:#f37329;stop-opacity:1"
          offset="1"
-         id="stop5052-7" />
+         id="stop862" />
     </linearGradient>
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2545"
-       xlink:href="#linearGradient5060-1" />
     <linearGradient
-       id="linearGradient5060-1">
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0"
-         id="stop5062-5" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         offset="1"
-         id="stop5064-9" />
-    </linearGradient>
-    <radialGradient
-       r="117.14286"
-       fy="486.64789"
-       fx="605.71429"
-       cy="486.64789"
-       cx="605.71429"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
+       xlink:href="#linearGradient864"
+       id="linearGradient866-3"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient2547"
-       xlink:href="#linearGradient5060-1" />
-    <radialGradient
-       r="86.70845"
-       fy="35.736916"
-       fx="33.966679"
-       cy="35.736916"
-       cx="33.966679"
-       gradientTransform="matrix(0.4949305,0,0,0.5336295,0.1113962,-0.3686884)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3239"
-       xlink:href="#linearGradient259-3" />
+       gradientTransform="matrix(1.4210525,0,0,1.4210525,-12.42105,-1.0526286)" />
     <linearGradient
-       id="linearGradient259-3">
-      <stop
-         style="stop-color:#828282;stop-opacity:1;"
-         offset="0"
-         id="stop260-6" />
-      <stop
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="1"
-         id="stop261-5" />
-    </linearGradient>
-    <radialGradient
-       r="86.70845"
-       fy="35.736916"
-       fx="33.966679"
-       cy="35.736916"
-       cx="33.966679"
-       gradientTransform="matrix(0.4568944,0,0,0.5332867,1.7561321,-0.3677758)"
+       gradientTransform="matrix(0.6756758,0,0,0.6756758,-0.2162229,-0.2162123)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3236"
-       xlink:href="#linearGradient259-3" />
-    <linearGradient
-       y2="18.911581"
-       x2="12.872127"
-       y1="5.0561161"
-       x1="12.872127"
-       gradientTransform="matrix(1.0407062,0,0,0.9903846,-0.2996983,0.556229)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3233"
-       xlink:href="#linearGradient3522" />
-    <linearGradient
-       id="linearGradient3522">
-      <stop
-         id="stop3524"
-         offset="0"
-         style="stop-color:#81aac3;stop-opacity:1;" />
-      <stop
-         id="stop3526"
-         offset="1"
-         style="stop-color:#4e82a3;stop-opacity:1;" />
-    </linearGradient>
+       xlink:href="#linearGradient1258"
+       id="linearGradient5397-6"
+       y2="41.665707"
+       x2="30.526697"
+       y1="6.3348765"
+       x1="30.526697" />
   </defs>
   <metadata
-     id="metadata4190">
+     id="metadata9772">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       id="layer1-6"
-       transform="translate(-0.9999962,1.000001)">
-      <g
-         style="display:inline"
-         id="g5022"
-         transform="matrix(0.01132763,0,0,0.00627146,22.575195,21.94509)">
-        <rect
-           y="-150.69685"
-           x="-1559.2523"
-           height="478.35718"
-           width="1339.6335"
-           id="rect4173-3"
-           style="opacity:0.40206185;fill:url(#linearGradient2543);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-        <path
-           id="path5058-9"
-           d="m -219.61876,-150.68038 c 0,0 0,478.33079 0,478.33079 142.874166,0.90045 345.40022,-107.16966 345.40014,-239.196175 0,-132.026537 -159.436816,-239.134595 -345.40014,-239.134615 z"
-           style="opacity:0.40206185;fill:url(#radialGradient2545);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-        <path
-           style="opacity:0.40206185;fill:url(#radialGradient2547);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-           d="m -1559.2523,-150.68038 c 0,0 0,478.33079 0,478.33079 -142.8742,0.90045 -345.4002,-107.16966 -345.4002,-239.196175 0,-132.026537 159.4368,-239.134595 345.4002,-239.134615 z"
-           id="path5018-4" />
-      </g>
-      <path
-         id="path3385-8"
-         d="m 6.7690983,22.47398 c -1.0446036,0 -2.0892069,0 -3.1338103,0 -0.2539024,-0.248338 -0.060832,-0.741392 -0.1211597,-1.092965 0,-6.586737 0,-13.1734745 0,-19.7602117 l 0.035409,-0.085295 0.085751,-0.035221 0,0 c 1.0872192,0 2.0039749,0 3.0911942,0"
-         style="fill:url(#radialGradient3239);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-      <path
-         id="rect15391-1"
-         d="m 18.499999,1.5000005 c 0.963515,0 1.922912,0 2.875108,0 0.234392,0.2481792 0.05616,0.740917 0.111849,1.0922641 0,6.5825075 0.0082,13.1087054 0.0082,19.6912134 0,0.289929 -0.466483,0.204902 -1.022573,0.204902 -0.649464,0 -1.298928,-0.02815 -1.948391,-0.02815"
-         style="fill:url(#radialGradient3236);fill-opacity:1;fill-rule:nonzero;stroke:#333333;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-      <rect
-         ry="0"
-         rx="0"
-         y="1.5"
-         x="6.4999995"
-         height="21"
-         width="11.999999"
-         id="rect3457-2"
-         style="fill:url(#linearGradient3233);fill-opacity:1;stroke:#333333;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-      <path
-         id="path3460-9"
-         d="m 6.5,11.5 12.001874,0"
-         style="fill:none;stroke:#333333;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
-      <g
-         style="stroke-width:0.99938756;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-         transform="matrix(0.9359974,0,0,1.0449527,0.3671035,-0.08854594)"
-         id="g2547">
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3464-3"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="2.0974374" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3466-9"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="4.0987401" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3468-0"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="6.1000419" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3470-8"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="8.1013441" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3472-8"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="10.102646" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3474-5"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="12.103948" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3476-0"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="14.105249" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3478-9"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="16.106552" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3480-6"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="18.107853" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect3482-3"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="20.109156" />
-      </g>
-      <g
-         style="stroke-width:0.99938756;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-         transform="matrix(0.9359974,0,0,1.0449527,15.530262,-0.08854594)"
-         id="g2559">
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2561"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="2.0974374" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2563"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="4.0987401" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2565"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="6.1000419" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2567"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="8.1013441" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2569"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="10.102646" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2571"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="12.103948" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2573"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="14.105249" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2575"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="16.106552" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2577"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="18.107853" />
-        <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
-           id="rect2579"
-           width="1"
-           height="0.89926022"
-           x="4.3610935"
-           y="20.109156" />
-      </g>
-      <path
-         id="path4015"
-         d="m 7.5,12.5 c 3.333178,0 6.666355,0 9.999531,0"
-         style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-      <path
-         id="path4017"
-         d="m 7.5,2.5 c 3.333178,0 6.666355,0 9.999531,0"
-         style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
-    </g>
-    <g
-       id="g4069"
-       transform="translate(-1.0896629,-4.2980233e-7)">
-      <path
-         d="M 30.336573,5.1374014 C 26.352786,5.7744768 22.357966,6.3466041 18.377301,6.9999529 17.293846,7.5436608 17.68155,8.924547 17.611742,9.8986297 c 0,4.2144263 0,8.4288533 0,12.6432793 -2.781775,-0.619984 -5.992201,1.550319 -6.015986,4.498468 -0.125246,1.893247 1.701443,3.46199 3.539108,3.288603 2.49102,-0.127751 4.631859,-2.540795 4.365136,-5.117414 -1e-6,-4.214885 0,-9.086613 0,-13.301497 3.285323,-0.473717 6.714809,-0.994733 10,-1.469346 -1e-6,3.249117 0,7.155077 0,10.404194 -2.665607,-0.767935 -5.884488,0.992466 -6.326195,3.806668 -0.369336,1.658445 0.789572,3.325339 2.372564,3.799314 2.963189,0.971326 6.277676,-1.893482 5.928197,-4.95702 -0.0083,-5.746315 0.02496,-11.492648 0,-17.2389466 -0.06963,-0.5711739 -0.515871,-1.1464116 -1.137993,-1.117531 z"
-         id="path3406"
-         style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         d="m 30.000005,21.144821 0.03938,-10.956601 c 0.415084,-0.05396 0.06373,-0.0087 0.623454,-0.0895 0.0077,2.046583 0.01052,3.425029 0.01052,11.154425 0,0.05752 -0.241748,-0.02887 -0.673359,-0.108321 l 2e-6,0 z"
-         id="path3996"
-         style="opacity:0.4;fill:url(#linearGradient4076);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <path
-         d="m 31.118916,23.987885 c 0,1.952861 -1.719402,3.828641 -3.840392,4.189672 -2.120989,0.361031 -3.840392,-0.929402 -3.840392,-2.882263 0,-1.952862 1.719403,-3.828644 3.840392,-4.189675 2.12099,-0.361031 3.840392,0.929404 3.840392,2.882266 z"
-         id="path2716"
-         style="opacity:0.6;fill:url(#radialGradient4078);fill-opacity:1;stroke:none" />
-      <path
-         d="M 18,23.020986 18.108863,8.1088628 c 0,0 0.121115,-0.6858866 0.822996,-0.6887362 0.06098,0.1056173 11.514845,-1.8024314 11.514845,-1.8024314 0,0 0.712084,0.8840227 -4.382414,1.6157947 -7.251274,1.0415697 -7.248723,1.0830782 -7.248723,1.8315569 0,2.2077592 -0.152408,6.2680122 -0.152408,14.3067872 C 18.507249,23.238791 18.312702,23.100441 18,23.020986 l 0,0 z"
-         id="path2720"
-         style="opacity:0.4;fill:url(#linearGradient4080);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <path
-         d="m 19.272394,25.836409 c 0,1.888845 -1.632984,3.703135 -3.647372,4.052331 -2.01439,0.349196 -3.647374,-0.898935 -3.647374,-2.787781 0,-1.888844 1.632984,-3.703136 3.647374,-4.052332 2.014388,-0.349196 3.647372,0.898937 3.647372,2.787782 z"
-         id="path2712"
-         style="opacity:0.6;fill:url(#radialGradient4082);fill-opacity:1;stroke:none" />
-    </g>
-  </g>
+  <rect
+     width="27"
+     height="27"
+     rx="1.5"
+     ry="1.5"
+     x="2.5"
+     y="2.5"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path1057"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1.00225;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 22.382812,7.5 c -0.123328,0 -0.254311,5.315e-4 -0.394531,0.039063 L 13.011719,10.037109 C 12.450832,10.191187 12,10.810011 12,11.425781 v 1.25 0.628907 8.496093 a 3.302484,2.5243025 0 0 0 -1.386719,-0.236328 3.302484,2.5243025 0 0 0 -3.3027341,2.525391 3.302484,2.5243025 0 0 0 3.3027341,2.523437 3.302484,2.5243025 0 0 0 2.654297,-1.027343 c 0.507761,-0.459537 0.763407,-1.040105 0.730469,-1.63086 h 0.0039 L 14,13.804688 21,11.976562 v 7.753907 a 2.45,3.2187476 86.08906 0 0 -1.449219,-0.164063 2.45,3.2187476 86.08906 0 0 -3.042969,2.664063 2.45,3.2187476 86.08906 0 0 0.109376,0.498047 c 0.01269,0.043 0.02412,0.08624 0.04102,0.128906 0.06979,0.178004 0.176517,0.339377 0.306641,0.488281 a 2.45,3.2187476 86.08906 0 0 2.921875,1.109375 2.45,3.2187476 86.08906 0 0 2.83789,-1.658203 2.45,3.2187476 86.08906 0 0 0.0039,-0.0098 c 0.176625,-0.307873 0.269365,-0.641018 0.267578,-0.980468 H 23 V 10.253906 8.3730469 C 23,7.91122 22.77039,7.5 22.400391,7.5 Z" />
+  <path
+     id="path4192"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#fffdfd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00225;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 22.382812,6.5 c -0.123328,0 -0.254311,5.315e-4 -0.394531,0.039063 L 13.011719,9.0371094 C 12.450832,9.1911873 12,9.8100111 12,10.425781 v 1.25 0.628907 8.496093 c -0.434334,-0.154744 -0.907522,-0.235386 -1.386719,-0.236328 -1.8245655,-1.06e-4 -3.3035209,1.130757 -3.3027341,2.525391 6.252e-4,1.39387 1.479167,2.523543 3.3027341,2.523437 1.047895,-0.0012 2.032876,-0.382407 2.654297,-1.027343 0.507761,-0.459537 0.763407,-1.040105 0.730469,-1.63086 h 0.0039 L 14,12.804688 21,10.976562 V 18.6 c -0.455679,-0.140133 -0.951786,-0.132233 -1.449219,-0.1 -1.773199,0.121714 -3.135468,1.380761 -3.042969,2.730469 0.01361,0.169108 0.05026,0.33602 0.109376,0.498047 0.01269,0.043 0.02412,0.08624 0.04102,0.128906 0.06979,0.178004 0.176517,0.339377 0.306641,0.488281 0.609488,0.761901 1.733475,1.188655 2.921875,1.109375 1.271948,-0.08706 2.384875,-0.737351 2.83789,-1.658203 0.0013,-0.0033 0.0026,-0.0065 0.0039,-0.0098 0.176625,-0.307873 0.269365,-0.641018 0.267578,-0.980468 H 23 V 9.2539062 7.3730469 C 23,6.91122 22.77039,6.5 22.400391,6.5 Z"
+     sodipodi:nodetypes="sccscccccccccccccccccccccccsss" />
+  <rect
+     width="25.000002"
+     height="25.000002"
+     x="3.4999988"
+     y="3.4999988"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="0.5"
+     ry="0.5" />
+  <rect
+     width="27"
+     height="27"
+     rx="1.5"
+     ry="1.5"
+     x="2.5"
+     y="2.5"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/categories/48/applications-multimedia.svg
+++ b/elementary-xfce/categories/48/applications-multimedia.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="48"
    height="48"
-   id="svg3534">
+   id="svg2"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview80"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="23.776465"
+     inkscape:cy="27.577164"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="434"
+     inkscape:window-y="115"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
   <metadata
-     id="metadata189016">
+     id="metadata191584">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -22,425 +44,90 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3536">
+     id="defs4">
     <linearGradient
-       id="linearGradient5048">
+       xlink:href="#linearGradient864"
+       id="linearGradient866"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0526314,0,0,2.0526314,-17.052628,-0.63157645)" />
+    <linearGradient
+       id="linearGradient864">
       <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop860" />
       <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="1"
+         id="stop862" />
     </linearGradient>
     <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient2493"
-       xlink:href="#linearGradient5048"
+       gradientTransform="translate(0.00124365,-0.00124435)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(4.772373e-2,0,0,2.325004e-2,0.7512812,23.481385)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2490"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-4.772373e-2,0,0,2.325004e-2,35.239332,23.481385)" />
+       xlink:href="#linearGradient878"
+       id="linearGradient5397"
+       y2="41.414486"
+       x2="30.526697"
+       y1="6.5909567"
+       x1="30.526697" />
     <linearGradient
-       id="linearGradient2490">
+       id="linearGradient878">
       <stop
-         id="stop2492"
-         style="stop-color:#2e4a5a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#6e8796;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.248152"
-       y1="34.992569"
-       x2="12.248152"
-       y2="1.9999406"
-       id="linearGradient3487"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3993">
-      <stop
-         id="stop3995"
-         style="stop-color:#a3c0d0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4001"
-         style="stop-color:#427da1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.872127"
-       y1="5.0561161"
-       x2="12.872127"
-       y2="18.911581"
-       id="linearGradient2478"
-       xlink:href="#linearGradient3993"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6465384,0,0,1.5556175,-2.2508569,1.0175998)" />
-    <linearGradient
-       x1="6"
-       y1="36"
-       x2="6"
-       y2="1.9852973"
-       id="linearGradient3508"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       cx="33.966679"
-       cy="35.736916"
-       r="86.70845"
-       fx="33.966679"
-       fy="35.736916"
-       id="radialGradient2484"
-       xlink:href="#linearGradient259"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7979406,0,0,0.8394112,-1.9632013,-0.4324909)" />
-    <linearGradient
-       id="linearGradient3582">
-      <stop
-         id="stop3584"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3586"
-         style="stop-color:#5a5a5a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="33"
-       y1="36.014702"
-       x2="33"
-       y2="2"
-       id="linearGradient3526"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient259">
-      <stop
-         id="stop260"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop261"
-         style="stop-color:#434343;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="33.966679"
-       cy="35.736916"
-       r="86.70845"
-       fx="33.966679"
-       fy="35.736916"
-       id="radialGradient2481"
-       xlink:href="#linearGradient259"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7979932,0,0,0.8388723,-1.9637331,-0.4310554)" />
-    <linearGradient
-       id="linearGradient3461">
-      <stop
-         id="stop3463"
+         id="stop870"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3465"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.722891"
-       y1="3"
-       x2="16.722891"
-       y2="35.055153"
-       id="linearGradient3467"
-       xlink:href="#linearGradient3461"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop872"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0" />
       <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop874"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop876"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2487"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(4.772373e-2,0,0,2.325004e-2,0.7606733,23.481385)" />
-    <linearGradient
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient2454"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4456368,0,0,0.3243297,34.628984,-32.463266)" />
-    <linearGradient
-       id="linearGradient3668">
-      <stop
-         id="stop3670"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3672"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.757765"
-       fy="37.841019"
-       id="radialGradient2451"
-       xlink:href="#linearGradient3668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0091641,-0.1636283,2.2026911e-2,0.9432895,23.014711,0.9649117)" />
-    <linearGradient
-       id="linearGradient2372">
-      <stop
-         id="stop2374"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2376"
-         style="stop-color:#ffffff;stop-opacity:0.34482759"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="28.503141"
-       y1="137.53885"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient2448"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3228678,0,0,0.3243297,19.695285,-29.783826)" />
-    <linearGradient
-       id="linearGradient7067">
-      <stop
-         id="stop7069"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7071"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.68769"
-       fy="37.45607"
-       id="radialGradient2445"
-       xlink:href="#linearGradient7067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9584434,-0.1715415,3.3651004e-2,0.9119853,5.8299551,5.1403631)" />
   </defs>
+  <rect
+     width="39"
+     height="39"
+     rx="2.0526314"
+     ry="2.0526314"
+     x="4.5"
+     y="4.5"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="37"
+     height="37"
+     x="5.5012512"
+     y="5.4987478"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="39"
+     height="39"
+     rx="2.0526314"
+     ry="2.0526314"
+     x="4.5"
+     y="4.5"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <g
-     id="layer1">
-    <rect
-       width="23.043743"
-       height="5.6464386"
-       x="6.4781284"
-       y="32.005966"
-       id="rect4173"
-       style="opacity:0.40206185;fill:url(#linearGradient2493);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="layer14"
+     transform="matrix(2,0,0,2,-1378.0004,964.384)">
     <path
-       d="M 6.4781291,32.006159 C 6.4781291,32.006159 6.4781291,37.652285 6.4781291,37.652285 C 4.0204748,37.662915 0.536718,36.387275 0.536718,34.828859 C 0.536718,33.270444 3.2792746,32.006159 6.4781291,32.006159 L 6.4781291,32.006159 z"
-       id="path5018"
-       style="opacity:0.40206185;fill:url(#radialGradient2490);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       width="18.985626"
-       height="32.985138"
-       rx="0"
-       ry="0"
-       x="8.5071878"
-       y="2.5"
-       id="rect3457"
-       style="fill:url(#linearGradient2478);fill-opacity:1;stroke:url(#linearGradient3487);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       d="M 9.471651,19.5 L 26.474626,19.5"
-       id="path3460"
-       style="fill:none;stroke:#333333;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="M 9.5,20.5 C 15.164886,20.5 20.829772,20.5 26.494658,20.5"
-       id="path3360"
-       style="opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;marker:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
-    <path
-       d="M 8.5,2.5074512 C 8.5,6.5693327 8.5,29.871705 8.5,35.499548 C 6.8158614,35.499548 5.4022535,35.499548 3.7181147,35.499548 C 3.3087664,35.108905 3.6200397,34.333318 3.522778,33.780288 C 3.522778,23.419199 3.522778,13.058112 3.522778,2.6970247 L 3.579865,2.5628542 L 3.7181147,2.5074512 L 3.7181147,2.5074512 C 5.47096,2.5074512 6.7471548,2.5074512 8.5,2.5074512 z"
-       id="path3385"
-       style="fill:url(#radialGradient2484);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3508);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="4"
-       id="rect3464"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="8"
-       id="rect3466"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="12"
-       id="rect3468"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="16"
-       id="rect3470"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="20"
-       id="rect3474"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="24"
-       id="rect3476"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="28"
-       id="rect3478"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="5"
-       y="32"
-       id="rect3480"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <path
-       d="M 27.5,35.477909 C 27.5,33.290399 27.5,5.4100099 27.5,2.5069991 C 29.18284,2.5069991 30.638905,2.5069991 32.301972,2.5069991 C 32.538056,2.5069991 32.49732,3.5427151 32.49732,4.2251554 C 32.49732,14.57959 32.497322,24.934023 32.497322,35.288456 C 32.094774,35.68547 31.295558,35.383576 30.725671,35.477909 C 29.591345,35.477909 28.634326,35.477909 27.5,35.477909 z"
-       id="rect15391"
-       style="fill:url(#radialGradient2481);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3526);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="4"
-       id="rect3362"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="8"
-       id="rect3365"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="20"
-       id="rect3373"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="16"
-       id="rect3375"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="24"
-       id="rect3377"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="28"
-       id="rect3379"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="2"
-       height="2"
-       x="29"
-       y="32"
-       id="rect3381"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="27"
-       height="31.000002"
-       rx="0"
-       ry="0"
-       x="4.5"
-       y="3.5"
-       id="rect2689"
-       style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient3467);stroke-width:1.00000012;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="M 29.521871,32.006159 C 29.521871,32.006159 29.521871,37.652285 29.521871,37.652285 C 31.979525,37.662915 35.463284,36.387275 35.463282,34.828859 C 35.463282,33.270444 32.720725,32.006159 29.521871,32.006159 L 29.521871,32.006159 z"
-       id="path5058"
-       style="opacity:0.40206185;fill:url(#radialGradient2487);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="m 45.745331,7.4929592 c -6.00729,0.9606681 -12.031218,1.8233986 -18.033799,2.8086058 -1.63378,0.819876 -1.049147,2.902162 -1.154413,4.371015 -1e-6,6.355079 0,12.710159 0,19.065238 -4.194736,-0.934895 -9.035848,2.33778 -9.071714,6.783396 -0.188862,2.854893 2.565665,5.220454 5.336743,4.958998 3.756296,-0.19264 7.194805,-3.831353 6.792605,-7.716726 -1e-6,-6.35577 0,-13.702017 0,-20.057787 4.954052,-0.714335 9.897511,-1.499993 14.851364,-2.215678 -2e-6,4.899456 0,10.789389 0,15.688845 -4.019561,-1.157997 -8.855706,1.496573 -9.521772,5.740205 -0.556934,2.500827 1.190623,5.014395 3.577672,5.729118 4.468295,1.464696 9.466325,-2.855247 8.939333,-7.474862 -0.01247,-8.665068 0.03763,-17.330162 0,-25.9952042 C 47.356345,8.31683 46.68345,7.4494092 45.745331,7.4929592 Z"
-       id="path3406"
-       style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       d="m 44.985349,31.831 0.05939,-16.721737 c 0.625919,-0.08136 0.0961,-0.01312 0.940128,-0.134964 0.01157,3.086113 0.01586,5.725277 0.01586,17.380701 0,0.08673 -0.382517,-0.368234 -1.015378,-0.524 z"
-       id="path3996"
-       style="opacity:0.4;fill:url(#linearGradient2454);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="M 46.92532,35.918255 C 46.92532,38.863042 44.332575,41.691596 41.134261,42.236007 C 37.935947,42.780418 35.343201,40.834529 35.343201,37.889742 C 35.343201,34.944954 37.935947,32.116398 41.134261,31.571987 C 44.332575,31.027576 46.92532,32.973467 46.92532,35.918255 z"
-       id="path2716"
-       style="opacity:0.6;fill:url(#radialGradient2451);fill-opacity:1;stroke:none" />
-    <path
-       d="M 27.061539,34.460235 L 27.061539,11.989291 C 27.061539,11.989291 27.178518,10.742467 28.2369,10.73817 C 28.32885,10.897434 46.093006,7.8560634 46.093006,7.8560634 C 46.093006,7.8560634 46.772805,8.9592907 39.090635,10.062755 C 28.156188,11.633374 28.061539,11.695966 28.061539,12.824623 C 28.061539,16.153779 28.061539,22.867344 28.061539,34.989291 C 27.826437,34.78867 27.533073,34.580048 27.061539,34.460235 L 27.061539,34.460235 z"
-       id="path2720"
-       style="opacity:0.4;fill:url(#linearGradient2448);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="M 29.06154,38.705709 C 29.06154,41.553963 26.599107,44.289794 23.561541,44.816359 C 20.523974,45.342924 18.06154,43.460823 18.06154,40.612568 C 18.06154,37.764314 20.523974,35.028481 23.561541,34.501916 C 26.599107,33.975351 29.06154,35.857454 29.06154,38.705709 z"
-       id="path2712"
-       style="opacity:0.6;fill:url(#radialGradient2445);fill-opacity:1;stroke:none" />
+       inkscape:connector-curvature="0"
+       d="m 698.99439,-475.39289 c -0.554,0.14844 -1,0.73897 -1,1.3125 v 7.0933 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34976,0.35071 -2.19558,1.48415 -1.90625,2.53125 0.28933,1.0471 1.61899,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07146 1.9375,-1.90625 l 0.0312,-7.09369 5.99963,-1.62463 v 5.53094 c -0.56177,-0.29416 -1.28326,-0.4131 -2.03125,-0.21875 -1.34975,0.35071 -2.19557,1.48415 -1.90625,2.53125 0.28933,1.0471 1.619,1.63196 2.96875,1.28125 1.07683,-0.27979 1.81912,-1.07145 1.9375,-1.90625 l 0.0312,-9.43651 c 0,-0.43016 -0.2677,-0.88338 -0.625,-0.81269 -2.15319,0.426 -4.24977,1.10385 -6.37453,1.65578 z"
+       id="path16590"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       sodipodi:nodetypes="cscsssccccsssccsc" />
   </g>
 </svg>

--- a/elementary-xfce/categories/64/applications-multimedia.svg
+++ b/elementary-xfce/categories/64/applications-multimedia.svg
@@ -1,495 +1,135 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
+   version="1.1"
    width="64"
    height="64"
-   id="svg3645">
+   id="svg9767"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="45.519999"
+     inkscape:cy="27.046834"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="487"
+     inkscape:window-y="9"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg9767"
+     inkscape:snap-global="false" />
+  <defs
+     id="defs9769">
+    <linearGradient
+       id="linearGradient1258">
+      <stop
+         id="stop1250"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1252"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop1254"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1256"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient864">
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop860" />
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="1"
+         id="stop862" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient864"
+       id="linearGradient866-3"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.8947365,0,0,2.8947365,-25.894731,-2.7368357)" />
+    <linearGradient
+       gradientTransform="matrix(1.4324326,0,0,1.4324325,-2.3783899,-2.378368)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient1258"
+       id="linearGradient5397-6"
+       y2="41.414486"
+       x2="30.526697"
+       y1="6.5909567"
+       x1="30.526697" />
+  </defs>
   <metadata
-     id="metadata201261">
+     id="metadata9772">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs3647">
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2704"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06425912,0,0,0.03294261,-2.7264193,29.921384)" />
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient2738"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05798817,0,0,0.03294117,1.0414214,29.922185)" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2735"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.06425912,0,0,0.03294261,46.726428,29.921384)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#2e4a5a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#6e8796;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="53.623615"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2761"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8907504,0,0,0.897368,62.028164,-0.09276433)" />
-    <linearGradient
-       id="linearGradient3993">
-      <stop
-         id="stop3995"
-         style="stop-color:#a3c0d0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4001"
-         style="stop-color:#427da1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="14.76559"
-       cy="10.898237"
-       r="18.000002"
-       fx="14.76559"
-       fy="10.898237"
-       id="radialGradient2759"
-       xlink:href="#linearGradient3993"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.5043855e-8,2.1417804,-3.9271891,-3.7952071e-8,56.744744,-21.611305)" />
-    <linearGradient
-       x1="16.745687"
-       y1="46.132927"
-       x2="16.745687"
-       y2="1.4097958"
-       id="linearGradient2799"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9390161,0,0,0.9685595,-9.9949431,2.3255007)" />
-    <linearGradient
-       x1="-22.539846"
-       y1="11.109024"
-       x2="-22.539846"
-       y2="46.263954"
-       id="linearGradient2797"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8780592,0,0,1.005124,33.683618,1.4039638)" />
-    <linearGradient
-       id="linearGradient3582">
-      <stop
-         id="stop3584"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3586"
-         style="stop-color:#5a5a5a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.745687"
-       y1="46.132927"
-       x2="16.745687"
-       y2="1.4097958"
-       id="linearGradient2803"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.94249645,0,0,0.96733084,-10.081993,2.2996837)" />
-    <linearGradient
-       id="linearGradient3932">
-      <stop
-         id="stop3934"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3936"
-         style="stop-color:#434343;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-22.539846"
-       y1="11.109024"
-       x2="-22.539846"
-       y2="46.263954"
-       id="linearGradient2801"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88131363,0,0,1.0038489,33.758456,1.3793159)" />
-    <linearGradient
-       id="linearGradient3461">
-      <stop
-         id="stop3463"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3465"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.722891"
-       y1="3"
-       x2="16.722891"
-       y2="35.055153"
-       id="linearGradient2711"
-       xlink:href="#linearGradient3461"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3704188,0,0,1.3548813,-1.6675427,-0.2427393)" />
-    <linearGradient
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient2698"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5926969,0,0,0.4313585,45.147714,-45.096144)" />
-    <linearGradient
-       id="linearGradient2372">
-      <stop
-         id="stop2374"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2376"
-         style="stop-color:#ffffff;stop-opacity:0.34482759"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="28.503141"
-       y1="137.53885"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient3642"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.43156223,0,0,0.4313585,25.099436,-39.532831)" />
-    <linearGradient
-       id="linearGradient3668">
-      <stop
-         id="stop3670"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3672"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.757765"
-       fy="37.841019"
-       id="radialGradient3634"
-       xlink:href="#linearGradient3668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3489023,-0.2176256,0.02944234,1.254575,29.536356,-0.63700841)" />
-    <linearGradient
-       id="linearGradient7067">
-      <stop
-         id="stop7069"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7071"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.68769"
-       fy="37.45607"
-       id="radialGradient3622"
-       xlink:href="#linearGradient7067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3682213,-0.24366446,0.04803835,1.2954203,4.7548569,3.6201773)" />
-    <linearGradient
-       xlink:href="#linearGradient2372-1"
-       id="linearGradient3025"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.59566175,0,0,0.4313585,45.060332,-45.096486)"
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074" />
-    <linearGradient
-       id="linearGradient2372-1">
-      <stop
-         id="stop2374-7"
-         style="stop-color:white;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2376-8"
-         style="stop-color:white;stop-opacity:0.34482759"
-         offset="1" />
-    </linearGradient>
-  </defs>
+  <rect
+     width="55"
+     height="55"
+     rx="3.5"
+     ry="3.5"
+     x="4.5"
+     y="4.5"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="53"
+     height="53"
+     x="5.5"
+     y="5.5"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="2.5"
+     ry="2.5" />
+  <rect
+     width="55"
+     height="55"
+     rx="3.5"
+     ry="3.5"
+     x="4.5"
+     y="4.5"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2704);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-     id="path5058"
-     d="m 36,42 c 0,0 0,7.999906 0,7.999906 3.309186,0.01506 8.000002,-1.792372 8,-4.000468 C 44,43.791346 40.307198,42 36,42 l 0,0 0,0 z" />
-  <rect
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#linearGradient2738);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-     id="rect4173"
-     y="42"
-     x="8"
-     height="8"
-     width="28" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path1406"
+     d="m 46.075702,13 c 1.105626,0.186092 1.923986,1.375453 1.923986,2.69837 v 27.976224 c -0.36442,2.567349 -2.745564,5.002024 -6.060442,5.86249 -4.155074,1.078576 -8.248258,-0.720106 -9.138934,-3.940362 -0.890662,-3.220254 1.713086,-6.706042 5.86816,-7.784616 2.30259,-0.597704 4.601828,-0.231916 6.331162,0.672745 V 24.059625 l -18.999641,4.665629 v 20.099691 c -0.36442,2.567348 -2.666972,5.002022 -5.98185,5.86249 -4.155074,1.078576 -7.936776,-0.919716 -8.827438,-4.139972 -0.89066,-3.220254 1.40159,-6.50643 5.556666,-7.585006 2.302588,-0.597704 4.523,-0.231916 6.252332,0.672746 V 21.997808 c 0,-1.763868 1.373558,-3.579956 3.07899,-4.036468 L 46.075812,13 h 1.1e-4"
+     sodipodi:nodetypes="cscsssccccssscsccc" />
   <path
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2735);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-     id="path5018"
-     d="m 8,42 c 0,0 0,7.999906 0,7.999906 C 4.690814,50.01497 0,48.207534 0,45.999438 0,43.791346 3.6928017,42 8,42 l 0,0 0,0 z" />
-  <rect
-     style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2759);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2761);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect3457"
-     y="3.4999609"
-     x="10.499961"
-     ry="0"
-     rx="0"
-     height="44.00008"
-     width="25.000078" />
-  <path
-     style="fill:none;stroke:#333333;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="path3460"
-     d="m 11.5,26.5 22.983652,0" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-     id="path3360"
-     d="m 11.500366,27.500002 c 7.666659,0 15.333315,0 22.999972,0" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2797);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2799);stroke-width:0.97335815;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path3385"
-     d="m 10.51317,3.4866942 c 0,5.4204174 0,36.5164968 0,44.0266268 -2.3667663,0 -4.3533493,0 -6.7201169,0 -0.5752686,-0.521297 -0.1378274,-1.556287 -0.2745122,-2.294283 0,-13.826456 0,-27.652911 0,-41.4793657 l 0.080226,-0.1790457 0.1942862,-0.073947 0,0 c 2.4633227,0 4.2567952,0 6.7201189,0 l -2e-6,1.5e-5 z" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3464"
-     y="5"
-     x="6"
-     height="2"
-     width="3" />
-  <path
-     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2801);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2803);stroke-width:0.97335815;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect15391"
-     d="m 35.486678,47.483025 c 0,-2.919009 0,-40.1225498 0,-43.996322 2.364832,0 4.410985,0 6.74803,0 0.331762,0 0.274518,1.3820564 0.274518,2.292704 0,13.81694 3e-6,27.633875 3e-6,41.450811 -0.565687,0.529776 -1.688795,0.126927 -2.489636,0.252807 -1.594026,0 -2.938888,0 -4.532915,0 l 0,0 z" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3766"
-     y="25"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3760"
-     y="5"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3772"
-     y="30"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient2711);stroke-width:0.99868685;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     id="rect2689"
-     y="4.4993439"
-     x="4.4993434"
-     ry="0"
-     rx="0"
-     height="42.001316"
-     width="37.001312" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3774"
-     y="40"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3768"
-     y="35"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3762"
-     y="10"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3776"
-     y="45"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3770"
-     y="20"
-     x="37"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3764"
-     y="15"
-     x="37"
-     height="2"
-     width="3" />
-  <path
-     style="opacity:0.4;fill:url(#linearGradient2698);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3996"
-     d="M 58.921679,40.149364 59.00067,18.17532 c 0.832473,-0.108209 -0.161228,-0.01745 0.96133,-0.179502 0.01539,4.10453 0,6.869076 0,22.37079 0,0.115351 -0.174707,-0.0579 -1.040325,-0.217244 l 4e-6,0 0,0 z" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3744"
-     y="10"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3746"
-     y="15"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3748"
-     y="25"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3750"
-     y="35"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3752"
-     y="20"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3754"
-     y="30"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3756"
-     y="40"
-     x="6"
-     height="2"
-     width="3" />
-  <rect
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     id="rect3758"
-     y="45"
-     x="6"
-     height="2"
-     width="3" />
-  <g
-     id="g4213">
-    <path
-       d="M 60.221217,8.0456586 36.116286,13.780739 c -2.183797,1.090436 -1.402345,3.859876 -1.54305,5.81345 l 0,25.456811 C 28.291771,43.304931 21.74388,47.82059 21.648,53.972958 c -0.01275,3.749068 3.618738,6.931485 7.884936,6.643321 5.020866,-0.256211 9.46392,-5.143639 8.926318,-10.311185 l 0,-26.676856 20.052098,-4.946852 0,20.866164 c -5.372758,-1.540136 -11.837007,1.990442 -12.727306,7.634472 -0.744427,3.3261 1.59145,6.669146 4.782106,7.619727 5.972561,1.948046 12.653192,-3.797478 11.948787,-9.941566 -0.01666,-11.524541 0.05029,-23.049116 0,-34.573622 C 62.374583,9.1410425 61.475156,7.9877371 60.221217,8.0456586 Z"
-       id="path3406"
-       style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="m 34.945549,45.711658 0.10022,-29.686243 c 0,0 0.362761,-1.623107 1.470839,-1.764415 0.355253,-0.261 23.86742,-5.7327771 23.86742,-5.7327771 0,0 0.501182,0.9980476 -9.441858,3.4714351 -12.060027,3 -14.961469,3.635635 -14.961469,5.136749 l 0,29.479008 c -0.314249,-0.266826 -0.404861,-0.544293 -1.03514,-0.703644 z"
-       id="path2720"
-       style="opacity:0.4;fill:url(#linearGradient3642);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 61.496544,45.850937 c 0,3.916567 -3.465601,7.678544 -7.740636,8.40261 -4.275036,0.724067 -7.740638,-1.863965 -7.740638,-5.780532 0,-3.916568 3.465602,-7.678548 7.740638,-8.402614 4.275035,-0.724067 7.740636,1.863968 7.740636,5.780536 l 0,0 z"
-       id="path2716"
-       style="opacity:0.6;fill:url(#radialGradient3634);fill-opacity:1;stroke:none" />
-    <path
-       d="m 37.919,51.297735 c 0,4.04578 -3.515238,7.93186 -7.851499,8.679813 -4.336262,0.747953 -7.851501,-1.92546 -7.851501,-5.971233 0,-4.04577 3.515239,-7.931862 7.851501,-8.679816 4.336261,-0.747952 7.851499,1.925464 7.851499,5.971236 z"
-       id="path2712"
-       style="opacity:0.6;fill:url(#radialGradient3622);fill-opacity:1;stroke:none" />
-    <path
-       d="m 58.903197,40.149022 0.07939,-21.974044 c 0.836638,-0.108209 -0.162034,-0.01745 0.966139,-0.179502 0.01547,4.10453 0,6.869076 0,22.37079 0,0.115351 -0.17558,-0.0579 -1.045529,-0.217244 l 4e-6,0 z"
-       id="path3996-1"
-       style="opacity:0.4;fill:url(#linearGradient3025);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-  </g>
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#fffdfd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path16590-0"
+     d="m 46.075702,12.000458 c 1.105626,0.186092 1.923986,1.375453 1.923986,2.69837 v 27.976224 c -0.36442,2.567349 -2.745564,5.002024 -6.060442,5.86249 -4.155074,1.078576 -8.248258,-0.720106 -9.138934,-3.940362 -0.890662,-3.220254 1.713086,-6.706042 5.86816,-7.784616 2.30259,-0.597704 4.601828,-0.231916 6.331162,0.672745 V 23.060083 l -18.999641,4.665629 v 20.099691 c -0.36442,2.567348 -2.666972,5.002022 -5.98185,5.86249 -4.155074,1.078576 -7.936776,-0.919716 -8.827438,-4.139972 -0.89066,-3.220254 1.40159,-6.50643 5.556666,-7.585006 2.302588,-0.597704 4.523,-0.231916 6.252332,0.672746 V 20.998266 c 0,-1.763868 1.373558,-3.579956 3.07899,-4.036468 l 19.997119,-4.96134 h 1.1e-4"
+     sodipodi:nodetypes="cscsssccccssscsccc" />
 </svg>

--- a/elementary-xfce/categories/96/applications-multimedia.svg
+++ b/elementary-xfce/categories/96/applications-multimedia.svg
@@ -1,500 +1,134 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="96"
    height="96"
-   id="svg3645">
+   id="svg2"
+   sodipodi:docname="applications-multimedia.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview80"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="28.549436"
+     inkscape:cy="51.795572"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="664"
+     inkscape:window-y="41"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
   <metadata
-     id="metadata201261">
+     id="metadata191584">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs3647">
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2704"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.09825958,0,0,0.05007547,-3.8690084,43.749482)" />
+     id="defs4">
     <linearGradient
-       id="linearGradient5048">
+       xlink:href="#linearGradient864"
+       id="linearGradient866"
+       x1="23.932209"
+       y1="2.4120836"
+       x2="23.932209"
+       y2="21.493765"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.1578943,0,0,4.1578943,-35.157887,-1.8947318)" />
+    <linearGradient
+       id="linearGradient864">
       <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0"
+         id="stop860" />
       <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="1"
+         id="stop862" />
     </linearGradient>
     <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient2738"
-       xlink:href="#linearGradient5048"
+       gradientTransform="matrix(2.0810812,0,0,2.0810812,-1.9459637,-1.9459318)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.08867058,0,0,0.05007328,1.8924531,43.750698)" />
+       xlink:href="#linearGradient878"
+       id="linearGradient5397"
+       y2="41.273151"
+       x2="30.526697"
+       y1="5.7558489"
+       x1="30.526697" />
     <linearGradient
-       id="linearGradient5060">
+       id="linearGradient878">
       <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient2735"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.09825958,0,0,0.05007547,71.750081,43.749482)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#2e4a5a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#6e8796;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="53.623615"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2761"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2470497,0,0,1.3664459,89.639755,-1.9704234)" />
-    <linearGradient
-       id="linearGradient3993">
-      <stop
-         id="stop3995"
-         style="stop-color:#a3c0d0;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4001"
-         style="stop-color:#427da1;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="14.76559"
-       cy="10.898237"
-       r="18.000002"
-       fx="14.76559"
-       fy="10.898237"
-       id="radialGradient2759"
-       xlink:href="#linearGradient3993"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-3.506137e-8,3.2613451,-5.4980603,-5.779061e-8,82.242967,-34.737269)" />
-    <linearGradient
-       x1="16.745687"
-       y1="46.132927"
-       x2="16.745687"
-       y2="1.4097958"
-       id="linearGradient2799"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6079296,0,0,1.4747661,-17.603536,1.7089339)" />
-    <linearGradient
-       x1="-22.539846"
-       y1="11.109024"
-       x2="-22.539846"
-       y2="46.263954"
-       id="linearGradient2797"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5035497,0,0,1.5304407,57.189695,0.30576597)" />
-    <linearGradient
-       id="linearGradient3582">
-      <stop
-         id="stop3584"
-         style="stop-color:#333333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3586"
-         style="stop-color:#5a5a5a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.745687"
-       y1="46.132927"
-       x2="16.745687"
-       y2="1.4097958"
-       id="linearGradient2803"
-       xlink:href="#linearGradient3582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6146264,0,0,1.4729824,-25.578408,1.6791642)" />
-    <linearGradient
-       id="linearGradient3932">
-      <stop
-         id="stop3934"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3936"
-         style="stop-color:#434343;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-22.539846"
-       y1="11.109024"
-       x2="-22.539846"
-       y2="46.263954"
-       id="linearGradient2801"
-       xlink:href="#linearGradient3932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5098122,0,0,1.5285894,49.526338,0.27769385)" />
-    <linearGradient
-       id="linearGradient3461">
-      <stop
-         id="stop3463"
+         id="stop870"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3465"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop872"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03683824" />
+      <stop
+         id="stop874"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="16.722891"
-       y1="3"
-       x2="16.722891"
-       y2="35.055153"
-       id="linearGradient2711"
-       xlink:href="#linearGradient3461"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.111134,0,0,2.0968394,-3.0004105,-2.8399402)" />
-    <linearGradient
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient2698"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.90623783,0,0,0.65565371,97.902542,-70.273048)" />
-    <linearGradient
-       id="linearGradient2372">
       <stop
-         id="stop2374"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2376"
-         style="stop-color:#ffffff;stop-opacity:0.34482759"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="28.503141"
-       y1="137.53885"
-       x2="26.256771"
-       y2="125.39074"
-       id="linearGradient3642"
-       xlink:href="#linearGradient2372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6565774,0,0,0.65565371,65.070707,-61.270813)" />
-    <linearGradient
-       id="linearGradient3668">
-      <stop
-         id="stop3670"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3672"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.058823"
-       cy="41.058823"
-       r="5.7384715"
-       fx="14.757765"
-       fy="37.841019"
-       id="radialGradient3634"
-       xlink:href="#linearGradient3668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1967087,-0.35407535,0.0479473,2.0411849,70.161217,-6.3103769)" />
-    <linearGradient
-       id="linearGradient7067">
-      <stop
-         id="stop7069"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7071"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="17.102713"
-       cy="40.675251"
-       r="5.7384715"
-       fx="14.731584"
-       fy="37.072498"
-       id="radialGradient3622"
-       xlink:href="#linearGradient7067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0870229,-0.46374376,0.15494142,1.9697281,30.013799,7.1254451)" />
-    <linearGradient
-       xlink:href="#linearGradient2372-1"
-       id="linearGradient3025"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.85326785,0,0,0.63758931,97.170909,-65.643269)"
-       x1="28.739122"
-       y1="144.11652"
-       x2="26.256771"
-       y2="125.39074" />
-    <linearGradient
-       id="linearGradient2372-1">
-      <stop
-         id="stop2374-7"
-         style="stop-color:white;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2376-8"
-         style="stop-color:white;stop-opacity:0.34482759"
+         id="stop876"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
   </defs>
-  <g
-     id="g4286"
-     transform="translate(0,1.000004)">
-    <path
-       d="m 55.348139,62.109968 c 0,0 0,12.160471 0,12.160471 5.060124,0.02281 12.232924,-2.72451 12.232921,-6.080998 0,-3.356482 -5.64672,-6.079473 -12.232921,-6.079473 l 0,0 0,0 z"
-       id="path5058"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2704);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <rect
-       width="42.815212"
-       height="12.160657"
-       x="12.532922"
-       y="62.109974"
-       id="rect4173"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#linearGradient2738);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="m 12.53292,62.109968 c 0,0 0,12.160471 0,12.160471 C 7.4727938,74.293332 0.3,71.545929 0.3,68.189441 c 0,-3.356482 5.6467185,-6.079473 12.23292,-6.079473 l 0,0 0,0 z"
-       id="path5018"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2735);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <rect
-       width="35.000076"
-       height="67.000076"
-       rx="0"
-       ry="0"
-       x="17.500313"
-       y="3.5003123"
-       id="rect3457"
-       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2759);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2761);stroke-width:0.99992168;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <path
-       d="m 17.500351,37.50035 34.999649,0"
-       id="path3460"
-       style="fill:none;stroke:#333333;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="m 18.500476,38.500351 c 11.66635,0 23.332697,0 34.999044,0"
-       id="path3360"
-       style="display:block;overflow:visible;visibility:visible;opacity:0.36637932;fill:none;stroke:#ffffff;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
-    <path
-       d="m 17.50298,3.48702 0.01068,67.026642 -12.0212928,0 0,-3.493363 -0.00535,-63.533279 z"
-       id="path3385"
-       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2797);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2799);stroke-width:0.97335798;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="8.0000029"
-       id="rect3464"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <path
-       d="m 52.487022,70.481124 0,-66.9944519 12.026642,0 -0.009,67.0266449 -12.017661,-0.03219 z"
-       id="rect15391"
-       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2801);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2803);stroke-width:0.97335798;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-    <rect
-       width="57.000614"
-       height="65.002014"
-       rx="0"
-       ry="0"
-       x="6.4996939"
-       y="4.4989934"
-       id="rect2689"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient2711);stroke-width:0.99868685;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="15.000003"
-       id="rect3744"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="22.000004"
-       id="rect3746"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="36.000004"
-       id="rect3748"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="50.000004"
-       id="rect3750"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="29.000004"
-       id="rect3752"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="10"
-       y="43.000004"
-       id="rect3754"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="2.9999995"
-       x="10"
-       y="57.000004"
-       id="rect3756"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="2.9999995"
-       x="10"
-       y="64"
-       id="rect3758"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="8.0000029"
-       id="rect3464-8"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="15.000003"
-       id="rect3744-1"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="22.000004"
-       id="rect3746-3"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="36.000004"
-       id="rect3748-7"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="50.000004"
-       id="rect3750-3"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="29.000004"
-       id="rect3752-0"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="3.0000002"
-       x="55"
-       y="43.000004"
-       id="rect3754-2"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="2.9999995"
-       x="55"
-       y="57.000004"
-       id="rect3756-0"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-    <rect
-       width="5"
-       height="2.9999995"
-       x="55"
-       y="64"
-       id="rect3758-9"
-       style="fill:#ffffff;fill-opacity:1;stroke:none" />
-  </g>
-  <g
-     id="g4320"
-     transform="translate(-29.00035,1.000004)">
-    <path
-       d="m 118.96303,59.297912 0.12079,-33.399976 c 1.27286,-0.164476 -0.24653,-0.02654 1.46984,-0.272839 0.0236,6.238781 0,10.440818 0,34.00302 0,0.175329 -0.26709,-0.08801 -1.59063,-0.330205 l 0,0 0,0 z"
-       id="path3996"
-       style="opacity:0.4;fill:url(#linearGradient2698);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 119.02269,11.825286 -37.110293,8.7386 c -3.355225,1.661509 -2.154585,5.881332 -2.370773,8.858013 l 0,38.636362 c -9.23954,-3.144597 -19.956046,2.722008 -20.041274,13.146735 0.171243,4.732728 2.474545,8.075416 8.037151,9.849 10.247081,2.622861 18.711333,-7.558226 17.974667,-14.837597 l 0,-40.647779 30.983182,-7.63762 0,31.894039 c -8.25481,-2.346723 -18.286305,3.032857 -19.654172,11.632721 -1.14375,5.06798 2.445129,10.161807 7.347302,11.610236 9.17634,2.968228 19.44059,-5.786301 18.35832,-15.148045 -0.0256,-17.560059 0.0773,-35.120173 0,-52.680179 -0.21564,-1.745439 -1.59752,-3.502745 -3.52411,-3.414486 z"
-       id="path3406"
-       style="fill:#4d4d4d;fill-opacity:1;stroke:#333333;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-    <path
-       d="m 80.050551,68.298597 0,-43.795544 c -0.09988,5.1e-5 0.231088,-3.335277 2.859999,-3.639477 0.845463,-0.335588 35.84203,-8.51358 35.84203,-8.51358 0,0 0.76249,0.947752 -14.36482,4.707237 -18.348087,4.559922 -22.78741,5.52607 -22.78741,7.807726 l 0,44.843412 c -0.478098,-0.405568 -0.687568,-0.637023 -1.549784,-1.105609 z"
-       id="path2720"
-       style="opacity:0.4;fill:url(#linearGradient3642);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-    <path
-       d="m 122.20892,69.325186 c 0,6.372153 -5.64387,12.492915 -12.60578,13.670996 -6.96196,1.177977 -12.605747,-3.032694 -12.605747,-9.404901 0,-6.372226 5.643787,-12.492936 12.605747,-13.670983 6.96191,-1.178061 12.60578,3.032656 12.60578,9.404888 l 0,0 z"
-       id="path2716"
-       style="opacity:0.6;fill:url(#radialGradient3634);fill-opacity:1;stroke:none" />
-    <path
-       d="m 85.014655,78.025417 c 0,6.165491 -6.422643,11.68776 -13.036982,12.827579 -6.753486,1.209399 -11.22652,-4.670515 -11.976323,-8.69987 -1.194889,-6.4212 4.352206,-13.576093 11.663823,-14.186699 6.771141,-1.609575 13.481329,3.49859 13.349482,10.05899 z"
-       id="path2712"
-       style="opacity:0.6;fill:url(#radialGradient3622);fill-opacity:1;stroke:none" />
-    <path
-       d="m 117.00039,60.458282 -4e-5,-33.063709 1.6,-0.365577 c 0.0224,6.066891 0,11.519982 0,34.433 0,0.1705 -0.55822,-0.640595 -1.59998,-1.003714 l 0,0 z"
-       id="path3996-1"
-       style="opacity:0.4;fill:url(#linearGradient3025);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-  </g>
+  <rect
+     width="79"
+     height="79"
+     rx="4.1578941"
+     ry="4.1578941"
+     x="8.5"
+     y="8.5"
+     id="rect5505-21-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient866);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="77"
+     height="77"
+     x="9.499999"
+     y="9.499999"
+     id="rect6741-9-0"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient5397);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="3.0821075"
+     ry="3.0821075" />
+  <rect
+     width="79"
+     height="79"
+     rx="4"
+     ry="4"
+     x="8.5"
+     y="8.5"
+     id="rect5505-21-8-1-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#a62100;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path988"
+     d="m 66.51527,21.107 c 1.437286,0.241916 2.485133,1.528574 2.485133,3.248332 v 37.726705 c -0.473737,3.337486 -3.553164,6.502503 -7.862422,7.621089 -5.401492,1.40212 -10.722526,-0.93612 -11.880384,-5.122373 -1.157838,-4.186249 2.226969,-8.717684 7.628461,-10.119803 2.993308,-0.777002 5.866256,-0.301487 8.114345,0.874549 V 35.224753 L 39,42.720904 v 26.357081 c -0.473736,3.337488 -3.567496,6.502501 -7.876754,7.621088 -5.401492,1.402121 -10.722546,-0.936118 -11.880384,-5.122371 -1.157839,-4.186249 2.226969,-8.717683 7.628461,-10.119806 2.993308,-0.776999 5.880574,-0.301484 8.128663,0.874553 V 33.975394 c 0,-2.292982 1.784803,-4.653852 4.001822,-5.247306 L 66.51541,21.107 h 1.4e-4"
+     sodipodi:nodetypes="cscscsccccssscsccc" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path16590-0-5"
+     d="m 66.51527,20.106962 c 1.437286,0.241916 2.485133,1.528574 2.485133,3.248332 v 37.726705 c -0.473737,3.337486 -3.553164,6.502503 -7.862422,7.621089 -5.401492,1.40212 -10.722526,-0.93612 -11.880384,-5.122373 -1.157838,-4.186249 2.226969,-8.717684 7.628461,-10.119803 2.993308,-0.777002 5.866256,-0.301487 8.114345,0.874549 V 34.224715 L 39,41.720866 v 26.357081 c -0.473736,3.337488 -3.567496,6.502501 -7.876754,7.621088 -5.401492,1.402121 -10.722546,-0.936118 -11.880384,-5.122371 -1.157839,-4.186249 2.226969,-8.717683 7.628461,-10.119806 2.993308,-0.776999 5.880574,-0.301484 8.128663,0.874553 V 32.975356 c 0,-2.292982 1.784803,-4.653852 4.001822,-5.247306 L 66.51541,20.106962 h 1.4e-4"
+     sodipodi:nodetypes="cscscsccccssscsccc" />
 </svg>

--- a/elementary-xfce/categories/symbolic/applications-multimedia-symbolic.svg
+++ b/elementary-xfce/categories/symbolic/applications-multimedia-symbolic.svg
@@ -1,14 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   height="16"
+   id="svg6"
+   version="1.1"
    width="16"
-   id="svg2"
-   version="1.1">
+   height="16"
+   sodipodi:docname="applications-multimedia-symbolic.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="5.9993591"
+     inkscape:cy="10.69499"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="544"
+     inkscape:window-y="76"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6" />
   <metadata
      id="metadata12">
     <rdf:RDF>
@@ -22,15 +44,8 @@
   </metadata>
   <defs
      id="defs10" />
-  <g
-     color="#bebebe"
-     transform="translate(-892 -464)"
-     id="g4">
-    <path
-       d="M893.75 464a.748.748 0 0 0-.75.75v13.5c0 .415.335.75.75.75h5.28a1.9 1.9 0 0 1 .365-1H896.5a.499.499 0 0 1-.5-.5v-5c0-.277.223-.5.5-.5h4.674a1.518 1.518 0 0 1 1.015-.852l.541-.148h-6.23a.499.499 0 0 1-.5-.5v-5c0-.277.223-.5.5-.5h7c.277 0 .5.223.5.5v5c0 .057-.014.11-.031.16l2.31-.635-.008.004c.203-.057.424-.071.637-.03a1 1 0 0 1 .092.022v-5.271a.748.748 0 0 0-.75-.75zm.25 1h1v1h-1zm11 0h1v1h-1zm-11 2h1v1h-1zm11 0h1v1h-1zm-11 2h1v1h-1zm11 0h1v1h-1zm1.723 1.98a.385.385 0 0 0-.178.01l-4.09 1.124c-.252.069-.455.348-.455.625V478a.988 1.508 82.262 0 0-.87.04.988 1.508 82.262 0 0-1.083 1.29.988 1.508 82.262 0 0 1.822.58.988 1.508 82.262 0 0 1.13-1.086H903v-5.015l3-.823V477a.988 1.508 82.262 0 0-.87.04.988 1.508 82.262 0 0-1.083 1.29.988 1.508 82.262 0 0 1.822.58.988 1.508 82.262 0 0 1.129-1.053H907v-6.492c0-.207-.114-.354-.277-.384zM894 471h1v1h-1zm0 2h1v1h-1zm0 2h1v1h-1zm0 2h1v1h-1z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path6" />
-  </g>
+  <path
+     id="path2"
+     style="color:#000000;font-variation-settings:normal;opacity:1;vector-effect:none;fill:#666666;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="M 2.5 1 C 1.669 1 1 1.669 1 2.5 L 1 13.5 C 1 14.331 1.669 15 2.5 15 L 13.5 15 C 14.331 15 15 14.331 15 13.5 L 15 2.5 C 15 1.669 14.331 1 13.5 1 L 2.5 1 z M 10.636719 4 C 10.666452 3.9984423 10.695396 4.0007334 10.722656 4.0058594 C 10.886229 4.0366285 11 4.182875 11 4.390625 L 11 10.716797 C 11.003761 10.765897 11.003882 10.815111 11 10.865234 L 11 10.882812 L 10.998047 10.880859 C 10.934469 11.560291 10.170342 12.057445 9.28125 11.994141 C 8.3853676 11.930353 7.7006678 11.322168 7.7539062 10.634766 C 7.8038175 9.9903253 8.4837311 9.5054978 9.3066406 9.5 C 9.3615013 9.4996335 9.4166637 9.5018726 9.4726562 9.5058594 C 9.6592983 9.5191486 9.8364528 9.5569417 10 9.6132812 L 10 6.0117188 L 7 6.8339844 L 7 11.337891 C 7.0037194 11.391266 7.0037424 11.445531 7 11.5 C 6.9999549 11.500656 7.0000462 11.501297 7 11.501953 C 6.9467773 12.258095 6.1749148 12.814308 5.2792969 12.744141 C 4.3836791 12.673974 3.7006838 12.00419 3.7539062 11.248047 C 3.8038028 10.539163 4.483974 10.006047 5.3066406 10 C 5.3614851 9.9995969 5.4166801 10.001474 5.4726562 10.005859 C 5.6595476 10.020502 5.8362488 10.062802 6 10.125 L 6 5.7636719 C 6 5.4866719 6.2027663 5.2079829 6.4550781 5.1386719 L 10.544922 4.015625 C 10.576462 4.00696 10.606985 4.0015577 10.636719 4 z " />
 </svg>


### PR DESCRIPTION
Proposal for a new multimedia category icon. This is more legible at small sizes, less busy, and easier to see in dark themes. The music note matches the audio mime icon in style and color.

![e-xfce-multimedia](https://user-images.githubusercontent.com/1984060/180084389-8a738749-2be8-46c4-b278-0e8a4ddeb001.png)