### PR TITLE
Fix gtk-preferences symlinks at 16px and 24px

### DIFF
--- a/elementary-xfce/categories/16/gtk-preferences.svg
+++ b/elementary-xfce/categories/16/gtk-preferences.svg
@@ -1,1 +1,1 @@
-../../apps/32/preferences-desktop.svg
+../../apps/16/preferences-desktop.svg

--- a/elementary-xfce/categories/24/gtk-preferences.svg
+++ b/elementary-xfce/categories/24/gtk-preferences.svg
@@ -1,1 +1,1 @@
-../../apps/32/preferences-desktop.svg
+../../apps/24/preferences-desktop.svg


### PR DESCRIPTION
These were both pointing to the 32px icon.

Fixes #319