### PR TITLE
Update LibreOffice icons

### DIFF
--- a/elementary-xfce/apps/128/libreoffice-base.svg
+++ b/elementary-xfce/apps/128/libreoffice-base.svg
@@ -1,134 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.0"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3331"
+   sodipodi:docname="libreoffice-base.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.6640625"
+     inkscape:cx="46.545455"
+     inkscape:cy="59.870968"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="676"
+     inkscape:window-y="47"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3242-593-605-251-305"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,138 +61,186 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3242-593-605-251-305">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2749"
-         style="stop-color:#d78ec1;stop-opacity:1"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2751"
-         style="stop-color:#c564be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop2753"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop2755"
-         style="stop-color:#5e2c73;stop-opacity:1"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3332-412-419-652-471">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         id="stop2759"
-         style="stop-color:#650d5c;stop-opacity:1"
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2761"
-         style="stop-color:#ad53a5;stop-opacity:1"
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.729731,0,0,2.7297285,-1.513514,1.4865182)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8727273,0,0,1.8727273,4.0727275,7.0727249)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9999964,0,0,2.008692,7.0000024e-6,2.4608829)" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4097"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
   </defs>
-  <metadata
-     id="metadata4212">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       d="m 17.5,-43.499995 61.944628,0 31.055372,30.557142 0,62.442852 -93,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="opacity:0.86046543;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path4255"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       transform="matrix(2.4463758,0,0,2.6188144,5.2869808,-46.32737)" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 18,-42.999994 61.152918,0 L 110,-13.235292 110,49 18,49 z"
-       id="path3102" />
-    <path
-       style="fill:none;stroke:#813384;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 36.041419,-10.476068 c 0,1.766224 0,11.979686 0,13.597806 0,5.439088 13.942124,10.903616 27.95858,10.878174 13.941924,-0.0253 27.95858,-5.439086 27.95858,-10.878174 0,-1.915468 0,-11.900186 0,-13.597806"
-       id="path4358" />
-    <path
-       style="fill:#951fa6;fill-opacity:0.5977654;fill-rule:nonzero;stroke:#813384;stroke-width:0.9265058;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path4247"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       transform="matrix(2.3298816,0,0,-1.9999999,8.0828388,27.999998)" />
-    <path
-       d="m 36.041419,-0.476068 c 0,1.766224 0,11.979686 0,13.597806 0,5.439088 13.942124,10.903616 27.95858,10.878174 13.941924,-0.0253 27.95858,-5.439086 27.95858,-10.878174 0,-1.91547 0,-11.900186 0,-13.597806"
-       style="fill:none;stroke:#813384;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path3992" />
-    <path
-       id="path3994"
-       style="fill:none;stroke:#813384;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 36.041419,9.523932 c 0,1.766224 0,11.979686 0,13.597806 0,5.439086 13.942124,10.903614 27.95858,10.878174 13.941924,-0.0253 27.95858,-5.439088 27.95858,-10.878174 0,-1.91547 0,-11.900186 0,-13.597806" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
-    <path
-       style="fill:#951fa6;fill-opacity:0.27374303;stroke:none"
-       d="m 36,-5 1,30 c 0,0 9.366095,9 26.999999,9 C 81.633905,34 92,24 92,24 L 91,-5 C 91,-5 78.694921,4 63.999999,4 49.305079,4 36,-5 36,-5 z"
-       id="path3996" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.499997"
+     x="12.5"
+     ry="5.2820516"
+     rx="5.2820516"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.499998"
+     x="13.5"
+     ry="3.8113203"
+     rx="3.8113208"
+     height="101"
+     width="101" />
+  <path
+     d="M 18.5,21.499997 H 83.999856 L 109.5,46.652106 V 112.5 h -91 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#452981;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 35,58 1,30 c 0,5.956265 14.588145,11.5 28,11.5 13.411855,0 29,-5.493557 29,-11.5 L 91.964286,58 C 91.964286,58 79.21974,68.5 64,68.5 48.78026,68.5 35,58 35,58 Z"
+     id="path3996"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 35.5,55 V 68 C 35.5,73.666627 49.712114,79.526414 64,79.499908 78.211911,79.473548 92.5,73.666627 92.5,68 V 55"
+     id="path4358"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247"
+     d="m 92.5,55.5 c 0.0042,-7.181051 -12.756936,-13 -28.5,-13 -15.743064,0 -28.50417,5.818949 -28.5,13 -0.0042,7.181051 12.756936,13 28.5,13 15.743064,0 28.50417,-5.818949 28.5,-13 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 35.5,64 c 0,1.840112 0,12.480844 0,14.166656 0,5.666627 14.212114,11.359758 28.5,11.333252 14.211911,-0.02636 28.5,-5.666625 28.5,-11.333252 0,-1.995601 0,-12.398018 0,-14.166656"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992" />
+  <path
+     id="path3994"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 35.5,74 V 88 C 35.5,93.666624 49.712114,99.52641 64,99.49991 78.211911,99.47351 92.5,93.666624 92.5,88 V 74"
+     sodipodi:nodetypes="cscsc" />
 </svg>

--- a/elementary-xfce/apps/128/libreoffice-draw.svg
+++ b/elementary-xfce/apps/128/libreoffice-draw.svg
@@ -1,134 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.0"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3331"
+   sodipodi:docname="libreoffice-draw.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.328125"
+     inkscape:cx="57.337243"
+     inkscape:cy="60.527859"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="47"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3846-5"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient3856-6"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,131 +61,225 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3846-5">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop3848-48"
-         style="stop-color:#fff3cb;stop-opacity:1"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3850-1"
-         style="stop-color:#fdde76;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3852-28"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3854-9"
-         style="stop-color:#e48b20;stop-opacity:1"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3856-6">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         id="stop3858-8"
-         style="stop-color:#b67926;stop-opacity:1"
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3860-0"
-         style="stop-color:#eab41a;stop-opacity:1"
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.729731,0,0,2.7297285,-1.513514,1.4865182)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8727273,0,0,1.8727273,4.0727275,7.0727249)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9999964,0,0,2.008692,7.0000024e-6,2.4608829)" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4097"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       gradientTransform="matrix(2.7605228,0,0,2.6070199,-3.506062,-8.064025)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4102"
+       id="linearGradient3918"
+       y2="13.663627"
+       x2="16.887266"
+       y1="27.196552"
+       x1="30.913437" />
+    <linearGradient
+       id="linearGradient4102">
+      <stop
+         offset="0"
+         style="stop-color:#f9c440;stop-opacity:1"
+         id="stop4104" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4106" />
+    </linearGradient>
   </defs>
-  <metadata
-     id="metadata4212">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.499997"
+     x="12.5"
+     ry="5.2820516"
+     rx="5.2820516"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.499998"
+     x="13.5"
+     ry="3.8113203"
+     rx="3.8113208"
+     height="101"
+     width="101" />
+  <path
+     d="M 18.5,21.499997 H 83.999856 L 109.5,46.652106 V 112.5 h -91 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#ad5f00;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <g
+     id="g4227"
+     transform="translate(0,13.000017)">
     <path
-       d="m 17.5,-43.499995 61.944628,0 31.055372,30.557142 0,62.442852 -93,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       d="M 41.638982,84.702408 C 53.168454,92.088092 78.34069,82.207109 57.413234,55.764519 36.675224,29.5613 78.017552,12.37512 90.28574,42.678349"
+       id="path2783"
+       style="fill:url(#linearGradient3918);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
+       d="M 38.8664,31.951431 78.636186,81.615692"
+       id="path3571"
+       style="fill:none;fill-opacity:1;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 81.08573,81.872804 c 9.78e-4,1.450333 -1.176164,2.62658 -2.628572,2.62658 -1.452414,0 -2.629554,-1.176247 -2.628576,-2.62658 -9.78e-4,-1.450336 1.176162,-2.626583 2.628576,-2.626583 1.452408,0 2.62955,1.176247 2.628572,2.626583 z M 41.657116,32.001338 c 9.76e-4,1.450334 -1.176164,2.626581 -2.628576,2.626581 -1.45241,0 -2.62955,-1.176247 -2.628574,-2.626581 -9.76e-4,-1.450335 1.176164,-2.626582 2.628574,-2.626582 1.452412,0 2.629552,1.176247 2.628576,2.626582 z"
+       id="path3575"
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       d="m 34,80.999996 h 8 V 89 h -8 z"
+       id="path20772" />
+    <path
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       d="m 86,36.999974 h 8 v 8.000004 h -8 z"
+       id="path20770" />
+    <path
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       d="m 54,50.999981 h 8 v 8.000004 h -8 z"
+       id="rect3569" />
+    <path
+       d="m 35,81.999983 h 6 v 6 h -6 z"
+       id="path18832"
        style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 18,-42.999994 61.152918,0 L 110,-13.235292 110,49 18,49 z"
-       id="path3102" />
-    <g
-       id="g4631">
-      <path
-         id="path4025"
-         d="m 33.500001,32.5 18.3,-57 42.699998,57 z"
-         style="fill:#f3ba00;fill-opacity:0.42682932;stroke:#f3ba00;stroke-width:3;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         id="path5086"
-         d="m 49.5,-30.500001 5,0 0,5.000001 -5,0 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 29.5,30.499999 5,0 0,5.000001 -5,0 z"
-         id="path4627" />
-      <path
-         id="path4629"
-         d="m 93.5,30.499999 5,0 0,5.000001 -5,0 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    </g>
+       sodipodi:nodetypes="ccccc" />
     <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
+       d="m 55,51.999983 h 6 v 6 h -6 z"
+       id="path19009"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 87,37.999983 h 6 v 6 h -6 z"
+       id="path19011"
+       style="fill:#ffffff;fill-opacity:1;stroke:none"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/elementary-xfce/apps/128/libreoffice-impress.svg
+++ b/elementary-xfce/apps/128/libreoffice-impress.svg
@@ -1,134 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.0"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3331"
+   sodipodi:docname="libreoffice-impress.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.7675533"
+     inkscape:cx="47.643652"
+     inkscape:cy="80.290835"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="510"
+     inkscape:window-y="138"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5344-867"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2490-113-580-0"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,135 +61,174 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2490-113-580-0">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop5567-3"
-         style="stop-color:#71171c;stop-opacity:1"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5569-2"
-         style="stop-color:#ed8137;stop-opacity:1"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient5344-867">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         offset="0"
-         style="stop-color:#f9c590;stop-opacity:1"
-         id="stop5559" />
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="0.39698008"
-         style="stop-color:#f19860;stop-opacity:1"
-         id="stop5561" />
-      <stop
-         offset="1"
-         style="stop-color:#ce5d36;stop-opacity:1"
-         id="stop5563" />
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.729731,0,0,2.7297285,-1.513514,1.4865182)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8727273,0,0,1.8727273,4.0727275,7.0727249)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9999964,0,0,2.008692,7.0000024e-6,2.4608829)" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4097"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
   </defs>
-  <metadata
-     id="metadata4212">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       d="m 17.5,-43.499995 61.944628,0 31.055372,30.557142 0,62.442852 -93,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 18,-42.999994 61.152918,0 L 110,-13.235292 110,49 18,49 z"
-       id="path3102" />
-    <g
-       id="g4821">
-      <path
-         d="M 100,12.999999 A 20,20 0 1 1 89.420243,-4.6425345 L 80.000015,12.999999 z"
-         id="path3035-6"
-         style="color:#000000;fill:#d37241;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         id="path4673"
-         d="m 28,28 30,0 0,6 -30,0 z"
-         style="fill:#d37241;fill-opacity:1;stroke:none" />
-      <path
-         style="fill:#d37241;fill-opacity:1;stroke:none"
-         d="m 28,16 24,0 0,6 -24,0 z"
-         id="path9580" />
-      <path
-         id="path9582"
-         d="m 28,4.0000005 24,0 L 52,10 28,10 z"
-         style="fill:#d37241;fill-opacity:1;stroke:none" />
-      <path
-         style="fill:#d37241;fill-opacity:1;stroke:none"
-         d="m 28,-8 30,0 0,6 -30,0 z"
-         id="path9584" />
-      <path
-         id="path9586"
-         d="m 28,-26 52,0 6,6 -58,0 z"
-         style="fill:#d37241;fill-opacity:1;stroke:none" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.499997"
+     x="12.5"
+     ry="5.2820516"
+     rx="5.2820516"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.499998"
+     x="13.5"
+     ry="3.8113203"
+     rx="3.8113208"
+     height="101"
+     width="101" />
+  <path
+     d="M 18.5,21.499997 H 83.999856 L 109.5,46.652106 V 112.5 h -91 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#a62100;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="M 96.000001,67.998389 A 32.000001,31.998401 0 1 1 79.072374,39.771748 L 63.999997,67.998389 Z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 96.000001,67.99502 c 0,14.402658 -9.600003,27.000953 -23.461107,30.837828 -13.842977,3.831842 -28.538898,-1.978975 -35.978233,-14.384002 -0.0568,0.0512 27.439336,-16.453826 27.439336,-16.453826 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3962"
+     d="m 96.000001,68.009541 c 0,13.873513 -9.286403,26.914144 -23.461107,30.837837 -0.312401,-0.0544 -8.538897,-30.837837 -8.538897,-30.837837 z" />
 </svg>

--- a/elementary-xfce/apps/128/libreoffice-main.svg
+++ b/elementary-xfce/apps/128/libreoffice-main.svg
@@ -1,134 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.0"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3331"
+   sodipodi:docname="libreoffice-main.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.7675533"
+     inkscape:cx="46.980092"
+     inkscape:cy="80.290835"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="174"
+     inkscape:window-y="354"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4-0"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2781-9"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,137 +61,204 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4-0">
+       id="linearGradient3688-464-309">
       <stop
-         offset="0"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         id="stop5430-5-9" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop5432-2-9" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         id="stop5434-9-9" />
-      <stop
-         offset="1"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         id="stop5436-2-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2781-9">
-      <stop
-         id="stop2783-7"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2785-6"
-         style="stop-color:#525252;stop-opacity:1;"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4139-7">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4141-2" />
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0.90839696;"
-         offset="1"
-         id="stop4143-0" />
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient4139-7"
-       id="radialGradient5165"
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(9.5501741e-8,4.7750871,-6.3667826,1.2733565e-7,117.64014,-162.37718)"
-       cx="25"
-       cy="8"
-       fx="25"
-       fy="8"
-       r="17" />
+       gradientTransform="matrix(2.729731,0,0,2.7297285,-1.513514,1.4865182)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#666666;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8727273,0,0,1.8727273,4.0727275,7.0727249)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9999964,0,0,2.008692,7.0000024e-6,2.4608829)" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4097"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
   </defs>
-  <metadata
-     id="metadata4212">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
     </g>
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 18,-42.999994 61.152918,0 L 110,-13.235292 110,49 18,49 z"
-       id="path3102" />
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       d="m 17.5,-43.499995 61.944628,0 31.055372,30.557142 0,62.442852 -93,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
-    <path
-       style="fill:url(#radialGradient5165);fill-opacity:1;stroke:none"
-       d="m 18,-43.000009 61.152937,0 L 110,-13.2353 110,49 18,49 z"
-       id="path3102-3" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.499997"
+     x="12.5"
+     ry="5.2820516"
+     rx="5.2820516"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.499998"
+     x="13.5"
+     ry="3.8113203"
+     rx="3.8113208"
+     height="101"
+     width="101" />
+  <path
+     d="M 18.5,21.499997 H 83.999856 L 109.5,46.652106 V 112.5 h -91 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#000000;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.499998;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3181"
+     width="24"
+     height="20"
+     x="39"
+     y="38" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3403"
+     width="24"
+     height="20"
+     x="39"
+     y="60" />
+  <rect
+     style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3443"
+     width="24"
+     height="20"
+     x="39"
+     y="82" />
+  <rect
+     style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3483"
+     width="24"
+     height="20"
+     x="65"
+     y="38" />
+  <rect
+     style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3563"
+     width="24"
+     height="20"
+     x="65"
+     y="82" />
+  <rect
+     style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3851"
+     width="24"
+     height="20"
+     x="65"
+     y="60" />
 </svg>

--- a/elementary-xfce/apps/128/libreoffice-math.svg
+++ b/elementary-xfce/apps/128/libreoffice-math.svg
@@ -1,134 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.0"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3331"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.7675533"
+     inkscape:cx="47.643652"
+     inkscape:cy="80.290835"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="47"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4-0"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2781-9"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,125 +61,182 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4-0">
+       id="linearGradient3688-464-309">
       <stop
-         offset="0"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         id="stop5430-5-9" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop5432-2-9" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         id="stop5434-9-9" />
-      <stop
-         offset="1"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         id="stop5436-2-5" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2781-9">
-      <stop
-         id="stop2783-7"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2785-6"
-         style="stop-color:#525252;stop-opacity:1;"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.729731,0,0,2.7297285,-1.513514,1.4865182)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#485a6c;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#667885;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8727273,0,0,1.8727273,4.0727275,7.0727249)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9999964,0,0,2.008692,7.0000024e-6,2.4608829)" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4093"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient4095"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient4097"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
   </defs>
-  <metadata
-     id="metadata4212">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       d="m 17.5,-43.499995 61.944628,0 31.055372,30.557142 0,62.442852 -93,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 18,-42.999994 61.152918,0 L 110,-13.235292 110,49 18,49 z"
-       id="path3102" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 26.5,5.5 9.40909,0 9.40909,28 9.409092,-54 40.772726,0"
-       id="path4018" />
-    <g
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Sans"
-       id="text4042"
-       transform="matrix(3.5999492,0,0,3.5999492,-22.198882,-80.198374)">
-      <path
-         d="m 22.24707,22.698101 0,-0.698242 5.308564,0 0,0.698242 -1.043915,0.290039 1.471679,2.169087 1.944336,-2.190571 -0.983192,-0.268555 0,-0.698242 3.333381,0 0,0.698242 -0.814056,0.225586 -2.835937,3.232563 3.201172,4.919922 1.004384,0.225586 0,0.698242 -5.555634,0 0,-0.698242 1.253398,-0.247071 -1.761719,-2.717773 -2.341797,2.739258 0.905646,0.225586 0,0.698242 L 22,32 22,31.301758 22.902344,31.129883 26.125,27.348633 23.224609,22.966656 22.24707,22.698101"
-         style="font-size:22px;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
-         id="path3142" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.499997"
+     x="12.5"
+     ry="5.2820516"
+     rx="5.2820516"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.499998"
+     x="13.5"
+     ry="3.8113203"
+     rx="3.8113208"
+     height="101"
+     width="101" />
+  <path
+     d="M 18.5,21.499997 H 83.999856 L 109.5,46.652106 V 112.5 h -91 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#0e141f;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="m 37,50 v 1 h -1 v 1 h 1 v 1 h 1.09961 V 52 H 39 v -1 h -0.90039 v -1 z m 26,0 v 1 h -3 v 1 h 3 v 1 h 1.099611 V 52 H 67 v -1 h -2.900389 v -1 z m 26,0 v 1 h -1 v 1 h 1 v 1 h 1.099611 V 52 H 91 v -1 h -0.900389 v -1 z m -49,1 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 12,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m -47,3 v 3 h 1.09961 v -3 z m 26,0 v 3 h 1.099611 v -3 z m 26,0 v 3 h 1.099611 v -3 z m -52,4 v 3 h 1.09961 v -3 z m 26,0 v 3 h 1.099611 v -3 z m 26,0 v 3 h 1.099611 v -3 z m -53,4 v 1 h 1 v 2 h 1.09961 V 63 H 39 V 62 H 38.09961 37 Z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v 2 h 1.099611 V 63 H 67 v -1 h -2.900389 -0.0996 -1 -3 z m 8,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 1 v 2 h 1.099611 V 63 H 91 V 62 H 90.099611 89 Z m -51,4 v 3 h 1.09961 v -3 z m 26,0 v 3 h 1.099611 v -3 z m 26,0 v 3 h 1.099611 v -3 z m -52,4 v 3 h 1.09961 v -3 z m 26,0 v 3 h 1.099611 v -3 z m 26,0 v 3 h 1.099611 v -3 z m -52,4 v 3 h 1.09961 v -3 z m 26,0 v 3 h 1.099611 v -3 z m 26,0 v 3 h 1.099611 v -3 z m -52,4 v 3 h 1.09961 v -3 z m 26,0 v 3 h 1.099611 v -3 z m 26,0 v 3 h 1.099611 v -3 z m -52,4 v 1 h -1 v 1 h 1 v 1 h 1.09961 V 84 H 39 v -1 h -0.90039 v -1 z m 26,0 v 1 h -3 v 1 h 3 v 1 h 1.099611 V 84 H 67 v -1 h -2.900389 v -1 z m 26,0 v 1 h -1 v 1 h 1 v 1 h 1.099611 V 84 H 91 v -1 h -0.900389 v -1 z m -49,1 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 12,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z m 4,0 v 1 h 3 v -1 z"
+     fill="#f09e6f"
+     id="path23"
+     sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+     style="fill:#f37329;fill-opacity:1" />
+  <path
+     d="m 71.89648,89.900391 c -0.71051,0 -1.18523,0.105306 -1.42773,0.316406 -0.23971,0.2083 -0.361429,0.627312 -0.361328,1.257812 v 1.027344 c -1.01e-4,0.428 -0.0754,0.724017 -0.226561,0.886717 -0.151201,0.1629 -0.726803,-0.144677 -0.83008,0.24414 h -0.265619 v 0.61133 h 0.265619 c 0.399501,0 0.67497,0.0825 0.826171,0.248046 0.1542,0.1655 0.230369,0.46373 0.23047,0.89453 v 1.02344 c -1.01e-4,0.6306 0.121618,1.0506 0.361328,1.26172 0.242501,0.21119 0.71722,0.3164 1.42773,0.3164 h 0.275401 v -0.61523 h -0.30079 c -0.399511,0 -0.660601,-0.0609 -0.7832,-0.1836 -0.119799,-0.1227 -0.179689,-0.38887 -0.179689,-0.79687 v -1.06055 c 0,-0.4451 -0.063,-0.77005 -0.191401,-0.972646 -0.1284,-0.20261 -0.35127,-0.34293 -0.66797,-0.41993 0.313901,-0.0713 0.533711,-0.20755 0.662111,-0.41015 0.1309,-0.2026 0.19726,-0.52857 0.19726,-0.976566 v -1.060546 c 0,-0.4052 0.0598,-0.668316 0.179689,-0.791016 0.122601,-0.1254 0.383701,-0.189353 0.7832,-0.189453 h 0.30079 v -0.611328 z m 6.966801,0 v 0.611328 h 0.29102 c 0.40241,1e-4 0.66441,0.06385 0.787111,0.189453 0.122999,0.1255 0.183588,0.388615 0.183588,0.791016 v 1.060546 c 0,0.447996 0.065,0.773966 0.193361,0.976566 0.131201,0.2026 0.354069,0.33915 0.66797,0.41015 -0.3167,0.077 -0.53957,0.21732 -0.66797,0.41993 C 80.18976,94.561966 80.125,94.886926 80.125,95.332026 v 1.06055 c 0,0.4023 -0.0609,0.66551 -0.183588,0.79101 -0.122701,0.1253 -0.384701,0.18946 -0.787111,0.18946 h -0.29102 v 0.61523 h 0.265631 c 0.710409,0 1.184119,-0.1052 1.42382,-0.3164 0.23971,-0.21111 0.35938,-0.63112 0.35938,-1.26172 v -1.02344 c 0,-0.4308 0.0772,-0.72903 0.22851,-0.89453 0.153999,-0.165196 0.727881,-0.6361 0.83399,-0.248046 h 0.273439 v -0.61133 h -0.273439 c -0.4023,0 -0.67998,-0.0815 -0.83399,-0.24414 -0.150891,-0.1627 -0.22851,-0.458717 -0.22851,-0.886717 v -1.027344 c 0,-0.6305 -0.11967,-1.049512 -0.35938,-1.257812 -0.2397,-0.2111 -1.241438,-1.003006 -1.42382,-0.316406 z m -14.76758,0.878906 v 1.361328 h -1.28125 v 0.613281 h 1.28125 v 2.60156 c 0,0.5792 0.120771,0.98781 0.363281,1.22461 0.242599,0.2368 0.65939,0.35547 1.25,0.35547 h 0.9629 v -0.63086 h -0.88672 c -0.33381,0 -0.56708,-0.0692 -0.70118,-0.20899 -0.134101,-0.1399 -0.201171,-0.38643 -0.201171,-0.74023 v -2.60156 h 1.789071 v -0.613281 h -1.789071 v -1.361328 z m -15.27734,1.119141 c -0.57641,0 -1.01898,0.125853 -1.33008,0.376953 -0.311011,0.2482 -0.4668,0.601144 -0.4668,1.060549 0,0.3624 0.1042,0.65013 0.3125,0.86133 0.208309,0.2082 0.53849,0.356306 0.99219,0.445306 l 0.29492,0.0586 0.0352,0.0117 c 0.699,0.1399 1.04883,0.39066 1.04883,0.75586 0,0.2539 -0.0959,0.4531 -0.28711,0.5957 -0.1912,0.1397 -0.4605,0.20899 -0.80859,0.20899 -0.23972,0 -0.49548,-0.0373 -0.76368,-0.11133 -0.2682,-0.0771 -0.54789,-0.1906 -0.84179,-0.3418 v 0.81446 c 0.3025,0.0998 0.58209,0.1717 0.84179,0.2207 0.2596,0.051 0.50919,0.0781 0.7461,0.0781 0.5992,0 1.06759,-0.13303 1.40429,-0.39843 0.3367,-0.2682 0.50391,-0.6396 0.50391,-1.11328 0,-0.35661 -0.10023,-0.64665 -0.30273,-0.86915 -0.1998,-0.222596 -0.49581,-0.369366 -0.886719,-0.443346 l -0.31641,-0.0606 c -0.52221,-0.0999 -0.84927,-0.203 -0.98047,-0.3086 -0.1309,-0.1056 -0.19726,-0.26451 -0.19726,-0.47851 0,-0.2368 0.0876,-0.413245 0.26171,-0.527345 0.17691,-0.1165 0.44419,-0.175781 0.80079,-0.175781 0.2369,0 0.46895,0.03361 0.69726,0.09961 0.2282,0.0656 0.45429,0.163622 0.67969,0.294922 v -0.769531 -0.002 c -0.2283,-0.0942 -0.46037,-0.164938 -0.69727,-0.210938 -0.23681,-0.049 -0.48343,-0.07227 -0.74023,-0.07227 z m 5.02148,0.01953 c -0.576411,0 -1.03031,0.223875 -1.36132,0.671875 -0.331001,0.447997 -0.4961,1.068127 -0.4961,1.861323 0,0.7789 0.1651,1.39084 0.4961,1.83594 0.33381,0.4422 0.78781,0.66406 1.36132,0.66406 0.2882,0 0.54101,-0.0639 0.75782,-0.18945 0.2198,-0.1283 0.39308,-0.31008 0.521479,-0.54688 v 2.43555 h 0.79297 v -6.617184 h -0.79297 v 0.611328 c -0.1313,-0.2368 -0.305689,-0.416462 -0.52539,-0.539062 -0.21691,-0.1254 -0.468609,-0.1875 -0.753909,-0.1875 z m 6.683599,0.07617 c -0.04128,0.371514 -0.698749,0.09084 -0.972659,0.273437 -0.2711,0.1797 -0.47231,0.439792 -0.60351,0.779305 V 92.109372 H 58.15625 v 4.792964 h 0.791022 v -2.38281 c 0,-0.581996 0.13092,-1.027736 0.390619,-1.335936 0.259611,-0.308195 0.634189,-0.460937 1.125,-0.460937 0.2083,0 0.400219,0.02984 0.574219,0.08984 0.174101,0.06 0.34536,0.153852 0.51367,0.285157 v -0.802735 c -0.1541,-0.1028 -0.31607,-0.179516 -0.48437,-0.228516 -0.1684,-0.049 -0.521544,-0.265092 -0.542969,-0.07227 z m 12.70703,0.02148 1.716801,2.294922 -1.884771,2.499996 h 0.912111 l 1.400389,-1.92188 1.402341,1.92188 h 0.912109 l -1.88281,-2.499996 1.7168,-2.294922 H 76.63672 L 75.375,93.74999 74.103521,92.015618 Z m -19.265629,0.570313 c 0.3795,-10e-7 0.665379,0.156804 0.85938,0.470699 0.1973,0.311 0.294919,0.76915 0.294919,1.376946 0,0.6077 -0.098,1.06892 -0.294919,1.38282 -0.194001,0.311 -0.47988,0.46679 -0.85938,0.46679 -0.3795,0 -0.66722,-0.15579 -0.86132,-0.46679 -0.1907,-0.311 -0.28711,-0.77222 -0.28711,-1.38282 0,-0.610696 0.096,-1.069856 0.28711,-1.380856 0.1941,-0.310989 0.48182,-0.466789 0.86132,-0.466789 z"
+     fill="url(#a)"
+     id="path25"
+     style="fill:#273445;fill-opacity:1"
+     sodipodi:nodetypes="sccccsccsccccsccscsssccssccccsccccsscccsscsccscsscsccscsscsccccccscsccscsccccccccsccccscsccccscsccccscscccccccssscsccccccccssccccccscsccccsscccccccccccccscscscscs" />
+  <path
+     style="fill:#4e6174;fill-opacity:1"
+     d="m 63.451179,62.007812 9.669919,10.726562 v 0.136719 l -9.98047,11.136719 h 4.96094 l 7.74219,-8.287109 h 0.15429 l 8.51172,8.287109 h 5.373051 L 78.927739,72.689453 v -0.136719 l 10.23242,-10.544922 h -4.96094 l -8.097649,7.650391 h -0.154301 l -7.121091,-7.650391 z"
+     id="path2159" />
+  <path
+     style="fill:#4e6174;fill-opacity:1"
+     d="M 59.980469,51 49.34961,76.035156 43.05274,64.117187 37,66.349609 38.07618,69.984374 40.99219,68.501953 48.48243,84 h 1.77539 L 62.48829,55 h 24.50976 v 2 h 3.001949 v -6 h -30.01757 z"
+     id="path25-3" />
 </svg>

--- a/elementary-xfce/apps/128/libreoffice-writer.svg
+++ b/elementary-xfce/apps/128/libreoffice-writer.svg
@@ -24,11 +24,11 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="2.6640625"
-     inkscape:cx="61.747801"
-     inkscape:cy="70.944282"
+     inkscape:cx="61.372434"
+     inkscape:cy="71.131965"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="674"
+     inkscape:window-x="601"
      inkscape:window-y="69"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3331" />
@@ -61,14 +61,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient2877-634-617"
-       xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
        id="linearGradient3688-464-309">
       <stop
          id="stop2889"
@@ -79,37 +71,6 @@
          style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2875-742-326"
-       xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2873-966-168"
-       xlink:href="#linearGradient3688-166-749"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
     <linearGradient
        id="linearGradient3308-4-6-931-761">
       <stop

--- a/elementary-xfce/apps/16/libreoffice-base.svg
+++ b/elementary-xfce/apps/16/libreoffice-base.svg
@@ -1,147 +1,164 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3331"
+   sodipodi:docname="libreoffice-base.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
-  <defs
-     id="defs3175">
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.4324327,-0.43242832)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
-    <linearGradient
-       id="linearGradient3924-4-8">
-      <stop
-         id="stop3926-0-4"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
-      <stop
-         id="stop3930-2-1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-9-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.89884232,-0.95086799,-1.6560106e-8,16.034654,-6.0133847)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient3242-593-605-251-305" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.38461539,0,0,0.38461539,-1.2307693,-1.2307688)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient3332-412-419-652-471" />
-    <linearGradient
-       id="linearGradient3242-593-605-251-305">
-      <stop
-         offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1"
-         id="stop2749" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1"
-         id="stop2751" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         id="stop2753" />
-      <stop
-         offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1"
-         id="stop2755" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3332-412-419-652-471">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1"
-         id="stop2759" />
-      <stop
-         offset="1"
-         style="stop-color:#ad53a5;stop-opacity:1"
-         id="stop2761" />
-    </linearGradient>
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="30.140427"
+     inkscape:cx="7.0337424"
+     inkscape:cy="6.585839"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="597"
+     inkscape:window-y="68"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
   <metadata
-     id="metadata3178">
+     id="metadata143580">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="0.5"
-       x="0.5"
-       ry="1.1538459"
-       rx="1.1538459"
-       height="15"
-       width="15" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="1.5"
-       x="1.5"
-       height="13"
-       width="13" />
-    <path
-       d="m 1.5,1.4999999 8.658929,0 L 14.5,5.7714278 14.5,14.5 l -13,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 2,1.9999993 7.97647,0 L 14,5.8823526 l 0,8.1176484 -12,0 z"
-       id="path3102" />
-    <path
-       style="fill:#edc4f3;fill-opacity:1;fill-rule:nonzero;stroke:#813384;stroke-width:3.39934611;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path8459"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       transform="matrix(0.375,0,0,-0.23076923,-1,15.269231)" />
-    <path
-       transform="matrix(0.375,0,0,-0.23076923,-1,13.269231)"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       id="path8436"
-       style="fill:#edc4f3;fill-opacity:1;fill-rule:nonzero;stroke:#813384;stroke-width:3.39934611;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       style="fill:#db82e8;fill-opacity:1;fill-rule:nonzero;stroke:#813384;stroke-width:3.39934659;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path4247"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       transform="matrix(0.375,0,0,-0.23076923,-0.99999996,11.269231)" />
-  </g>
+  <defs
+     id="defs3333">
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135162,0,0,0.35135137,-0.43243486,-0.4324319)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27272728,0,0,0.27272727,-0.7272728,-0.7272727)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="51.912369"
+       x2="19.702679"
+       y2="11.561417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29999946,0,0,0.29739076,-1.5999989,-1.4382584)" />
+  </defs>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="0.5"
+     x="0.5"
+     ry="0.5"
+     rx="0.5"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="1.4999971"
+     x="1.4999981"
+     height="13.000006"
+     width="13.000004" />
+  <path
+     d="m 2,2 h 8.5 L 14,5.5 V 14 H 2 Z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.501961"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 4,6 v 5 c 0,0.770247 1.9987799,1.740211 3.9998846,1.740211 C 10.00099,12.740211 12,11.665468 12,11 V 6 C 12,6 10.270734,7.7672336 7.9998846,7.7672336 5.7290355,7.7672336 4,6 4,6 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 4.2500005,6.0086169 V 7.913785 c 0,0.8430786 1.6180717,1.340159 3.7498841,1.336215 C 10.120362,9.24607 11.749999,8.7568636 11.749999,7.913785 V 6.0086169"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="M 11.749999,6.0086169 C 11.750634,4.9402225 10.348816,4.5 7.9998846,4.5 5.6509536,4.5 4.2493783,4.9402225 4.2500005,6.0086169 4.2493717,7.0770111 5.6509536,7.5 7.9998846,7.5 10.348816,7.5 11.750622,7.0770111 11.749999,6.0086169 Z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="M 4.2500005,7.4741309 V 9.5258504 C 4.2500005,10.368929 5.8680722,11.003943 7.9998846,11 10.120362,10.9961 11.749999,10.368929 11.749999,9.5258504 V 7.4741309"
+     style="fill:none;stroke:#7239b3;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 4.2500005,8.9396449 v 2.3448221 c 0,0.843078 1.6180717,1.469456 3.7498841,1.465514 2.1204774,-0.0039 3.7501144,-0.622436 3.7501144,-1.465514 V 8.9396449"
+     sodipodi:nodetypes="cscsc" />
 </svg>

--- a/elementary-xfce/apps/16/libreoffice-draw.svg
+++ b/elementary-xfce/apps/16/libreoffice-draw.svg
@@ -1,148 +1,199 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3331"
+   sodipodi:docname="libreoffice-draw.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
-  <defs
-     id="defs3175">
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.4324327,-0.43242832)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
-    <linearGradient
-       id="linearGradient3924-4-8">
-      <stop
-         id="stop3926-0-4"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
-      <stop
-         id="stop3930-2-1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-9-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.89884232,-0.95086799,-1.6560106e-8,16.034654,-6.0133847)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient3846-5" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.38461539,0,0,0.38461539,-1.2307693,-1.2307688)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient3856-6" />
-    <linearGradient
-       id="linearGradient3856-6">
-      <stop
-         offset="0"
-         style="stop-color:#b67926;stop-opacity:1"
-         id="stop3858-8" />
-      <stop
-         offset="1"
-         style="stop-color:#eab41a;stop-opacity:1"
-         id="stop3860-0" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3846-5">
-      <stop
-         offset="0"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         id="stop3848-48" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fdde76;stop-opacity:1"
-         id="stop3850-1" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#f9c440;stop-opacity:1"
-         id="stop3852-28" />
-      <stop
-         offset="1"
-         style="stop-color:#e48b20;stop-opacity:1"
-         id="stop3854-9" />
-    </linearGradient>
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="15.070214"
+     inkscape:cx="10.086121"
+     inkscape:cy="11.247352"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="599"
+     inkscape:window-y="56"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g4258" />
   <metadata
-     id="metadata3178">
+     id="metadata143580">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3333">
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135162,0,0,0.35135137,-0.43243486,-0.4324319)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27272728,0,0,0.27272727,-0.7272728,-0.7272727)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="51.912369"
+       x2="19.702679"
+       y2="11.561417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29999946,0,0,0.29739076,-1.5999989,-1.4382584)" />
+    <linearGradient
+       gradientTransform="matrix(0.65942749,0,0,0.64652213,-4.0326729,-3.5947163)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4102"
+       id="linearGradient3064"
+       y2="8.6535578"
+       x2="14.005782"
+       y1="16.387245"
+       x1="20.453684" />
+    <linearGradient
+       id="linearGradient4102">
+      <stop
+         offset="0"
+         style="stop-color:#f9c440;stop-opacity:1"
+         id="stop4104" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4106" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="0.5"
+     x="0.5"
+     ry="0.5"
+     rx="0.5"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="1.4999971"
+     x="1.4999981"
+     height="13.000006"
+     width="13.000004" />
+  <path
+     d="m 2,2 h 8.5 L 14,5.5 V 14 H 2 Z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.501961"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
   <g
-     id="layer1">
+     id="g4258">
+    <path
+       d="m 5.0000026,11 c 1.7284353,2.817675 4.9593062,0.424509 3,-2.9999999 -1.8807679,-3.2872389 2.0000004,-5.860683 3.0000004,-2"
+       id="path2783"
+       style="fill:url(#linearGradient3064);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="0.5"
-       x="0.5"
-       ry="1.1538459"
-       rx="1.1538459"
-       height="15"
-       width="15" />
+       width="2"
+       height="2"
+       x="4.0000029"
+       y="10"
+       id="rect3565-6"
+       style="fill:#e99f20;fill-opacity:1;stroke:none" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="1.5"
-       x="1.5"
-       height="13"
-       width="13" />
+       width="2"
+       height="2"
+       x="10.000003"
+       y="5"
+       id="rect3567-9"
+       style="fill:#e99f20;fill-opacity:1;stroke:none" />
     <path
-       d="m 1.5,1.4999999 8.658929,0 L 14.5,5.7714278 14.5,14.5 l -13,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       d="m 5.997024,4.1092653 5.082184,8.8854897"
+       id="path3571"
+       style="fill:none;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 2,1.9999993 7.97647,0 L 14,5.8823526 l 0,8.1176484 -12,0 z"
-       id="path3102" />
+       d="m 6.4999976,3.5 c 3.72e-4,0.552176 -0.447453,1 -1,1 -0.552547,0 -1.000372,-0.447824 -1,-1 -3.72e-4,-0.552176 0.447453,-1 1,-1 0.552547,0 1.000372,0.447824 1,1 z"
+       id="path3573"
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:#f3ba00;fill-opacity:0.42682932;stroke:#f3ba00;stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 4.5,11.5 6.6,4.4999999 11.499999,11.5 z"
-       id="path4025" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 5.5,3.4999997 2,0 0,2.0000003 -2,0 z"
-       id="path5086" />
-    <path
-       id="path5177"
-       d="m 3.5,10.5 2,0 0,2 -2,0 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 10.5,10.5 2,0 0,2 -2,0 z"
-       id="path5179" />
+       d="m 11.500002,12.5 c 3.73e-4,0.552177 -0.447452,1 -1,1 -0.5525461,0 -1.0003711,-0.447823 -0.9999991,-1 -3.72e-4,-0.552175 0.447453,-1 0.9999991,-1 0.552548,0 1.000373,0.447825 1,1 z"
+       id="path3575"
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       width="2"
+       height="2"
+       x="7.0000029"
+       y="7"
+       id="rect3569-2"
+       style="fill:#e99f20;fill-opacity:1;stroke:none" />
   </g>
 </svg>

--- a/elementary-xfce/apps/16/libreoffice-impress.svg
+++ b/elementary-xfce/apps/16/libreoffice-impress.svg
@@ -1,148 +1,151 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3331"
+   sodipodi:docname="libreoffice-impress.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
-  <defs
-     id="defs3175">
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.4324327,-0.43242832)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
-    <linearGradient
-       id="linearGradient3924-4-8">
-      <stop
-         id="stop3926-0-4"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
-      <stop
-         id="stop3930-2-1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-9-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.89884232,-0.95086799,-1.6560106e-8,16.034654,-6.0133847)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient5344-867" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.38461539,0,0,0.38461539,-1.2307693,-1.2307688)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient2490-113-580-0" />
-    <linearGradient
-       id="linearGradient5344-867">
-      <stop
-         id="stop5559"
-         style="stop-color:#f9c590;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5561"
-         style="stop-color:#f19860;stop-opacity:1"
-         offset="0.39698008" />
-      <stop
-         id="stop5563"
-         style="stop-color:#ce5d36;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2490-113-580-0">
-      <stop
-         offset="0"
-         style="stop-color:#71171c;stop-opacity:1"
-         id="stop5567-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ed8137;stop-opacity:1"
-         id="stop5569-2" />
-    </linearGradient>
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="30.140427"
+     inkscape:cx="7.0337424"
+     inkscape:cy="6.585839"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="597"
+     inkscape:window-y="68"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
   <metadata
-     id="metadata3178">
+     id="metadata143580">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="0.5"
-       x="0.5"
-       ry="1.1538459"
-       rx="1.1538459"
-       height="15"
-       width="15" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="1.5"
-       x="1.5"
-       height="13"
-       width="13" />
-    <path
-       d="m 1.5,1.4999999 8.658929,0 L 14.5,5.7714278 14.5,14.5 l -13,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 2,1.9999993 7.97647,0 L 14,5.8823526 l 0,8.1176484 -12,0 z"
-       id="path3102" />
-    <path
-       style="color:#000000;fill:#d37241;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3035-6"
-       d="m 13,8.9999996 a 3,3 0 1 1 -1.586964,-2.64638 l -1.413034,2.64638 z" />
-    <path
-       id="path4675"
-       d="M 3,5 6,5 6,6 3,6 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="M 3,7 5,7 5,8 3,8 z"
-       id="path5963" />
-    <path
-       id="path5965"
-       d="m 3,9 2,0 0,1 -2,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 3,11 3,0 0,1 -3,0 z"
-       id="path5967" />
-  </g>
+  <defs
+     id="defs3333">
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135162,0,0,0.35135137,-0.43243486,-0.4324319)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27272728,0,0,0.27272727,-0.7272728,-0.7272727)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="51.912369"
+       x2="19.702679"
+       y2="11.561417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29999946,0,0,0.29739076,-1.5999989,-1.4382584)" />
+  </defs>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="0.5"
+     x="0.5"
+     ry="0.5"
+     rx="0.5"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="1.4999971"
+     x="1.4999981"
+     height="13.000006"
+     width="13.000004" />
+  <path
+     d="m 2,2 h 8.5 L 14,5.5 V 14 H 2 Z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.501961"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="M 12,7.9997993 A 4,3.9998 0 1 1 9.8840469,4.4714687 L 8.0000005,7.9997993 Z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="M 12,7.9993776 C 12,9.7997102 10.8,11.374497 9.0673622,11.854106 7.3369897,12.333087 5.5,11.606734 4.570083,10.056106 c -0.00707,0.0064 3.4299175,-2.0567284 3.4299175,-2.0567284 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3962"
+     d="M 12,8.0011925 C 12,9.7353822 10.8392,11.365461 9.0673622,11.855922 9.0283165,11.849139 8.0000005,8.0011925 8.0000005,8.0011925 Z" />
 </svg>

--- a/elementary-xfce/apps/16/libreoffice-main.svg
+++ b/elementary-xfce/apps/16/libreoffice-main.svg
@@ -1,153 +1,181 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3331"
+   sodipodi:docname="libreoffice-main.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
-  <defs
-     id="defs3175">
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.4324327,-0.43242832)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
-    <linearGradient
-       id="linearGradient3924-4-8">
-      <stop
-         id="stop3926-0-4"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
-      <stop
-         id="stop3930-2-1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-9-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.89884232,-0.95086799,-1.6560106e-8,16.034654,-6.0133847)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.38461539,0,0,0.38461539,-1.2307693,-1.2307688)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient2781" />
-    <linearGradient
-       id="linearGradient2781">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop2783" />
-      <stop
-         offset="1"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop2785" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
-      <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4139">
-      <stop
-         id="stop4141"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop4143"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.90839696;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient4139"
-       id="radialGradient6800"
-       cx="5"
-       cy="-0.28571305"
-       fx="5"
-       fy="-0.28571305"
-       r="6"
-       gradientTransform="matrix(-2.6431557e-8,2.3333334,-2,0,7.428574,-10.666667)"
-       gradientUnits="userSpaceOnUse" />
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="30.140427"
+     inkscape:cx="7.0337424"
+     inkscape:cy="6.585839"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="597"
+     inkscape:window-y="68"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
   <metadata
-     id="metadata3178">
+     id="metadata143580">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="0.5"
-       x="0.5"
-       ry="1.1538459"
-       rx="1.1538459"
-       height="15"
-       width="15" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="1.5"
-       x="1.5"
-       height="13"
-       width="13" />
-    <path
-       d="m 1.5,1.4999999 8.658929,0 L 14.5,5.7714278 14.5,14.5 l -13,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:url(#radialGradient6800);fill-opacity:1;stroke:none"
-       d="m 2,1.9999993 7.97647,0 L 14,5.8823526 l 0,8.1176484 -12,0 z"
-       id="path3102" />
-  </g>
+  <defs
+     id="defs3333">
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135162,0,0,0.35135137,-0.43243486,-0.4324319)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#666666;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27272728,0,0,0.27272727,-0.7272728,-0.7272727)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="51.912369"
+       x2="19.702679"
+       y2="11.561417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29999946,0,0,0.29739076,-1.5999989,-1.4382584)" />
+  </defs>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="0.5"
+     x="0.5"
+     ry="0.5"
+     rx="0.5"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="1.4999971"
+     x="1.4999981"
+     height="13.000006"
+     width="13.000004" />
+  <path
+     d="m 2,2 h 8.5 L 14,5.5 V 14 H 2 Z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.501961"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3181"
+     width="2"
+     height="2"
+     x="5"
+     y="4" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3403"
+     width="2"
+     height="2"
+     x="5"
+     y="7" />
+  <rect
+     style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3443"
+     width="2"
+     height="2"
+     x="5"
+     y="10" />
+  <rect
+     style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3483"
+     width="2"
+     height="2"
+     x="9"
+     y="4" />
+  <rect
+     style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3563"
+     width="2"
+     height="2"
+     x="9"
+     y="10" />
+  <rect
+     style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3851"
+     width="2"
+     height="2"
+     x="9"
+     y="7" />
 </svg>

--- a/elementary-xfce/apps/16/libreoffice-math.svg
+++ b/elementary-xfce/apps/16/libreoffice-math.svg
@@ -1,145 +1,161 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="16"
+   height="16"
+   id="svg3331"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
-  <defs
-     id="defs3175">
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
-       x1="23.99999"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.4324327,-0.43242832)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
-    <linearGradient
-       id="linearGradient3924-4-8">
-      <stop
-         id="stop3926-0-4"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
-      <stop
-         id="stop3930-2-1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932-9-0"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.89884232,-0.95086799,-1.6560106e-8,16.034654,-6.0133847)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.38461539,0,0,0.38461539,-1.2307693,-1.2307688)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient2781" />
-    <linearGradient
-       id="linearGradient2781">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop2783" />
-      <stop
-         offset="1"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop2785" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
-      <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="15.070214"
+     inkscape:cx="9.9865868"
+     inkscape:cy="11.247352"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="599"
+     inkscape:window-y="56"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
   <metadata
-     id="metadata3178">
+     id="metadata143580">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="0.5"
-       x="0.5"
-       ry="1.1538459"
-       rx="1.1538459"
-       height="15"
-       width="15" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="1.5"
-       x="1.5"
-       height="13"
-       width="13" />
-    <path
-       d="m 1.5,1.4999999 8.658929,0 L 14.5,5.7714278 14.5,14.5 l -13,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="m 2,1.9999993 7.97647,0 L 14,5.8823526 l 0,8.1176484 -12,0 z"
-       id="path3102" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 3.5,8.5602546 0.7082509,0 L 5.4658268,11.5 6.7234026,5.5 11.5,5.5"
-       id="path4018" />
-    <g
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Sans"
-       id="text4042"
-       transform="matrix(0.39999436,0,0,0.39999436,-1.0998759,-0.9389001)">
-      <path
-         d="m 22.24707,23.045807 0,-0.698242 5.392578,0 0,0.698242 -1.127929,0.290039 1.471679,2.169087 1.944336,-2.190571 -1.009765,-0.268555 0,-0.698242 3.4375,0 0,0.698242 -0.891602,0.225586 -2.835937,3.232563 3.201172,4.919922 0.966796,0.225586 0,0.698242 -5.392578,0 0,-0.698242 1.12793,-0.247071 -1.761719,-2.717773 -2.341797,2.739258 1.009766,0.225586 0,0.698242 -3.4375,0 0,-0.698242 0.902344,-0.171875 3.222656,-3.78125 -2.900391,-4.381977 -0.977539,-0.268555"
-         style="font-size:22px;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
-         id="path3142" />
-    </g>
-  </g>
+  <defs
+     id="defs3333">
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135162,0,0,0.35135137,-0.43243486,-0.4324319)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#485a6c;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#667885;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27272728,0,0,0.27272727,-0.7272728,-0.7272727)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="51.912369"
+       x2="19.702679"
+       y2="11.561417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29999946,0,0,0.29739076,-1.5999989,-1.4382584)" />
+  </defs>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="0.5"
+     x="0.5"
+     ry="0.5"
+     rx="0.5"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="1.4999971"
+     x="1.4999981"
+     height="13.000006"
+     width="13.000004" />
+  <path
+     d="m 2,2 h 8.5 L 14,5.5 V 14 H 2 Z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.501961"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="M 7.5,5 6,10.25 5,8 H 3.0004152 V 9 H 4 l 1.5,3.000001 H 6.75 L 8.5,6 H 12 V 5 Z"
+     fill="url(#a)"
+     id="path23"
+     style="fill:#4e6174;fill-opacity:1;stroke-width:1"
+     sodipodi:nodetypes="cccccccccccc" />
+  <path
+     d="M 8.9999988,11.500003 12.500002,7.9999985"
+     fill="none"
+     stroke="#666666"
+     stroke-linecap="round"
+     stroke-width="2"
+     id="path25"
+     style="stroke:#4e6174;stroke-width:0.999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="M 12.500002,11.500003 8.9999988,7.9999985"
+     fill="none"
+     stroke="#666666"
+     stroke-linecap="round"
+     stroke-width="2"
+     id="path27"
+     style="stroke:#4e6174;stroke-width:0.999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/apps/24/libreoffice-base.svg
+++ b/elementary-xfce/apps/24/libreoffice-base.svg
@@ -1,288 +1,268 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="libreoffice-base.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="40.187236"
+     inkscape:cx="10.724798"
+     inkscape:cy="12.205368"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="554"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="true"
+     showguides="false" />
   <defs
-     id="defs3428">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
       <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient28344">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3242-593-605-251-305"
-       id="radialGradient3184"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749-0"
-       id="radialGradient3152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,30.90089,-18.18536)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-166-749-0">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-6"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885-6"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-464-309-50"
-       id="radialGradient3154"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,-17.099109,-105.10005)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-464-309-50">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-0"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891-5"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3702-501-757-0"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.98701298,0,0,1.0121954,0.31168824,-0.57315547)" />
     <linearGradient
-       id="linearGradient3702-501-757-0">
-      <stop
-         id="stop2895-4"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-7"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-1"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-6"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="55.537769"
+       x2="12.051564"
+       y2="8.3442049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717947,0.30769224,-0.17948716)" />
     <linearGradient
-       id="linearGradient3242-593-605-251-305">
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="27.720701"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945957,0,0,0.45945958,0.97297122,0.51351071)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42857143,0,0,0.42857151,1.7142857,1.2857123)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-6">
       <stop
+         style="stop-color:#a56de2;stop-opacity:1"
          offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1"
-         id="stop2749" />
+         id="stop36980-7" />
       <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1"
-         id="stop2751" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         id="stop2753" />
-      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
          offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1"
-         id="stop2755" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3332-412-419-652-471">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1"
-         id="stop2759" />
-      <stop
-         offset="1"
-         style="stop-color:#ad53a5;stop-opacity:1"
-         id="stop2761" />
+         id="stop36982-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
+     id="layer1">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.01216"
+       id="g3712"
+       transform="matrix(0.57894737,0,0,0.28227184,-1.8947368,9.733215)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect2801"
+         y="39.914661"
+         x="37.81818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47.000031"
+         x="-10.181818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3700"
+         y="39.914661"
+         x="10.181818"
+         height="7.0853682"
+         width="27.636364" />
     </g>
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect27907"
+       y="2.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="19"
+       width="19" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
-       y="10.499998"
+       y="2.499999"
        x="2.5"
        ry="1"
        rx="1"
        height="19.000002"
-       width="19.000002" />
+       width="19" />
+    <path
+       d="M 20,9 V 20 H 4 V 4 h 11 z"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:none;stroke-width:0.999994px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       id="path3872"
+       sodipodi:nodetypes="cccccc" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect28226"
+       y="3.4999971"
+       x="3.4999981"
+       height="17.000006"
+       width="17.000004" />
     <path
-       d="M 3.4999999,11.5 14.823213,11.5 20.5,17.085714 20.5,28.5 l -17,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 7,9 v 7 c 0,1.073678 2.498475,2.236356 4.999857,2.236356 C 14.501237,18.236356 17,16.927623 17,16 V 9 c 0,0 -2.161583,2 -5.000143,2 C 9.1612941,11 7,9 7,9 Z"
+       id="path3996-3"
+       sodipodi:nodetypes="cczccsc" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 4,12 14.635293,12 20,17.17647 20,28 4,28 z"
-       id="path3102" />
+       style="fill:none;stroke:#7239b3;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.25,8.8529204 V 11.508609 C 7.25,12.68381 9.33509,13.505497 11.999857,13.5 14.650452,13.4945 16.75,12.68381 16.75,11.508609 V 8.8529204"
+       id="path4358-6"
+       sodipodi:nodetypes="csssc" />
     <path
-       style="opacity:0.86046543;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path4255"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       transform="matrix(0.48125,0,0,0.48147989,0.45000017,11.73148)" />
+       style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4247-7"
+       d="M 16.75,8.8529204 C 16.750794,7.3636431 14.93602,6.7499995 11.999857,6.7499995 9.0636916,6.7499995 7.2492223,7.3636431 7.25,8.8529204 7.249214,10.342197 9.0636916,11 11.999857,11 14.93602,11 16.750779,10.342197 16.75,8.8529204 Z"
+       sodipodi:nodetypes="cscsc" />
     <path
-       style="fill:#951fa6;fill-opacity:0.33519556;stroke:none"
-       d="m 7.0500001,19.499993 0,1.499982 c 0,0 1.65,1.499998 4.9500009,1.499998 3.3,0 4.95,-1.499998 4.95,-1.499998 l 0,-1.499982 c 0,0 -2.200001,1.499998 -4.95,1.499998 -2.7500009,0 -4.9500009,-1.499998 -4.9500009,-1.499998 z"
-       id="path3988" />
+       d="m 7.25,10.895758 v 2.859974 c 0,1.175199 2.08509,1.999764 4.749857,1.994268 C 14.650452,15.7445 16.75,14.930931 16.75,13.755732 v -2.859974"
+       style="fill:none;stroke:#7239b3;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3992-5"
+       sodipodi:nodetypes="csssc" />
     <path
-       style="fill:none;stroke:#813384;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 6.5,17.999979 c 0,0.324727 0,2.202515 0,2.500013 0,0.999999 2.7426888,2.004675 5.5,1.999997 2.742649,-0.0046 5.5,-0.999998 5.5,-1.999997 0,-0.352167 0,-2.187899 0,-2.500013"
-       id="path4358" />
-    <path
-       style="fill:#951fa6;fill-opacity:0.5977654;fill-rule:nonzero;stroke:#813384;stroke-width:2.38175035;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path4247"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       transform="matrix(0.45833333,0,0,-0.38461486,1.0000003,25.11537)" />
-    <path
-       id="path3990"
-       d="m 7.0500001,21.599991 0,1.399998 c 0,0 1.65,1.099998 4.9500009,1.099998 3.3,0 4.95,-1.099998 4.95,-1.099998 l 0,-1.399998 c 0,0 -2.200001,1.399998 -4.95,1.399998 -2.7500009,0 -4.9500009,-1.399998 -4.9500009,-1.399998 z"
-       style="fill:#951fa6;fill-opacity:0.27374303;stroke:none" />
-    <path
-       d="m 6.5,19.999976 c 0,0.324728 0,2.202515 0,2.500013 0,0.999999 2.7426888,2.004675 5.5,1.999998 2.742649,-0.0047 5.5,-0.999999 5.5,-1.999998 0,-0.352167 0,-2.187898 0,-2.500013"
-       style="fill:none;stroke:#813384;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path3992" />
-    <path
-       id="path3994"
-       style="fill:none;stroke:#813384;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 6.5,21.999973 c 0,0.324728 0,2.202515 0,2.500014 0,0.999998 2.7426888,2.004674 5.5,1.999997 2.742649,-0.0047 5.5,-0.999999 5.5,-1.999997 0,-0.352167 0,-2.187899 0,-2.500014" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
-    <path
-       style="fill:#951fa6;fill-opacity:0.27374303;stroke:none"
-       d="m 7.0500001,23.599988 0,1.399998 c 0,0 1.65,1.099998 4.9500009,1.099998 3.3,0 4.95,-1.099998 4.95,-1.099998 l 0,-1.399998 c 0,0 -2.200001,1.399998 -4.95,1.399998 -2.7500009,0 -4.9500009,-1.399998 -4.9500009,-1.399998 z"
-       id="path3996" />
+       id="path3994-3"
+       style="fill:none;stroke:#7239b3;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 7.25,12.938596 v 3.26854 c 0,1.1752 2.08509,2.048333 4.749857,2.042838 C 14.650452,18.244474 16.75,17.382336 16.75,16.207136 v -3.26854"
+       sodipodi:nodetypes="cscsc" />
   </g>
 </svg>

--- a/elementary-xfce/apps/24/libreoffice-draw.svg
+++ b/elementary-xfce/apps/24/libreoffice-draw.svg
@@ -1,270 +1,301 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="libreoffice-draw.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="12.367111"
+     inkscape:cy="10.52573"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="138"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="true"
+     showguides="false" />
   <defs
-     id="defs3428">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
       <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient28344">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3846-5"
-       id="radialGradient3184"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient3856-6"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749-0"
-       id="radialGradient3152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,30.90089,-18.18536)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-166-749-0">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-6"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885-6"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-464-309-50"
-       id="radialGradient3154"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,-17.099109,-105.10005)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-464-309-50">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-0"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891-5"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3702-501-757-0"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.98701298,0,0,1.0121954,0.31168824,-0.57315547)" />
     <linearGradient
-       id="linearGradient3702-501-757-0">
-      <stop
-         id="stop2895-4"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-7"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-1"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-6"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="55.537769"
+       x2="12.051564"
+       y2="8.3442049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717947,0.30769224,-0.17948716)" />
     <linearGradient
-       id="linearGradient3846-5">
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="27.720701"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945957,0,0,0.45945958,0.97297122,0.51351071)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42857143,0,0,0.42857151,1.7142857,1.2857123)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-6">
       <stop
-         id="stop3848-48"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3850-1"
-         style="stop-color:#fdde76;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3852-28"
          style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.66093999" />
+         offset="0"
+         id="stop36980-7" />
       <stop
-         id="stop3854-9"
-         style="stop-color:#e48b20;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="1"
+         id="stop36982-5" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3856-6">
+       gradientTransform="matrix(0.99786952,0,0,0.87022197,-6.2569621,-3.8122049)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4102-6"
+       id="linearGradient3064-3"
+       y2="8.6535578"
+       x2="14.005782"
+       y1="16.387245"
+       x1="20.453684" />
+    <linearGradient
+       id="linearGradient4102-6">
       <stop
-         id="stop3858-8"
-         style="stop-color:#b67926;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#f9c440;stop-opacity:1"
+         id="stop4104-7" />
       <stop
-         id="stop3860-0"
-         style="stop-color:#eab41a;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4106-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
+     id="layer1">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.01216"
+       id="g3712"
+       transform="matrix(0.57894737,0,0,0.28227184,-1.8947368,9.733215)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect2801"
+         y="39.914661"
+         x="37.81818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47.000031"
+         x="-10.181818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3700"
+         y="39.914661"
+         x="10.181818"
+         height="7.0853682"
+         width="27.636364" />
     </g>
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect27907"
+       y="2.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="19"
+       width="19" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
-       y="10.499998"
+       y="2.499999"
        x="2.5"
        ry="1"
        rx="1"
        height="19.000002"
-       width="19.000002" />
+       width="19" />
+    <path
+       d="M 20,9 V 20 H 4 V 4 h 11 z"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:none;stroke-width:0.999994px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       id="path3872"
+       sodipodi:nodetypes="cccccc" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect28226"
+       y="3.4999971"
+       x="3.4999981"
+       height="17.000006"
+       width="17.000004" />
     <path
-       d="M 3.4999999,11.5 14.823213,11.5 20.5,17.085714 20.5,28.5 l -17,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       d="M 7.4116089,15.832356 C 10.02714,19.62496 14.91621,16.403746 11.951316,11.794341 9.1052716,7.3697005 14.97779,3.9058322 16.491026,9.1023305"
+       id="path2783"
+       style="fill:url(#linearGradient3064-3);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <rect
+       width="3"
+       height="3"
+       x="6"
+       y="14"
+       id="rect3565-6"
+       style="fill:#e99f20;fill-opacity:1;stroke:none;stroke-width:0.999999" />
+    <rect
+       width="3"
+       height="3"
+       x="15"
+       y="8"
+       id="rect3567-9"
+       style="fill:#e99f20;fill-opacity:1;stroke:none;stroke-width:0.999997" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 4,12 14.635293,12 20,17.17647 20,28 4,28 z"
-       id="path3102" />
+       d="M 8.1109117,8.1109127 15.889086,15.889088"
+       id="path3571"
+       style="fill:none;stroke:#e99f20;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
     <path
-       style="fill:#f3ba00;fill-opacity:0.42682932;stroke:#f3ba00;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 6.5,25.5 3.000001,-10 7,10 z"
-       id="path4025" />
+       d="M 8.4999987,7.2500005 C 8.5004635,7.9402208 7.9406827,8.500001 7.2499996,8.500001 6.5593163,8.500001 5.9995353,7.9402208 6.0000003,7.2500005 5.9995353,6.5597803 6.5593163,6 7.2499996,6 7.9406827,6 8.5004635,6.5597802 8.4999987,7.2500005 Z"
+       id="path3573"
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 8.5,13.5 2,0 0,2 -2,0 z"
-       id="path5086" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
-    <path
-       id="path4429"
-       d="m 5.5,24.5 2,0 0,2 -2,0 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 16.5,24.5 2,0 0,2 -2,0 z"
-       id="path4431" />
+       d="m 17.999998,16.750001 c 4.66e-4,0.690221 -0.559315,1.25 -1.25,1.25 -0.690682,0 -1.250463,-0.559779 -1.249998,-1.25 C 15.499535,16.059781 16.059316,15.5 16.749998,15.5 c 0.690685,0 1.250466,0.559781 1.25,1.250001 z"
+       id="path3575"
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       width="2"
+       height="2"
+       x="11"
+       y="11"
+       id="rect3569-2"
+       style="fill:#e99f20;fill-opacity:1;stroke:none;stroke-width:0.999998" />
   </g>
 </svg>

--- a/elementary-xfce/apps/24/libreoffice-impress.svg
+++ b/elementary-xfce/apps/24/libreoffice-impress.svg
@@ -1,274 +1,255 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="libreoffice-impress.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="12.21781"
+     inkscape:cy="10.52573"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="407"
+     inkscape:window-y="83"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="true"
+     showguides="false" />
   <defs
-     id="defs3428">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
       <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient28344">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5344-867"
-       id="radialGradient3184"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2490-113-580"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient5344-867">
-      <stop
-         offset="0"
-         style="stop-color:#f9c590;stop-opacity:1"
-         id="stop5559" />
-      <stop
-         offset="0.39698008"
-         style="stop-color:#f19860;stop-opacity:1"
-         id="stop5561" />
-      <stop
-         offset="1"
-         style="stop-color:#ce5d36;stop-opacity:1"
-         id="stop5563" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2490-113-580">
-      <stop
-         offset="0"
-         style="stop-color:#71171c;stop-opacity:1"
-         id="stop5567" />
-      <stop
-         offset="1"
-         style="stop-color:#ed8137;stop-opacity:1"
-         id="stop5569" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749-0"
-       id="radialGradient3152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,30.90089,-18.18536)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-166-749-0">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-6"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885-6"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-464-309-50"
-       id="radialGradient3154"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,-17.099109,-105.10005)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-464-309-50">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-0"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891-5"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3702-501-757-0"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.98701298,0,0,1.0121954,0.31168824,-0.57315547)" />
     <linearGradient
-       id="linearGradient3702-501-757-0">
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-6"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="55.537769"
+       x2="12.051564"
+       y2="8.3442049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717947,0.30769224,-0.17948716)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="27.720701"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945957,0,0,0.45945958,0.97297122,0.51351071)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42857143,0,0,0.42857151,1.7142857,1.2857123)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-6">
       <stop
-         id="stop2895-4"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0"
+         id="stop36980-7" />
       <stop
-         id="stop2897-7"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-1"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="1"
+         id="stop36982-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
+     id="layer1">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.01216"
+       id="g3712"
+       transform="matrix(0.57894737,0,0,0.28227184,-1.8947368,9.733215)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect2801"
+         y="39.914661"
+         x="37.81818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47.000031"
+         x="-10.181818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3700"
+         y="39.914661"
+         x="10.181818"
+         height="7.0853682"
+         width="27.636364" />
     </g>
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect27907"
+       y="2.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="19"
+       width="19" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
-       y="10.499998"
+       y="2.499999"
        x="2.5"
        ry="1"
        rx="1"
        height="19.000002"
-       width="19.000002" />
+       width="19" />
+    <path
+       d="M 20,9 V 20 H 4 V 4 h 11 z"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:none;stroke-width:0.999994px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       id="path3872"
+       sodipodi:nodetypes="cccccc" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect28226"
+       y="3.4999971"
+       x="3.4999981"
+       height="17.000006"
+       width="17.000004" />
     <path
-       d="M 3.4999999,11.5 14.823213,11.5 20.5,17.085714 20.5,28.5 l -17,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       d="M 18,11.999699 A 6,5.9997 0 1 1 14.82607,6.7072025 L 12,11.999699 Z"
+       id="path3035"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 4,12 14.635293,12 20,17.17647 20,28 4,28 z"
-       id="path3102" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path3964"
+       d="m 18,11.999066 c 0,2.700499 -1.8,5.06268 -4.398957,5.782093 C 11.005485,18.499631 8.25,17.410101 6.8551243,15.084159 6.8445193,15.093759 12,11.999066 12,11.999066 Z" />
     <path
-       style="color:#000000;fill:#d37241;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3035-6"
-       d="M 19,21 A 4,4 0 1 1 16.884048,17.471493 L 15.000002,21 z" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 6,24 4,0 0,1 -4,0 z"
-       id="path4673" />
-    <path
-       id="path4172"
-       d="m 6,22 3,0 0,1 -3,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 6,20 3,0 0,1 -3,0 z"
-       id="path4174" />
-    <path
-       id="path4176"
-       d="m 6,18 4,0 0,1 -4,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 6,15 9,0 1,1 -10,0 z"
-       id="path4178" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path3962"
+       d="m 18,12.001788 c 0,2.601285 -1.7412,5.046404 -4.398957,5.782095 C 13.542473,17.773683 12,12.001788 12,12.001788 Z" />
   </g>
 </svg>

--- a/elementary-xfce/apps/24/libreoffice-main.svg
+++ b/elementary-xfce/apps/24/libreoffice-main.svg
@@ -1,275 +1,285 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="libreoffice-main.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="12.118276"
+     inkscape:cy="10.52573"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="562"
+     inkscape:window-y="185"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="true"
+     showguides="false" />
   <defs
-     id="defs3428">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4"
-       id="radialGradient3184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2781"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient2781">
-      <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop2783" />
+         id="stop22025" />
       <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop2785" />
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
+       inkscape:collect="always"
+       id="linearGradient28344">
       <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4139">
-      <stop
-         id="stop4141"
+         style="stop-color:#feffff;stop-opacity:0"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
+         id="stop28340" />
       <stop
-         id="stop4143"
+         style="stop-color:#feffff;stop-opacity:0.5"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.90839696;" />
+         id="stop28342" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient4139"
-       id="radialGradient6440"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6608997e-8,0.83044984,-1.1072665,2.2145329e-8,21.32872,-8.7612453)"
-       cx="25"
-       cy="8"
-       fx="25"
-       fy="8"
-       r="17" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749-4"
-       id="radialGradient3152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,30.90089,-18.18536)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-166-749-4">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop2883-4"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885-68"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-464-309-3"
-       id="radialGradient3154"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,-17.099109,-105.10005)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-464-309-3">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2889-8"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891-1"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3702-501-757-12"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.98701298,0,0,1.0121954,0.31168824,-0.57315547)" />
     <linearGradient
-       id="linearGradient3702-501-757-12">
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-6"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="55.537769"
+       x2="12.051564"
+       y2="8.3442049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717947,0.30769224,-0.17948716)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="27.720701"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945957,0,0,0.45945958,0.97297122,0.51351071)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42857143,0,0,0.42857151,1.7142857,1.2857123)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-6">
       <stop
-         id="stop2895-59"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0"
+         id="stop36980-7" />
       <stop
-         id="stop2897-78"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-36"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#666666;stop-opacity:1"
+         offset="1"
+         id="stop36982-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
+     id="layer1">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.01216"
+       id="g3712"
+       transform="matrix(0.57894737,0,0,0.28227184,-1.8947368,9.733215)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect2801"
+         y="39.914661"
+         x="37.81818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47.000031"
+         x="-10.181818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3700"
+         y="39.914661"
+         x="10.181818"
+         height="7.0853682"
+         width="27.636364" />
     </g>
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect27907"
+       y="2.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="19"
+       width="19" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
-       y="10.499998"
+       y="2.499999"
        x="2.5"
        ry="1"
        rx="1"
        height="19.000002"
-       width="19.000002" />
+       width="19" />
+    <path
+       d="M 20,9 V 20 H 4 V 4 h 11 z"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:none;stroke-width:0.999994px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       id="path3872"
+       sodipodi:nodetypes="cccccc" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
-    <path
-       d="M 3.4999999,11.5 14.823213,11.5 20.5,17.085714 20.5,28.5 l -17,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
-    <path
-       style="fill:url(#radialGradient6440);fill-opacity:1;stroke:none"
-       d="M 4,12 14.635293,12 20,17.176471 20,28 4,28 z"
-       id="path3102-8" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect28226"
+       y="3.4999971"
+       x="3.4999981"
+       height="17.000006"
+       width="17.000004" />
+    <rect
+       style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.499998;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3181"
+       width="3"
+       height="3"
+       x="8"
+       y="7" />
+    <rect
+       style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3403"
+       width="3"
+       height="3"
+       x="8"
+       y="11" />
+    <rect
+       style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3443"
+       width="3"
+       height="3"
+       x="8"
+       y="15" />
+    <rect
+       style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3483"
+       width="3"
+       height="3"
+       x="13"
+       y="7" />
+    <rect
+       style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3563"
+       width="3"
+       height="3"
+       x="13"
+       y="15" />
+    <rect
+       style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3851"
+       width="3"
+       height="3"
+       x="13"
+       y="11" />
   </g>
 </svg>

--- a/elementary-xfce/apps/24/libreoffice-math.svg
+++ b/elementary-xfce/apps/24/libreoffice-math.svg
@@ -1,267 +1,265 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="12.168043"
+     inkscape:cy="10.52573"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="551"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="true"
+     showguides="false" />
   <defs
-     id="defs3428">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
       <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient28344">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4"
-       id="radialGradient3184"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,30.90089,-18.18536)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
     <linearGradient
-       xlink:href="#linearGradient2781"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient2781">
+       id="linearGradient3688-166-749">
       <stop
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop2783" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
       <stop
          offset="1"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop2785" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
-      <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient3688-166-749-4"
-       id="radialGradient3152"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientTransform="matrix(1.3844326,0,0,1.4170737,-17.099109,-105.10005)"
        cx="4.9929786"
        cy="43.5"
        fx="4.9929786"
        fy="43.5"
        r="2.5" />
     <linearGradient
-       id="linearGradient3688-166-749-4">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop2883-4"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2885-68"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309-3"
-       id="radialGradient3154"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309-3">
-      <stop
-         id="stop2889-8"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-1"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3702-501-757-12"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
        x2="25.058096"
-       y2="39.999443" />
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.98701298,0,0,1.0121954,0.31168824,-0.57315547)" />
     <linearGradient
-       id="linearGradient3702-501-757-12">
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-6"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="55.537769"
+       x2="12.051564"
+       y2="8.3442049"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717947,0.30769224,-0.17948716)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="27.720701"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945957,0,0,0.45945958,0.97297122,0.51351071)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.42857143,0,0,0.42857151,1.7142857,1.2857123)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-6">
       <stop
-         id="stop2895-59"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#485a6c;stop-opacity:1"
+         offset="0"
+         id="stop36980-7" />
       <stop
-         id="stop2897-78"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-36"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#667885;stop-opacity:1"
+         offset="1"
+         id="stop36982-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
+     id="layer1">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.01216"
+       id="g3712"
+       transform="matrix(0.57894737,0,0,0.28227184,-1.8947368,9.733215)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect2801"
+         y="39.914661"
+         x="37.81818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47.000031"
+         x="-10.181818"
+         height="7.0853686"
+         width="3.4545455" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2.01216"
+         id="rect3700"
+         y="39.914661"
+         x="10.181818"
+         height="7.0853682"
+         width="27.636364" />
     </g>
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect27907"
+       y="2.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="19"
+       width="19" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
-       y="10.499998"
+       y="2.499999"
        x="2.5"
        ry="1"
        rx="1"
        height="19.000002"
-       width="19.000002" />
+       width="19" />
+    <path
+       d="M 20,9 V 20 H 4 V 4 h 11 z"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:none;stroke-width:0.999994px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       id="path3872"
+       sodipodi:nodetypes="cccccc" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect28226"
+       y="3.4999971"
+       x="3.4999981"
+       height="17.000006"
+       width="17.000004" />
     <path
-       d="M 3.4999999,11.5 14.823213,11.5 20.5,17.085714 20.5,28.5 l -17,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       d="m 10.499584,9 -1.4999992,6.25 -1,-2.25 H 6 v 1 h 0.9995848 l 1.5,3.000001 H 9.7495844 L 11.499584,10 H 17 V 9 Z"
+       fill="url(#a)"
+       id="path23"
+       style="fill:#4e6174;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="cccccccccccc" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 4,12 14.635293,12 20,17.176471 20,28 4,28 z"
-       id="path3102-8" />
+       d="m 12.499999,16.500003 4.000003,-4.000004"
+       fill="none"
+       stroke="#666666"
+       stroke-linecap="round"
+       stroke-width="2"
+       id="path25"
+       style="stroke:#4e6174;stroke-width:0.999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 5.5,20.735294 1.5,0 1.5,4.764706 1.5,-9 6.5,0"
-       id="path4018" />
-    <g
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Sans"
-       id="text4042"
-       transform="matrix(0.49999295,0,0,0.49999295,1.551e-4,9.0002256)">
-      <path
-         d="m 22.24707,22.698101 0,-0.698242 5.392578,0 0,0.698242 -1.127929,0.290039 1.471679,2.169087 1.944336,-2.190571 -1.009765,-0.268555 0,-0.698242 3.4375,0 0,0.698242 -0.891602,0.225586 -2.835937,3.232563 3.201172,4.919922 0.966796,0.225586 0,0.698242 -5.392578,0 0,-0.698242 1.12793,-0.247071 -1.761719,-2.717773 -2.341797,2.739258 L 25.4375,31.301758 25.4375,32 22,32 22,31.301758 22.902344,31.129883 26.125,27.348633 23.224609,22.966656 22.24707,22.698101"
-         style="font-size:22px;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
-         id="path3142" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
+       d="M 16.500002,16.500003 12.499999,12.499999"
+       fill="none"
+       stroke="#666666"
+       stroke-linecap="round"
+       stroke-width="2"
+       id="path27"
+       style="stroke:#4e6174;stroke-width:0.999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   </g>
 </svg>

--- a/elementary-xfce/apps/32/libreoffice-base.svg
+++ b/elementary-xfce/apps/32/libreoffice-base.svg
@@ -1,134 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3331"
+   sodipodi:docname="libreoffice-base.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="10.65625"
+     inkscape:cx="28.293255"
+     inkscape:cy="32.703812"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="79"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     showguides="false" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs3353">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3242-593-605-251-305"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient3332-412-419-652-471"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,140 +67,185 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3242-593-605-251-305">
+       id="linearGradient3688-464-309">
       <stop
-         offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1"
-         id="stop2749" />
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1"
-         id="stop2751" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         id="stop2753" />
-      <stop
-         offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1"
-         id="stop2755" />
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3332-412-419-652-471">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1"
-         id="stop2759" />
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#ad53a5;stop-opacity:1"
-         id="stop2761" />
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162191,0,0,0.62162146,1.081081,1.0810863)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45454546,0,0,0.45454545,1.4545454,1.4545455)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="60.005447"
+       x2="19.702679"
+       y2="9.7770748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4999991,0,0,0.49565127,1.800003e-6,0.26956932)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168-6"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326-3"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617-2"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
   </defs>
-  <metadata
-     id="metadata3356">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1">
+     style="display:inline;stroke-width:2.14836"
+     id="g2036"
+     transform="matrix(0.64999974,0,0,0.27777804,0.39999974,16.94444)">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.14836"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2873-966-168-6);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2875-742-326-3);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2877-634-617-2);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 6,7 19.294117,7 26,13.470588 26,27 6,27 z"
-       id="path3102" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
-    <path
-       d="m 5.4999999,6.4999999 13.9874991,0 L 26.5,13.4 l 0,14.1 -20.9999993,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <g
-       id="g5739">
-      <path
-         transform="matrix(0.56873195,0,0,0.5252488,2.350227,7.3889485)"
-         d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-         id="path4255"
-         style="opacity:0.86046543;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         id="path3988"
-         d="m 10,14 2.06e-4,9 c 0,0 2.099917,1 5.999794,1 3.899876,0 6.000206,-1 6.000206,-1 L 22,14 c 0,0 -2.750103,2 -6,2 -3.249897,0 -6,-2 -6,-2 z"
-         style="fill:#951fa6;fill-opacity:0.33519556;stroke:none" />
-      <path
-         id="path4358"
-         d="m 9.5,13 c 0,0.360806 0,2.947224 0,3.277776 0,1.111103 3.241257,2.227404 6.499794,2.222206 3.24121,-0.0052 6.499793,-1.111103 6.499793,-2.222206 0,-0.391294 0,-2.930984 0,-3.277776"
-         style="fill:none;stroke:#813384;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         transform="matrix(0.54164947,0,0,-0.38461539,3.0002064,20.115385)"
-         d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-         id="path4247"
-         style="fill:#951fa6;fill-opacity:0.5977654;fill-rule:nonzero;stroke:#813384;stroke-width:2.19092464;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         id="path3992"
-         style="fill:none;stroke:#813384;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 9.5,16 c 0,0.360807 0,2.947224 0,3.277776 0,1.111103 3.241257,2.227404 6.499794,2.222206 3.24121,-0.0052 6.499793,-1.111103 6.499793,-2.222206 0,-0.391294 0,-2.930984 0,-3.277776" />
-      <path
-         d="m 9.5,19 c 0,0.360806 0,2.947224 0,3.277776 0,1.111104 3.241257,2.227404 6.499794,2.222206 3.24121,-0.0052 6.499793,-1.111102 6.499793,-2.222206 0,-0.391294 0,-2.930984 0,-3.277776"
-         style="fill:none;stroke:#813384;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         id="path3994" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="3.5"
+     x="3.5"
+     ry="1"
+     rx="1"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="4.4999981"
+     x="4.5"
+     height="23.000004"
+     width="23" />
+  <path
+     d="M 5.5,5.5 H 20.999964 L 26.5,11 v 15.5 h -21 z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:#452981;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 10,13.5 v 8.25 c 0,1.313954 2.531218,2.233333 5.9998,2.233333 C 19.468384,23.983333 22,22.885213 22,21.75 V 13.5 c 0,0 -2.06406,2 -6.0002,2 C 12.063661,15.5 10,13.5 10,13.5 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 9.5,12.5 v 3.25 c 0,1.438196 2.804658,2.506728 6.4998,2.5 C 19.675295,18.2433 22.5,17.188196 22.5,15.75 V 12.5"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="m 22.5,12.5 c 0.0011,-1.822559 -2.428717,-3 -6.5002,-3 -4.071481,0 -6.5008785,1.177441 -6.4998,3 -0.00109,1.822559 2.428319,2.5 6.4998,2.5 4.071483,0 6.501279,-0.677441 6.5002,-2.5 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 9.5,15 v 3.5 c 0,1.438196 2.804658,2.756727 6.4998,2.75 C 19.675295,21.2433 22.5,19.938196 22.5,18.5 V 15"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 9.5,17.5 v 4 c 0,1.438195 2.804658,2.506726 6.4998,2.5 C 19.675295,23.9933 22.5,22.938195 22.5,21.5 v -4"
+     sodipodi:nodetypes="cscsc" />
 </svg>

--- a/elementary-xfce/apps/32/libreoffice-draw.svg
+++ b/elementary-xfce/apps/32/libreoffice-draw.svg
@@ -1,134 +1,55 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3331"
+   sodipodi:docname="libreoffice-draw.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="21.3125"
+     inkscape:cx="16.422287"
+     inkscape:cy="10.768328"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="507"
+     inkscape:window-y="110"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g3173" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs3353">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3846-5"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient3856-6"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,127 +66,221 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3856-6">
+       id="linearGradient3688-464-309">
       <stop
-         offset="0"
-         style="stop-color:#b67926;stop-opacity:1"
-         id="stop3858-8" />
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#eab41a;stop-opacity:1"
-         id="stop3860-0" />
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3846-5">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         offset="0"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         id="stop3848-48" />
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
       <stop
-         offset="0.26238"
-         style="stop-color:#fdde76;stop-opacity:1"
-         id="stop3850-1" />
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162191,0,0,0.62162146,1.081081,1.0810863)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
       <stop
-         offset="0.66093999"
          style="stop-color:#f9c440;stop-opacity:1"
-         id="stop3852-28" />
+         offset="0"
+         id="stop36980" />
       <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
          offset="1"
-         style="stop-color:#e48b20;stop-opacity:1"
-         id="stop3854-9" />
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45454546,0,0,0.45454545,1.4545454,1.4545455)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="60.005447"
+       x2="19.702679"
+       y2="9.7770748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4999991,0,0,0.49565127,1.800003e-6,0.26956932)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168-6"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326-3"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617-2"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="28.534189"
+       y1="24.239939"
+       x2="16.887266"
+       y2="13.663627"
+       id="linearGradient3182"
+       xlink:href="#linearGradient4102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6594275,0,0,0.6465221,-27.820701,1.2237333)" />
+    <linearGradient
+       id="linearGradient4102">
+      <stop
+         id="stop4104"
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4106"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
   </defs>
-  <metadata
-     id="metadata3356">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1">
+     style="display:inline;stroke-width:2.14836"
+     id="g2036"
+     transform="matrix(0.64999974,0,0,0.27777804,0.39999974,16.94444)">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.14836"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2873-966-168-6);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2875-742-326-3);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2877-634-617-2);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="3.5"
+     x="3.5"
+     ry="1"
+     rx="1"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="4.4999981"
+     x="4.5"
+     height="23.000004"
+     width="23" />
+  <path
+     d="M 5.5,5.5 H 20.999964 L 26.5,11 v 15.5 h -21 z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:#ad5f00;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <g
+     id="g3173"
+     transform="translate(27.788038,-1.3186218)">
+    <path
+       style="fill:url(#linearGradient3182);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path2783"
+       d="m -17.036553,24.22914 c 2.754134,1.831596 8.767223,-0.618817 3.768118,-7.176388 -4.95385,-6.498209 4.921913,-10.7602589 7.852511,-3.245276" />
     <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 6,7 19.294117,7 26,13.470588 26,27 6,27 z"
-       id="path3102" />
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       id="rect3565"
+       y="23.318623"
+       x="-18.788029"
+       height="2"
+       width="2" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       id="rect3567"
+       y="13.318622"
+       x="-5.7880378"
+       height="2"
+       width="2" />
     <path
-       d="m 5.5,6.4999999 13.987499,0 L 26.5,13.4 l 0,14.1 -20.9999992,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
+       style="fill:none;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3571"
+       d="m -17.698862,11.147278 9.500118,12.316379" />
     <path
-       style="fill:#f3ba00;fill-opacity:0.42682932;stroke:#f3ba00;stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 8.5,24.5 5,-14 10,14 z"
-       id="path4025" />
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3573"
+       d="m -16.288038,11.318411 c 3.72e-4,0.552176 -0.447453,1 -1,1 -0.552547,0 -1.000372,-0.447824 -1,-1 -3.72e-4,-0.552177 0.447453,-1 1,-1 0.552547,0 1.000372,0.447823 1,1 z" />
     <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 12.5,8.5 2,0 0,2 -2,0 z"
-       id="path5086" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 22.5,23.5 2,0 0,2 -2,0 z"
-       id="path5080" />
-    <path
-       id="path5084"
-       d="m 7.5,23.5 2.0000001,0 0,2 L 7.5,25.5 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3575"
+       d="m -7.288029,23.318411 c 3.73e-4,0.552177 -0.447452,1 -1,1 -0.552546,0 -1.000371,-0.447823 -0.999999,-1 -3.72e-4,-0.552175 0.447453,-1 0.999999,-1 0.552548,0 1.000373,0.447825 1,1 z" />
+    <rect
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       id="rect3569"
+       y="15.818411"
+       x="-14.788028"
+       height="2"
+       width="2" />
   </g>
 </svg>

--- a/elementary-xfce/apps/32/libreoffice-impress.svg
+++ b/elementary-xfce/apps/32/libreoffice-impress.svg
@@ -1,134 +1,55 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3331"
+   sodipodi:docname="libreoffice-impress.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="15.070213"
+     inkscape:cx="15.32825"
+     inkscape:cy="12.309049"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="507"
+     inkscape:window-y="110"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs3353">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5344-867"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2490-113-580-0"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,131 +66,172 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient5344-867">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop5559"
-         style="stop-color:#f9c590;stop-opacity:1"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5561"
-         style="stop-color:#f19860;stop-opacity:1"
-         offset="0.39698008" />
-      <stop
-         id="stop5563"
-         style="stop-color:#ce5d36;stop-opacity:1"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2490-113-580-0">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         offset="0"
-         style="stop-color:#71171c;stop-opacity:1"
-         id="stop5567-3" />
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
       <stop
-         offset="1"
-         style="stop-color:#ed8137;stop-opacity:1"
-         id="stop5569-2" />
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162191,0,0,0.62162146,1.081081,1.0810863)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45454546,0,0,0.45454545,1.4545454,1.4545455)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="60.005447"
+       x2="19.702679"
+       y2="9.7770748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4999991,0,0,0.49565127,1.800003e-6,0.26956932)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168-6"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326-3"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617-2"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
   </defs>
-  <metadata
-     id="metadata3356">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1">
+     style="display:inline;stroke-width:2.14836"
+     id="g2036"
+     transform="matrix(0.64999974,0,0,0.27777804,0.39999974,16.94444)">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.14836"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2873-966-168-6);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2875-742-326-3);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2877-634-617-2);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 6,7 19.294117,7 26,13.470588 26,27 6,27 z"
-       id="path3102" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
-    <path
-       d="m 5.4999999,6.4999999 13.9874991,0 L 26.5,13.4 l 0,14.1 -20.9999993,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="color:#000000;fill:#d37241;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3035-6"
-       d="M 24,19 A 5,5 0 1 1 21.35506,14.589366 L 19.000003,19 z" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 8,23 5,0 0,1 -5,0 z"
-       id="path4673" />
-    <path
-       id="path4774"
-       d="m 8,20 4,0 0,1 -4,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       id="path4776"
-       d="m 8,17 4,0 0,1 -4,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 8,14 5,0 0,1 -5,0 z"
-       id="path4778" />
-    <path
-       id="path4780"
-       d="m 8,10 11,0 1,1 -12,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="3.5"
+     x="3.5"
+     ry="1"
+     rx="1"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="4.4999981"
+     x="4.5"
+     height="23.000004"
+     width="23" />
+  <path
+     d="M 5.5,5.5 H 20.999964 L 26.5,11 v 15.5 h -21 z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:#a62100;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="M 23,15.999649 A 7.0000001,6.9996501 0 1 1 19.297082,9.8250703 l -3.297081,6.1745787 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 23,15.998911 c 0,3.150582 -2.1,5.906458 -5.132116,6.745774 -3.028152,0.838218 -6.242884,-0.432901 -7.8702388,-3.146499 -0.012371,0.01123 6.0023558,-3.599275 6.0023558,-3.599275 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3962"
+     d="m 23,16.002087 c 0,3.034832 -2.0314,5.887469 -5.132116,6.745776 -0.06833,-0.01187 -1.867883,-6.745776 -1.867883,-6.745776 z" />
 </svg>

--- a/elementary-xfce/apps/32/libreoffice-main.svg
+++ b/elementary-xfce/apps/32/libreoffice-main.svg
@@ -1,134 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3331"
+   sodipodi:docname="libreoffice-main.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="21.3125"
+     inkscape:cx="17.853372"
+     inkscape:cy="17.196481"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="58"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     showguides="false" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs3353">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,121 +67,202 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4139">
+       id="linearGradient3308-4-6-931-761">
       <stop
-         id="stop4141"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
       <stop
-         id="stop4143"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.90839696;" />
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient4139"
-       id="radialGradient5969"
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0761246e-8,1.0380623,-1.3840831,2.7681661e-8,27.660899,-18.951557)"
-       cx="25"
-       cy="8"
-       fx="25"
-       fy="8"
-       r="17" />
+       gradientTransform="matrix(0.62162191,0,0,0.62162146,1.081081,1.0810863)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#666666;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45454546,0,0,0.45454545,1.4545454,1.4545455)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="60.005447"
+       x2="19.702679"
+       y2="9.7770748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4999991,0,0,0.49565127,1.800003e-6,0.26956932)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168-6"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326-3"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617-2"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
   </defs>
-  <metadata
-     id="metadata3356">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1">
+     style="display:inline;stroke-width:2.14836"
+     id="g2036"
+     transform="matrix(0.64999974,0,0,0.27777804,0.39999974,16.94444)">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.14836"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2873-966-168-6);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2875-742-326-3);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2877-634-617-2);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
-    <path
-       style="fill:url(#radialGradient5969);fill-opacity:1;stroke:none"
-       d="M 6,7 19.294117,7 26,13.470588 26,27 6,27 z"
-       id="path3102-5" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
-    <path
-       d="m 5.4999999,6.4999999 13.9874991,0 L 26.5,13.4 l 0,14.1 -20.9999993,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="3.5"
+     x="3.5"
+     ry="1"
+     rx="1"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="4.4999981"
+     x="4.5"
+     height="23.000004"
+     width="23" />
+  <path
+     d="M 5.5,5.5 H 20.999964 L 26.5,11 v 15.5 h -21 z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3181"
+     width="5"
+     height="4"
+     x="10"
+     y="10" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3403"
+     width="5"
+     height="4"
+     x="10"
+     y="15" />
+  <rect
+     style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3443"
+     width="5"
+     height="4"
+     x="10"
+     y="20" />
+  <rect
+     style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3483"
+     width="5"
+     height="4"
+     x="17"
+     y="10" />
+  <rect
+     style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3563"
+     width="5"
+     height="4"
+     x="17"
+     y="20" />
+  <rect
+     style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3851"
+     width="5"
+     height="4"
+     x="17"
+     y="15" />
 </svg>

--- a/elementary-xfce/apps/32/libreoffice-math.svg
+++ b/elementary-xfce/apps/32/libreoffice-math.svg
@@ -1,134 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.0"
+   width="32"
+   height="32"
+   id="svg3331"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:zoom="21.3125"
+     inkscape:cx="17.806452"
+     inkscape:cy="17.196481"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="79"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     showguides="false" />
+  <metadata
+     id="metadata143580">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
-     id="defs3353">
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
-      <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
+     id="defs3333">
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
@@ -145,113 +67,292 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
+       id="linearGradient3688-464-309">
       <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient3308-4-6-931-761">
+      <stop
+         id="stop2919"
+         style="stop-color:#ffffff;stop-opacity:0.5"
+         offset="0" />
+      <stop
+         id="stop2921"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3308-4-6-931-761"
+       id="linearGradient3039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162191,0,0,0.62162146,1.081081,1.0810863)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984">
+      <stop
+         style="stop-color:#485a6c;stop-opacity:1"
+         offset="0"
+         id="stop36980" />
+      <stop
+         style="stop-color:#667885;stop-opacity:1"
+         offset="1"
+         id="stop36982" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1306"
+       x1="24.315639"
+       y1="64.701698"
+       x2="24.315639"
+       y2="8.0000029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45454546,0,0,0.45454545,1.4545454,1.4545455)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1462"
+       x1="19.702679"
+       y1="60.005447"
+       x2="19.702679"
+       y2="9.7770748"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4999991,0,0,0.49565127,1.800003e-6,0.26956932)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168-6"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326-3"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617-2"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
   </defs>
-  <metadata
-     id="metadata3356">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
   <g
-     id="layer1">
+     style="display:inline;stroke-width:2.14836"
+     id="g2036"
+     transform="matrix(0.64999974,0,0,0.27777804,0.39999974,16.94444)">
     <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
+       style="opacity:0.4;stroke-width:2.14836"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2873-966-168-6);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2875-742-326-3);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2877-634-617-2);fill-opacity:1;stroke:none;stroke-width:2.14836"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 6,7 19.294117,7 26,13.470588 26,27 6,27 z"
-       id="path3102" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 7.4999999,18.5 2.0454547,0 2.0454544,6 2.045454,-11 8.863637,0"
-       id="path4018" />
-    <path
-       d="m 5.4999999,6.4999999 13.9874991,0 L 26.5,13.4 l 0,14.1 -20.9999993,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999988px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <g
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Sans"
-       id="text4042"
-       transform="matrix(0.69999013,0,0,0.69999013,-0.85528577,2.1665885)">
-      <path
-         d="m 22.897798,21.889129 0,-0.698242 5.392578,0 0,0.698242 -1.127929,0.290039 1.471679,2.169087 1.944336,-2.190571 -1.009765,-0.268555 0,-0.698242 3.4375,0 0,0.698242 -0.891602,0.225586 -2.835937,3.232563 3.201172,4.919922 0.966796,0.225586 0,0.698242 -5.392578,0 0,-0.698242 1.12793,-0.247071 -1.761719,-2.717773 -2.341797,2.739258 1.009766,0.225586 0,0.698242 -3.4375,0 0,-0.698242 0.902344,-0.171875 3.222656,-3.78125 -2.900391,-4.381977 -0.977539,-0.268555"
-         style="font-size:22px;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
-         id="path3142" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1306);fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="3.5"
+     x="3.5"
+     ry="1"
+     rx="1"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:1;fill:none;stroke:url(#linearGradient3039);stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="4.4999981"
+     x="4.5"
+     height="23.000004"
+     width="23" />
+  <path
+     d="M 5.5,5.5 H 20.999964 L 26.5,11 v 15.5 h -21 z"
+     style="opacity:1;fill:url(#linearGradient1462);fill-opacity:1;stroke:#0e141f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <g
+     fill="#f09e6f"
+     id="g21"
+     style="fill:#f37329;fill-opacity:1;stroke-width:2"
+     transform="matrix(0.5,0,0,0.5,-151.5,-35.21387)">
+    <path
+       d="m 327,90.42774 h 2 v 2 h -2 z"
+       id="path2378"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 331,90.42774 h 2 v 2 h -2 z"
+       id="path2380"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 335,90.42774 h 2 v 2 h -2 z"
+       id="path2382"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 339,90.42774 h 2 v 2 h -2 z"
+       id="path2386"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 343,90.42774 h 2 v 2 h -2 z"
+       id="path2388"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 347,90.42774 h 2 v 2 h -2 z"
+       id="path2390"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 327,114.42774 h 2 v 2 h -2 z"
+       id="path3475"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 331,114.42774 h 2 v 2 h -2 z"
+       id="path3477"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 335,114.42774 h 2 v 2 h -2 z"
+       id="path3479"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 339,114.42774 h 2 v 2 h -2 z"
+       id="path3483"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 343,114.42774 h 2 v 2 h -2 z"
+       id="path3485"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 347,114.42774 h 2 v 2 h -2 z"
+       id="path3487"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,90.42774 v 2 h -2 v -2 z"
+       id="path3471-7"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 349,94.42774 v 1.999996 h -2 V 94.42774 Z"
+       id="path3475-3-3"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 349,98.42774 v 2.00001 h -2 v -2.00001 z"
+       id="path3477-5-6"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 349,102.42775 v 2 h -2 v -2 z"
+       id="path3479-6-0"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 349,106.42774 v 2 h -2 v -2 z"
+       id="path3481-2-6"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 349,110.42774 v 2 h -2 v -2 z"
+       id="path3485-1-6"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 323,90.42774 h 2 v 2 h -2 z"
+       id="path4290"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,114.42774 v 2 h -2 v -2 z"
+       id="path4555"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 323,114.42774 h 2 v 2 h -2 z"
+       id="path4557"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,94.42774 v 1.999996 h -2 V 94.42774 Z"
+       id="path7216"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,98.42774 v 2.00001 h -2 v -2.00001 z"
+       id="path7218"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,102.42775 v 2 h -2 v -2 z"
+       id="path7220"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,106.42774 v 2 h -2 v -2 z"
+       id="path7222"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+    <path
+       d="m 321,110.42774 v 2 h -2 v -2 z"
+       id="path7224"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1.99999" />
+  </g>
+  <path
+     d="m 14.499997,13 -1.5,6.5 -1.49983,-3.5 H 9.9728272 v 1 h 0.7086298 l 1.68165,4 h 1.41841 l 1.71848,-7 H 20 v 1 h 1 v -2 z"
+     fill="url(#a)"
+     id="path23"
+     style="fill:#4e6174;fill-opacity:1;stroke-width:1"
+     sodipodi:nodetypes="cccccccccccccc" />
+  <path
+     d="m 16,20.5 4,-4"
+     fill="none"
+     stroke="#666666"
+     stroke-linecap="round"
+     stroke-width="2"
+     id="path25"
+     style="stroke:#4e6174;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 20,20.5 -4,-4"
+     fill="none"
+     stroke="#666666"
+     stroke-linecap="round"
+     stroke-width="2"
+     id="path27"
+     style="stroke:#4e6174;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/apps/48/libreoffice-base.svg
+++ b/elementary-xfce/apps/48/libreoffice-base.svg
@@ -1,84 +1,82 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="libreoffice-base.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="29.263023"
+     inkscape:cy="22.544472"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="580"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:bbox-paths="true" />
   <defs
      id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient36984">
       <stop
+         style="stop-color:#a56de2;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop36980" />
       <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop36982" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient2959"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3.7e-6,1.00001)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop3926" />
+         id="stop22025" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.06316455" />
-      <stop
-         offset="0.95056331"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop3930" />
-      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop3932" />
+         id="stop22027" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(1.9428467e-8,2.33699,-2.4722567,-4.3056275e-8,44.890104,-11.434799)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2874"
-       xlink:href="#linearGradient3242-593-605-251-305" />
     <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="translate(1.2e-6,1)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2876"
-       xlink:href="#linearGradient3332-412-419-652-471" />
+       inkscape:collect="always"
+       id="linearGradient28344">
+      <stop
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
+      <stop
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
+    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
        id="radialGradient3013"
@@ -145,35 +143,35 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       id="linearGradient3332-412-419-652-471">
-      <stop
-         id="stop2759"
-         style="stop-color:#650d5c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2761"
-         style="stop-color:#ad53a5;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="47.863083"
+       x2="12.051564"
+       y2="6.5310311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
     <linearGradient
-       id="linearGradient3242-593-605-251-305">
-      <stop
-         id="stop2749"
-         style="stop-color:#d78ec1;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2751"
-         style="stop-color:#c564be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop2753"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop2755"
-         style="stop-color:#5e2c73;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="43.930134"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
   </defs>
   <metadata
      id="metadata3663">
@@ -183,106 +181,91 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="5.5"
-       x="4.5"
-       ry="2"
-       rx="2"
-       height="39"
-       width="39" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="6.5"
-       x="5.5"
-       ry="1"
-       rx="1"
-       height="37"
-       width="37" />
-    <path
-       d="M 6.4999999,7.5 29.812499,7.5 41.5,19 l 0,23.5 -34.9999999,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 7,8 29.599999,8 41,19 41,42 7,42 z"
-       id="path3102" />
-    <g
-       id="g4739"
-       transform="matrix(1.049997,0,0,1,-0.64996086,-4.8000634e-7)">
-      <path
-         transform="matrix(0.875,0,0,0.96296108,2.0000001,7.462921)"
-         d="M 36,18.5 C 36,22.089851 30.627417,25 24,25 17.372583,25 12,22.089851 12,18.5 12,14.910149 17.372583,12 24,12 c 6.627417,0 12,2.910149 12,6.5 z"
-         id="path4255"
-         style="opacity:0.86046543;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         id="path3988"
-         d="m 14,22.999968 0,2.999968 c 0,0 3,3 9,3 6,0 9,-3 9,-3 l 0,-2.999968 c 0,0 -4,3 -9,3 -5,0 -9,-3 -9,-3 z"
-         style="fill:#951fa6;fill-opacity:0.33519556;stroke:none" />
-      <path
-         id="path4358"
-         d="m 13,19.999935 c 0,0.649456 0,4.405036 0,5.000033 0,2 4.986707,4.009355 10,4 4.986635,-0.0093 10,-2 10,-4 0,-0.704335 0,-4.375803 0,-5.000033"
-         style="fill:none;stroke:#813384;stroke-width:1.95180285;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         transform="matrix(0.83333333,0,0,-0.76923076,3.0000001,34.230737)"
-         d="M 36,18.5 C 36,22.089851 30.627417,25 24,25 17.372583,25 12,22.089851 12,18.5 12,14.910149 17.372583,12 24,12 c 6.627417,0 12,2.910149 12,6.5 z"
-         id="path4247"
-         style="fill:#951fa6;fill-opacity:0.5977654;fill-rule:nonzero;stroke:#813384;stroke-width:2.4378016;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-      <path
-         style="fill:#951fa6;fill-opacity:0.27374303;stroke:none"
-         d="m 14,27.199968 0,2.8 c 0,0 3,2.2 9,2.2 6,0 9,-2.2 9,-2.2 l 0,-2.8 c 0,0 -4,2.8 -9,2.8 -5,0 -9,-2.8 -9,-2.8 z"
-         id="path3990" />
-      <path
-         id="path3992"
-         style="fill:none;stroke:#813384;stroke-width:1.95180285;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         d="m 13,23.999935 c 0,0.649456 0,4.405036 0,5.000033 0,2 4.986707,4.009355 10,4 4.986635,-0.0093 10,-2 10,-4 0,-0.704335 0,-4.375803 0,-5.000033" />
-      <path
-         d="m 13,27.999935 c 0,0.649456 0,4.405036 0,5.000033 0,2 4.986707,4.009355 10,4 4.986635,-0.0093 10,-2 10,-4 0,-0.704335 0,-4.375803 0,-5.000033"
-         style="fill:none;stroke:#813384;stroke-width:1.95180285;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-         id="path3994" />
-      <path
-         id="path3996"
-         d="m 14,31.199968 0,2.8 c 0,0 3,2.2 9,2.2 6,0 9,-2.2 9,-2.2 l 0,-2.8 c 0,0 -4,2.8 -9,2.8 -5,0 -9,-2.8 -9,-2.8 z"
-         style="fill:#951fa6;fill-opacity:0.27374303;stroke:none" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect27907"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <path
+     d="m 41.5,17.5 v 24 H 6.5000001 l -2e-7,-35 H 30.5 Z"
+     style="fill:url(#linearGradient22031);fill-opacity:1;stroke:#452981;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect28226"
+     y="5.4999981"
+     x="5.4999981"
+     ry="2"
+     rx="2"
+     height="37"
+     width="37" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 13,21 v 12 c 0,2.016344 5.6812,3.5 10.999694,3.5 C 29.318187,36.5 35,34.742053 35,33 V 21 c 0,0 -4.964892,3.626316 -11.000306,3.626316 C 17.96428,24.626316 13,21 13,21 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 12.500001,19.368421 v 5.063158 c 0,2.207002 5.833807,4.078745 11.499693,4.068421 5.635757,-0.01027 11.500305,-1.861419 11.500305,-4.068421 v -5.063158"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="M 35.499999,19.563158 C 35.501699,16.766328 30.242633,14.5 23.999694,14.5 c -6.242939,0 -11.501347,2.266328 -11.499693,5.063158 -0.0017,2.79683 5.256754,4.936842 11.499693,4.936842 6.242939,0 11.501959,-2.140012 11.500305,-4.936842 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 12.500001,22.873684 v 5.51754 c 0,2.207002 5.833807,4.1191 11.499693,4.108776 5.635757,-0.01027 11.500305,-1.901774 11.500305,-4.108776 v -5.51754"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 12.500001,26.768421 v 5.452631 c 0,2.207001 5.833807,4.289268 11.499693,4.278948 5.635757,-0.01028 11.500305,-2.071947 11.500305,-4.278948 v -5.452631"
+     sodipodi:nodetypes="cscsc" />
 </svg>

--- a/elementary-xfce/apps/48/libreoffice-draw.svg
+++ b/elementary-xfce/apps/48/libreoffice-draw.svg
@@ -1,84 +1,82 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="libreoffice-draw.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041668"
+     inkscape:cx="27.307917"
+     inkscape:cy="19.354838"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="607"
+     inkscape:window-y="104"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:bbox-paths="true" />
   <defs
      id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient36984">
       <stop
+         style="stop-color:#f9c440;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop36980" />
       <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop36982" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient2959"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3.7e-6,1.00001)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop3926" />
+         id="stop22025" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.06316455" />
-      <stop
-         offset="0.95056331"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop3930" />
-      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop3932" />
+         id="stop22027" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(1.9428467e-8,2.33699,-2.4722567,-4.3056275e-8,44.890104,-11.434799)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2874"
-       xlink:href="#linearGradient3846-5" />
     <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="translate(1.2e-6,1)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2876"
-       xlink:href="#linearGradient3856-6" />
+       inkscape:collect="always"
+       id="linearGradient28344">
+      <stop
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
+      <stop
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
+    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
        id="radialGradient3013"
@@ -145,33 +143,53 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       id="linearGradient3846-5">
-      <stop
-         id="stop3848-48"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3850-1"
-         style="stop-color:#fdde76;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3852-28"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3854-9"
-         style="stop-color:#e48b20;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="47.863083"
+       x2="12.051564"
+       y2="6.5310311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
     <linearGradient
-       id="linearGradient3856-6">
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="43.930134"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       x1="28.534189"
+       y1="24.239939"
+       x2="16.887266"
+       y2="13.663627"
+       id="linearGradient3058"
+       xlink:href="#linearGradient4102"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0501977,0,0,0.9932209,-1.6816234,0.23626909)" />
+    <linearGradient
+       id="linearGradient4102">
       <stop
-         id="stop3858-8"
-         style="stop-color:#b67926;stop-opacity:1"
+         id="stop4104"
+         style="stop-color:#f9c440;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3860-0"
-         style="stop-color:#eab41a;stop-opacity:1"
+         id="stop4106"
+         style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
   </defs>
@@ -183,84 +201,97 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="5.5"
-       x="4.5"
-       ry="2"
-       rx="2"
-       height="39"
-       width="39" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="6.5"
-       x="5.5"
-       ry="1"
-       rx="1"
-       height="37"
-       width="37" />
-    <path
-       d="M 6.4999999,7.5 29.812499,7.5 41.5,19 l 0,23.5 -34.9999999,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 7,8 29.599999,8 41,19 41,42 7,42 z"
-       id="path3102" />
-    <path
-       style="fill:#f3ba00;fill-opacity:0.42682932;stroke:#f3ba00;stroke-width:1.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="M 14,35.999999 20,17 34,35.999999 z"
-       id="path4025" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 18.5,13.5 3,0 0,3 -3,0 z"
-       id="path5086" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 33.5,34.5 3,0 0,3 -3,0 z"
-       id="path5080" />
-    <path
-       id="path5084"
-       d="m 11.5,34.5 3,0 0,3 -3,0 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect27907"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <path
+     d="m 41.5,17.5 v 24 H 6.5000001 l -2e-7,-35 H 30.5 Z"
+     style="fill:url(#linearGradient22031);fill-opacity:1;stroke:#ad5f00;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect28226"
+     y="5.4999981"
+     x="5.4999981"
+     ry="2"
+     rx="2"
+     height="37"
+     width="37" />
+  <path
+     style="fill:url(#linearGradient3058);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path2783"
+     d="m 15.493102,35.578369 c 4.386207,2.813793 13.962591,-0.950658 6.001067,-11.02474 C 13.604717,14.570743 29.332759,8.0231611 34,19.568068" />
+  <path
+     style="fill:#f37329;fill-opacity:1;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path3571"
+     d="M 14.438316,15.481333 29.568109,34.402394" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3575"
+     d="m 30.5,34.500348 c 3.72e-4,0.552547 -0.447453,1.000673 -1,1.000673 -0.552547,0 -1.000372,-0.448126 -1,-1.000673 -3.72e-4,-0.552548 0.447453,-1.000674 1,-1.000674 0.552547,0 1.000372,0.448126 1,1.000674 z m -15,-19.000001 c 3.72e-4,0.552548 -0.447453,1.000673 -1,1.000673 -0.552547,0 -1.000372,-0.448125 -1,-1.000673 -3.72e-4,-0.552548 0.447453,-1.000673 1,-1.000673 0.552547,0 1.000372,0.448125 1,1.000673 z" />
+  <path
+     style="fill:#e99f20;fill-opacity:1;stroke:none"
+     id="rect3569"
+     d="m 20,23.000347 h 3 v 3 h -3 z m 12,-5 h 3 v 3 h -3 z m -19,16 h 3 v 3 h -3 z" />
+  <path
+     d="m 33,19.000347 h 1 v 1 h -1 z"
+     id="path19011"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 21,24 h 1 v 1 h -1 z"
+     id="path1890"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 14,35 h 1 v 1 h -1 z"
+     id="path1892"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccc" />
 </svg>

--- a/elementary-xfce/apps/48/libreoffice-impress.svg
+++ b/elementary-xfce/apps/48/libreoffice-impress.svg
@@ -1,84 +1,82 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="libreoffice-impress.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="28.068614"
+     inkscape:cy="21.947267"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="601"
+     inkscape:window-y="104"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:bbox-paths="true" />
   <defs
      id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient36984">
       <stop
+         style="stop-color:#f37329;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop36980" />
       <stop
+         style="stop-color:#ffa154;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop36982" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient2959"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3.7e-6,1.00001)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop3926" />
+         id="stop22025" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.06316455" />
-      <stop
-         offset="0.95056331"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop3930" />
-      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop3932" />
+         id="stop22027" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(1.9428467e-8,2.33699,-2.4722567,-4.3056275e-8,44.890104,-11.434799)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2874"
-       xlink:href="#linearGradient5344-867" />
     <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="translate(1.2e-6,1)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2876"
-       xlink:href="#linearGradient2490-113-580" />
+       inkscape:collect="always"
+       id="linearGradient28344">
+      <stop
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
+      <stop
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
+    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
        id="radialGradient3013"
@@ -145,31 +143,35 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       id="linearGradient2490-113-580">
-      <stop
-         offset="0"
-         style="stop-color:#71171c;stop-opacity:1"
-         id="stop5567" />
-      <stop
-         offset="1"
-         style="stop-color:#ed8137;stop-opacity:1"
-         id="stop5569" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="47.863083"
+       x2="12.051564"
+       y2="6.5310311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
     <linearGradient
-       id="linearGradient5344-867">
-      <stop
-         offset="0"
-         style="stop-color:#f9c590;stop-opacity:1"
-         id="stop5559" />
-      <stop
-         offset="0.39698008"
-         style="stop-color:#f19860;stop-opacity:1"
-         id="stop5561" />
-      <stop
-         offset="1"
-         style="stop-color:#ce5d36;stop-opacity:1"
-         id="stop5563" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="43.930134"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
   </defs>
   <metadata
      id="metadata3663">
@@ -179,92 +181,78 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="5.5"
-       x="4.5"
-       ry="2"
-       rx="2"
-       height="39"
-       width="39" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="6.5"
-       x="5.5"
-       ry="1"
-       rx="1"
-       height="37"
-       width="37" />
-    <path
-       d="M 6.4999999,7.5 29.812499,7.5 41.5,19 l 0,23.5 -34.9999999,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 7,8 29.599999,8 41,19 41,42 7,42 z"
-       id="path3102" />
-    <path
-       id="path3986"
-       d="M 11,16 30.090907,16 32,18 11,18 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="color:#000000;fill:#d37241;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3035-6"
-       d="m 37.906328,28.046836 a 6.9531641,6.9531641 0 1 1 -3.67814,-6.133572 l -3.27502,6.133572 z" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 11,33 11,0 0,2 -11,0 z"
-       id="path4673" />
-    <path
-       id="path4675"
-       d="m 11,21 11,0 0,2 -11,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 11,25 9.533333,0 0,2 L 11,27 z"
-       id="path4677" />
-    <path
-       id="path4679"
-       d="m 11,29 9.533333,0 0,2 L 11,31 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect27907"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <path
+     d="m 41.5,17.5 v 24 H 6.5000001 l -2e-7,-35 H 30.5 Z"
+     style="fill:url(#linearGradient22031);fill-opacity:1;stroke:#a62100;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect28226"
+     y="5.4999981"
+     x="5.4999981"
+     ry="2"
+     rx="2"
+     height="37"
+     width="37" />
+  <path
+     d="M 36,24.999397 A 12,11.9994 0 1 1 29.65214,14.414406 l -5.652139,10.584991 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 36,24.998133 c 0,5.400997 -3.6,10.125356 -8.797914,11.564184 -5.191117,1.436944 -10.702085,-0.742116 -13.491838,-5.393999 -0.02121,0.01925 10.289753,-6.170185 10.289753,-6.170185 z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3962"
+     d="m 36,25.003579 c 0,5.202567 -3.4824,10.092802 -8.797914,11.564186 -0.117144,-0.02035 -3.202085,-11.564186 -3.202085,-11.564186 z" />
 </svg>

--- a/elementary-xfce/apps/48/libreoffice-main.svg
+++ b/elementary-xfce/apps/48/libreoffice-main.svg
@@ -1,95 +1,83 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="libreoffice-main.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.5520834"
+     inkscape:cx="41.806451"
+     inkscape:cy="13.653959"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="580"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:bbox-paths="true"
+     inkscape:lockguides="true" />
   <defs
      id="defs3660">
     <linearGradient
-       id="linearGradient4139">
+       inkscape:collect="always"
+       id="linearGradient36984">
       <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
+         style="stop-color:#333333;stop-opacity:1"
          offset="0"
-         id="stop4141" />
+         id="stop36980" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0.90839696;"
+         style="stop-color:#666666;stop-opacity:1"
          offset="1"
-         id="stop4143" />
+         id="stop36982" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop22025" />
       <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient2959"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3.7e-6,1.00001)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient28344">
       <stop
+         style="stop-color:#feffff;stop-opacity:0"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop3926" />
+         id="stop28340" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.06316455" />
-      <stop
-         offset="0.95056331"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop3930" />
-      <stop
+         style="stop-color:#feffff;stop-opacity:0.5"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop3932" />
+         id="stop28342" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(1.9428467e-8,2.33699,-2.4722567,-4.3056275e-8,44.890104,-11.434799)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2874"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="translate(1.2e-6,1)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2876"
-       xlink:href="#linearGradient2781" />
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
        id="radialGradient3013"
@@ -156,45 +144,35 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
-      <stop
-         offset="0"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         id="stop5430-5" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop5432-2" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         id="stop5434-9" />
-      <stop
-         offset="1"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         id="stop5436-2" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2781">
-      <stop
-         id="stop2783"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2785"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient4139"
-       id="radialGradient4145"
-       cx="25"
-       cy="8"
-       fx="25"
-       fy="8"
-       r="17"
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="47.863083"
+       x2="12.051564"
+       y2="6.5310311"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.5294118e-8,1.7647059,-2.3529412,4.7058824e-8,43.823528,-36.117647)" />
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="43.930134"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
   </defs>
   <metadata
      id="metadata3663">
@@ -204,68 +182,108 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="5.5"
-       x="4.5"
-       ry="2"
-       rx="2"
-       height="39"
-       width="39" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="6.5"
-       x="5.5"
-       ry="1"
-       rx="1"
-       height="37"
-       width="37" />
-    <path
-       d="M 6.4999999,7.5 29.812499,7.5 41.5,19 l 0,23.5 -34.9999999,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:url(#radialGradient4145);fill-opacity:1;stroke:none"
-       d="M 7,8 29.599999,8 41,19 41,42 7,42 z"
-       id="path3102" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect27907"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <path
+     d="m 41.5,17.5 v 24 H 6.5000001 l -2e-7,-35 H 30.5 Z"
+     style="fill:url(#linearGradient22031);fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect28226"
+     y="5.4999981"
+     x="5.4999981"
+     ry="2"
+     rx="2"
+     height="37"
+     width="37" />
+  <rect
+     style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.500001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3181"
+     width="9"
+     height="7"
+     x="14"
+     y="13" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.500001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3403"
+     width="9"
+     height="7"
+     x="14"
+     y="22" />
+  <rect
+     style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.500001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3443"
+     width="9"
+     height="7"
+     x="14"
+     y="31" />
+  <rect
+     style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.500001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3483"
+     width="9"
+     height="7"
+     x="25"
+     y="13" />
+  <rect
+     style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.500001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3563"
+     width="9"
+     height="7"
+     x="25"
+     y="31" />
+  <rect
+     style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.500001;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3851"
+     width="9"
+     height="7"
+     x="25"
+     y="22" />
 </svg>

--- a/elementary-xfce/apps/48/libreoffice-math.svg
+++ b/elementary-xfce/apps/48/libreoffice-math.svg
@@ -1,84 +1,82 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="29.31279"
+     inkscape:cy="22.444937"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="580"
+     inkscape:window-y="65"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:snap-global="true"
+     showguides="false"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:bbox-paths="true" />
   <defs
      id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient36984">
       <stop
+         style="stop-color:#485a6c;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop36980" />
       <stop
+         style="stop-color:#667885;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop36982" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3924"
-       id="linearGradient2959"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(3.7e-6,1.00001)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient3924">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop3926" />
+         id="stop22025" />
       <stop
-         id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         offset="0.06316455" />
-      <stop
-         offset="0.95056331"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop3930" />
-      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop3932" />
+         id="stop22027" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(1.9428467e-8,2.33699,-2.4722567,-4.3056275e-8,44.890104,-11.434799)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2874"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4" />
     <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="translate(1.2e-6,1)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2876"
-       xlink:href="#linearGradient2781" />
+       inkscape:collect="always"
+       id="linearGradient28344">
+      <stop
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
+      <stop
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
+    </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
        id="radialGradient3013"
@@ -145,35 +143,35 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
-      <stop
-         offset="0"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         id="stop5430-5" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop5432-2" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         id="stop5434-9" />
-      <stop
-         offset="1"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         id="stop5436-2" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="47.863083"
+       x2="12.051564"
+       y2="6.5310311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
     <linearGradient
-       id="linearGradient2781">
-      <stop
-         id="stop2783"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2785"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="43.930134"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="46.958855"
+       x2="12.817238"
+       y2="9.2174301"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-1)" />
   </defs>
   <metadata
      id="metadata3663">
@@ -183,81 +181,284 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="5.5"
-       x="4.5"
-       ry="2"
-       rx="2"
-       height="39"
-       width="39" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="6.5"
-       x="5.5"
-       ry="1"
-       rx="1"
-       height="37"
-       width="37" />
-    <path
-       d="M 6.4999999,7.5 29.812499,7.5 41.5,19 l 0,23.5 -34.9999999,0 z"
-       style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-       id="path3872" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       d="M 7,8 29.599999,8 41,19 41,42 7,42 z"
-       id="path3102" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 12,27 3,0 3,9 3,-17 13,0"
-       id="path4018" />
-    <g
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Sans"
-       id="text4042"
-       transform="translate(0,4)">
-      <path
-         d="m 22.24707,22.698101 0,-0.698242 5.392578,0 0,0.698242 -1.127929,0.290039 1.471679,2.169087 1.944336,-2.190571 -1.009765,-0.268555 0,-0.698242 3.4375,0 0,0.698242 -0.891602,0.225586 -2.835937,3.232563 3.201172,4.919922 0.966796,0.225586 0,0.698242 -5.392578,0 0,-0.698242 1.12793,-0.247071 -1.761719,-2.717773 -2.341797,2.739258 L 25.4375,31.301758 25.4375,32 22,32 22,31.301758 22.902344,31.129883 26.125,27.348633 23.224609,22.966656 22.24707,22.698101"
-         style="font-size:22px;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
-         id="path3142" />
-    </g>
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect27907"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <path
+     d="m 41.5,17.5 v 24 H 6.5000001 l -2e-7,-35 H 30.5 Z"
+     style="fill:url(#linearGradient22031);fill-opacity:1;stroke:#0e141f;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+     id="rect28226"
+     y="5.4999981"
+     x="5.4999981"
+     ry="2"
+     rx="2"
+     height="37"
+     width="37" />
+  <path
+     d="M 20.75,19 19,30 16.992,25 H 14 v 2 h 1.69122 l 2,5 H 20.5 l 2,-11 H 32 v 1 h 2 v -3 z m 3.73828,3.9946 c -0.896475,0.002 -1.337753,1.09155 -0.69531,1.7168 l 2.79297,2.79297 -2.79297,2.79297 c -0.981813,0.942505 0.471555,2.395873 1.41406,1.41406 L 28,28.91843 30.79297,31.7114 c 0.942505,0.981813 2.395873,-0.471555 1.41406,-1.41406 l -2.79297,-2.79297 2.79297,-2.79297 c 0.654108,-0.635814 0.185248,-1.743691 -0.72656,-1.7168 -0.259799,0.0077 -0.506379,0.116324 -0.6875,0.30274 L 28,26.09031 25.20703,23.29734 C 25.018288,23.103319 24.75896,22.994089 24.48828,22.9946 Z"
+     fill="url(#a)"
+     id="path15"
+     style="fill:#4e6174;fill-opacity:1"
+     sodipodi:nodetypes="ccccccccccccccccccccccccccccc" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6387"
+     width="1"
+     height="2"
+     x="12"
+     y="20" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6389"
+     width="1"
+     height="2"
+     x="12"
+     y="23" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6391"
+     width="1"
+     height="2"
+     x="12"
+     y="26" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6393"
+     width="1"
+     height="2"
+     x="12"
+     y="29" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6395"
+     width="1"
+     height="1"
+     x="12"
+     y="32" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6500"
+     width="1"
+     height="2"
+     x="16"
+     y="-29"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6502"
+     width="1"
+     height="2"
+     x="16"
+     y="-26"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6504"
+     width="1"
+     height="2"
+     x="16"
+     y="-23"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6506"
+     width="1"
+     height="2"
+     x="16"
+     y="-20"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6508"
+     width="1"
+     height="2"
+     x="16"
+     y="-17"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6510"
+     width="1"
+     height="2"
+     x="16"
+     y="-14"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6512"
+     width="1"
+     height="3"
+     x="16"
+     y="-33"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6780"
+     width="1"
+     height="1"
+     x="35"
+     y="18" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6782"
+     width="1"
+     height="2"
+     x="35"
+     y="20" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6784"
+     width="1"
+     height="2"
+     x="35"
+     y="23" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6786"
+     width="1"
+     height="2"
+     x="35"
+     y="26" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6788"
+     width="1"
+     height="2"
+     x="35"
+     y="29" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect6790"
+     width="1"
+     height="1"
+     x="35"
+     y="32" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect7020"
+     width="1"
+     height="1"
+     x="12"
+     y="18" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11485"
+     width="1"
+     height="2"
+     x="16"
+     y="-36"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11645"
+     width="1"
+     height="2"
+     x="34"
+     y="-29"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11647"
+     width="1"
+     height="2"
+     x="34"
+     y="-26"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11649"
+     width="1"
+     height="2"
+     x="34"
+     y="-23"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11651"
+     width="1"
+     height="2"
+     x="34"
+     y="-20"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11653"
+     width="1"
+     height="2"
+     x="34"
+     y="-17"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11655"
+     width="1"
+     height="2"
+     x="34"
+     y="-14"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11657"
+     width="1"
+     height="3"
+     x="34"
+     y="-33"
+     transform="rotate(90)" />
+  <rect
+     style="fill:#f37329;fill-opacity:1;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+     id="rect11659"
+     width="1"
+     height="2"
+     x="34"
+     y="-36"
+     transform="rotate(90)" />
 </svg>

--- a/elementary-xfce/apps/64/libreoffice-base.svg
+++ b/elementary-xfce/apps/64/libreoffice-base.svg
@@ -1,15 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="64"
    height="64"
-   id="svg3331">
+   id="svg3331"
+   sodipodi:docname="libreoffice-base.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.6640625"
+     inkscape:cx="57.994135"
+     inkscape:cy="6.1935484"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="-368"
+     inkscape:window-y="341"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true" />
   <metadata
      id="metadata143580">
     <rdf:RDF>
@@ -18,7 +45,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -106,78 +132,51 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4324331,0,0,1.432432,-2.3783784,-2.3783618)"
        x1="23.99999"
-       y1="4.999989"
+       y1="9.0873976"
        x2="23.99999"
-       y2="43" />
+       y2="50.794746" />
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1289202,0,0,1.7349781,4.8530991,-3.9105612)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-7"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop22025" />
       <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3242-593-605-251-305">
-      <stop
-         id="stop2749"
-         style="stop-color:#d78ec1;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2751"
-         style="stop-color:#c564be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop2753"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop2755"
-         style="stop-color:#5e2c73;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3332-412-419-652-471">
+       inkscape:collect="always"
+       id="linearGradient36984-7">
       <stop
-         id="stop2759"
-         style="stop-color:#650d5c;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
       <stop
-         id="stop2761"
-         style="stop-color:#ad53a5;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(2.739912e-8,3.2957551,-3.4865158,-6.0720387e-8,61.460407,-19.382409)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3402"
-       xlink:href="#linearGradient3242-593-605-251-305" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(1.4102564,0,0,1.4102564,-1.8461505,-1.846154)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3404"
-       xlink:href="#linearGradient3332-412-419-652-471" />
   </defs>
   <g
      style="display:inline"
@@ -212,7 +211,7 @@
     </g>
   </g>
   <rect
-     style="color:#000000;fill:url(#radialGradient3402);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3404);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
      id="rect5505-21"
      y="4.5"
      x="4.5"
@@ -230,44 +229,33 @@
      height="53.000004"
      width="53" />
   <path
-     d="m 8.5,8.5000025 31.30535,0 L 55.5,23.942859 l 0,31.557138 -47,0 z"
-     style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path3872" />
+     d="M 7.5,7.5 H 42 L 56.5,22 v 34.5 h -49 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#452981;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
   <path
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     d="m 9,9.0000031 30.576459,0 L 55,23.882354 l 0,31.117643 -46,0 z"
-     id="path3102" />
-  <g
-     id="g3136">
-    <path
-       transform="matrix(1.2231879,0,0,1.3094072,2.6434911,7.8363152)"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       id="path4255"
-       style="opacity:0.86046543;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       id="path4358"
-       d="m 18.02071,25.761966 c 0,0.883112 0,5.989843 0,6.798903 0,2.719544 6.971062,5.451808 13.97929,5.439087 6.970962,-0.01265 13.97929,-2.719543 13.97929,-5.439087 0,-0.957734 0,-5.950093 0,-6.798903"
-       style="fill:none;stroke:#813384;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       transform="matrix(1.1649408,0,0,-0.99999997,4.0414201,44.999999)"
-       d="m 36,18.5 a 12,6.5 0 1 1 -24,0 12,6.5 0 1 1 24,0 z"
-       id="path4247"
-       style="fill:#951fa6;fill-opacity:0.5977654;fill-rule:nonzero;stroke:#813384;stroke-width:1.85301161;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       id="path3992"
-       style="fill:none;stroke:#813384;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 18.02071,30.761966 c 0,0.883112 0,5.989843 0,6.798903 0,2.719544 6.971062,5.451808 13.97929,5.439087 6.970962,-0.01265 13.97929,-2.719543 13.97929,-5.439087 0,-0.957735 0,-5.950093 0,-6.798903" />
-    <path
-       d="m 18.02071,35.761966 c 0,0.883112 0,5.989843 0,6.798903 0,2.719543 6.971062,5.451807 13.97929,5.439087 6.970962,-0.01265 13.97929,-2.719544 13.97929,-5.439087 0,-0.957735 0,-5.950093 0,-6.798903"
-       style="fill:none;stroke:#813384;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       id="path3994" />
-    <path
-       id="path3996"
-       d="M 19,29 18.60508,43.324031 C 18.60508,43.324031 23.183048,48 32,48 40.816953,48 45.055937,43.324031 45.055937,43.324031 L 45,29 c 0,0 -5.652539,4 -13,4 -7.34746,0 -13,-4 -13,-4 z"
-       style="fill:#951fa6;fill-opacity:0.27374303;stroke:none" />
-  </g>
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 18,26.87888 -3.85e-4,16 c 0,2.543137 7.294072,4.62112 13.999999,4.62112 C 38.705541,47.5 46,45.076065 46,42.87888 v -16 c 0,0 -6.390516,5.39305 -14.000386,5.39305 C 24.389744,32.27193 18,26.87888 18,26.87888 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
   <path
-     style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3333"
-     d="M 7.6652546,6 C 6.5920186,6 6,6.2098917 6,8.3999999 L 6.0173037,38 C 7.5132162,37.967773 56.864566,26.204122 58,25.638279 L 58,8.3999999 C 58,6.2969752 57.512806,6 56.46834,6 z" />
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 17.5,25.640351 v 6.385965 c 0,2.783606 7.355671,5.662098 14.499614,5.649077 C 39.105569,37.662443 46.5,34.809922 46.5,32.026316 v -6.385965"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="M 46.5,25.885965 C 46.5021,22.358432 39.871146,19.5 31.999614,19.5 24.128082,19.5 17.497915,22.358432 17.5,25.885965 c -0.0021,3.527534 6.628082,6.385965 14.499614,6.385965 7.871532,0 14.502471,-2.858431 14.500386,-6.385965 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 17.5,30.061404 v 6.959059 c 0,2.783606 7.355671,5.580232 14.499614,5.567211 C 39.105569,42.574724 46.5,39.804069 46.5,37.020463 v -6.959059"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 17.5,34.973684 v 6.877193 c 0,2.783605 7.355671,5.662096 14.499614,5.649079 C 39.105569,47.486986 46.5,44.634482 46.5,41.850877 v -6.877193"
+     sodipodi:nodetypes="cscsc" />
 </svg>

--- a/elementary-xfce/apps/64/libreoffice-draw.svg
+++ b/elementary-xfce/apps/64/libreoffice-draw.svg
@@ -1,15 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="64"
    height="64"
-   id="svg3331">
+   id="svg3331"
+   sodipodi:docname="libreoffice-draw.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.65625"
+     inkscape:cx="27.495601"
+     inkscape:cy="31.202346"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="418"
+     inkscape:window-y="389"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true" />
   <metadata
      id="metadata143580">
     <rdf:RDF>
@@ -18,7 +45,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -106,77 +132,70 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4324331,0,0,1.432432,-2.3783784,-2.3783618)"
        x1="23.99999"
-       y1="4.999989"
+       y1="9.0873976"
        x2="23.99999"
-       y2="43" />
+       y2="50.794746" />
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-7"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3802614,0,0,1.3035093,-1.7530309,0.46843107)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1289202,0,0,1.7349781,4.8530991,-3.9105612)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
+       xlink:href="#linearGradient4102"
+       id="linearGradient3918"
+       y2="13.663627"
+       x2="16.887266"
+       y1="24.239939"
+       x1="28.534189" />
     <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       id="linearGradient4102">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         style="stop-color:#f9c440;stop-opacity:1"
+         id="stop4104" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(2.739912e-8,3.2957551,-3.4865158,-6.0720387e-8,61.460407,-19.382409)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3402"
-       xlink:href="#linearGradient3846-5" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(1.4102564,0,0,1.4102564,-1.8461505,-1.846154)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3404"
-       xlink:href="#linearGradient3856-6" />
-    <linearGradient
-       id="linearGradient3856-6">
-      <stop
-         offset="0"
-         style="stop-color:#b67926;stop-opacity:1"
-         id="stop3858-8" />
-      <stop
-         offset="1"
-         style="stop-color:#eab41a;stop-opacity:1"
-         id="stop3860-0" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3846-5">
-      <stop
-         offset="0"
-         style="stop-color:#fff3cb;stop-opacity:1"
-         id="stop3848-48" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#fdde76;stop-opacity:1"
-         id="stop3850-1" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#f9c440;stop-opacity:1"
-         id="stop3852-28" />
-      <stop
-         offset="1"
-         style="stop-color:#e48b20;stop-opacity:1"
-         id="stop3854-9" />
+         id="stop4106" />
     </linearGradient>
   </defs>
   <g
@@ -212,7 +231,7 @@
     </g>
   </g>
   <rect
-     style="color:#000000;fill:url(#radialGradient3402);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3404);stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
      id="rect5505-21"
      y="4.5"
      x="4.5"
@@ -230,34 +249,39 @@
      height="53.000004"
      width="53" />
   <path
-     d="m 8.5,8.5000025 31.30535,0 L 55.5,23.942859 l 0,31.557138 -47,0 z"
-     style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path3872" />
+     d="M 7.5,7.5 H 42 L 56.5,22 v 34.5 h -49 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#ad5f00;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
   <path
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     d="m 9,9.0000031 30.576459,0 L 55,23.882354 l 0,31.117643 -46,0 z"
-     id="path3102" />
-  <g
-     id="g5575">
-    <path
-       id="path4025"
-       d="m 17.5,46.5 8.7,-27 20.3,27 z"
-       style="fill:#f3ba00;fill-opacity:0.42682932;stroke:#f3ba00;stroke-width:3;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       id="path5086"
-       d="m 24,14.999999 4,0 L 28,19 24,19 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-       d="m 14,44.999999 4,0 L 18,49 14,49 z"
-       id="path5571" />
-    <path
-       id="path5573"
-       d="m 46,44.999999 4,0 L 50,49 46,49 z"
-       style="fill:#ffffff;fill-opacity:1;stroke:#f3ba00;stroke-width:1.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-  </g>
+     style="fill:url(#linearGradient3918);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path2783"
+     d="m 20.819491,46.851624 c 5.764736,3.69284 18.350854,-1.247649 7.887126,-14.468937 C 18.337612,19.281084 39.008776,10.687998 45.14287,25.839605" />
   <path
-     style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3333"
-     d="M 7.6652546,6 C 6.5920186,6 6,6.2098917 6,8.3999999 L 6.0173037,38 C 7.5132162,37.967773 56.864566,26.204122 58,25.638279 L 58,8.3999999 C 58,6.2969752 57.512806,6 56.46834,6 z" />
+     style="fill:#f37329;fill-opacity:1;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path3571"
+     d="M 19.4332,20.476149 39.318093,45.308267" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3575"
+     d="m 40.542865,45.436823 c 4.89e-4,0.725166 -0.588082,1.313289 -1.314286,1.313289 -0.726207,0 -1.314777,-0.588123 -1.314288,-1.313289 -4.89e-4,-0.725168 0.588081,-1.313291 1.314288,-1.313291 0.726204,0 1.314775,0.588123 1.314286,1.313291 z M 20.828558,20.501102 c 4.88e-4,0.725167 -0.588082,1.31329 -1.314288,1.31329 -0.726205,0 -1.314775,-0.588123 -1.314287,-1.31329 -4.88e-4,-0.725167 0.588082,-1.31329 1.314287,-1.31329 0.726206,0 1.314776,0.588123 1.314288,1.31329 z" />
+  <path
+     style="fill:#e99f20;fill-opacity:1;stroke:none"
+     id="rect3569"
+     d="m 27,30.000419 h 4 v 4 h -4 z m 16,-7 h 4 v 4 h -4 z m -26,22 h 4 v 4 h -4 z" />
+  <path
+     d="m 44,24 h 2 v 2 h -2 z"
+     id="path19011"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 28,31 h 2 v 2 h -2 z"
+     id="path4241"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 18,46 h 2 v 2 h -2 z"
+     id="path4243"
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccc" />
 </svg>

--- a/elementary-xfce/apps/64/libreoffice-impress.svg
+++ b/elementary-xfce/apps/64/libreoffice-impress.svg
@@ -1,15 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="64"
    height="64"
-   id="svg3331">
+   id="svg3331"
+   sodipodi:docname="libreoffice-impress.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.7675533"
+     inkscape:cx="17.916137"
+     inkscape:cy="33.576167"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="528"
+     inkscape:window-y="138"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true" />
   <metadata
      id="metadata143580">
     <rdf:RDF>
@@ -18,7 +45,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -106,73 +132,50 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4324331,0,0,1.432432,-2.3783784,-2.3783618)"
        x1="23.99999"
-       y1="4.999989"
+       y1="9.0873976"
        x2="23.99999"
-       y2="43" />
+       y2="50.794746" />
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1289202,0,0,1.7349781,4.8530991,-3.9105612)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-7"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop22025" />
       <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(2.739912e-8,3.2957551,-3.4865158,-6.0720387e-8,61.460407,-19.382409)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3402"
-       xlink:href="#linearGradient5344-867" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(1.4102564,0,0,1.4102564,-1.8461505,-1.846154)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3404"
-       xlink:href="#linearGradient2490-113-580-0" />
-    <linearGradient
-       id="linearGradient5344-867">
-      <stop
-         id="stop5559"
-         style="stop-color:#f9c590;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5561"
-         style="stop-color:#f19860;stop-opacity:1"
-         offset="0.39698008" />
-      <stop
-         id="stop5563"
-         style="stop-color:#ce5d36;stop-opacity:1"
-         offset="1" />
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2490-113-580-0">
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
       <stop
+         style="stop-color:#f37329;stop-opacity:1"
          offset="0"
-         style="stop-color:#71171c;stop-opacity:1"
-         id="stop5567-3" />
+         id="stop36980-5" />
       <stop
+         style="stop-color:#ffa154;stop-opacity:1"
          offset="1"
-         style="stop-color:#ed8137;stop-opacity:1"
-         id="stop5569-2" />
+         id="stop36982-3" />
     </linearGradient>
   </defs>
   <g
@@ -208,7 +211,7 @@
     </g>
   </g>
   <rect
-     style="color:#000000;fill:url(#radialGradient3402);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3404);stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
      id="rect5505-21"
      y="4.5"
      x="4.5"
@@ -226,42 +229,20 @@
      height="53.000004"
      width="53" />
   <path
-     d="m 8.5,8.5000025 31.30535,0 L 55.5,23.942859 l 0,31.557138 -47,0 z"
-     style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path3872" />
+     d="M 7.5,7.5 H 42 L 56.5,22 v 34.5 h -49 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#a62100;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
   <path
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     d="m 9,9.0000031 30.576459,0 L 55,23.882354 l 0,31.117643 -46,0 z"
-     id="path3102" />
-  <g
-     id="g9607">
-    <path
-       d="m 50,38.999999 a 10,10 0 1 1 -5.28988,-8.821267 l -4.710114,8.821267 z"
-       id="path3035-6"
-       style="color:#000000;fill:#d37241;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992186;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       id="path4673"
-       d="m 14,46 15,0 0,3 -15,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 14,40 12,0 0,3 -12,0 z"
-       id="path9580" />
-    <path
-       id="path9582"
-       d="m 14,34 12,0 0,3 -12,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-    <path
-       style="fill:#d37241;fill-opacity:1;stroke:none"
-       d="m 14,28 15,0 0,3 -15,0 z"
-       id="path9584" />
-    <path
-       id="path9586"
-       d="m 14,19 26,0 3,3 -29,0 z"
-       style="fill:#d37241;fill-opacity:1;stroke:none" />
-  </g>
+     d="m 47.000001,32.999247 a 15.000001,14.999251 0 1 1 -7.934825,-13.23124 l -7.065175,13.23124 z"
+     id="path3035"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
-     style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3333"
-     d="M 7.6652546,6 C 6.5920186,6 6,6.2098917 6,8.3999999 L 6.0173037,38 C 7.5132162,37.967773 56.864566,26.204122 58,25.638279 L 58,8.3999999 C 58,6.2969752 57.512806,6 56.46834,6 z" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3964"
+     d="m 47.000001,32.997666 c 0,6.751246 -4.5,12.656696 -10.997393,14.45523 C 29.513712,49.249078 22.625,46.525252 19.13781,40.710399 19.1113,40.734459 32.000001,32.997666 32.000001,32.997666 Z" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path3962"
+     d="m 47.000001,33.004473 c 0,6.50321 -4.353,12.616004 -10.997393,14.455233 -0.14643,-0.02543 -4.002607,-14.455233 -4.002607,-14.455233 z" />
 </svg>

--- a/elementary-xfce/apps/64/libreoffice-main.svg
+++ b/elementary-xfce/apps/64/libreoffice-main.svg
@@ -1,15 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="64"
    height="64"
-   id="svg3331">
+   id="svg3331"
+   sodipodi:docname="libreoffice-main.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.5351066"
+     inkscape:cx="35.898629"
+     inkscape:cy="39.08372"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="703"
+     inkscape:window-y="108"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true" />
   <metadata
      id="metadata143580">
     <rdf:RDF>
@@ -18,7 +45,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -106,99 +132,51 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4324331,0,0,1.432432,-2.3783784,-2.3783618)"
        x1="23.99999"
-       y1="4.999989"
+       y1="9.0873976"
        x2="23.99999"
-       y2="43" />
+       y2="50.794746" />
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1289202,0,0,1.7349781,4.8530991,-3.9105612)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-7"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop22025" />
       <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop22027" />
     </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(2.739912e-8,3.2957551,-3.4865158,-6.0720387e-8,61.460407,-19.382409)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3402"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4" />
     <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(1.4102564,0,0,1.4102564,-1.8461505,-1.846154)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3404"
-       xlink:href="#linearGradient2781" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient2781">
+       inkscape:collect="always"
+       id="linearGradient36984-7">
       <stop
+         style="stop-color:#333333;stop-opacity:1"
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop2783" />
+         id="stop36980-5" />
       <stop
+         style="stop-color:#666666;stop-opacity:1"
          offset="1"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop2785" />
+         id="stop36982-3" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
-      <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4139">
-      <stop
-         id="stop4141"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop4143"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.90839696;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient4139"
-       id="radialGradient6391"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(4.7750866e-8,2.3875433,-3.183391,6.3667821e-8,58.82007,-50.688581)"
-       cx="25"
-       cy="8"
-       fx="25"
-       fy="8"
-       r="17" />
   </defs>
   <g
      style="display:inline"
@@ -233,7 +211,7 @@
     </g>
   </g>
   <rect
-     style="color:#000000;fill:url(#radialGradient3402);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3404);stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
      id="rect5505-21"
      y="4.5"
      x="4.5"
@@ -251,15 +229,50 @@
      height="53.000004"
      width="53" />
   <path
-     d="m 8.5,8.5000025 31.30535,0 L 55.5,23.942859 l 0,31.557138 -47,0 z"
-     style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path3872" />
-  <path
-     style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3333"
-     d="M 7.6652546,6 C 6.5920186,6 6,6.2098917 6,8.3999999 L 6.0173037,38 C 7.5132162,37.967773 56.864566,26.204122 58,25.638279 L 58,8.3999999 C 58,6.2969752 57.512806,6 56.46834,6 z" />
-  <path
-     style="fill:url(#radialGradient6391);fill-opacity:1;stroke:none"
-     d="M 9,9 39.576471,9 55,23.882353 55,55 9,55 z"
-     id="path3102-3" />
+     d="M 7.5,7.5 H 42 L 56.5,22 v 34.5 h -49 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
+  <rect
+     style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3181"
+     width="12"
+     height="10"
+     x="19"
+     y="16" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3403"
+     width="12"
+     height="10"
+     x="19"
+     y="28" />
+  <rect
+     style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3443"
+     width="12"
+     height="10"
+     x="19"
+     y="40" />
+  <rect
+     style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3483"
+     width="12"
+     height="10"
+     x="33"
+     y="16" />
+  <rect
+     style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3563"
+     width="12"
+     height="10"
+     x="33"
+     y="40" />
+  <rect
+     style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+     id="rect3851"
+     width="12"
+     height="10"
+     x="33"
+     y="28" />
 </svg>

--- a/elementary-xfce/apps/64/libreoffice-math.svg
+++ b/elementary-xfce/apps/64/libreoffice-math.svg
@@ -1,15 +1,42 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="64"
    height="64"
-   id="svg3331">
+   id="svg3331"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.5351066"
+     inkscape:cx="31.651842"
+     inkscape:cy="49.966115"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="633"
+     inkscape:window-y="192"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3331"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true" />
   <metadata
      id="metadata143580">
     <rdf:RDF>
@@ -18,7 +45,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -106,77 +132,50 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.4324331,0,0,1.432432,-2.3783784,-2.3783618)"
        x1="23.99999"
-       y1="4.999989"
+       y1="9.0873976"
        x2="23.99999"
-       y2="43" />
+       y2="50.794746" />
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1289202,0,0,1.7349781,4.8530991,-3.9105612)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-7"
+       id="linearGradient1136"
+       x1="16.476357"
+       y1="63.728039"
+       x2="16.476357"
+       y2="6.6716003"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient22029">
       <stop
+         style="stop-color:#dedede;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop22025" />
       <stop
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(2.739912e-8,3.2957551,-3.4865158,-6.0720387e-8,61.460407,-19.382409)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3402"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(1.4102564,0,0,1.4102564,-1.8461505,-1.846154)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3404"
-       xlink:href="#linearGradient2781" />
-    <linearGradient
-       id="linearGradient2781">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop2783" />
-      <stop
-         offset="1"
-         style="stop-color:#525252;stop-opacity:1;"
-         id="stop2785" />
+         id="stop22027" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-4">
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient1850"
+       x1="19.924658"
+       y1="60.550831"
+       x2="19.924658"
+       y2="11.291978"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
       <stop
-         id="stop5430-5"
-         style="stop-color:#6b6b6b;stop-opacity:1;"
-         offset="0" />
+         style="stop-color:#485a6c;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
       <stop
-         id="stop5432-2"
-         style="stop-color:#525252;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop5434-9"
-         style="stop-color:#4b4b4b;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop5436-2"
-         style="stop-color:#3f3f3f;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#667885;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
     </linearGradient>
   </defs>
   <g
@@ -212,7 +211,7 @@
     </g>
   </g>
   <rect
-     style="color:#000000;fill:url(#radialGradient3402);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3404);stroke-width:0.99999994000000003;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1136);fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
      id="rect5505-21"
      y="4.5"
      x="4.5"
@@ -230,31 +229,196 @@
      height="53.000004"
      width="53" />
   <path
-     d="m 8.5,8.5000025 31.30535,0 L 55.5,23.942859 l 0,31.557138 -47,0 z"
-     style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     id="path3872" />
-  <path
-     style="fill:#ffffff;fill-opacity:1;stroke:none"
-     d="m 9,9.0000031 30.576459,0 L 55,23.882354 l 0,31.117643 -46,0 z"
-     id="path3102" />
+     d="M 7.5,7.5 H 42 L 56.5,22 v 34.5 h -49 z"
+     style="opacity:1;fill:url(#linearGradient1850);fill-opacity:1;stroke:#0e141f;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.50196081;paint-order:normal"
+     id="path3872"
+     sodipodi:nodetypes="cccccc" />
   <g
-     id="g4295">
+     fill="#f09e6f"
+     id="g21"
+     style="fill:#f37329;fill-opacity:1"
+     transform="translate(-303,-73)">
     <path
-       id="path4018"
-       d="m 11.5,34.5 4.704545,0 4.704545,14 4.704546,-27 20.386363,0"
-       style="fill:none;stroke:#000000;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-    <g
-       transform="matrix(1.7999746,0,0,1.7999746,-12.599441,-8.5991872)"
-       id="text4042"
-       style="font-size:12px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Droid Sans;-inkscape-font-specification:Sans">
-      <path
-         id="path3142"
-         style="font-size:22px;font-family:Liberation Serif;-inkscape-font-specification:Liberation Serif Bold"
-         d="m 22.24707,22.698101 0,-0.698242 5.392578,0 0,0.698242 -1.127929,0.290039 1.471679,2.169087 1.944336,-2.190571 -1.009765,-0.268555 0,-0.698242 3.4375,0 0,0.698242 -0.891602,0.225586 -2.835937,3.232563 3.201172,4.919922 0.966796,0.225586 0,0.698242 -5.392578,0 0,-0.698242 1.12793,-0.247071 -1.761719,-2.717773 -2.341797,2.739258 L 25.4375,31.301758 25.4375,32 22,32 22,31.301758 22.902344,31.129883 26.125,27.348633 23.224609,22.966656 22.24707,22.698101" />
-    </g>
+       d="m 325,92 h 2 v 1 h -2 z"
+       id="path2300"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 328,92 h 2 v 1 h -2 z"
+       id="path2378"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 331,92 h 2 v 1 h -2 z"
+       id="path2380"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 334,92 h 2 v 1 h -2 z"
+       id="path2382"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 337,92 h 2 v 1 h -2 z"
+       id="path2384"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 340,92 h 2 v 1 h -2 z"
+       id="path2386"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 343,92 h 2 v 1 h -2 z"
+       id="path2388"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 346,92 h 2 v 1 h -2 z"
+       id="path2390"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 325,114 h 2 v 1 h -2 z"
+       id="path3473"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 328,114 h 2 v 1 h -2 z"
+       id="path3475"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 331,114 h 2 v 1 h -2 z"
+       id="path3477"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 334,114 h 2 v 1 h -2 z"
+       id="path3479"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 337,114 h 2 v 1 h -2 z"
+       id="path3481"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 340,114 h 2 v 1 h -2 z"
+       id="path3483"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 343,114 h 2 v 1 h -2 z"
+       id="path3485"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 346,114 h 2 v 1 h -2 z"
+       id="path3487"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 321,92 v 2 h -1 v -2 z"
+       id="path3471-7"
+       style="fill:#f37329;fill-opacity:1;stroke-width:0.999997" />
+    <path
+       d="m 321,95 v 2 h -1 v -2 z"
+       id="path3473-5"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 321,98 v 1.999997 h -1 V 98 Z"
+       id="path3475-3"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 321,101 v 2 h -1 v -2 z"
+       id="path3477-5"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 321,104 v 2 h -1 v -2 z"
+       id="path3479-6"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 321,107 v 2 h -1 v -2 z"
+       id="path3481-2"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 321,110 v 2 h -1 v -2 z"
+       id="path3483-9"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 350,95 v 2 h -1 v -2 z"
+       id="path3473-5-9"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,98 v 1.999996 h -1 V 98 Z"
+       id="path3475-3-3"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,101 v 2.00001 h -1 V 101 Z"
+       id="path3477-5-6"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,104.00001 v 2 h -1 v -2 z"
+       id="path3479-6-0"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,107.00001 v 2 h -1 v -2 z"
+       id="path3481-2-6"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,110.00001 v 2 h -1 v -2 z"
+       id="path3483-9-2"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 322,92 h 2 v 1 h -2 z"
+       id="path4290"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1" />
+    <path
+       d="m 321,113 v 2 h -1 v -2 z"
+       id="path4555"
+       style="fill:#f37329;fill-opacity:1;stroke-width:0.999997"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 322,114 h 2 v 1 h -2 z"
+       id="path4557"
+       style="fill:#f37329;fill-opacity:1;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,113 v 2 h -1 v -2 z"
+       id="path4721"
+       style="fill:#f37329;fill-opacity:1;stroke-width:0.999997"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 350,92 v 2 h -1 v -2 z"
+       id="path4883"
+       style="fill:#f37329;fill-opacity:1;stroke-width:0.999997"
+       sodipodi:nodetypes="ccccc" />
   </g>
   <path
-     style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-     id="path3333"
-     d="M 7.6652546,6 C 6.5920186,6 6,6.2098917 6,8.3999999 L 6.0173037,38 C 7.5132162,37.967773 56.864566,26.204122 58,25.638279 L 58,8.3999999 C 58,6.2969752 57.512806,6 56.46834,6 z" />
+     d="m 28,24 -3,11 -2.99966,-6 h -3.05468 v 2 h 1.41726 l 3.36329,7 h 2.83683 L 30,26 h 13 v 2 h 2 v -4 z"
+     fill="url(#a)"
+     id="path23"
+     style="fill:#4e6174;fill-opacity:1"
+     sodipodi:nodetypes="cccccccccccccc" />
+  <path
+     d="m 33,37 8,-8"
+     fill="none"
+     stroke="#666666"
+     stroke-linecap="round"
+     stroke-width="2"
+     id="path25"
+     style="stroke:#4e6174;stroke-opacity:1" />
+  <path
+     d="M 41,37 33,29"
+     fill="none"
+     stroke="#666666"
+     stroke-linecap="round"
+     stroke-width="2"
+     id="path27"
+     style="stroke:#4e6174;stroke-opacity:1" />
+  <path
+     d="m 41.89653,44 c -0.71051,0 -1.18523,0.10531 -1.42773,0.31641 -0.23971,0.2083 -0.36143,0.62731 -0.36133,1.25781 v 1.02735 c -10e-5,0.428 -0.0754,0.72401 -0.22656,0.88671 -0.1512,0.1629 -0.7268,-0.14467 -0.83008,0.24414 h -0.26562 v 0.61133 h 0.26562 c 0.3995,0 0.67497,0.0825 0.82617,0.24805 0.1542,0.1655 0.23037,0.46373 0.23047,0.89453 v 1.02344 c -10e-5,0.6306 0.12162,1.0506 0.36133,1.26172 0.2425,0.21119 0.71722,0.3164 1.42773,0.3164 h 0.2754 v -0.61523 h -0.30079 c -0.39951,0 -0.6606,-0.0609 -0.7832,-0.1836 -0.1198,-0.1227 -0.17969,-0.38887 -0.17969,-0.79687 v -1.06055 c 0,-0.4451 -0.063,-0.77005 -0.1914,-0.97265 -0.1284,-0.20261 -0.35127,-0.34293 -0.66797,-0.41993 0.3139,-0.0713 0.53371,-0.20755 0.66211,-0.41015 0.1309,-0.2026 0.19726,-0.52857 0.19726,-0.97656 V 45.5918 c 0,-0.4052 0.0598,-0.66831 0.17969,-0.79102 0.1226,-0.12539 0.3837,-0.18935 0.7832,-0.18945 h 0.30079 V 44 Z m 1.96709,0 v 0.61133 h 0.29102 c 0.40241,10e-5 0.66441,0.0639 0.78711,0.18945 0.123,0.12551 0.18358,0.38862 0.18358,0.79102 v 1.06055 c 0,0.44799 0.065,0.77396 0.19336,0.97656 0.1312,0.2026 0.35407,0.33915 0.66798,0.41015 -0.31671,0.077 -0.53958,0.21732 -0.66798,0.41993 -0.1286,0.20259 -0.19336,0.52755 -0.19336,0.97265 v 1.06055 c 0,0.4023 -0.0609,0.66551 -0.18358,0.79101 -0.1227,0.1253 -0.3847,0.18946 -0.78711,0.18946 h -0.29102 v 0.61523 h 0.26563 c 0.71041,0 1.18412,-0.1052 1.42381,-0.3164 0.23971,-0.21111 0.35938,-0.63112 0.35938,-1.26172 v -1.02344 c 0,-0.4308 0.0772,-0.72903 0.22851,-0.89453 0.154,-0.1652 0.4317,-0.24805 0.83399,-0.24805 h 0.27344 v -0.61133 h -0.27344 c -0.4023,0 -0.67998,-0.0815 -0.83399,-0.24414 -0.15089,-0.1627 -0.22851,-0.45871 -0.22851,-0.88671 v -1.02735 c 0,-0.6305 -0.11967,-1.04951 -0.35938,-1.25781 C 45.31336,44.10531 44.83964,44 44.12924,44 Z m -9.76787,0.87891 v 1.36133 H 32.8145 v 0.61328 h 1.28125 v 2.60156 c 0,0.5792 0.12077,0.98781 0.36328,1.22461 0.2426,0.2368 0.65939,0.35547 1.25,0.35547 h 0.9629 V 50.4043 h -0.88672 c -0.33381,0 -0.56708,-0.0692 -0.70118,-0.20899 -0.1341,-0.1399 -0.20117,-0.38643 -0.20117,-0.74023 v -2.60156 h 1.78907 v -0.61328 h -1.78907 v -1.36133 z m -15.27734,1.11914 c -0.57641,0 -1.01898,0.12585 -1.33008,0.37695 -0.31101,0.2482 -0.4668,0.60115 -0.4668,1.06055 0,0.3624 0.1042,0.65013 0.3125,0.86133 0.20831,0.2082 0.53849,0.35631 0.99219,0.44531 l 0.29492,0.0586 0.0352,0.0117 c 0.699,0.1399 1.04883,0.39066 1.04883,0.75586 0,0.2539 -0.0959,0.4531 -0.28711,0.5957 -0.1912,0.1397 -0.4605,0.20899 -0.80859,0.20899 -0.23972,0 -0.49548,-0.0373 -0.76368,-0.11133 -0.2682,-0.0771 -0.54789,-0.1906 -0.84179,-0.3418 v 0.81446 c 0.3025,0.0998 0.58209,0.1717 0.84179,0.2207 0.2596,0.051 0.50919,0.0781 0.7461,0.0781 0.5992,0 1.06759,-0.13303 1.40429,-0.39843 0.3367,-0.2682 0.50391,-0.6396 0.50391,-1.11328 0,-0.35661 -0.10023,-0.64665 -0.30273,-0.86915 -0.1998,-0.2226 -0.49581,-0.36937 -0.88672,-0.44335 l -0.31641,-0.0606 c -0.52221,-0.0999 -0.84927,-0.203 -0.98047,-0.3086 -0.1309,-0.1056 -0.19726,-0.26451 -0.19726,-0.47851 0,-0.2368 0.0876,-0.41324 0.26171,-0.52734 0.17691,-0.1165 0.44419,-0.17578 0.80079,-0.17578 0.2369,0 0.46895,0.0336 0.69726,0.0996 0.2282,0.0656 0.45429,0.16362 0.67969,0.29492 v -0.76953 -0.002 c -0.2283,-0.0942 -0.46037,-0.16494 -0.69727,-0.21094 -0.23681,-0.049 -0.48343,-0.0723 -0.74023,-0.0723 z m 5.02148,0.0195 c -0.57641,0 -1.03031,0.22388 -1.36132,0.67188 -0.331,0.44799 -0.4961,1.06812 -0.4961,1.86132 0,0.7789 0.1651,1.39084 0.4961,1.83594 0.33381,0.4422 0.78781,0.66406 1.36132,0.66406 0.2882,0 0.54101,-0.0639 0.75782,-0.18945 0.2198,-0.1283 0.39308,-0.31008 0.52148,-0.54688 v 2.43555 h 0.79297 v -6.61718 h -0.79297 v 0.61132 c -0.1313,-0.2368 -0.30569,-0.41646 -0.52539,-0.53906 -0.21691,-0.1254 -0.46861,-0.1875 -0.75391,-0.1875 z m 6.6836,0.0762 c -0.0413,0.37152 -0.69875,0.0908 -0.97266,0.27344 -0.2711,0.1797 -0.47231,0.43979 -0.60351,0.7793 V 46.20898 H 28.1563 v 4.79297 h 0.79102 v -2.38281 c 0,-0.582 0.13092,-1.02774 0.39062,-1.33594 0.25961,-0.30819 0.63419,-0.46093 1.125,-0.46093 0.2083,0 0.40022,0.0298 0.57422,0.0898 0.1741,0.06 0.34536,0.15385 0.51367,0.28515 v -0.80273 c -0.1541,-0.1028 -0.31607,-0.17952 -0.48437,-0.22852 -0.1684,-0.049 -0.52154,-0.26509 -0.54297,-0.0723 z m -6.5586,0.59181 c 0.3795,0 0.66538,0.15681 0.85938,0.4707 0.1973,0.311 0.29492,0.76915 0.29492,1.37695 0,0.6077 -0.098,1.06892 -0.29492,1.38282 -0.194,0.311 -0.47988,0.46679 -0.85938,0.46679 -0.3795,0 -0.66722,-0.15579 -0.86132,-0.46679 -0.1907,-0.311 -0.28711,-0.77222 -0.28711,-1.38282 0,-0.6107 0.096,-1.06986 0.28711,-1.38086 0.1941,-0.31099 0.48182,-0.46679 0.86132,-0.46679 z"
+     fill="url(#a)"
+     id="path25-6"
+     style="fill:#273445;fill-opacity:1"
+     sodipodi:nodetypes="sccccsccsccccsccscsssccssccccsccccsscccsscsccscsscsccscsscsccccccscsccscsccccccccsccccscsccccscsccccscscccccccssscsccccccccssccccccscsccccssscscscscs" />
 </svg>

--- a/elementary-xfce/apps/96/libreoffice-base.svg
+++ b/elementary-xfce/apps/96/libreoffice-base.svg
@@ -4,7 +4,7 @@
    height="96"
    id="svg3658"
    version="1.1"
-   sodipodi:docname="libreoffice-writer.svg"
+   sodipodi:docname="libreoffice-base.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -23,31 +23,19 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="28.416666"
-     inkscape:cx="12.404693"
-     inkscape:cy="16.27566"
+     inkscape:zoom="4.2580073"
+     inkscape:cx="51.902213"
+     inkscape:cy="32.057249"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="137"
-     inkscape:window-y="80"
+     inkscape:window-x="351"
+     inkscape:window-y="46"
      inkscape:window-maximized="0"
      inkscape:current-layer="layer1"
      inkscape:snap-global="false"
      showguides="false" />
   <defs
      id="defs3660">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient36984">
-      <stop
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0"
-         id="stop36980" />
-      <stop
-         style="stop-color:#64baff;stop-opacity:1"
-         offset="1"
-         id="stop36982" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        id="linearGradient22029">
@@ -140,7 +128,7 @@
        gradientTransform="matrix(0.98701298,0,0,1,0.31168803,0)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient36984"
+       xlink:href="#linearGradient36984-7"
        id="linearGradient1100"
        x1="12.051564"
        y1="47.863083"
@@ -168,6 +156,18 @@
        y2="10.155718"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.9999992,0,0,2.0120474,-1.9999904,-7.5662607)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3663">
@@ -220,7 +220,7 @@
        height="77"
        width="77" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
        y="4.4999981"
        x="7.4999919"
@@ -230,78 +230,9 @@
        width="77" />
     <path
        d="m 80.499992,29 v 48.499846 l -69,3.08e-4 V 8.4999999 h 49.5 z"
-       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#002e99;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#452981;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
        id="path3872"
        sodipodi:nodetypes="cccccc" />
-    <path
-       id="path1014"
-       d="m 25.999994,62.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999997"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999998"
-       d="M 25.999992,55 H 65.99999 V 54 H 25.999992 Z"
-       id="path1016"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1018"
-       d="m 25.999993,47.999999 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       d="m 25.999993,41.000001 h 16.000001 v -1 H 25.999993 Z"
-       id="path1020"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1022"
-       d="m 25.999993,34.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3978"
-       d="m 25.999994,61.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       d="M 25.999992,53.999999 H 65.99999 v -1 H 25.999992 Z"
-       id="path3980"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3982"
-       d="M 25.999993,47 H 41.999994 V 46 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       d="m 25.999993,39.999999 h 16.000001 v -1 H 25.999993 Z"
-       id="path3984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3986"
-       d="m 25.999993,33.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <g
-       id="path2720"
-       transform="matrix(1.8260863,0,0,1.6436096,6.7391332,-14.324323)"
-       style="fill:#3098fa;fill-opacity:1;stroke-width:0.577218">
-      <path
-         style="color:#000000;fill:#3689e6;fill-opacity:1;stroke-width:0.577218px;-inkscape-stroke:none"
-         d="m 25.059527,33.051841 1.369048,2.433668 2.738096,-4.867336 2.738097,6.08417 H 23.14286 Z"
-         id="path10475"
-         sodipodi:nodetypes="cccccc" />
-    </g>
-    <rect
-       style="fill:none;fill-opacity:1;stroke:#3689e6;stroke-width:0.999998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1162"
-       width="17"
-       height="14"
-       x="48.499992"
-       y="32.5"
-       rx="0.64602071"
-       ry="0.74367297" />
     <rect
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect28226"
@@ -311,5 +242,30 @@
        rx="4"
        height="75.000008"
        width="75.000008" />
+    <path
+       style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:0.999991"
+       d="m 23.999992,35 v 24 c 0,4.702314 11.411678,8.499993 22,8.499993 10.588322,0 22,-3.758065 22,-8.499993 V 35 c 0,0 -9.984398,8 -22,8 -12.015602,0 -22,-8 -22,-8 z"
+       id="path3996"
+       sodipodi:nodetypes="cczccsc" />
+    <path
+       style="fill:none;stroke:#7239b3;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.499959,33 v 9.5 c 0,4.473653 11.220107,9.020926 22.500033,9 11.219946,-0.02081 22.500033,-4.526347 22.500033,-9 V 33"
+       id="path4358"
+       sodipodi:nodetypes="csssc" />
+    <path
+       style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:0.999991;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4247"
+       d="m 68.500025,32.763152 c 0.0033,-5.669251 -10.07128,-10.263157 -22.500033,-10.263157 -12.428754,0 -22.503325,4.593906 -22.500033,10.263157 C 23.496659,38.432402 33.571238,43.5 45.999992,43.5 c 12.428753,0 22.503325,-5.067598 22.500033,-10.736848 z"
+       sodipodi:nodetypes="cscsc" />
+    <path
+       d="m 23.499959,39 v 11.5 c 0,4.473652 11.220107,9.020926 22.500033,9 11.219946,-0.02081 22.500033,-4.526348 22.500033,-9 V 39"
+       style="fill:none;stroke:#7239b3;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3992"
+       sodipodi:nodetypes="csssc" />
+    <path
+       id="path3994"
+       style="fill:none;stroke:#7239b3;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 23.499959,47 v 11.5 c 0,4.47365 11.220107,9.020843 22.500033,8.999922 C 57.219938,67.479082 68.500025,62.97365 68.500025,58.5 V 47"
+       sodipodi:nodetypes="cscsc" />
   </g>
 </svg>

--- a/elementary-xfce/apps/96/libreoffice-calc.svg
+++ b/elementary-xfce/apps/96/libreoffice-calc.svg
@@ -23,9 +23,9 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="2.5117021"
-     inkscape:cx="56.336298"
-     inkscape:cy="7.9627277"
+     inkscape:zoom="40.187234"
+     inkscape:cx="19.894378"
+     inkscape:cy="9.8414338"
      inkscape:window-width="1317"
      inkscape:window-height="890"
      inkscape:window-x="159"
@@ -215,8 +215,8 @@
        id="rect27907"
        y="4.4999981"
        x="7.4999919"
-       ry="5.9230766"
-       rx="5.9230766"
+       ry="5"
+       rx="5"
        height="77"
        width="77" />
     <rect

--- a/elementary-xfce/apps/96/libreoffice-draw.svg
+++ b/elementary-xfce/apps/96/libreoffice-draw.svg
@@ -4,7 +4,7 @@
    height="96"
    id="svg3658"
    version="1.1"
-   sodipodi:docname="libreoffice-writer.svg"
+   sodipodi:docname="libreoffice-draw.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -23,31 +23,19 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="28.416666"
-     inkscape:cx="12.404693"
-     inkscape:cy="16.27566"
+     inkscape:zoom="14.208333"
+     inkscape:cx="49.196483"
+     inkscape:cy="31.565984"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="137"
-     inkscape:window-y="80"
+     inkscape:window-x="646"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
      inkscape:current-layer="layer1"
      inkscape:snap-global="false"
      showguides="false" />
   <defs
      id="defs3660">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient36984">
-      <stop
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0"
-         id="stop36980" />
-      <stop
-         style="stop-color:#64baff;stop-opacity:1"
-         offset="1"
-         id="stop36982" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        id="linearGradient22029">
@@ -140,7 +128,7 @@
        gradientTransform="matrix(0.98701298,0,0,1,0.31168803,0)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient36984"
+       xlink:href="#linearGradient36984-7"
        id="linearGradient1100"
        x1="12.051564"
        y1="47.863083"
@@ -168,6 +156,38 @@
        y2="10.155718"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.9999992,0,0,2.0120474,-1.9999904,-7.5662607)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
+      <stop
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
+      <stop
+         style="stop-color:#ffe16b;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
+    </linearGradient>
+    <linearGradient
+       y2="13.663627"
+       x2="16.887266"
+       y1="24.239939"
+       x1="28.534189"
+       gradientTransform="matrix(2.1754095,0,0,2.0660869,-7.6976544,-7.1442831)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3060"
+       xlink:href="#linearGradient4102" />
+    <linearGradient
+       id="linearGradient4102">
+      <stop
+         id="stop4104"
+         style="stop-color:#f9c440;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4106"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3663">
@@ -220,7 +240,7 @@
        height="77"
        width="77" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#ad5f00;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
        y="4.4999981"
        x="7.4999919"
@@ -230,78 +250,9 @@
        width="77" />
     <path
        d="m 80.499992,29 v 48.499846 l -69,3.08e-4 V 8.4999999 h 49.5 z"
-       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#002e99;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#ad5f00;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
        id="path3872"
        sodipodi:nodetypes="cccccc" />
-    <path
-       id="path1014"
-       d="m 25.999994,62.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999997"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999998"
-       d="M 25.999992,55 H 65.99999 V 54 H 25.999992 Z"
-       id="path1016"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1018"
-       d="m 25.999993,47.999999 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       d="m 25.999993,41.000001 h 16.000001 v -1 H 25.999993 Z"
-       id="path1020"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1022"
-       d="m 25.999993,34.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3978"
-       d="m 25.999994,61.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       d="M 25.999992,53.999999 H 65.99999 v -1 H 25.999992 Z"
-       id="path3980"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3982"
-       d="M 25.999993,47 H 41.999994 V 46 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       d="m 25.999993,39.999999 h 16.000001 v -1 H 25.999993 Z"
-       id="path3984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3986"
-       d="m 25.999993,33.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <g
-       id="path2720"
-       transform="matrix(1.8260863,0,0,1.6436096,6.7391332,-14.324323)"
-       style="fill:#3098fa;fill-opacity:1;stroke-width:0.577218">
-      <path
-         style="color:#000000;fill:#3689e6;fill-opacity:1;stroke-width:0.577218px;-inkscape-stroke:none"
-         d="m 25.059527,33.051841 1.369048,2.433668 2.738096,-4.867336 2.738097,6.08417 H 23.14286 Z"
-         id="path10475"
-         sodipodi:nodetypes="cccccc" />
-    </g>
-    <rect
-       style="fill:none;fill-opacity:1;stroke:#3689e6;stroke-width:0.999998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1162"
-       width="17"
-       height="14"
-       x="48.499992"
-       y="32.5"
-       rx="0.64602071"
-       ry="0.74367297" />
     <rect
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect28226"
@@ -311,5 +262,36 @@
        rx="4"
        height="75.000008"
        width="75.000008" />
+    <path
+       style="fill:url(#linearGradient3060);fill-opacity:1;fill-rule:evenodd;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path2783"
+       d="m 27.878563,66.373908 c 9.085714,5.8531 28.922509,-1.9776 12.430782,-22.9334 -16.342437,-20.76622 16.237079,-34.3865507 25.904936,-10.3709" />
+    <path
+       style="fill:#f37329;fill-opacity:1;stroke:#e99f20;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3571"
+       d="m 25.69365,24.568378 31.340285,39.35933" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#e99f20;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path3575"
+       d="m 58.557689,64.451108 c 7.56e-4,1.1315 -0.912221,2.049 -2.038696,2.049 -1.126475,0 -2.039453,-0.9175 -2.038695,-2.049 -7.58e-4,-1.1312 0.91222,-2.0487 2.038695,-2.0487 1.126475,0 2.039452,0.9175 2.038696,2.0487 z M 27.577383,25.549078 c 7.58e-4,1.1312 -0.912221,2.04866 -2.038695,2.04866 -1.126475,0 -2.039453,-0.91746 -2.038695,-2.04866 -7.58e-4,-1.13151 0.91222,-2.04897 2.038695,-2.04897 1.126474,0 2.039453,0.91746 2.038695,2.04897 z" />
+    <path
+       style="fill:#e99f20;fill-opacity:1;stroke:none"
+       id="rect3569"
+       d="m 37.999993,39.984048 h 6 v 6.03216 h -6 z m 24,-10.00001 6,4.5e-4 v 6.03169 l -6,-4.5e-4 z m -39,32.98397 h 6 v 6.0321 h -6 z" />
+    <path
+       d="m 23.999992,64 h 4 v 4 h -4 z"
+       id="path19011"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 38.999992,41 h 4 v 4 h -4 z"
+       id="path2907"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       d="m 62.999992,31 h 4 v 4 h -4 z"
+       id="path2909"
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/elementary-xfce/apps/96/libreoffice-impress.svg
+++ b/elementary-xfce/apps/96/libreoffice-impress.svg
@@ -4,7 +4,7 @@
    height="96"
    id="svg3658"
    version="1.1"
-   sodipodi:docname="libreoffice-writer.svg"
+   sodipodi:docname="libreoffice-impress.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -23,31 +23,19 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="28.416666"
-     inkscape:cx="12.404693"
-     inkscape:cy="16.27566"
+     inkscape:zoom="2.5117021"
+     inkscape:cx="16.323592"
+     inkscape:cy="-2.5878865"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="137"
-     inkscape:window-y="80"
+     inkscape:window-x="540"
+     inkscape:window-y="67"
      inkscape:window-maximized="0"
      inkscape:current-layer="layer1"
      inkscape:snap-global="false"
      showguides="false" />
   <defs
      id="defs3660">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient36984">
-      <stop
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0"
-         id="stop36980" />
-      <stop
-         style="stop-color:#64baff;stop-opacity:1"
-         offset="1"
-         id="stop36982" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        id="linearGradient22029">
@@ -140,7 +128,7 @@
        gradientTransform="matrix(0.98701298,0,0,1,0.31168803,0)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient36984"
+       xlink:href="#linearGradient36984-7"
        id="linearGradient1100"
        x1="12.051564"
        y1="47.863083"
@@ -168,6 +156,18 @@
        y2="10.155718"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.9999992,0,0,2.0120474,-1.9999904,-7.5662607)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
+      <stop
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
+      <stop
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3663">
@@ -220,7 +220,7 @@
        height="77"
        width="77" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#a62100;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
        y="4.4999981"
        x="7.4999919"
@@ -230,78 +230,9 @@
        width="77" />
     <path
        d="m 80.499992,29 v 48.499846 l -69,3.08e-4 V 8.4999999 h 49.5 z"
-       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#002e99;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#a62100;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
        id="path3872"
        sodipodi:nodetypes="cccccc" />
-    <path
-       id="path1014"
-       d="m 25.999994,62.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999997"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999998"
-       d="M 25.999992,55 H 65.99999 V 54 H 25.999992 Z"
-       id="path1016"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1018"
-       d="m 25.999993,47.999999 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       d="m 25.999993,41.000001 h 16.000001 v -1 H 25.999993 Z"
-       id="path1020"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1022"
-       d="m 25.999993,34.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3978"
-       d="m 25.999994,61.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       d="M 25.999992,53.999999 H 65.99999 v -1 H 25.999992 Z"
-       id="path3980"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3982"
-       d="M 25.999993,47 H 41.999994 V 46 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       d="m 25.999993,39.999999 h 16.000001 v -1 H 25.999993 Z"
-       id="path3984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3986"
-       d="m 25.999993,33.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <g
-       id="path2720"
-       transform="matrix(1.8260863,0,0,1.6436096,6.7391332,-14.324323)"
-       style="fill:#3098fa;fill-opacity:1;stroke-width:0.577218">
-      <path
-         style="color:#000000;fill:#3689e6;fill-opacity:1;stroke-width:0.577218px;-inkscape-stroke:none"
-         d="m 25.059527,33.051841 1.369048,2.433668 2.738096,-4.867336 2.738097,6.08417 H 23.14286 Z"
-         id="path10475"
-         sodipodi:nodetypes="cccccc" />
-    </g>
-    <rect
-       style="fill:none;fill-opacity:1;stroke:#3689e6;stroke-width:0.999998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1162"
-       width="17"
-       height="14"
-       x="48.499992"
-       y="32.5"
-       rx="0.64602071"
-       ry="0.74367297" />
     <rect
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect28226"
@@ -311,5 +242,17 @@
        rx="4"
        height="75.000008"
        width="75.000008" />
+    <path
+       d="M 69.999992,44.998792 A 24,23.9988 0 1 1 57.304274,23.828812 l -11.304282,21.16998 z"
+       id="path3035"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffc27d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#ffa154;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path3964"
+       d="m 69.999992,44.996266 c 0,10.801992 -7.2,20.250714 -17.595828,23.128368 -10.382232,2.873886 -21.404172,-1.484232 -26.983674,-10.788 -0.0426,0.0384 20.579502,-12.340368 20.579502,-12.340368 z" />
+    <path
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#f37329;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00001;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path3962"
+       d="m 69.999992,45.007156 c 0,10.405134 -6.9648,20.185608 -17.595828,23.128374 -0.2343,-0.0408 -6.404172,-23.128374 -6.404172,-23.128374 z" />
   </g>
 </svg>

--- a/elementary-xfce/apps/96/libreoffice-main.svg
+++ b/elementary-xfce/apps/96/libreoffice-main.svg
@@ -4,7 +4,7 @@
    height="96"
    id="svg3658"
    version="1.1"
-   sodipodi:docname="libreoffice-writer.svg"
+   sodipodi:docname="libreoffice-main.svg"
    inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -23,31 +23,19 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="28.416666"
-     inkscape:cx="12.404693"
-     inkscape:cy="16.27566"
+     inkscape:zoom="3.5520832"
+     inkscape:cx="40.258066"
+     inkscape:cy="6.3343111"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="137"
-     inkscape:window-y="80"
+     inkscape:window-x="540"
+     inkscape:window-y="67"
      inkscape:window-maximized="0"
      inkscape:current-layer="layer1"
      inkscape:snap-global="false"
      showguides="false" />
   <defs
      id="defs3660">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient36984">
-      <stop
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0"
-         id="stop36980" />
-      <stop
-         style="stop-color:#64baff;stop-opacity:1"
-         offset="1"
-         id="stop36982" />
-    </linearGradient>
     <linearGradient
        inkscape:collect="always"
        id="linearGradient22029">
@@ -140,7 +128,7 @@
        gradientTransform="matrix(0.98701298,0,0,1,0.31168803,0)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient36984"
+       xlink:href="#linearGradient36984-7"
        id="linearGradient1100"
        x1="12.051564"
        y1="47.863083"
@@ -168,6 +156,18 @@
        y2="10.155718"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.9999992,0,0,2.0120474,-1.9999904,-7.5662607)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
+      <stop
+         style="stop-color:#333333;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
+      <stop
+         style="stop-color:#666666;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3663">
@@ -220,7 +220,7 @@
        height="77"
        width="77" />
     <rect
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect5505-21"
        y="4.4999981"
        x="7.4999919"
@@ -230,78 +230,9 @@
        width="77" />
     <path
        d="m 80.499992,29 v 48.499846 l -69,3.08e-4 V 8.4999999 h 49.5 z"
-       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#002e99;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#000000;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
        id="path3872"
        sodipodi:nodetypes="cccccc" />
-    <path
-       id="path1014"
-       d="m 25.999994,62.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999997"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999998"
-       d="M 25.999992,55 H 65.99999 V 54 H 25.999992 Z"
-       id="path1016"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1018"
-       d="m 25.999993,47.999999 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       d="m 25.999993,41.000001 h 16.000001 v -1 H 25.999993 Z"
-       id="path1020"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path1022"
-       d="m 25.999993,34.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3978"
-       d="m 25.999994,61.000001 h 39.999998 v -1 H 25.999994 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999995"
-       d="M 25.999992,53.999999 H 65.99999 v -1 H 25.999992 Z"
-       id="path3980"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3982"
-       d="M 25.999993,47 H 41.999994 V 46 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999991"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.99999"
-       d="m 25.999993,39.999999 h 16.000001 v -1 H 25.999993 Z"
-       id="path3984"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       id="path3986"
-       d="m 25.999993,33.000295 h 16.000001 v -1 H 25.999993 Z"
-       style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999984"
-       sodipodi:nodetypes="ccccc" />
-    <g
-       id="path2720"
-       transform="matrix(1.8260863,0,0,1.6436096,6.7391332,-14.324323)"
-       style="fill:#3098fa;fill-opacity:1;stroke-width:0.577218">
-      <path
-         style="color:#000000;fill:#3689e6;fill-opacity:1;stroke-width:0.577218px;-inkscape-stroke:none"
-         d="m 25.059527,33.051841 1.369048,2.433668 2.738096,-4.867336 2.738097,6.08417 H 23.14286 Z"
-         id="path10475"
-         sodipodi:nodetypes="cccccc" />
-    </g>
-    <rect
-       style="fill:none;fill-opacity:1;stroke:#3689e6;stroke-width:0.999998;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="rect1162"
-       width="17"
-       height="14"
-       x="48.499992"
-       y="32.5"
-       rx="0.64602071"
-       ry="0.74367297" />
     <rect
        style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
        id="rect28226"
@@ -311,5 +242,47 @@
        rx="4"
        height="75.000008"
        width="75.000008" />
+    <rect
+       style="fill:#64baff;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3181"
+       width="18"
+       height="14"
+       x="26.99999"
+       y="22" />
+    <rect
+       style="fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3403"
+       width="18"
+       height="14"
+       x="26.99999"
+       y="38" />
+    <rect
+       style="fill:#667885;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3443"
+       width="18"
+       height="14"
+       x="26.99999"
+       y="54" />
+    <rect
+       style="fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3483"
+       width="18"
+       height="14"
+       x="46.999992"
+       y="22" />
+    <rect
+       style="fill:#cd9ef7;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3563"
+       width="18"
+       height="14"
+       x="46.999992"
+       y="54" />
+    <rect
+       style="fill:#fbd051;fill-opacity:1;stroke:none;stroke-width:0.499999;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.501961;paint-order:markers fill stroke"
+       id="rect3851"
+       width="18"
+       height="14"
+       x="46.999992"
+       y="38" />
   </g>
 </svg>

--- a/elementary-xfce/apps/96/libreoffice-math.svg
+++ b/elementary-xfce/apps/96/libreoffice-math.svg
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="96"
+   height="96"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="libreoffice-math.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234042"
+     inkscape:cx="35.533673"
+     inkscape:cy="26.774672"
+     inkscape:window-width="1317"
+     inkscape:window-height="890"
+     inkscape:window-x="739"
+     inkscape:window-y="107"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:snap-global="false"
+     showguides="false" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient22029">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop22025" />
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="1"
+         id="stop22027" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient28344">
+      <stop
+         style="stop-color:#feffff;stop-opacity:0"
+         offset="0"
+         id="stop28340" />
+      <stop
+         style="stop-color:#feffff;stop-opacity:0.5"
+         offset="1"
+         id="stop28342" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.4,28.306905,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9035948,0,0,1.4,-19.693094,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757"
+       gradientTransform="matrix(0.98701298,0,0,1,0.31168803,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36984-7"
+       id="linearGradient1100"
+       x1="12.051564"
+       y1="47.863083"
+       x2="12.051564"
+       y2="6.5310311"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9743589,0,0,1.9743589,-1.384623,-6.3589763)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28344"
+       id="linearGradient28346"
+       x1="13.09245"
+       y1="50.435913"
+       x2="13.09245"
+       y2="8.0094023"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0270272,0,0,2.0270273,-2.6486576,-7.675679)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient22029"
+       id="linearGradient22031"
+       x1="12.817238"
+       y1="45.610401"
+       x2="12.817238"
+       y2="10.155718"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9999992,0,0,2.0120474,-1.9999904,-7.5662607)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36984-7">
+      <stop
+         style="stop-color:#485a6c;stop-opacity:1"
+         offset="0"
+         id="stop36980-5" />
+      <stop
+         style="stop-color:#667885;stop-opacity:1"
+         offset="1"
+         id="stop36982-3" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3663">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(2.0000079,5)">
+    <g
+       style="opacity:0.4;stroke-width:0.505917"
+       id="g3712"
+       transform="matrix(2.261934,0,0,1.1428571,-8.2864217,31.285716)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:0.505917"
+         id="rect2801"
+         y="40"
+         x="37.81818"
+         height="7"
+         width="4.75" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:0.505917"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10.181818"
+         height="7"
+         width="4.75" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:0.505917"
+         id="rect3700"
+         y="40"
+         x="10.181818"
+         height="7.0000005"
+         width="27.636364" />
+    </g>
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1100);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect27907"
+       y="4.4999981"
+       x="7.4999919"
+       ry="5"
+       rx="5"
+       height="77"
+       width="77" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect5505-21"
+       y="4.4999981"
+       x="7.4999919"
+       ry="5"
+       rx="5"
+       height="77"
+       width="77" />
+    <path
+       d="m 80.499992,29 v 48.499846 l -69,3.08e-4 V 8.4999999 h 49.5 z"
+       style="opacity:1;fill:url(#linearGradient22031);fill-opacity:1;stroke:#0e141f;stroke-width:1px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.50196081"
+       id="path3872"
+       sodipodi:nodetypes="cccccc" />
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient28346);stroke-width:0.999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;enable-background:accumulate"
+       id="rect28226"
+       y="5.4999952"
+       x="8.4999886"
+       ry="4"
+       rx="4"
+       height="75.000008"
+       width="75.000008" />
+    <path
+       d="m 26.999992,27 v 1 h -1 v 1 h 1 v 1 h 1.000353 v -1 h 1 v -1 h -1 v -1 z m 19.000172,0 v 1 h -0.999996 v 1 h 0.999996 v 1 h 1.000004 v -1 h 1 v -1 h -1 v -1 z m 19.000004,0 v 1 h -1 v 1 h 1 v 1 h 1 v -1 h 1 v -1 h -1 v -1 z m -34.999823,1 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 6.999823,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m -34.000176,3 v 2 h 1.000353 v -2 z m 19.000172,0 v 2 h 1.000004 v -2 z m 19.000004,0 v 2 h 1 v -2 z m -38.000176,3 v 2 h 1.000353 v -2 z m 19.000172,0 v 2 h 1.000004 v -2 z m 19.000004,0 v 2 h 1 v -2 z m -39.000176,3 v 1 h 1 v 1 h 1.000353 v -1 h 1 v -1 h -1 -1.000353 z m 4.000353,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 2.999823,0 v 1 h 0.999996 v 1 h 1.000004 v -1 h 1 v -1 h -1 -0.999996 z m 4,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 1 v 1 h 1 v -1 h 1 v -1 h -1 -1 z m -37.000176,3 v 2 h 1.000353 v -2 z m 19.000172,0 v 2 h 1.000004 v -2 z m 19.000004,0 v 2 h 1 v -2 z m -38.000176,3 v 2 h 1.000353 v -2 z m 19.000172,0 v 2 h 1.000004 v -2 z m 19.000004,0 v 2 h 1 v -2 z m -38.000176,3 v 2 h 1.000353 v -2 z m 19.000172,0 v 2 h 1.000004 v -2 z m 19.000004,0 v 2 h 1 v -2 z m -38.000176,3 v 2 h 1.000353 v -2 z m 19.000172,0 v 2 h 1.000004 v -2 z m 19.000004,0 v 2 h 1 v -2 z m -38.000176,3 v 1 h -1 v 1 h 1 v 1 h 1.000353 v -1 h 1 v -1 h -1 v -1 z m 19.000172,0 v 1 h -0.999996 v 1 h 0.999996 v 1 h 1.000004 v -1 h 1 v -1 h -1 v -1 z m 19.000004,0 v 1 h -1 v 1 h 1 v 1 h 1 v -1 h 1 v -1 h -1 v -1 z m -34.999823,1 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 6.999823,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z m 3,0 v 1 h 2 v -1 z"
+       fill="#f09e6f"
+       id="path23"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+       style="fill:#f37329;fill-opacity:1;stroke-width:0.999997" />
+    <path
+       style="fill:#4e6174;fill-opacity:1;stroke-width:0.999997"
+       d="m 46.750168,37 6.985352,8.050781 V 45.15332 L 46.250168,54 h 3.720705 l 5.806643,-6.709473 h 0.115717 L 62.277023,54 h 4.029788 l -8.21631,-8.98291 V 44.914551 L 64.750168,37 h -3.75 l -5.029293,5.743652 H 55.855149 L 50.750168,37 Z"
+       id="path2159"
+       sodipodi:nodetypes="ccccccccccccccccc" />
+    <path
+       style="fill:#4e6174;fill-opacity:1;stroke-width:0.999997"
+       d="m 43.250168,28 -7.25,19.5 -4.75,-9 -4.25,2 V 44 l 3,-1.5 5.25,11.5 h 1.75 l 8.5,-23 h 18.5 v 2 h 2 v -5 z"
+       id="path25-3"
+       sodipodi:nodetypes="cccccccccccccc" />
+    <path
+       d="m 53.896697,58.635544 c -0.71051,0 -1.18523,0.105306 -1.42773,0.316406 -0.23971,0.2083 -0.361429,0.627312 -0.361328,1.257812 v 1.027344 c -1.01e-4,0.428 -0.0754,0.724017 -0.226561,0.886717 -0.151201,0.1629 -0.726803,-0.144677 -0.83008,0.24414 h -0.265619 v 0.61133 h 0.265619 c 0.399501,0 0.67497,0.0825 0.826171,0.24805 0.1542,0.1655 0.230369,0.46373 0.23047,0.89453 v 1.02344 c -1.01e-4,0.6306 0.121618,1.0506 0.361328,1.26172 0.242501,0.21119 0.71722,0.3164 1.42773,0.3164 h 0.275401 v -0.61523 h -0.30079 c -0.399511,0 -0.660601,-0.0609 -0.7832,-0.1836 -0.119799,-0.1227 -0.179689,-0.38887 -0.179689,-0.79687 v -1.06055 c 0,-0.4451 -0.063,-0.77005 -0.191401,-0.97265 -0.1284,-0.20261 -0.35127,-0.34293 -0.66797,-0.41993 0.313901,-0.0713 0.533711,-0.20755 0.662111,-0.41015 0.1309,-0.2026 0.19726,-0.52857 0.19726,-0.976566 v -1.060546 c 0,-0.4052 0.0598,-0.668316 0.179689,-0.791016 0.122601,-0.1254 0.383701,-0.189353 0.7832,-0.189453 h 0.30079 v -0.611328 z m 6.966801,0 v 0.611328 h 0.29102 c 0.40241,10e-5 0.66441,0.06385 0.787111,0.189453 0.122999,0.1255 0.183588,0.388615 0.183588,0.791016 v 1.060546 c 0,0.447996 0.065,0.773966 0.193361,0.976566 0.131201,0.2026 0.354069,0.33915 0.66797,0.41015 -0.3167,0.077 -0.53957,0.21732 -0.66797,0.41993 -0.128601,0.20259 -0.193361,0.52755 -0.193361,0.97265 v 1.06055 c 0,0.4023 -0.0609,0.66551 -0.183588,0.79101 -0.122701,0.1253 -0.384701,0.18946 -0.787111,0.18946 h -0.29102 v 0.61523 h 0.265631 c 0.710409,0 1.184119,-0.1052 1.42382,-0.3164 0.23971,-0.21111 0.35938,-0.63112 0.35938,-1.26172 v -1.02344 c 0,-0.4308 0.0772,-0.72903 0.22851,-0.89453 0.153999,-0.1652 0.727881,-0.636104 0.83399,-0.24805 h 0.273439 v -0.61133 h -0.273439 c -0.4023,0 -0.67998,-0.0815 -0.83399,-0.24414 -0.150891,-0.1627 -0.22851,-0.458717 -0.22851,-0.886717 v -1.027344 c 0,-0.6305 -0.11967,-1.049512 -0.35938,-1.257812 -0.2397,-0.2111 -1.241438,-1.003006 -1.42382,-0.316406 z m -14.76758,0.878906 v 1.361328 h -1.28125 v 0.613281 h 1.28125 v 2.601564 c 0,0.5792 0.120771,0.98781 0.363281,1.22461 0.242599,0.2368 0.65939,0.35547 1.25,0.35547 h 0.9629 v -0.63086 h -0.88672 c -0.33381,0 -0.56708,-0.0692 -0.70118,-0.20899 -0.134101,-0.1399 -0.201171,-0.38643 -0.201171,-0.74023 v -2.601564 h 1.789071 V 60.875778 H 46.883028 V 59.51445 Z m -15.27734,1.119141 c -0.57641,0 -1.01898,0.125853 -1.33008,0.376953 -0.311011,0.2482 -0.4668,0.601144 -0.4668,1.060549 0,0.3624 0.1042,0.65013 0.3125,0.86133 0.208309,0.2082 0.53849,0.35631 0.99219,0.44531 l 0.29492,0.0586 0.0352,0.0117 c 0.699,0.1399 1.04883,0.39066 1.04883,0.75586 0,0.2539 -0.0959,0.4531 -0.28711,0.5957 -0.1912,0.1397 -0.4605,0.20899 -0.80859,0.20899 -0.23972,0 -0.49548,-0.0373 -0.76368,-0.11133 -0.2682,-0.0771 -0.54789,-0.1906 -0.84179,-0.3418 v 0.81446 c 0.3025,0.0998 0.58209,0.1717 0.84179,0.2207 0.2596,0.051 0.50919,0.0781 0.7461,0.0781 0.5992,0 1.06759,-0.13303 1.40429,-0.39843 0.3367,-0.2682 0.50391,-0.6396 0.50391,-1.11328 0,-0.35661 -0.10023,-0.64665 -0.30273,-0.86915 -0.1998,-0.2226 -0.49581,-0.36937 -0.886719,-0.44335 l -0.31641,-0.0606 c -0.52221,-0.0999 -0.84927,-0.203 -0.98047,-0.3086 -0.1309,-0.1056 -0.19726,-0.26451 -0.19726,-0.47851 0,-0.2368 0.0876,-0.413245 0.26171,-0.527345 0.17691,-0.1165 0.44419,-0.175781 0.80079,-0.175781 0.2369,0 0.46895,0.03361 0.69726,0.09961 0.2282,0.0656 0.45429,0.163622 0.67969,0.294922 v -0.769531 -0.002 c -0.2283,-0.0942 -0.46037,-0.164938 -0.69727,-0.210938 -0.23681,-0.049 -0.48343,-0.07227 -0.74023,-0.07227 z m 5.02148,0.01953 c -0.576411,0 -1.03031,0.223875 -1.36132,0.671875 -0.331001,0.447997 -0.4961,1.068127 -0.4961,1.861327 0,0.7789 0.1651,1.39084 0.4961,1.83594 0.33381,0.4422 0.78781,0.66406 1.36132,0.66406 0.2882,0 0.54101,-0.0639 0.75782,-0.18945 0.2198,-0.1283 0.39308,-0.31008 0.521479,-0.54688 v 2.43555 h 0.79297 v -6.617188 h -0.79297 v 0.611328 c -0.1313,-0.2368 -0.305689,-0.416462 -0.52539,-0.539062 -0.21691,-0.1254 -0.468609,-0.1875 -0.753909,-0.1875 z m 6.683599,0.07617 c -0.04128,0.371514 -0.698749,0.09084 -0.972659,0.273437 -0.2711,0.1797 -0.47231,0.439792 -0.60351,0.779305 v -0.937508 h -0.791021 v 4.792968 h 0.791022 v -2.38281 c 0,-0.582 0.13092,-1.02774 0.390619,-1.33594 0.259611,-0.308195 0.634189,-0.460937 1.125,-0.460937 0.2083,0 0.400219,0.02984 0.574219,0.08984 0.174101,0.06 0.34536,0.153852 0.51367,0.285157 v -0.802735 c -0.1541,-0.1028 -0.31607,-0.179516 -0.48437,-0.228516 -0.1684,-0.049 -0.521544,-0.265092 -0.542969,-0.07227 z m 12.70703,0.02148 1.716801,2.294922 -1.884771,2.5 h 0.912111 l 1.400389,-1.92188 1.402341,1.92188 h 0.912109 l -1.88281,-2.5 1.7168,-2.294922 h -0.88672 l -1.26172,1.734372 -1.271479,-1.734372 z m -19.265629,0.570313 c 0.3795,-10e-7 0.665379,0.156804 0.85938,0.470699 0.1973,0.311 0.294919,0.76915 0.294919,1.37695 0,0.6077 -0.098,1.06892 -0.294919,1.38282 -0.194001,0.311 -0.47988,0.46679 -0.85938,0.46679 -0.3795,0 -0.66722,-0.15579 -0.86132,-0.46679 -0.1907,-0.311 -0.28711,-0.77222 -0.28711,-1.38282 0,-0.6107 0.096,-1.06986 0.28711,-1.38086 0.1941,-0.310989 0.48182,-0.466789 0.86132,-0.466789 z"
+       fill="url(#a)"
+       id="path25"
+       style="fill:#273445;fill-opacity:1"
+       sodipodi:nodetypes="sccccsccsccccsccscsssccssccccsccccsscccsscsccscsscsccscsscsccccccscsccscsccccccccsccccscsccccscsccccscscccccccssscsccccccccssccccccscsccccsscccccccccccccscscscscs" />
+  </g>
+</svg>


### PR DESCRIPTION
Update the remaining LibreOffice icons to match
the newer style that Write and Calc use.
Should also more closely mirror the mimetype icons.

Draft:

![e-xfce-libreoffice](https://user-images.githubusercontent.com/1984060/183056088-0e8845b6-2d79-437a-9a15-87852e79b9e4.png)

This is what I currently have. I don't like the Presentation one, and am not sure what to use for Main/Startcenter. Any feedback would be appreciated.

Fixes #320 