### PR TITLE
Draft: Update `software-properties` icon

### DIFF
--- a/elementary-xfce/apps/128/software-properties.svg
+++ b/elementary-xfce/apps/128/software-properties.svg
@@ -1,0 +1,404 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="128"
+   height="128"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041668"
+     inkscape:cx="84.10557"
+     inkscape:cy="105.0088"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="62"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135034,1.4865135)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="48.335194"
+       x2="12.168998"
+       y2="-0.20351125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6410258,0,0,2.6410258,0.6153836,0.9743586)" />
+    <linearGradient
+       id="linearGradient5128">
+      <stop
+         id="stop5130"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5132"
+         style="stop-color:#959595;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10691">
+      <stop
+         id="stop10693"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop10695"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="64"
+       y1="21.523018"
+       x2="64"
+       y2="103.06695"
+       id="linearGradient2902"
+       xlink:href="#XMLID_6_"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43558142,0,0,0.43558135,74.122791,74.558368)"
+       spreadMethod="pad" />
+    <linearGradient
+       x1="64"
+       y1="21.523018"
+       x2="64"
+       y2="103.06695"
+       id="XMLID_6_"
+       xlink:href="#XMLID_5_"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="pad">
+      <stop
+         id="stop31"
+         style="stop-color:#d9d9d9;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop33"
+         style="stop-color:#cccccc;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="21.941401"
+       x2="63.9995"
+       y2="104.0591"
+       id="XMLID_5_"
+       xlink:href="#linearGradient2199"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="pad">
+      <stop
+         id="stop24"
+         style="stop-color:#dadada;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop26"
+         style="stop-color:#cccccc;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="21.941401"
+       x2="63.9995"
+       y2="104.0591"
+       id="linearGradient2199"
+       xlink:href="#linearGradient2193"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="pad">
+      <stop
+         id="stop2201"
+         style="stop-color:#fcfcfd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2203"
+         style="stop-color:#cccccc;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="21.941401"
+       x2="63.9995"
+       y2="104.0591"
+       id="linearGradient2193"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop2195"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2197"
+         style="stop-color:#e8e9ef;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="49.273136"
+       y1="22.274775"
+       x2="49.373875"
+       y2="102.04791"
+       id="linearGradient2904"
+       xlink:href="#XMLID_6_"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43558142,0,0,0.43558135,74.122791,74.558368)" />
+    <linearGradient
+       x1="63.9995"
+       y1="21.941401"
+       x2="63.9995"
+       y2="104.0591"
+       id="linearGradient2907"
+       xlink:href="#XMLID_5_"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3725513,0,0,0.37255135,78.156712,78.529264)"
+       spreadMethod="pad" />
+    <linearGradient
+       x1="86.132919"
+       y1="105.105"
+       x2="84.63858"
+       y2="20.895"
+       id="linearGradient2909"
+       xlink:href="#linearGradient5128"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3725513,0,0,0.37255135,78.156712,78.529264)" />
+    <linearGradient
+       x1="64"
+       y1="6.8743429"
+       x2="64"
+       y2="117.22547"
+       id="linearGradient2912"
+       xlink:href="#XMLID_4_"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4447628,0,0,0.4447629,73.535171,74.721205)" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="XMLID_4_"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop11"
+         style="stop-color:#f2f2f2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop13"
+         style="stop-color:#d8d8d8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="6.702713"
+       cy="73.615715"
+       r="7.228416"
+       fx="6.702713"
+       fy="73.615715"
+       id="radialGradient2916"
+       xlink:href="#linearGradient10691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.7352585,0,0,1.1067432,75.963636,38.527128)" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient2455-1"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient2457-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient2459-7"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+  </defs>
+  <metadata
+     id="metadata3663">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline;opacity:0.4">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.5"
+     x="12.5"
+     ry="8"
+     rx="8"
+     height="103"
+     width="103" />
+  <path
+     d="M 128,120.00081 C 127.998,124.41878 115.91061,128 101,128 86.089384,128 74.001514,124.41878 74,120.00081 73.9985,115.58222 86.087242,112 101,112 c 14.91276,0 27.00152,3.58222 27,8.00081 z"
+     id="path10689"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2916);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.8;marker:none" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.5"
+     x="13.5"
+     ry="7"
+     rx="7"
+     height="101"
+     width="101" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42.108666,71 c -3.597168,0.004 -5.450004,4.28414 -2.98224,6.889308 l 21.891338,23.832462 c 1.619528,1.70431 4.344944,1.70431 5.964474,0 L 88.873572,77.889308 C 91.341336,75.28414 89.488502,71.003878 85.891334,71 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="m 55.441257,40.500002 c -2.032468,0 -3.670307,1.360988 -3.670307,3.051543 V 66.946709 H 41.691538 c -3.665829,0.0041 -5.556208,4.359085 -3.04134,7.009012 l 22.312445,24.241492 c 1.65044,1.733589 4.424272,1.733589 6.074715,0 L 89.349803,73.955721 c 2.514868,-2.649927 0.624491,-7.005067 -3.04134,-7.009012 H 76.229051 V 43.551545 c 0,-1.690555 -1.637839,-3.051543 -3.670307,-3.051543 z" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42,67 c -3.480434,8.8e-5 -5.300646,4.137154 -2.949218,6.703124 l 22,24 c 1.585552,1.730088 4.312884,1.730088 5.898436,0 l 22,-24 C 91.300646,71.137154 89.480434,67.000088 86,67 Z"
+     id="path6081"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="24"
+     height="30"
+     x="52"
+     y="41"
+     rx="3"
+     ry="3" />
+  <path
+     d="m 125.76304,96.301521 h -2.01206 c -0.54303,0 -1.17093,-0.451992 -1.34358,-0.966582 -0.009,-0.02672 -1.2487,-3.025778 -1.2487,-3.025778 -0.255,-0.51292 -0.13168,-1.275 0.25209,-1.65896 l 1.42259,-1.42274 c 0.32691,-0.327201 0.50752,-0.763748 0.50752,-1.229093 0,-0.464925 -0.18061,-0.901472 -0.50752,-1.228673 l -5.60136,-5.601235 c -0.32691,-0.327201 -0.76334,-0.507495 -1.22863,-0.507495 -0.46528,0 -0.90172,0.180294 -1.22861,0.507495 l -1.42261,1.422325 c -0.38376,0.383543 -1.14627,0.507077 -1.63163,0.264598 -0.0272,-0.01252 -3.02663,-1.251211 -3.02663,-1.251211 -0.54178,-0.182797 -0.99369,-0.810491 -0.99369,-1.353462 V 78.238258 C 107.69933,77.279608 106.91932,76.5 105.96116,76.5 h -7.921076 c -0.958571,0 -1.738224,0.779608 -1.738224,1.738258 v 2.012452 c 0,0.542971 -0.451904,1.171081 -0.966513,1.343445 -0.02675,0.01 -3.026217,1.248707 -3.026217,1.248707 -0.512935,0.255 -1.275445,0.131466 -1.65921,-0.252077 L 89.227319,81.16846 c -0.327327,-0.327201 -0.763764,-0.507495 -1.229044,-0.507495 -0.465285,0 -0.90172,0.180711 -1.22863,0.507495 l -5.601777,5.601235 c -0.677648,0.677773 -0.677648,1.780408 0,2.457766 l 1.422601,1.42274 c 0.383344,0.383544 0.507086,1.14604 0.26462,1.631834 -0.01254,0.02713 -1.251619,3.02661 -1.251619,3.02661 -0.182685,0.541718 -0.810169,0.993289 -1.353206,0.993289 H 78.759522 C 77.801368,96.301521 76.5,97.081123 76.5,98.039777 v 7.920853 c 0,0.95824 0.779651,1.73785 1.738224,1.73785 h 2.012458 c 0.543038,0 1.170938,0.45157 1.343172,0.96658 0.01,0.0266 1.249111,3.02578 1.249111,3.02578 0.255008,0.51291 0.131269,1.27541 -0.252079,1.65937 l -1.4226,1.42274 c -0.677648,0.67736 -0.677648,1.78041 0,2.45777 l 5.601778,5.60124 c 0.32691,0.32719 0.763345,0.50749 1.228628,0.50749 0.4657,0 0.902135,-0.1803 1.229046,-0.50749 l 1.422601,-1.42234 c 0.383763,-0.38354 1.146274,-0.50749 1.63162,-0.26459 0.02717,0.0121 3.026631,1.2512 3.026631,1.2512 0.541366,0.18281 0.99327,0.81009 0.99327,1.35347 v 2.01203 c 0,0.95866 0.779653,1.73827 1.738224,1.73827 h 7.920656 c 0.95816,0 1.73782,-0.77961 1.73782,-1.73827 v -2.01203 c 0,-0.54338 0.4519,-1.17107 0.96693,-1.34387 0.0267,-0.009 3.02621,-1.2487 3.02621,-1.2487 0.51294,-0.255 1.27587,-0.13105 1.65922,0.25209 l 1.4226,1.42231 c 0.32691,0.32722 0.76334,0.5075 1.22863,0.5075 0.46527,0 0.90171,-0.18028 1.22863,-0.5075 l 5.60136,-5.60123 c 0.3269,-0.32679 0.50749,-0.76334 0.50749,-1.22868 0,-0.46533 -0.18059,-0.90189 -0.50749,-1.22867 l -1.42261,-1.42274 c -0.38376,-0.38354 -0.5071,-1.14646 -0.26462,-1.63142 0.0126,-0.0276 1.25162,-3.02661 1.25162,-3.02661 0.18269,-0.54213 0.81018,-0.9937 1.35321,-0.9937 h 2.01204 c 0.95857,0 1.73822,-0.77961 1.73822,-1.73785 v -7.920853 c 9e-4,-0.958654 -0.77839,-1.738256 -1.73696,-1.738256 z m -23.76242,13.666089 c -4.424146,0 -8.023078,-3.59296 -8.023078,-8.00935 0,-4.416801 3.598932,-8.009754 8.023078,-8.009754 4.42373,0 8.02267,3.592953 8.02267,8.009754 0,4.41639 -3.59894,8.00935 -8.02267,8.00935 z"
+     id="path8"
+     style="fill:url(#linearGradient2912);fill-opacity:1;stroke:#888888;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     d="m 102,86.5 c -8.546699,0 -15.5,6.953298 -15.5,15.5 0,8.5467 6.953301,15.5 15.5,15.5 8.54671,0 15.5,-6.9533 15.5,-15.5 0,-8.546702 -6.95329,-15.5 -15.5,-15.5 z m 0,26.90007 c -6.296492,0 -11.400072,-5.10321 -11.400072,-11.40007 0,-6.296864 5.10358,-11.400072 11.400072,-11.400072 6.29649,0 11.40006,5.103579 11.40006,11.400072 0,6.29649 -5.10357,11.40007 -11.40006,11.40007 z"
+     id="path28"
+     style="fill:url(#linearGradient2907);stroke:url(#linearGradient2909);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none" />
+  <path
+     d="m 102,88.496978 c -7.457586,0 -13.503022,6.04543 -13.503022,13.503022 0,7.45759 6.045436,13.50302 13.503022,13.50302 7.45759,0 13.50303,-6.04543 13.50303,-13.50302 0,-7.457592 -6.04544,-13.503022 -13.50303,-13.503022 z m 0,22.432442 c -4.932085,0 -8.929417,-3.99776 -8.929417,-8.92942 0,-4.932082 3.997332,-8.929422 8.929417,-8.929422 4.93165,0 8.92942,3.99734 8.92942,8.929422 0,4.93166 -3.99777,8.92942 -8.92942,8.92942 z"
+     id="path35"
+     style="fill:url(#linearGradient2902);stroke:url(#linearGradient2904);stroke-width:0.993956;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+</svg>

--- a/elementary-xfce/apps/16/software-properties.svg
+++ b/elementary-xfce/apps/16/software-properties.svg
@@ -1,262 +1,174 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
    width="16"
    height="16"
-   id="svg2907">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="7.8826979"
+     inkscape:cy="5.7008797"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="773"
+     inkscape:window-y="189"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="24px" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486583,0.8648677)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="49.078144"
+       x2="12.168998"
+       y2="0.98788178"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33333332,0,0,0.3333334,9.220459e-8,-0.33333512)" />
+    <linearGradient
+       x1="25"
+       y1="0"
+       x2="25"
+       y2="16.000105"
+       id="linearGradient3262"
+       xlink:href="#linearGradient3309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75,0,0,0.75,-9.8676593,4.15625)" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313"
+         style="stop-color:#cccccc;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata88092">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs2909">
-    <linearGradient
-       id="linearGradient3054">
-      <stop
-         id="stop3056"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3058"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.29462135" />
-      <stop
-         id="stop3060"
-         style="stop-color:#ffffff;stop-opacity:0.6901961"
-         offset="0.43371025" />
-      <stop
-         id="stop3062"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3032">
-      <stop
-         id="stop3034"
-         style="stop-color:#dac197;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3036"
-         style="stop-color:#c1a581;stop-opacity:1"
-         offset="0.28352803" />
-      <stop
-         id="stop3038"
-         style="stop-color:#dbc298;stop-opacity:1"
-         offset="0.36018604" />
-      <stop
-         id="stop3040"
-         style="stop-color:#a68b60;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3022">
-      <stop
-         id="stop3024"
-         style="stop-color:#c9af8b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3026"
-         style="stop-color:#ad8757;stop-opacity:1"
-         offset="0.27982354" />
-      <stop
-         id="stop3028"
-         style="stop-color:#c2a57f;stop-opacity:1"
-         offset="0.3566308" />
-      <stop
-         id="stop3030"
-         style="stop-color:#9d7d53;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3275">
-      <stop
-         id="stop3277"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop3283"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.245" />
-      <stop
-         id="stop3285"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.77350003" />
-      <stop
-         id="stop3279"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4559">
-      <stop
-         id="stop4561"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop4563"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="44.994774"
-       y1="17.5"
-       x2="3.0052247"
-       y2="17.5"
-       id="linearGradient3009"
-       xlink:href="#linearGradient3275"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.36595005,0,0,0.36097048,-0.7828015,-0.81698)"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="23.451576"
-       y1="30.554907"
-       x2="43.00663"
-       y2="45.934479"
-       id="linearGradient3015"
-       xlink:href="#linearGradient4559"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46923034,0,0,0.4240274,-3.0041886,-3.4756141)" />
-    <linearGradient
-       x1="24.822832"
-       y1="15.377745"
-       x2="24.996943"
-       y2="37.27668"
-       id="linearGradient3018"
-       xlink:href="#linearGradient3032"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46923034,0,0,0.56212557,-3.0041886,-7.0808391)" />
-    <linearGradient
-       x1="15.464298"
-       y1="7.9756851"
-       x2="15.464298"
-       y2="45.04248"
-       id="linearGradient3020"
-       xlink:href="#linearGradient3022"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.36595005,0,0,0.36097048,-0.7828015,-1.5613271)" />
-    <linearGradient
-       x1="26"
-       y1="22"
-       x2="26"
-       y2="8"
-       id="linearGradient3052"
-       xlink:href="#linearGradient3054"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.49999973,0,0,0.49999987,-3.999993,-2.9999993)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148">
-      <stop
-         id="stop4627"
-         style="stop-color:#51cfee;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4629"
-         style="stop-color:#49a3d2;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop4631"
-         style="stop-color:#3470b4;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop4633"
-         style="stop-color:#273567;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631">
-      <stop
-         id="stop4637"
-         style="stop-color:#254b6d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4639"
-         style="stop-color:#415b73;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop4641"
-         style="stop-color:#6195b5;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="9.7552834"
-       fy="-8.7256308"
-       fx="61.240059"
-       cy="-8.7256308"
-       cx="61.240059"
-       gradientTransform="matrix(0,0.81309444,-0.81309402,0,3.9052373,-42.030455)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3105"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148" />
-    <linearGradient
-       y2="2.6887112"
-       x2="20"
-       y1="43"
-       x1="20"
-       gradientTransform="matrix(0.2261571,0,0,0.22615194,5.4822929,5.6623914)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3107"
-       xlink:href="#linearGradient3707-319-631" />
-    <linearGradient
-       id="linearGradient8918">
-      <stop
-         style="stop-color:#cee14b"
-         offset="0"
-         id="stop8920" />
-      <stop
-         style="stop-color:#9db029"
-         offset="1"
-         id="stop8922" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient8918"
-       id="radialGradient4033"
-       cx="10.219072"
-       cy="10.685375"
-       fx="10.219072"
-       fy="10.685375"
-       r="4.1793818"
-       gradientTransform="matrix(1.3948723,0.34295274,-0.27981092,1.1380592,-1.0453442,-4.9765267)"
-       gradientUnits="userSpaceOnUse" />
-  </defs>
   <g
      id="layer1">
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+       id="rect5505-21"
+       y="1.4999986"
+       x="1.5"
+       ry="2"
+       rx="2"
+       height="13.000003"
+       width="13" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="2.5"
+       x="2.5"
+       ry="1"
+       rx="1"
+       height="11"
+       width="11" />
     <path
-       d="m 2.5146738,1.5069219 10.7946932,0 c 0.63016,0 0.913749,-0.103437 1.094759,0.360971 L 15.502611,5.5 l 0,8.523181 c 0,0.560696 0.03767,0.475028 -0.592497,0.475028 l -13.8202288,0 c -0.6301632,0 -0.5924964,0.08566 -0.5924964,-0.475028 l 0,-8.523181 1.098485,-3.6321071 c 0.1759604,-0.455026 0.2886367,-0.360971 0.9188,-0.360971 z"
-       id="path2488"
-       style="fill:url(#linearGradient3018);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3020);stroke-width:0.99420077;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
+       style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+       d="m 6.5788897,4.4999996 c -0.262527,0 -0.473875,0.2127855 -0.473875,0.4770976 v 3.542611 H 4.4592149 c -0.6229398,6.68e-4 -0.943805,0.750404 -0.5164493,1.206721 L 7.4840637,13.15158 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 L 12.057737,9.7264292 c 0.427355,-0.456317 0.10649,-1.206042 -0.51645,-1.206721 H 9.896011 v -3.542611 c 0,-0.2643121 -0.211348,-0.4770976 -0.473874,-0.4770976 z"
+       id="path13703"
+       sodipodi:nodetypes="ssccccccccsss" />
     <path
-       d="m 2.8577405,1.8725639 10.1195695,0 c 0.590751,0 0.956367,0.200895 1.203801,0.752996 l 0.852275,2.317329 0,8.3545021 c 0,0.527261 -0.299624,0.792722 -0.890376,0.792722 l -12.3446678,0 c -0.5907508,0 -0.8317226,-0.291963 -0.8317226,-0.819224 l 0,-8.3280001 0.8247823,-2.367013 c 0.1649564,-0.427891 0.4755865,-0.703312 1.0663386,-0.703312 z"
-       id="path2490"
-       style="opacity:0.50549454;fill:none;stroke:url(#linearGradient3015);stroke-width:0.74211526;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible" />
+       style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+       d="m 6.5788897,3.7499995 c -0.262527,0 -0.473875,0.2127856 -0.473875,0.4770978 V 7.7745802 H 4.750251 c -1.1035033,0 -1.6820007,0.9976447 -0.8074854,1.9314247 l 3.5412981,3.4251501 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 L 12.057737,9.7060049 C 12.932275,8.8314672 12.257082,7.7745802 11.250251,7.7745802 H 9.896011 V 4.2270973 c 0,-0.2643122 -0.211348,-0.4770977 -0.473874,-0.4770977 z"
+       id="path12165"
+       sodipodi:nodetypes="ssccccccccsss" />
     <path
-       d="M 7,1 C 7.666667,1 8.333333,1 9,1 9,3.3333343 9,5.6666671 9,8 8.333333,8 7.666667,8 7,8 7,5.6666671 7,3.3333343 7,1 z"
-       id="rect3326"
-       style="opacity:0.4;fill:url(#linearGradient3052);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 0.4999356,5.5 15.0001274,0"
-       id="path3273"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3009);stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+       style="color:#000000;fill:#ffffff;stroke-width:0.999998;stroke-linejoin:round;-inkscape-stroke:none"
+       d="M 4.9191952,7.9995799 C 3.8798672,7.9999866 3.3593397,9.0532001 4.094,9.7865802 l 3.181251,3.1221768 c 0.4557289,0.45443 0.9942711,0.45443 1.45,0 l 3.181125,-3.1221768 c 0.734661,-0.7333801 0.214258,-1.7865936 -0.82507,-1.7870003 z"
+       id="path906"
+       sodipodi:nodetypes="ccccccc" />
+    <rect
+       style="fill:#ffffff;stroke-width:2.99999;stroke-linejoin:round"
+       id="rect902"
+       height="5"
+       x="6.0002513"
+       y="3.9995799"
+       rx="0.5"
+       ry="0.35714287"
+       width="4" />
   </g>
-  <path
-     style="fill:url(#radialGradient3105);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3107);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none"
-     id="path6495"
-     d="M 15.5,10.999841 C 15.5,13.485202 13.485133,15.5 11.000056,15.5 c -2.485303,0 -4.5000561,-2.014821 -4.5000561,-4.500159 0,-2.4852475 2.0147531,-4.4998408 4.5000561,-4.4998408 2.485077,0 4.499944,2.0145933 4.499944,4.4998408 l 0,0 z" />
-  <path
-     style="opacity:1;fill:url(#radialGradient4033);fill-opacity:1;fill-rule:nonzero;stroke:none"
-     id="path6534"
-     d="m 11.061324,6.7737306 -0.519638,0.060392 -0.571602,0.1585288 c 0.04869,-0.017331 0.09802,-0.036249 0.148468,-0.052843 l -0.06681,-0.1207838 -0.2227,0.037745 -0.111352,0.1056858 -0.170738,0.022647 -0.155891,0.07549 -0.07423,0.037745 -0.02227,0.030196 -0.11135,0.022647 -0.06681,0.1434308 -0.08908,-0.1811757 -0.02969,0.07549 0.01485,0.2038225 -0.141045,0.1207838 -0.08166,0.2189205 0.170738,0 0.06681,-0.1434307 0.02227,-0.052843 c 0.07507,-0.053988 0.14624,-0.1141118 0.222702,-0.1660779 l 0.178162,0.060392 c 0.115996,0.080141 0.232807,0.1615486 0.348899,0.2415676 L 9.970093,7.5135316 9.777085,7.4304926 9.688005,7.2493169 9.361376,7.2115719 9.353976,7.1738269 9.495019,7.2040229 9.576679,7.1209839 9.75484,7.0832389 C 9.797,7.0623869 9.83848,7.0473679 9.881037,7.0303959 l -0.111351,0.1056859 0.400864,0.2793125 0,0.1660777 -0.155892,0.1585286 0.207855,0.4227435 0.141045,-0.083039 0.178162,-0.2793121 c 0.250481,-0.078752 0.476232,-0.1703902 0.712647,-0.2793126 l -0.01485,0.1056858 0.118773,0.083039 0.207855,-0.1434308 -0.103927,-0.1207837 -0.141045,0.083039 -0.04454,-0.015098 c 0.01023,-0.00475 0.01942,-0.010265 0.02969,-0.015098 L 11.514154,6.954907 11.061327,6.7737313 z m -2.034011,0.8152904 0.170738,0.1207838 0.141045,0 0,-0.1434308 -0.170738,-0.07549 -0.141045,0.098137 0,0 z m 3.941824,-0.098137 -0.30436,0.07549 -0.193006,0.1283329 0,0.1132346 -0.304361,0.1962734 0.05939,0.2944111 0.178161,-0.1283332 0.111352,0.1283332 0.126199,0.07549 0.08166,-0.2189211 -0.04454,-0.1283325 0.04454,-0.090588 0.178162,-0.1660773 0.08166,0 -0.08166,0.1811761 0,0.1660772 c 0.07343,-0.020327 0.147553,-0.028243 0.222701,-0.037745 l -0.207855,0.1509803 -0.01484,0.090587 -0.237549,0.2038231 -0.244972,-0.060392 0,-0.1434308 -0.111351,0.07549 0.05197,0.1283331 -0.178164,0 -0.0965,0.1660776 -0.118774,0.1358818 -0.215278,0.045293 0.126197,0.1283328 0.02969,0.1283328 -0.15589,0 -0.207856,0.1132346 0,0.332155 0.0965,0 0.08908,0.098137 0.200432,-0.098137 0.07423,-0.2038228 0.148468,-0.090588 0.02969,-0.07549 0.237549,-0.060392 0.133621,0.1509797 0.141045,0.075489 -0.08166,0.166078 0.126198,-0.037745 0.06681,-0.166078 -0.163313,-0.1887245 0.06681,0 0.163315,0.1358816 0.02969,0.1811761 0.141043,0.1660776 0.03712,-0.2415674 0.07423,-0.037745 c 0.07902,0.083418 0.141302,0.1854319 0.207854,0.2793129 l 0.244973,0.015099 0.141044,0.090588 -0.06681,0.098136 -0.141044,0.1283331 -0.207857,0 -0.274668,-0.090587 -0.141044,0.015099 -0.103928,0.120784 -0.296936,-0.3019598 -0.207855,-0.060392 -0.304359,0.037745 -0.267243,0.07549 c -0.152451,0.175756 -0.308533,0.3534488 -0.452827,0.5359778 l -0.170738,0.422744 0.08166,0.09059 -0.148468,0.218921 0.163314,0.384998 c 0.135896,0.156327 0.27259,0.311598 0.408287,0.468036 l 0.200432,-0.173626 0.08166,0.105687 0.215279,-0.143431 0.07423,0.08304 0.215279,0 0.126199,0.14343 -0.07423,0.256666 0.148467,0.173627 -0.0074,0.301958 0.111352,0.218922 -0.08166,0.188724 c -0.008,0.135356 -0.01485,0.26472 -0.01485,0.400096 0.0655,0.183403 0.13116,0.366355 0.193008,0.551077 l 0.04454,0.294409 0,0.150981 0.118774,0 0.170737,-0.113236 0.207856,0 0.311783,-0.354801 -0.03712,-0.120785 0.207856,-0.188723 -0.155893,-0.173627 0.185585,-0.15098 0.178162,-0.113235 0.08166,-0.09059 -0.05197,-0.203823 c 0,-0.171597 10e-7,-0.341711 0,-0.513331 l 0.141045,-0.317057 0.178162,-0.196274 0.193007,-0.483134 0,-0.128334 c -0.09605,0.0123 -0.188108,0.0234 -0.282089,0.0302 l 0.193009,-0.196273 0.267242,-0.181176 0.141045,-0.166077 0,-0.181176 c -0.03199,-0.06135 -0.06429,-0.127376 -0.0965,-0.188725 l -0.126197,0.150979 -0.0965,-0.113234 -0.141046,-0.113234 0,-0.234019 0.163316,0.188724 0.185586,-0.02265 c 0.08372,0.07729 0.164115,0.146018 0.237547,0.23402 l 0.118778,-0.135886 c 0,-0.146289 -0.162022,-0.8684693 -0.512214,-1.4796016 C 14.281784,8.2614176 13.666936,7.7022558 13.666937,7.7022558 l -0.04454,0.083039 -0.163315,0.1811757 -0.207856,-0.2189207 0.207856,0 0.0965,-0.1056857 -0.386016,-0.07549 -0.200432,-0.07549 z M 8.507676,7.589021 8.433446,7.7852947 c 0,0 -0.129965,0.02182 -0.163314,0.030196 -0.4259011,0.3991062 -1.2847551,1.2647849 -1.4846791,2.8912613 0.0079,0.03771 0.141044,0.256666 0.141044,0.256666 l 0.32663,0.196273 0.326629,0.09059 0.141044,0.173626 0.215279,0.166078 0.1261981,-0.02265 0.08908,0.04529 0,0.0302 -0.118775,0.339704 -0.0965,0.143431 0.02969,0.06794 -0.07423,0.271764 0.2746661,0.51333 0.282088,0.249117 0.126197,0.181176 -0.01485,0.377449 0.08908,0.211372 -0.08908,0.407646 c 0,0 -0.01189,-0.0034 0,0.03775 0.01199,0.04112 0.496231,0.317713 0.527061,0.29441 0.03073,-0.02374 0.05939,-0.04529 0.05939,-0.04529 l -0.02969,-0.09059 0.126198,-0.120783 0.04454,-0.128332 0.200431,-0.06794 0.155891,-0.392548 -0.04454,-0.105686 0.103927,-0.166077 0.237549,-0.05284 0.1187749,-0.286862 -0.02969,-0.354802 0.185585,-0.264215 0.02969,-0.271763 C 9.9901181,12.261767 9.7402951,12.12983 9.4875631,11.997626 l -0.126198,-0.249116 -0.230125,-0.05284 -0.126198,-0.339704 -0.30436,0.03775 -0.267241,-0.196274 -0.282089,0.249116 0,0.03774 c -0.08449,-0.0248 -0.1845851,-0.02845 -0.2598181,-0.07549 l -0.05939,-0.181175 0,-0.196275 -0.193008,0.02265 c 0.01553,-0.125022 0.03632,-0.252449 0.05197,-0.377449 l -0.111351,0 -0.111351,0.143431 -0.103927,0.05284 -0.155892,-0.09059 -0.01484,-0.196274 0.02969,-0.211371 0.230125,-0.181176 0.185585,0 0.03712,-0.105685 0.230125,0.05284 0.1707381,0.21892 0.02969,-0.3623512 0.296936,-0.2491157 0.103927,-0.264215 0.222702,-0.090588 0.118774,-0.1811758 0.282089,-0.052843 0.141045,-0.2113717 c -0.139605,0 -0.283527,0 -0.423134,0 l 0.267243,-0.1283327 0.185585,0 0.237548,-0.083039 0.04454,0.2340185 0.103927,-0.1660778 -0.118774,-0.083039 0.02969,-0.098136 -0.0965,-0.090588 -0.103928,-0.030196 0.02969,-0.1132346 -0.08166,-0.1585286 -0.185585,0.07549 0.02969,-0.1434306 -0.215279,-0.128333 -0.170737,0.3019594 0.01485,0.1056859 -0.170738,0.07549 -0.103928,0.2340186 -0.05197,-0.218921 -0.289512,-0.1207836 -0.05197,-0.1660776 0.39344,-0.2264694 0.170738,-0.1660779 0.01485,-0.1962736 -0.09651,-0.052843 -0.126198,-0.015098 -10e-7,-3e-7 z m 3.184636,0.3623519 0,0.120783 0.06681,0.07549 0,0.1811758 -0.03712,0.2415674 0.193008,-0.037745 0.141045,-0.1434304 -0.126198,-0.1207841 C 11.888937,8.1576061 11.847463,8.0576671 11.796242,7.9513729 l -0.103928,0 z m -0.163315,0.2415668 -0.118773,0.037745 0.02969,0.2189205 0.155891,-0.08304 -0.06681,-0.1736263 0,0 z m 2.175055,1.9853833 0.178163,0.211371 0.215278,0.468038 0.13362,0.150979 -0.06681,0.15853 0.118775,0.14343 c -0.0545,0.0037 -0.107292,0.0076 -0.163315,0.0076 -0.101773,-0.217475 -0.182318,-0.436796 -0.259818,-0.664311 l -0.133622,-0.15098 -0.07423,-0.271763 0.05197,-0.05284 0,-10e-7 z" />
+  <g
+     id="g2479"
+     transform="matrix(0.64444446,0,0,0.64444446,6.2476987,5.45486)"
+     style="stroke-width:1.55172">
+    <path
+       d="m 8.1291082,4.53125 c -0.1863127,0 -0.328125,0.1418116 -0.328125,0.328125 v 0.9375 C 7.385556,5.9035254 7.0126102,6.0757837 6.6525457,6.2890625 L 5.9728582,5.609375 c -0.1317427,-0.1317434 -0.3370065,-0.1317434 -0.46875,0 l -1.125,1.125 c -0.1317427,0.1317434 -0.1317427,0.3370066 0,0.46875 L 5.0587957,7.8828125 C 4.8455174,8.2428767 4.673259,8.6158226 4.5666082,9.03125 h -0.9375 c -0.1863127,0 -0.328125,0.1418116 -0.328125,0.328125 v 1.593751 c 0,0.186313 0.1418122,0.328125 0.328125,0.328125 h 0.9375 c 0.1066507,0.415427 0.2789093,0.788373 0.4921875,1.148437 l -0.6796875,0.679688 c -0.1317427,0.131743 -0.1317427,0.337006 0,0.46875 l 1.125,1.125 c 0.1317434,0.131743 0.3370065,0.131743 0.46875,0 l 0.6796875,-0.679688 c 0.3600646,0.213279 0.7330103,0.385538 1.1484375,0.492188 v 0.9375 c 1e-7,0.186313 0.1418123,0.328125 0.328125,0.328125 h 1.59375 c 0.1863132,0 0.3281248,-0.141812 0.3281248,-0.328125 v -0.9375 c 0.415428,-0.10665 0.788373,-0.278908 1.148438,-0.492188 l 0.679687,0.679688 c 0.131744,0.131743 0.337007,0.131743 0.46875,0 l 1.125,-1.125 c 0.131744,-0.131744 0.131744,-0.337007 0,-0.46875 l -0.679687,-0.679688 c 0.213279,-0.360064 0.385537,-0.73301 0.492187,-1.148437 h 0.9375 c 0.186314,0 0.328125,-0.141812 0.328125,-0.328125 V 9.359375 c 0,-0.1863134 -0.141812,-0.328125 -0.328125,-0.328125 h -0.9375 C 13.178708,8.6158226 13.00645,8.2428767 12.793171,7.8828125 L 13.472858,7.203125 c 0.131744,-0.1317434 0.131744,-0.3370065 0,-0.46875 l -1.125,-1.125 c -0.131743,-0.1317434 -0.337006,-0.1317434 -0.46875,0 L 11.199421,6.2890625 C 10.839356,6.0757837 10.466411,5.9035254 10.050983,5.796875 v -0.9375 c 0,-0.1863134 -0.1418113,-0.328125 -0.3281248,-0.328125 z m 0.796875,4.125 c 0.828,0 1.4999998,0.672 1.4999998,1.5 0,0.828 -0.6719998,1.500001 -1.4999998,1.500001 -0.828,0 -1.5,-0.672001 -1.5,-1.500001 0,-0.828 0.672,-1.5 1.5,-1.5 z"
+       id="path2426"
+       style="display:block;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3262);fill-opacity:1;fill-rule:nonzero;stroke:#010101;stroke-width:1.16379;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+  </g>
 </svg>

--- a/elementary-xfce/apps/24/software-properties.svg
+++ b/elementary-xfce/apps/24/software-properties.svg
@@ -1,333 +1,265 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg2"
-   version="1.0">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="8.9384163"
+     inkscape:cy="10.134897"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="900"
+     inkscape:window-y="51"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     width="24px" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46088194,0,0,0.46088194,0.93883524,0.93883817)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="48.266846"
+       x2="12.168998"
+       y2="-0.0086730029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717949,0.30769232,-0.17948722)" />
+    <linearGradient
+       x1="25"
+       y1="0"
+       x2="25"
+       y2="16.000105"
+       id="linearGradient3262"
+       xlink:href="#linearGradient3309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75,0,0,0.75,-9.8676593,4.15625)" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313"
+         style="stop-color:#cccccc;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
   <metadata
-     id="metadata149425">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs4">
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient3681"
-       id="radialGradient2601"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5938225,0,0,1.5366531,41.140892,-103.93618)"
-       cx="5"
-       cy="41.5"
-       fx="5"
-       fy="41.5"
-       r="5" />
-    <linearGradient
-       id="linearGradient3703">
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         offset="0"
-         id="stop3705" />
-      <stop
-         id="stop3711"
-         offset="0.5"
-         style="stop-color:black;stop-opacity:1;" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         offset="1"
-         id="stop3707" />
-    </linearGradient>
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient3703"
-       id="linearGradient2599"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7570316,0,0,1.3969574,-17.394014,-16.411698)"
-       x1="17.554192"
-       y1="46.000275"
-       x2="17.554192"
-       y2="34.999718" />
-    <linearGradient
-       collect="always"
-       id="linearGradient3681">
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         offset="0"
-         id="stop3683" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         offset="1"
-         id="stop3685" />
-    </linearGradient>
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient3681"
-       id="radialGradient2597"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5938225,0,0,1.5366531,-6.6594735,-103.93618)"
-       cx="5"
-       cy="41.5"
-       fx="5"
-       fy="41.5"
-       r="5" />
-    <linearGradient
-       id="linearGradient3295">
-      <stop
-         style="stop-color:#c4a880;stop-opacity:1;"
-         offset="0"
-         id="stop3297" />
-      <stop
-         id="stop3299"
-         offset="0.23942046"
-         style="stop-color:#a37e4f;stop-opacity:1;" />
-      <stop
-         id="stop3301"
-         offset="0.27582464"
-         style="stop-color:#c0a37b;stop-opacity:1;" />
-      <stop
-         style="stop-color:#90734c;stop-opacity:1;"
-         offset="1"
-         id="stop3303" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3199">
-      <stop
-         id="stop3201"
-         offset="0"
-         style="stop-color:#dac197;stop-opacity:1" />
-      <stop
-         style="stop-color:#c1a581;stop-opacity:1"
-         offset="0.23942046"
-         id="stop3203" />
-      <stop
-         style="stop-color:#dbc298;stop-opacity:1"
-         offset="0.27582464"
-         id="stop3205" />
-      <stop
-         id="stop3207"
-         offset="1"
-         style="stop-color:#a68b60;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2605">
-      <stop
-         id="stop2607"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0.28755552"
-         id="stop2609" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.69019608;"
-         offset="0.32903713"
-         id="stop2611" />
-      <stop
-         id="stop2613"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3275">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="0"
-         id="stop3277" />
-      <stop
-         id="stop3283"
-         offset="0.245"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0.77350003"
-         id="stop3285" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop3279" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient8647">
-      <stop
-         style="stop-color:#8fb1dc;stop-opacity:1;"
-         offset="0"
-         id="stop8649" />
-      <stop
-         style="stop-color:#3465a4;stop-opacity:1;"
-         offset="1"
-         id="stop8651" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4873"
-       collect="always">
-      <stop
-         id="stop4875"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop4877"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient8918">
-      <stop
-         id="stop8920"
-         offset="0"
-         style="stop-color:#cee14b" />
-      <stop
-         id="stop8922"
-         offset="1"
-         style="stop-color:#9db029" />
-    </linearGradient>
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient3275"
-       id="linearGradient5772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5122637,0,0,0.4997701,-0.2933262,-0.2459769)"
-       spreadMethod="reflect"
-       x1="44.994774"
-       y1="17.5"
-       x2="3.0052247"
-       y2="17.5" />
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient2605"
-       id="linearGradient5775"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5,0,0,0.4999999,2.93e-7,-0.9999996)"
-       x1="26"
-       y1="22"
-       x2="26"
-       y2="8" />
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient3199"
-       id="linearGradient5781"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6568375,0,0,0.778273,-3.4038718,-8.380178)"
-       x1="24.822832"
-       y1="15.377745"
-       x2="24.996943"
-       y2="37.27668" />
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient3295"
-       id="linearGradient5783"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5122637,0,0,0.4997701,-0.2943328,-0.7383152)"
-       x1="15.464298"
-       y1="7.9756851"
-       x2="15.464298"
-       y2="45.04248" />
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient4873"
-       id="linearGradient6427"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6860753,0,0,0.6860594,-26.174154,18.90864)"
-       x1="63.397362"
-       y1="-12.742159"
-       x2="61.471611"
-       y2="-1.3244334" />
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient8918"
-       id="radialGradient6430"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.5398147e-2,0.9027041,-0.6532633,1.7867245e-2,28.045924,-9.5067203)"
-       cx="24.652573"
-       cy="18.94449"
-       fx="24.652485"
-       fy="18.944481"
-       r="8.6174498" />
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient8647"
-       id="radialGradient6433"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8501799,0,0,0.7000024,5.9018159,8.449972)"
-       cx="12.465816"
-       cy="5.3052077"
-       fx="12.465816"
-       fy="5.3052077"
-       r="10.499999" />
-  </defs>
   <g
-     label="Layer 1"
-     groupmode="layer"
      id="layer1">
     <g
-       id="g5647">
-      <g
-         transform="matrix(0.507121,0,0,0.4555355,-0.3702833,1.2033829)"
-         style="opacity:0.4;display:inline"
-         id="g3305">
-        <rect
-           transform="scale(-1,-1)"
-           y="-47.848343"
-           x="-3.6903627"
-           height="15.366531"
-           width="2.9601951"
-           id="rect2484"
-           style="opacity:1;fill:url(#radialGradient2597);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1" />
-        <rect
-           y="32.481812"
-           x="3.6903627"
-           height="15.366531"
-           width="40.41172"
-           id="rect2486"
-           style="opacity:1;fill:url(#linearGradient2599);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1" />
-        <rect
-           transform="scale(1,-1)"
-           y="-47.848343"
-           x="44.110001"
-           height="15.366531"
-           width="2.9601951"
-           id="rect3444"
-           style="opacity:1;fill:url(#radialGradient2601);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1;display:inline" />
-      </g>
-      <path
-         style="fill:url(#linearGradient5781);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5783);stroke-width:0.99420083;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible"
-         d="M 4.3215346,3.5097308 L 19.432146,3.5097308 C 20.314258,3.5097308 20.711229,3.3665214 20.96461,4.0095009 L 22.502289,8.0076617 L 22.502289,20.838717 C 22.502289,21.615011 22.555017,21.496402 21.672903,21.496402 L 2.3270891,21.496402 C 1.4449748,21.496402 1.4977016,21.615011 1.4977016,20.838717 L 1.4977016,8.0076617 L 3.0353813,4.0095009 C 3.2816939,3.3795096 3.4394204,3.5097308 4.3215346,3.5097308 z"
-         id="path2488"
-         nodetypes="ccccccccccc"
-         r_cx="true"
-         r_cy="true" />
-      <path
-         nodetypes="cccssscc"
-         id="rect3326"
-         d="M 11,3 C 11.666667,3 12.333334,3 13,3 C 13,5.3333335 13,7.6666662 13,10 C 12.803135,10 12.60627,10 12.409407,10 C 12.207843,10 12.006281,10 11.804718,10 C 11.642454,10 11.48019,10 11.317927,10 C 11.21195,10 11.105976,10 11,10 C 11,7.6666662 11,5.3333335 11,3 z"
-         style="opacity:0.4;fill:url(#linearGradient5775);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         id="path3273"
-         d="M 1.5022732,8.5 L 22.499732,8.5"
-         style="opacity:0.4;fill:none;fill-rule:evenodd;stroke:url(#linearGradient5772);stroke-width:0.99999994px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
-      <path
-         id="path2555"
-         d="M 16.494503,9.4999583 C 12.631142,9.4999583 9.4999585,12.63114 9.4999585,16.494501 C 9.4999585,20.357863 12.631142,23.500043 16.494503,23.500041 C 20.357864,23.500041 23.500049,20.357863 23.500042,16.494501 C 23.500042,12.63114 20.357864,9.4999583 16.494503,9.4999583 z"
-         style="fill:url(#radialGradient6433);fill-opacity:1;stroke:#204a87;stroke-width:0.99991703;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         d="M 14.203597,17.868227 L 14.010558,17.491418 L 13.648927,17.410778 L 13.456054,16.899831 L 12.973923,16.953494 L 12.564163,16.657784 L 12.129959,17.034297 L 12.129959,17.093681 C 11.998613,17.056304 11.83715,17.051203 11.720201,16.980307 L 11.623681,16.711412 L 11.623681,16.415374 L 11.334422,16.442187 C 11.358569,16.253768 11.382515,16.065675 11.406827,15.877285 L 11.237901,15.877285 L 11.069307,16.09252 L 10.900383,16.172996 L 10.659217,16.038859 L 10.63507,15.74282 L 10.68333,15.419968 L 11.045129,15.151071 L 11.334388,15.151071 L 11.382482,14.9895 L 11.744115,15.069974 L 12.009392,15.393154 L 12.057652,14.854739 L 12.515804,14.478225 L 12.684563,14.074569 L 13.022081,13.940136 L 13.214955,13.671241 L 13.648828,13.590143 L 13.866013,13.267618 C 13.648993,13.267618 13.431974,13.267618 13.214955,13.267618 L 13.624846,13.079196 L 13.91394,13.079196 L 14.323997,12.944439 L 14.372257,12.783486 L 14.227478,12.648727 L 14.058719,12.59477 L 14.106978,12.43349 L 13.986479,12.191443 L 13.697053,12.298731 L 13.745313,12.083661 L 13.407795,11.895241 L 13.142681,12.35236 L 13.166661,12.513935 L 12.90155,12.621878 L 12.732625,12.971547 L 12.660384,12.648694 L 12.202232,12.460272 L 12.129826,12.218224 L 12.732625,11.86823 L 12.997902,11.62618 L 13.022049,11.330304 L 12.877436,11.249501 L 12.684563,11.222525 L 12.564064,11.518562 C 12.564064,11.518562 12.362434,11.557509 12.310593,11.570131 C 11.648524,12.171624 10.310786,13.470066 10,15.921334 C 10.012307,15.978166 10.225279,16.307722 10.225279,16.307722 L 10.731557,16.603434 L 11.237837,16.738192 L 11.45502,17.007385 L 11.792374,17.249434 L 11.985246,17.222619 L 12.129858,17.28681 L 12.129858,17.330237 L 11.93712,17.841346 L 11.792341,18.056581 L 11.8406,18.164525 L 11.7201,18.567528 L 12.154139,19.347992 L 12.588011,19.724802 L 12.78105,19.993697 L 12.756771,20.558927 L 12.90155,20.881452 L 12.756771,21.500344 C 12.756771,21.500344 12.745428,21.496516 12.763902,21.558452 C 12.782542,21.620419 13.53642,22.033002 13.584348,21.997883 C 13.63211,21.962108 13.67294,21.930812 13.67294,21.930812 L 13.624846,21.796676 L 13.817586,21.608255 L 13.889993,21.419833 L 14.203532,21.311889 L 14.44453,20.719846 L 14.37229,20.558895 L 14.540718,20.316844 L 14.902516,20.235747 L 15.095554,19.805277 L 15.047296,19.267516 L 15.336555,18.86386 L 15.384814,18.460204 C 14.988985,18.266683 14.596408,18.067406 14.203532,17.86816 M 17.351194,10.271838 L 16.647419,10 L 15.836025,10.090502 L 14.834524,10.362157 L 14.645123,10.543492 L 15.267488,10.966059 L 15.267488,11.207619 L 15.023926,11.449181 L 15.348899,12.083727 L 15.564842,11.96258 L 15.836025,11.540014 C 16.254062,11.412592 16.62888,11.268175 17.02622,11.086986 L 17.351194,10.271801 M 23,15.388439 C 23,15.476958 23,15.388439 23,15.388439 L 22.813768,15.596409 C 22.699614,15.463782 22.571449,15.35225 22.441302,15.235764 L 22.155611,15.27721 L 21.894598,14.986314 L 21.894598,15.346319 L 22.118219,15.513147 L 22.267064,15.679334 L 22.465976,15.457548 C 22.516047,15.55001 22.565434,15.642472 22.615161,15.734933 L 22.615161,16.012013 L 22.391196,16.261427 L 21.981339,16.538811 L 21.670938,16.844195 L 21.472026,16.621735 L 21.571483,16.372321 L 21.372877,16.150535 L 21.037458,15.4437 L 20.751768,15.125175 L 20.676989,15.2081 L 20.789125,15.610225 L 21.000068,15.845826 C 21.120545,16.188712 21.239722,16.516437 21.397929,16.844195 C 21.643254,16.844195 21.874536,16.81852 22.118186,16.78826 L 22.118186,16.982415 L 21.820125,17.703235 L 21.546772,18.007946 L 21.323147,18.479819 C 21.323147,18.738468 21.323147,18.997116 21.323147,19.255731 L 21.397929,19.561115 L 21.273763,19.699336 L 21.000068,19.865826 L 20.714378,20.101425 L 20.950681,20.364692 L 20.627602,20.642412 L 20.689668,20.822077 L 20.205031,21.363062 L 19.882294,21.363062 L 19.608941,21.529553 L 19.434704,21.529553 L 19.434704,21.307768 L 19.360608,20.863523 C 19.264467,20.585128 19.164359,20.308723 19.062544,20.032316 C 19.062544,19.828289 19.074883,19.62625 19.087255,19.422256 L 19.211765,19.145175 L 19.037526,18.812162 L 19.050206,18.354775 L 18.813904,18.091509 L 18.932055,17.710446 L 18.739805,17.495399 L 18.404047,17.495399 L 18.292252,17.370692 L 17.956835,17.57883 L 17.820328,17.425985 L 17.509585,17.689385 C 17.298643,17.453617 17.087357,17.218015 16.876105,16.982415 L 16.627771,16.399986 L 16.851396,16.067645 L 16.727229,15.929121 L 17.000239,15.291059 C 17.224545,15.015967 17.458832,14.752063 17.695818,14.48718 L 18.118357,14.376287 L 18.590315,14.320991 L 18.913395,14.404255 L 19.37298,14.861303 L 19.534536,14.681301 L 19.757817,14.65367 L 20.180354,14.792194 L 20.503435,14.792194 L 20.72706,14.598039 L 20.826515,14.459516 L 20.602549,14.320991 L 20.22974,14.293362 C 20.126285,14.151873 20.030145,14.00314 19.907311,13.877422 L 19.782802,13.932716 L 19.733073,14.293362 L 19.509451,14.043945 L 19.460063,13.766226 L 19.21173,13.572745 L 19.111932,13.572745 L 19.360572,13.849825 L 19.261116,14.099241 L 19.06251,14.154535 L 19.186677,13.905119 L 18.962711,13.794564 L 18.764448,13.572778 L 18.391298,13.655704 L 18.341912,13.766259 L 18.118287,13.905119 L 17.994122,14.210168 L 17.683719,14.362505 L 17.546873,14.210168 L 17.39803,14.210168 L 17.39803,13.710999 L 17.721111,13.544509 L 17.969444,13.544509 L 17.919374,13.350691 L 17.721111,13.156536 L 18.056222,13.087088 L 18.242455,12.879456 L 18.391298,12.629703 L 18.664991,12.629703 L 18.590211,12.435885 L 18.764448,12.324993 L 18.764448,12.546778 L 19.136915,12.629703 L 19.509382,12.324993 L 19.5344,12.186132 L 19.857139,11.964516 C 19.740319,11.978836 19.6235,11.98935 19.509348,12.019978 L 19.509348,11.770259 L 19.633515,11.493011 L 19.509348,11.493011 L 19.236474,11.742427 L 19.161694,11.881119 L 19.236474,12.075442 L 19.111965,12.407782 L 18.913359,12.29689 L 18.739805,12.103072 L 18.466114,12.29689 L 18.366656,11.853488 L 18.838614,11.548609 L 18.838614,11.382119 L 19.136983,11.188133 L 19.608941,11.077072 L 19.93202,11.188133 L 20.528111,11.299025 L 20.379268,11.465213 L 20.056189,11.465213 L 20.379268,11.79789 L 20.627602,11.52081 L 20.703032,11.398898 C 20.703032,11.398898 21.655594,12.24062 22.199974,13.161354 C 22.744354,14.082392 23,15.167968 23,15.388439 z"
-         style="fill:url(#radialGradient6430);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00806236;stroke-miterlimit:4"
-         id="path6566" />
-      <path
-         id="path8655"
-         d="M 22.50007,16.499787 C 22.50007,19.813641 19.81355,22.50007 16.500075,22.50007 C 13.186299,22.50007 10.49993,19.81361 10.49993,16.499787 C 10.49993,13.186085 13.186299,10.49993 16.500075,10.49993 C 19.81355,10.49993 22.50007,13.186085 22.50007,16.499787 L 22.50007,16.499787 z"
-         style="opacity:0.40000000000000002;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6427);stroke-width:0.99985968999999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="opacity:0.4;stroke-width:2"
+       id="g3712"
+       transform="matrix(0.5789476,0,0,0.2857143,-1.894742,9.071428)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+       id="rect5505-21"
+       y="2.5"
+       x="2.5"
+       ry="2"
+       rx="2"
+       height="19"
+       width="19" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.947368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="3.4736843"
+       x="3.4736843"
+       ry="1"
+       rx="1"
+       height="17.052631"
+       width="17.052631" />
+    <path
+       style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+       d="m 10.473711,7.4997586 c -0.262527,0 -0.4741216,0.2127856 -0.4738746,0.4770976 V 12.270735 H 8.2087402 c -0.6229398,6.68e-4 -0.943805,0.750404 -0.5164493,1.206721 l 3.7910331,3.874304 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 l 3.791034,-3.874303 c 0.427355,-0.456317 0.10649,-1.206042 -0.51645,-1.206721 H 14.00071 V 7.9768562 c 0,-0.2643121 -0.211348,-0.4770976 -0.473874,-0.4770976 z"
+       id="path13703"
+       sodipodi:nodetypes="ssccccccccsss" />
+    <path
+       style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+       d="m 10.395522,5.9997589 c -0.262527,0 -0.395443,-0.014312 -0.395498,0.2500004 V 11.020735 H 7.9997733 c -0.7465022,8.01e-4 -1.1855804,1.150708 -0.7582247,1.607025 l 4.2417754,4.274 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 l 4.241776,-4.274 c 0.427355,-0.456317 -0.01711,-1.606217 -0.758225,-1.607025 H 13.999522 V 6.2497593 c 0,-0.264312 -0.132972,-0.2500004 -0.395498,-0.2500004 z"
+       id="path12165"
+       sodipodi:nodetypes="ssccccccccsss" />
+    <path
+       style="color:#000000;fill:#ffffff;stroke-width:0.999998;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 8.1551359,10.999759 c -1.0272527,4.03e-4 -1.5416082,1.242245 -0.8154835,1.968876 l 3.8446366,3.844636 c 0.450434,0.450248 1.180534,0.450248 1.630968,0 l 3.844637,-3.844636 c 0.726125,-0.726631 0.211769,-1.968473 -0.815484,-1.968876 z"
+       id="path906"
+       sodipodi:nodetypes="ccccccc" />
+    <rect
+       style="fill:#ffffff;stroke-width:2.99999;stroke-linejoin:round"
+       id="rect902"
+       width="4"
+       height="7"
+       x="9.999773"
+       y="5.9997592"
+       rx="0.5"
+       ry="0.5" />
+  </g>
+  <g
+     id="g2479"
+     transform="translate(9.0740168,7.84375)">
+    <path
+       d="m 8.1291082,4.53125 c -0.1863127,0 -0.328125,0.1418116 -0.328125,0.328125 v 0.9375 C 7.385556,5.9035254 7.0126102,6.0757837 6.6525457,6.2890625 L 5.9728582,5.609375 c -0.1317427,-0.1317434 -0.3370065,-0.1317434 -0.46875,0 l -1.125,1.125 c -0.1317427,0.1317434 -0.1317427,0.3370066 0,0.46875 L 5.0587957,7.8828125 C 4.8455174,8.2428767 4.673259,8.6158226 4.5666082,9.03125 h -0.9375 c -0.1863127,0 -0.328125,0.1418116 -0.328125,0.328125 v 1.593751 c 0,0.186313 0.1418122,0.328125 0.328125,0.328125 h 0.9375 c 0.1066507,0.415427 0.2789093,0.788373 0.4921875,1.148437 l -0.6796875,0.679688 c -0.1317427,0.131743 -0.1317427,0.337006 0,0.46875 l 1.125,1.125 c 0.1317434,0.131743 0.3370065,0.131743 0.46875,0 l 0.6796875,-0.679688 c 0.3600646,0.213279 0.7330103,0.385538 1.1484375,0.492188 v 0.9375 c 1e-7,0.186313 0.1418123,0.328125 0.328125,0.328125 h 1.59375 c 0.1863132,0 0.3281248,-0.141812 0.3281248,-0.328125 v -0.9375 c 0.415428,-0.10665 0.788373,-0.278908 1.148438,-0.492188 l 0.679687,0.679688 c 0.131744,0.131743 0.337007,0.131743 0.46875,0 l 1.125,-1.125 c 0.131744,-0.131744 0.131744,-0.337007 0,-0.46875 l -0.679687,-0.679688 c 0.213279,-0.360064 0.385537,-0.73301 0.492187,-1.148437 h 0.9375 c 0.186314,0 0.328125,-0.141812 0.328125,-0.328125 V 9.359375 c 0,-0.1863134 -0.141812,-0.328125 -0.328125,-0.328125 h -0.9375 C 13.178708,8.6158226 13.00645,8.2428767 12.793171,7.8828125 L 13.472858,7.203125 c 0.131744,-0.1317434 0.131744,-0.3370065 0,-0.46875 l -1.125,-1.125 c -0.131743,-0.1317434 -0.337006,-0.1317434 -0.46875,0 L 11.199421,6.2890625 C 10.839356,6.0757837 10.466411,5.9035254 10.050983,5.796875 v -0.9375 c 0,-0.1863134 -0.1418113,-0.328125 -0.3281248,-0.328125 z m 0.796875,4.125 c 0.828,0 1.4999998,0.672 1.4999998,1.5 0,0.828 -0.6719998,1.500001 -1.4999998,1.500001 -0.828,0 -1.5,-0.672001 -1.5,-1.500001 0,-0.828 0.672,-1.5 1.5,-1.5 z"
+       id="path2426"
+       style="display:block;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3262);fill-opacity:1;fill-rule:nonzero;stroke:#010101;stroke-width:0.75;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.30000001;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
   </g>
 </svg>

--- a/elementary-xfce/apps/32/software-properties.svg
+++ b/elementary-xfce/apps/32/software-properties.svg
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="32"
+   height="32"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="25.754446"
+     inkscape:cy="22.942608"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="594"
+     inkscape:window-y="216"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62162163,0,0,0.62162163,1.0810836,2.0810874)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="50.073002"
+       x2="12.168998"
+       y2="0.11462299"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6410257,0,0,0.6410257,0.61538445,0.974359)" />
+    <linearGradient
+       id="linearGradient5128">
+      <stop
+         id="stop5130"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5132"
+         style="stop-color:#959595;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309-1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311-5"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313-0"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10691">
+      <stop
+         id="stop10693"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop10695"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="7.228416"
+       fy="73.615715"
+       fx="6.702713"
+       cy="73.615715"
+       cx="6.702713"
+       gradientTransform="matrix(0.8992289,0,0,0.20751433,19.472727,15.223684)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3751"
+       xlink:href="#linearGradient10691" />
+    <linearGradient
+       xlink:href="#linearGradient3309-1"
+       id="linearGradient2840"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44444446,0,0,0.4444445,11.722221,10.833331)"
+       x1="32.036148"
+       y1="19"
+       x2="32.036148"
+       y2="47.012184" />
+    <linearGradient
+       xlink:href="#linearGradient5128"
+       id="linearGradient2836"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06008891,0,0,0.06008899,21.654305,21.714394)"
+       x1="86.132919"
+       y1="105.105"
+       x2="84.63858"
+       y2="20.895" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4159"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata3663">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="opacity:0.6;stroke-width:2"
+     id="g3712-8-2-4-4"
+     transform="matrix(0.7894751,0,0,0.35714285,-2.9473755,13.964286)">
+    <rect
+       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect2801-5-5-7-9"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4159);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3700-5-6-8-4"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="5.5"
+     x="4.5"
+     ry="1"
+     rx="1"
+     height="23"
+     width="23" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient3751);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.8;marker:none"
+     id="path10689"
+     d="m 31.999999,30.5 c 0,0.828427 -2.91015,1.5 -6.5,1.5 -3.58985,0 -6.5,-0.671573 -6.5,-1.5 0,-0.828427 2.91015,-1.5 6.5,-1.5 3.58985,0 6.5,0.671573 6.5,1.5 z" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 10.122893,18.500114 c -0.899292,0.001 -1.3625011,1.071035 -0.7455602,1.722327 l 5.8772212,5.958114 c 0.404882,0.426078 1.086236,0.426078 1.491118,0 l 5.877221,-5.958114 c 0.616941,-0.651292 0.153732,-1.721358 -0.74556,-1.722327 z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="m 13.866059,10.999999 c -0.479566,0 -0.867153,0.323008 -0.866018,0.724228 v 5.276156 h -2.499928 c -1.2856562,0 -1.4521951,1.620818 -0.8588061,2.249731 l 5.6421341,5.75 c 0.389426,0.411436 1.043918,0.411436 1.433344,0 l 5.642134,-5.75 c 0.593389,-0.628913 0.406061,-2.249731 -0.858806,-2.249731 h -2.499928 v -5.276156 c 0,-0.401222 -0.386452,-0.724228 -0.866018,-0.724228 z"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="6"
+     height="7"
+     x="13.000113"
+     y="11.000113"
+     rx="1"
+     ry="1" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 11.000113,17.000114 c -1.3359556,5.24e-4 -2.0048816,1.615555 -1.060547,2.560547 l 5,5 c 0.585795,0.585553 1.535299,0.585553 2.121094,0 l 5,-5 c 0.944335,-0.944992 0.275409,-2.560023 -1.060547,-2.560547 z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2840);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;marker:none;enable-background:accumulate"
+     id="rect2576"
+     d="m 24.555556,19.499999 c -0.332774,0 -0.611112,0.264449 -0.611112,0.597222 v 0.777778 c -0.210401,0.07061 -0.414556,0.152625 -0.611111,0.25 l -0.541668,-0.541667 c -0.235305,-0.235305 -0.611916,-0.235305 -0.847222,0 l -1.361111,1.347223 c -0.235305,0.235306 -0.235305,0.611917 0,0.847222 l 0.541667,0.541667 c -0.0997,0.19997 -0.178059,0.410636 -0.25,0.625 H 20.11111 c -0.332772,0 -0.611112,0.264449 -0.611111,0.597222 v 1.916667 c -10e-7,0.332773 0.27834,0.597223 0.611111,0.597222 h 0.763889 c 0.07194,0.214364 0.150299,0.42503 0.25,0.625 l -0.541667,0.541667 c -0.235305,0.235306 -0.235306,0.611916 0,0.847223 l 1.361111,1.347222 c 0.235306,0.235305 0.611918,0.235304 0.847222,0 L 23.333333,29.875 c 0.196555,0.09737 0.40071,0.179389 0.611111,0.250001 v 0.777777 c 0,0.332773 0.27834,0.597223 0.611112,0.597222 h 1.902777 c 0.332773,0 0.597222,-0.26445 0.597222,-0.597222 v -0.777777 c 0.214364,-0.07194 0.425031,-0.1503 0.625,-0.250001 l 0.541666,0.541667 c 0.235307,0.235305 0.611917,0.235305 0.847223,0 l 1.361111,-1.347222 c 0.235306,-0.235307 0.235304,-0.611918 0,-0.847223 l -0.555556,-0.555555 c 0.09737,-0.196555 0.179389,-0.400711 0.250001,-0.611112 h 0.777777 c 0.332773,0 0.597222,-0.26445 0.597222,-0.597222 V 24.541666 C 31.5,24.208893 31.235548,23.944444 30.902777,23.944444 H 30.125 c -0.07061,-0.210401 -0.152626,-0.414556 -0.250001,-0.611112 l 0.555556,-0.555555 c 0.235306,-0.235305 0.235306,-0.611916 0,-0.847222 l -1.361111,-1.347223 c -0.235305,-0.235305 -0.611917,-0.235305 -0.847223,0 l -0.541666,0.541667 c -0.199969,-0.0997 -0.410636,-0.178059 -0.625,-0.25 v -0.777778 c 0,-0.332773 -0.264451,-0.597222 -0.597222,-0.597222 z M 25.5,23.944444 c 0.858666,0 1.555555,0.696888 1.555555,1.555555 0,0.858667 -0.696889,1.555556 -1.555555,1.555556 -0.858668,0 -1.555556,-0.696889 -1.555556,-1.555556 0,-0.858667 0.696889,-1.555555 1.555556,-1.555555 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient2836);stroke-width:0.999996;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path28"
+     d="m 25.499998,22.999998 c -1.378501,0 -2.5,1.121501 -2.5,2.500002 0,1.378501 1.121499,2.500002 2.5,2.500002 1.378501,0 2.5,-1.121501 2.5,-2.500002 0,-1.378501 -1.121499,-2.500002 -2.5,-2.500002 z" />
+</svg>

--- a/elementary-xfce/apps/48/software-properties.svg
+++ b/elementary-xfce/apps/48/software-properties.svg
@@ -1,344 +1,344 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="48px"
+   height="48px"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
-   width="48"
-   height="48"
-   id="svg2817">
-  <metadata
-     id="metadata94146">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="33.941125"
+     inkscape:cy="34.637864"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="102"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658" />
   <defs
-     id="defs2819">
+     id="defs3660">
     <linearGradient
-       id="linearGradient3275">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
-         id="stop3277"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0" />
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
       <stop
-         id="stop3283"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.245" />
-      <stop
-         id="stop3285"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.77350003" />
-      <stop
-         id="stop3279"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
     </linearGradient>
     <linearGradient
-       x1="44.994774"
-       y1="17.5"
-       x2="3.0052247"
-       y2="17.5"
-       id="linearGradient2815"
-       xlink:href="#linearGradient3275"
+       id="linearGradient8265-821-176-38-919-66-249-7-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2687-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop2689-5-4" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
+       gradientTransform="translate(3.7e-6,1.00001)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
     <linearGradient
-       id="linearGradient3827">
+       id="linearGradient3924">
       <stop
-         id="stop3829"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
       <stop
-         id="stop4295"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.3021296" />
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
       <stop
-         id="stop4293"
-         style="stop-color:#ffffff;stop-opacity:0.6901961"
-         offset="0.34361121" />
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
-         id="stop3832"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       x1="26"
-       y1="22"
-       x2="26"
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="48.266846"
+       x2="12.168998"
+       y2="-0.0086730029"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3011"
+       gradientUnits="userSpaceOnUse"
+       x1="12"
+       y1="16"
+       x2="12"
        y2="8"
-       id="linearGradient2813"
-       xlink:href="#linearGradient3827"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(0.93934586,0,0,0.93934624,26.727523,26.727846)" />
     <linearGradient
-       id="linearGradient4559">
-      <stop
-         id="stop4561"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop4563"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.451576"
-       y1="30.554907"
-       x2="43.00663"
-       y2="45.934479"
-       id="linearGradient2811"
-       xlink:href="#linearGradient4559"
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3014"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2822251,0,0,1.1746872,-6.0701918,-5.3031677)" />
+       x1="12.47939"
+       y1="2"
+       x2="12.47939"
+       y2="22.006775"
+       gradientTransform="matrix(0.88947702,0,0,0.88959405,27.327505,27.324917)" />
     <linearGradient
-       id="linearGradient3295">
-      <stop
-         id="stop3297"
-         style="stop-color:#c9af8b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3299"
-         style="stop-color:#ad8757;stop-opacity:1"
-         offset="0.23942046" />
-      <stop
-         id="stop3301"
-         style="stop-color:#c2a57f;stop-opacity:1"
-         offset="0.27582464" />
-      <stop
-         id="stop3303"
-         style="stop-color:#9d7d53;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="15.464298"
-       y1="7.9756851"
-       x2="15.464298"
-       y2="45.04248"
-       id="linearGradient2809"
-       xlink:href="#linearGradient3295"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3199">
-      <stop
-         id="stop3201"
-         style="stop-color:#dac197;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3203"
-         style="stop-color:#c1a581;stop-opacity:1"
-         offset="0.23942046" />
-      <stop
-         id="stop3205"
-         style="stop-color:#dbc298;stop-opacity:1"
-         offset="0.27582464" />
-      <stop
-         id="stop3207"
-         style="stop-color:#a68b60;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.822832"
-       y1="15.377745"
-       x2="24.996943"
-       y2="37.27668"
-       id="linearGradient2807"
-       xlink:href="#linearGradient3199"
+       xlink:href="#linearGradient5128"
+       id="linearGradient3017"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2822251,0,0,1.5572619,-6.0701918,-15.290756)" />
+       gradientTransform="matrix(0.10816006,0,0,0.10816011,31.077886,31.185911)"
+       x1="86.132919"
+       y1="105.105"
+       x2="84.63858"
+       y2="20.895" />
+    <linearGradient
+       id="linearGradient5128">
+      <stop
+         id="stop5130"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5132"
+         style="stop-color:#959595;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3309-1"
+       id="linearGradient3021"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.70370375,0,0,0.70370375,16.185184,14.777776)"
+       x1="32.036148"
+       y1="19"
+       x2="32.036148"
+       y2="47.012184" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309-1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311-5"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313-0"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
     <radialGradient
-       cx="5"
-       cy="41.5"
-       r="5"
-       fx="5"
-       fy="41.5"
-       id="radialGradient2805"
-       xlink:href="#linearGradient3681"
+       xlink:href="#linearGradient10691"
+       id="radialGradient3026"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5938225,0,0,1.5366531,41.140892,-103.93618)" />
+       gradientTransform="matrix(1.2450863,0,0,0.34585722,29.654545,20.039474)"
+       cx="6.702713"
+       cy="73.615715"
+       fx="6.702713"
+       fy="73.615715"
+       r="7.228416" />
     <linearGradient
-       id="linearGradient3703">
+       id="linearGradient10691">
       <stop
-         id="stop3705"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop3711"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3707"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.554192"
-       y1="46.000275"
-       x2="17.554192"
-       y2="34.999718"
-       id="linearGradient2803"
-       xlink:href="#linearGradient3703"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7570316,0,0,1.3969574,-17.394014,-16.411698)" />
-    <linearGradient
-       id="linearGradient3681">
-      <stop
-         id="stop3683"
+         id="stop10693"
          style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3685"
+         id="stop10695"
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="5"
-       cy="41.5"
-       r="5"
-       fx="5"
-       fy="41.5"
-       id="radialGradient2801"
-       xlink:href="#linearGradient3681"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5938225,0,0,1.5366531,-6.6594735,-103.93618)" />
-    <linearGradient
-       id="linearGradient4873"
-       collect="always">
-      <stop
-         id="stop4875"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop4877"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient8647">
-      <stop
-         style="stop-color:#8fb1dc;stop-opacity:1;"
-         offset="0"
-         id="stop8649" />
-      <stop
-         style="stop-color:#3465a4;stop-opacity:1;"
-         offset="1"
-         id="stop8651" />
-    </linearGradient>
-    <linearGradient
-       collect="always"
-       xlink:href="#linearGradient4873"
-       id="linearGradient5559"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4292867,0,0,1.429254,-54.902217,39.017879)"
-       x1="63.397362"
-       y1="-12.742159"
-       x2="59.919094"
-       y2="-1.9899801" />
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient8924"
-       id="radialGradient5562"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.0796295e-2,1.8806334,-1.3065264,3.7223425e-2,56.991846,-19.739002)"
-       cx="24.652573"
-       cy="18.94449"
-       fx="24.652485"
-       fy="18.944481"
-       r="8.6174498" />
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient8647"
-       id="radialGradient5565"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6396161,0,0,1.349992,13.560846,18.4751)"
-       cx="12.465816"
-       cy="5.3052077"
-       fx="12.465816"
-       fy="5.3052077"
-       r="10.499999" />
-    <linearGradient
-       id="linearGradient8924">
-      <stop
-         id="stop8926"
-         offset="0"
-         style="stop-color:#cee14b" />
-      <stop
-         id="stop8928"
-         offset="1"
-         style="stop-color:#9db029" />
     </linearGradient>
   </defs>
+  <metadata
+     id="metadata3663">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
   <g
-     id="g6816">
+     id="layer1">
     <g
-       transform="translate(6.1178597e-7,-0.9999989)"
-       id="g2791">
-      <g
-         transform="matrix(0.9926623,0,0,0.9761474,0.2751901,1.2929634)"
-         id="g3305"
-         style="opacity:0.4;display:inline">
-        <rect
-           width="2.9601951"
-           height="15.366531"
-           x="-3.6903627"
-           y="-47.848343"
-           transform="scale(-1,-1)"
-           id="rect2484"
-           style="opacity:1;fill:url(#radialGradient2801);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1" />
-        <rect
-           width="40.41172"
-           height="15.366531"
-           x="3.6903627"
-           y="32.481812"
-           id="rect2486"
-           style="opacity:1;fill:url(#linearGradient2803);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1" />
-        <rect
-           width="2.9601951"
-           height="15.366531"
-           x="44.110001"
-           y="-47.848343"
-           transform="scale(1,-1)"
-           id="rect3444"
-           style="opacity:1;fill:url(#radialGradient2805);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1;display:inline" />
-      </g>
-      <path
-         d="M 9.010725,8.5 L 38.508448,8.5 C 40.230433,8.5 41.00537,8.2134495 41.5,9.5 L 44.501734,17.5 L 44.501734,43.173912 C 44.501734,44.727216 44.604664,44.489888 42.882671,44.489888 L 5.1173288,44.489888 C 3.3953364,44.489888 3.4982653,44.727216 3.4982653,43.173912 L 3.4982653,17.5 L 6.5,9.5 C 6.9808316,8.2394378 7.2887325,8.5 9.010725,8.5 z"
-         id="path2488"
-         style="fill:url(#linearGradient2807);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2809);stroke-width:0.99420077;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
-      <path
-         d="M 9.948194,9.5129459 L 37.601066,9.5129459 C 39.215359,9.5129459 40.214446,10.069482 40.890587,11.598974 L 43.219527,18.018695 L 43.219527,41.163252 C 43.219527,42.623928 42.400768,43.359337 40.786471,43.359337 L 7.0532679,43.359337 C 5.4389745,43.359337 4.7804918,42.55051 4.7804918,41.089833 L 4.7804918,18.018695 L 7.0343027,11.461335 C 7.4850649,10.275943 8.3338968,9.5129459 9.948194,9.5129459 z"
-         id="path2490"
-         style="opacity:0.50549454;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2811);stroke-width:0.74211526;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
-      <path
-         d="M 22,8 C 23.333333,8 24.666667,8 26,8 C 26,12.666667 26,17.333333 26,22 C 25.606271,22 25.212542,22 24.818813,22 C 24.415688,22 24.012563,22 23.609438,22 C 23.284909,22 22.960381,22 22.635853,22 C 22.423902,22 22.211951,22 22,22 C 22,17.333333 22,12.666667 22,8 z"
-         id="rect3326"
-         style="opacity:0.4;fill:url(#linearGradient2813);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="M 3.5052248,17.5 L 44.494775,17.5"
-         id="path3273"
-         style="opacity:0.4;fill:none;fill-rule:evenodd;stroke:url(#linearGradient2815);stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
+       style="opacity:0.4"
+       id="g3712"
+       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+         id="rect3696"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
-    <g
-       id="g6811">
-      <path
-         style="fill:url(#radialGradient5565);fill-opacity:1;stroke:#204a87;stroke-width:1.00009847;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         d="M 33.989397,20.50005 C 26.538703,20.50005 20.500049,26.538698 20.500049,33.989396 C 20.500049,41.440094 26.538703,47.499952 33.989397,47.499951 C 41.440092,47.499951 47.499962,41.440094 47.499949,33.989396 C 47.499949,26.538698 41.440092,20.50005 33.989397,20.50005 z"
-         id="path2555" />
-      <path
-         id="path6566"
-         style="fill:url(#radialGradient5562);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1.00806236000000005;stroke-miterlimit:4"
-         d="M 29.307194,37.292135 L 28.921117,36.507121 L 28.197851,36.339122 L 27.812108,35.27465 L 26.847843,35.386442 L 26.028324,34.770381 L 25.159917,35.554785 L 25.159917,35.678502 C 24.897223,35.600632 24.574301,35.590004 24.3404,35.442309 L 24.14736,34.882105 L 24.14736,34.265359 L 23.568841,34.321221 C 23.617135,33.928679 23.665029,33.536817 23.713653,33.144342 L 23.375803,33.144342 L 23.038614,33.592751 L 22.700765,33.760407 L 22.218433,33.480954 L 22.17014,32.86421 L 22.266659,32.191597 L 22.990259,31.631397 L 23.568774,31.631397 L 23.664963,31.294787 L 24.388226,31.462442 L 24.918784,32.135735 L 25.015304,31.014037 L 25.931604,30.229635 L 26.269123,29.388684 L 26.944162,29.108616 L 27.329907,28.548415 L 28.197653,28.379458 L 28.632023,27.707533 C 28.197984,27.707533 27.763946,27.707533 27.329907,27.707533 L 28.149691,27.314992 L 28.727878,27.314992 L 29.547995,27.034245 L 29.644512,26.698927 L 29.354954,26.418178 L 29.017436,26.305769 L 29.113954,25.969771 L 28.872954,25.465501 L 28.294106,25.689025 L 28.390625,25.240958 L 27.715586,24.848417 L 27.185361,25.800752 L 27.233324,26.137361 L 26.703097,26.362246 L 26.365246,27.090719 L 26.220768,26.418111 L 25.304464,26.025569 L 25.159648,25.521297 L 26.365246,24.792145 L 26.895807,24.287873 L 26.944096,23.671467 L 26.654868,23.503129 L 26.269123,23.446923 L 26.028128,24.06367 C 26.028128,24.06367 25.624868,24.144808 25.521183,24.171105 C 24.197046,25.424216 21.52157,28.129304 20.9,33.236111 C 20.92461,33.354513 21.350555,34.04109 21.350555,34.04109 L 22.363114,34.657154 L 23.375668,34.9379 L 23.81004,35.498716 L 24.484746,36.002983 L 24.870489,35.947122 L 25.159717,36.080852 L 25.159717,36.171324 L 24.774237,37.236139 L 24.484676,37.684542 L 24.5812,37.909428 L 24.340198,38.749018 L 25.208277,40.374984 L 26.076018,41.160002 L 26.462099,41.720199 L 26.413537,42.897763 L 26.703097,43.569692 L 26.413537,44.859044 C 26.413537,44.859044 26.390853,44.851075 26.427803,44.980107 C 26.465083,45.109205 27.97284,45.968756 28.068694,45.895589 C 28.164219,45.821056 28.245878,45.755861 28.245878,45.755861 L 28.149691,45.476406 L 28.535171,45.083863 L 28.679985,44.691319 L 29.307061,44.466434 L 29.789062,43.233012 L 29.644581,42.897696 L 29.981435,42.393423 L 30.705031,42.224473 L 31.091107,41.327657 L 30.994588,40.207322 L 31.573111,39.366376 L 31.669624,38.525425 C 30.877968,38.122254 30.092813,37.707092 29.307061,37.292 M 35.602388,21.466328 L 34.194838,20.9 L 32.572049,21.088545 L 30.569048,21.654493 L 30.190248,22.032274 L 31.434975,22.91262 L 31.434975,23.415873 L 30.94785,23.919125 L 31.597796,25.241099 L 32.029682,24.988706 L 32.572049,24.108361 C 33.408122,23.842896 34.157758,23.54203 34.952439,23.164552 L 35.602388,21.466249 M 46.9,32.125914 C 46.9,32.310327 46.9,32.125914 46.9,32.125914 L 46.527534,32.559184 C 46.299228,32.28288 46.042896,32.05052 45.782602,31.807843 L 45.211222,31.894188 L 44.689192,31.288156 L 44.689192,32.038164 L 45.13644,32.385722 L 45.434126,32.731945 L 45.831955,32.269891 C 45.932091,32.46252 46.030866,32.655146 46.130323,32.847776 L 46.130323,33.425023 L 45.682391,33.944641 L 44.86268,34.52252 L 44.241875,35.158738 L 43.844048,34.695281 L 44.042961,34.17567 L 43.645753,33.713613 L 42.974917,32.24104 L 42.403536,31.577446 L 42.253975,31.750208 L 42.478248,32.587969 L 42.900136,33.078802 C 43.141089,33.79315 43.379442,34.475911 43.695859,35.158738 C 44.18651,35.158738 44.64907,35.105248 45.136373,35.042207 L 45.136373,35.4467 L 44.540248,36.948404 L 43.993543,37.583217 L 43.546294,38.566289 C 43.546294,39.10514 43.546294,39.643991 43.546294,40.182772 L 43.695859,40.81899 L 43.447525,41.106947 L 42.900136,41.453802 L 42.328757,41.944636 L 42.801364,42.493104 L 42.155203,43.071688 L 42.279335,43.445992 L 41.310062,44.573044 L 40.664587,44.573044 L 40.117879,44.9199 L 39.769406,44.9199 L 39.769406,44.457846 L 39.621214,43.532338 C 39.428928,42.95235 39.228717,42.376501 39.025088,41.800658 C 39.025088,41.375599 39.049764,40.954685 39.074508,40.529695 L 39.323527,39.952447 L 38.975053,39.258667 L 39.000413,38.305781 L 38.527806,37.75731 L 38.764107,36.963426 L 38.37961,36.515413 L 37.70809,36.515413 L 37.484502,36.255605 L 36.813665,36.689227 L 36.540657,36.3708 L 35.919172,36.919552 C 35.497283,36.428367 35.074714,35.937532 34.652211,35.4467 L 34.155543,34.233302 L 34.60279,33.540923 L 34.354455,33.252333 L 34.900477,31.923038 C 35.34909,31.349932 35.817663,30.800128 36.291641,30.248289 L 37.136712,30.017261 L 38.080625,29.902066 L 38.726789,30.075531 L 39.645957,31.027713 L 39.969072,30.65271 L 40.415635,30.595146 L 41.260711,30.883734 L 41.906871,30.883734 L 42.354117,30.479247 L 42.55303,30.190655 L 42.105095,29.902066 L 41.359483,29.844501 C 41.152568,29.549733 40.960288,29.239872 40.714621,28.977962 L 40.465603,29.093157 L 40.366146,29.844501 L 39.9189,29.324885 L 39.820127,28.746302 L 39.323458,28.34322 L 39.12386,28.34322 L 39.621143,28.920467 L 39.422231,29.440085 L 39.025019,29.555283 L 39.273355,29.035663 L 38.825423,28.805341 L 38.428895,28.343287 L 37.682596,28.516047 L 37.58382,28.746371 L 37.136578,29.035663 L 36.88824,29.671181 L 36.26744,29.988551 L 35.993747,29.671181 L 35.696062,29.671181 L 35.696062,28.631245 L 36.342219,28.28439 L 36.838888,28.28439 L 36.738751,27.880603 L 36.342219,27.476116 L 37.012442,27.331433 L 37.38491,26.898866 L 37.682596,26.378545 L 38.22998,26.378545 L 38.080421,25.974759 L 38.428895,25.743732 L 38.428895,26.205788 L 39.173829,26.378545 L 39.918762,25.743732 L 39.968796,25.454441 L 40.614273,24.992741 C 40.380637,25.022574 40.147001,25.044477 39.918695,25.10829 L 39.918695,24.58804 L 40.167028,24.010439 L 39.918695,24.010439 L 39.372949,24.530054 L 39.223386,24.818995 L 39.372949,25.223836 L 39.123928,25.916211 L 38.726721,25.685186 L 38.37961,25.281402 L 37.832222,25.685186 L 37.633312,24.761432 L 38.577226,24.126268 L 38.577226,23.779413 L 39.173967,23.375275 L 40.117879,23.143897 L 40.764042,23.375275 L 41.956222,23.606302 L 41.658535,23.952528 L 41.012375,23.952528 L 41.658535,24.645606 L 42.155203,24.068351 L 42.306063,23.814371 C 42.306063,23.814371 44.211185,25.567955 45.299945,27.48615 C 46.388707,29.404984 46.9,31.666599 46.9,32.125914 z" />
-      <path
-         style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5559);stroke-width:1.00034523;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 46.499829,33.999553 C 46.499829,40.90324 40.903051,46.499827 34.000158,46.499827 C 27.096634,46.499827 21.500173,40.903174 21.500173,33.999553 C 21.500173,27.096187 27.096634,21.500172 34.000158,21.500172 C 40.903051,21.500172 46.499829,27.096187 46.499829,33.999553 L 46.499829,33.999553 z"
-         id="path8655" />
-    </g>
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+       id="rect5505-21"
+       y="5.5"
+       x="4.5"
+       ry="3"
+       rx="3"
+       height="39"
+       width="39" />
+    <path
+       style="color:#000000;opacity:1;fill:none;fill-opacity:1;stroke:#010000;stroke-linejoin:round;stroke-opacity:0.15000001;-inkscape-stroke:none"
+       d="m 21,16 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,37.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,27.572852 33.314645,26.001424 32.000078,26 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+       id="path13703"
+       sodipodi:nodetypes="ssccccccccsss" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="6.5"
+       x="5.5"
+       ry="2"
+       rx="2"
+       height="37"
+       width="37" />
+    <path
+       style="color:#000000;opacity:1;fill:none;fill-opacity:1;stroke:#010000;stroke-linejoin:round;stroke-opacity:0.30000001;-inkscape-stroke:none"
+       d="m 21,15 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,36.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,26.572852 33.314645,25.001424 32.000078,25 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+       id="path12165"
+       sodipodi:nodetypes="ssccccccccsss" />
+    <path
+       style="color:#000000;opacity:1;fill:#ffffff;fill-opacity:1;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 21,15 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,36.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,26.572852 33.314645,25.001424 32.000078,25 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+       id="path887"
+       sodipodi:nodetypes="ssccccccccsss" />
   </g>
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient3026);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.8;marker:none"
+     id="path10689"
+     d="m 47,45.5 c 0,1.380712 -4.029437,2.5 -9,2.5 -4.970563,0 -9,-1.119288 -9,-2.5 0,-1.380712 4.029437,-2.5 9,-2.5 4.970563,0 9,1.119288 9,2.5 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;fill:url(#linearGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3623"
+     d="m 36.642858,28.500001 c -0.501238,0 -0.904762,0.403524 -0.904762,0.904762 v 1.244047 c -0.459013,0.140947 -0.910886,0.317096 -1.328869,0.537203 l -0.876488,-0.876488 c -0.35443,-0.354429 -0.946168,-0.354429 -1.300595,0 l -1.922619,1.922618 c -0.354429,0.354428 -0.354429,0.946166 0,1.300596 l 0.876488,0.876488 c -0.220107,0.417983 -0.396256,0.869856 -0.537203,1.328869 h -1.244047 c -0.501238,0 -0.904762,0.403524 -0.904762,0.904762 v 2.714285 c 0,0.501239 0.403524,0.904762 0.904762,0.904762 h 1.244047 c 0.140947,0.459012 0.317096,0.910887 0.537203,1.32887 l -0.876488,0.876488 c -0.354429,0.354428 -0.354429,0.946166 0,1.300595 l 1.922619,1.922619 c 0.354427,0.354429 0.946165,0.354429 1.300595,0 l 0.876488,-0.876488 c 0.417983,0.220107 0.869856,0.396256 1.328869,0.537202 v 1.244048 c 0,0.501238 0.403524,0.904762 0.904762,0.904762 h 2.714285 c 0.501239,0 0.904762,-0.403524 0.904762,-0.904762 v -1.244048 c 0.459013,-0.140946 0.910887,-0.317095 1.32887,-0.537202 l 0.876488,0.876488 c 0.354428,0.354429 0.946166,0.354429 1.300595,0 l 1.922619,-1.922619 c 0.354429,-0.354429 0.354429,-0.946167 0,-1.300595 l -0.876488,-0.876488 c 0.220107,-0.417983 0.396256,-0.869858 0.537202,-1.32887 h 1.244048 c 0.501238,0 0.904762,-0.403523 0.904762,-0.904762 v -2.714285 c 0,-0.501238 -0.403524,-0.904762 -0.904762,-0.904762 H 45.351191 C 45.210245,35.279083 45.034096,34.82721 44.813989,34.409227 l 0.876488,-0.876488 c 0.354429,-0.35443 0.354429,-0.946168 0,-1.300595 l -1.922619,-1.922619 c -0.354429,-0.354429 -0.946167,-0.354429 -1.300595,0 l -0.876488,0.876488 c -0.417983,-0.220107 -0.869857,-0.396256 -1.32887,-0.537203 v -1.244047 c 0,-0.501238 -0.403523,-0.904762 -0.904762,-0.904762 z m 1.357143,7.238095 c 1.249215,0 2.261904,1.012689 2.261904,2.261905 0,1.249215 -1.012689,2.261904 -2.261904,2.261904 -1.249216,0 -2.261905,-1.012689 -2.261905,-2.261904 0,-1.249216 1.012689,-2.261905 2.261905,-2.261905 z" />
+  <path
+     style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999"
+     id="path3315"
+     d="m 38,33.5 c -2.482727,0 -4.5,2.017274 -4.5,4.5 0,2.482726 2.017273,4.5 4.5,4.5 2.482726,0 4.5,-2.017274 4.5,-4.5 0,-2.482726 -2.017274,-4.5 -4.5,-4.5 z m 0,2.25 c 1.242641,0 2.25,1.007359 2.25,2.25 0,1.242641 -1.007359,2.25 -2.25,2.25 -1.242641,0 -2.25,-1.007359 -2.25,-2.25 0,-1.242641 1.007359,-2.25 2.25,-2.25 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3017);stroke-width:0.999999;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path28"
+     d="m 38.000134,33.499998 c -2.481303,0 -4.500001,2.0187 -4.500001,4.5 0,2.481302 2.018698,4.500003 4.500001,4.500003 2.481301,0 4.500001,-2.018701 4.500001,-4.500003 0,-2.4813 -2.0187,-4.5 -4.500001,-4.5 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3014);stroke-width:0.999992;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3799"
+     d="m 36.667014,29.521104 c -0.06598,0.345802 -0.0084,0.801621 -0.0278,1.188882 0.05754,0.692174 -0.685143,0.936613 -1.217056,1.082289 -0.486566,0.276874 -1.199901,0.597717 -1.633942,0.04822 -0.263432,-0.263464 -0.526865,-0.526931 -0.790298,-0.7904 -0.384013,0.255023 -0.698025,0.679067 -1.05495,0.99949 -0.284156,0.32079 -0.672033,0.598612 -0.890781,0.946496 0.362035,0.436019 0.932631,0.745118 1.090319,1.313905 -0.02193,0.710309 -0.480459,1.360383 -0.722599,2.016732 -0.44636,0.502042 -1.1697,0.249681 -1.756136,0.31114 -0.306485,-0.01147 -0.06256,0.521613 -0.140372,0.734546 10e-4,0.662732 -0.0022,1.325591 0.0016,1.98824 0.574211,0.05711 1.207009,-0.133955 1.730473,0.159832 0.494204,0.515264 0.600961,1.311372 0.8955,1.947114 0.03715,0.669632 -0.651374,1.002067 -1.022308,1.459944 -0.193361,0.242332 0.342695,0.448487 0.458899,0.667522 0.45159,0.451649 0.903181,0.903298 1.354769,1.354947 0.464718,-0.27121 0.746919,-0.879773 1.285679,-1.071909 0.72505,-0.09488 1.346391,0.486116 2.031414,0.65294 0.578777,0.40217 0.32335,1.165747 0.379796,1.757085 -0.07873,0.372273 0.469518,0.115532 0.683974,0.190874 0.679468,-0.001 1.359067,0.0022 2.038454,-0.0016 0.0571,-0.574286 -0.133938,-1.207166 0.15981,-1.730699 0.515196,-0.494269 1.311201,-0.60104 1.946859,-0.895618 0.669544,-0.03716 1.001934,0.651461 1.459752,1.022443 0.242299,0.193387 0.448426,-0.342741 0.667434,-0.458961 0.451589,-0.451649 0.903178,-0.903297 1.354767,-1.354946 -0.271173,-0.464779 -0.879656,-0.747017 -1.071768,-1.28585 -0.09486,-0.725143 0.486053,-1.346568 0.652855,-2.031679 0.402117,-0.578854 1.165595,-0.323393 1.756855,-0.379846 0.372225,0.07874 0.115516,-0.469581 0.190846,-0.684064 -10e-4,-0.679558 0.0022,-1.359246 -0.0016,-2.038724 -0.57421,-0.05711 -1.207008,0.133957 -1.730473,-0.159831 -0.494195,-0.515257 -0.600952,-1.311366 -0.895491,-1.947106 -0.03715,-0.669633 0.651375,-1.002067 1.022307,-1.459945 0.193358,-0.242332 -0.342698,-0.448486 -0.458903,-0.667521 -0.451589,-0.451651 -0.903179,-0.9033 -1.354768,-1.354948 -0.464719,0.27121 -0.746919,0.879773 -1.28568,1.071909 -0.725048,0.09488 -1.346392,-0.486116 -2.031412,-0.65294 -0.578778,-0.402168 -0.323351,-1.165748 -0.379797,-1.757085 0.07873,-0.372274 -0.469519,-0.115533 -0.683974,-0.190872 -0.67075,0 -1.341503,0 -2.012253,0 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:url(#linearGradient3011);stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3822"
+     d="m 41.249674,38 a 3.25,3.2500013 0 1 1 -6.5,0 3.25,3.2500013 0 1 1 6.5,0 z" />
+  <path
+     style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.3;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3623-2"
+     d="m 36.642857,28.499999 c -0.501238,0 -0.904762,0.403524 -0.904762,0.904762 v 1.244048 c -0.459013,0.140947 -0.910886,0.317096 -1.328869,0.537202 l -0.876488,-0.876488 c -0.35443,-0.354429 -0.946168,-0.354429 -1.300595,0 l -1.92262,1.92262 c -0.354429,0.354427 -0.354429,0.946165 0,1.300595 l 0.876488,0.876488 c -0.220106,0.417983 -0.396255,0.869856 -0.537202,1.328869 h -1.244048 c -0.501238,0 -0.904762,0.403524 -0.904762,0.904762 v 2.714287 c 0,0.501238 0.403524,0.904762 0.904762,0.904762 h 1.244048 c 0.140947,0.459011 0.317096,0.910886 0.537202,1.328869 l -0.876488,0.876489 c -0.354429,0.354427 -0.354429,0.946165 0,1.300594 l 1.92262,1.92262 c 0.354427,0.354429 0.946165,0.354429 1.300595,0 l 0.876488,-0.876488 c 0.417983,0.220107 0.869856,0.396256 1.328869,0.537202 v 1.244048 c 0,0.501238 0.403524,0.904762 0.904762,0.904762 h 2.714287 c 0.501238,0 0.904762,-0.403524 0.904762,-0.904762 v -1.244048 c 0.459012,-0.140946 0.910886,-0.317095 1.328869,-0.537202 l 0.876489,0.876488 c 0.354427,0.354429 0.946165,0.354429 1.300594,0 l 1.92262,-1.92262 c 0.354429,-0.354429 0.354429,-0.946167 0,-1.300594 L 44.81399,41.590775 c 0.220107,-0.417983 0.396256,-0.869858 0.537202,-1.328869 h 1.244048 c 0.501238,0 0.904762,-0.403524 0.904762,-0.904762 v -2.714287 c 0,-0.501238 -0.403524,-0.904762 -0.904762,-0.904762 H 45.351192 C 45.210246,35.279082 45.034097,34.827209 44.81399,34.409226 l 0.876488,-0.876488 c 0.354429,-0.35443 0.354429,-0.946168 0,-1.300595 l -1.92262,-1.92262 c -0.354429,-0.354429 -0.946167,-0.354429 -1.300594,0 l -0.876489,0.876488 c -0.417983,-0.220106 -0.869857,-0.396255 -1.328869,-0.537202 v -1.244048 c 0,-0.501238 -0.403524,-0.904762 -0.904762,-0.904762 z M 38,35.738095 c 1.249216,0 2.261906,1.01269 2.261906,2.261905 0,1.249216 -1.01269,2.261906 -2.261906,2.261906 -1.249215,0 -2.261905,-1.01269 -2.261905,-2.261906 0,-1.249215 1.01269,-2.261905 2.261905,-2.261905 z" />
 </svg>

--- a/elementary-xfce/apps/64/software-properties.svg
+++ b/elementary-xfce/apps/64/software-properties.svg
@@ -1,372 +1,357 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
    width="64"
    height="64"
-   id="svg4030">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="47.129392"
+     inkscape:cy="47.875898"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="701"
+     inkscape:window-y="98"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient8265-821-176-38-919-66-249-7-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2687-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop2689-5-4" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.428193,0,0,1.428193,-2.2766241,-2.2766154)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="47.821507"
+       x2="12.168998"
+       y2="2.2241068"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461543,-3.2564104)" />
+    <linearGradient
+       id="linearGradient5128">
+      <stop
+         id="stop5130"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5132"
+         style="stop-color:#959595;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309-1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311-5"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313-0"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10691">
+      <stop
+         id="stop10693"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop10695"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="7.228416"
+       fy="73.615715"
+       fx="6.702713"
+       cy="73.615715"
+       cx="6.702713"
+       gradientTransform="matrix(1.8676293,0,0,0.41502866,37.981818,30.447369)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3751"
+       xlink:href="#linearGradient10691" />
+    <linearGradient
+       xlink:href="#linearGradient3309-1"
+       id="linearGradient2840"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96296296,0,0,0.96296296,20.648147,18.722221)"
+       x1="32.036148"
+       y1="19"
+       x2="32.036148"
+       y2="47.012184" />
+    <linearGradient
+       xlink:href="#linearGradient3397"
+       id="linearGradient2842"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96296296,0,0,0.96296296,20.648147,18.722221)"
+       x1="25.922546"
+       y1="19"
+       x2="25.922546"
+       y2="47.044857" />
+    <linearGradient
+       id="linearGradient3397">
+      <stop
+         id="stop3399"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3401"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient5128"
+       id="linearGradient2836"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.19228451,0,0,0.1922846,38.193783,38.38607)"
+       x1="86.132919"
+       y1="105.105"
+       x2="84.63858"
+       y2="20.895" />
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3688"
+       gradientUnits="userSpaceOnUse"
+       x1="15.321168"
+       y1="3"
+       x2="15.321168"
+       y2="29.045145"
+       gradientTransform="matrix(0.95818836,0,0,0.9581947,35.145794,35.145831)" />
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3698"
+       x1="16.116789"
+       y1="21.119221"
+       x2="16.116789"
+       y2="10.997566"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.98798062,0,0,0.9879797,34.576924,34.636579)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4159"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
   <metadata
-     id="metadata98139">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs4032">
-    <radialGradient
-       cx="5"
-       cy="41.5"
-       r="5"
-       fx="5"
-       fy="41.5"
-       id="radialGradient3944"
-       xlink:href="#linearGradient3681"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5938225,0,0,1.5366531,41.140892,-103.93618)" />
-    <linearGradient
-       id="linearGradient3703">
-      <stop
-         id="stop3705"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop3711"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3707"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.554192"
-       y1="46.000275"
-       x2="17.554192"
-       y2="34.999718"
-       id="linearGradient3942"
-       xlink:href="#linearGradient3703"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7570316,0,0,1.3969574,-17.394014,-16.411698)" />
-    <linearGradient
-       id="linearGradient3681">
-      <stop
-         id="stop3683"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3685"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="5"
-       cy="41.5"
-       r="5"
-       fx="5"
-       fy="41.5"
-       id="radialGradient3940"
-       xlink:href="#linearGradient3681"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5938225,0,0,1.5366531,-6.6594735,-103.93618)" />
-    <linearGradient
-       id="linearGradient3295">
-      <stop
-         id="stop3297"
-         style="stop-color:#c9af8b;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3299"
-         style="stop-color:#ad8757;stop-opacity:1"
-         offset="0.23942046" />
-      <stop
-         id="stop3301"
-         style="stop-color:#c2a57f;stop-opacity:1"
-         offset="0.27582464" />
-      <stop
-         id="stop3303"
-         style="stop-color:#9d7d53;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="15.464298"
-       y1="7.9756851"
-       x2="15.464298"
-       y2="45.04248"
-       id="linearGradient3974"
-       xlink:href="#linearGradient3295"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3414025,0,0,1.3287417,-0.1936585,0.370193)" />
-    <linearGradient
-       id="linearGradient3199">
-      <stop
-         id="stop3201"
-         style="stop-color:#dac197;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3203"
-         style="stop-color:#c1a581;stop-opacity:1"
-         offset="0.23942046" />
-      <stop
-         id="stop3205"
-         style="stop-color:#dac197;stop-opacity:1"
-         offset="0.27582464" />
-      <stop
-         id="stop3207"
-         style="stop-color:#a68b60;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="24.822832"
-       y1="15.377745"
-       x2="24.996943"
-       y2="37.27668"
-       id="linearGradient3972"
-       xlink:href="#linearGradient3199"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7199799,0,0,2.0691988,-8.336229,-19.947272)" />
-    <linearGradient
-       id="linearGradient3219">
-      <stop
-         id="stop3225"
-         style="stop-color:#cbad7a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3227"
-         style="stop-color:#cbae7d;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="24"
-       cy="31"
-       r="20"
-       fx="24"
-       fy="31"
-       id="radialGradient3969"
-       xlink:href="#linearGradient3219"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2339043,0,0,0.875,-21.613703,14.374997)" />
-    <linearGradient
-       id="linearGradient4559">
-      <stop
-         id="stop4561"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop4563"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.451576"
-       y1="30.554907"
-       x2="43.00663"
-       y2="45.934479"
-       id="linearGradient3966"
-       xlink:href="#linearGradient4559"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7199799,0,0,1.5608559,-8.336229,-6.6763471)" />
-    <linearGradient
-       id="linearGradient3275">
-      <stop
-         id="stop3277"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop3283"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.16682135" />
-      <stop
-         id="stop3285"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.83237511" />
-      <stop
-         id="stop3279"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="44.994774"
-       y1="17.5"
-       x2="3.0052247"
-       y2="17.5"
-       id="linearGradient3960"
-       xlink:href="#linearGradient3275"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3417982,0,0,1.3287417,-0.2031568,0.247021)"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3980">
-      <stop
-         id="stop3982"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3984"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0.32468599" />
-      <stop
-         id="stop3986"
-         style="stop-color:#ffffff;stop-opacity:0.6901961"
-         offset="0.3736864" />
-      <stop
-         id="stop3988"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="26"
-       y1="22"
-       x2="26"
-       y2="8"
-       id="linearGradient3963"
-       xlink:href="#linearGradient3980"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4999999,0,0,1.3571429,-3.9999994,0.1428574)" />
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient8647"
-       id="radialGradient5565"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6396161,0,0,1.349992,13.560846,18.4751)"
-       cx="12.465816"
-       cy="5.3052077"
-       fx="12.465816"
-       fy="5.3052077"
-       r="10.499999" />
-    <linearGradient
-       id="linearGradient8647">
-      <stop
-         style="stop-color:#8fb1dc;stop-opacity:1;"
-         offset="0"
-         id="stop8649" />
-      <stop
-         style="stop-color:#3465a4;stop-opacity:1;"
-         offset="1"
-         id="stop8651" />
-    </linearGradient>
-    <radialGradient
-       collect="always"
-       xlink:href="#linearGradient8924"
-       id="radialGradient5562"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.05079629,1.8806334,-1.3065264,0.03722342,56.991846,-19.739002)"
-       cx="24.652573"
-       cy="18.94449"
-       fx="24.652485"
-       fy="18.944481"
-       r="8.6174498" />
-    <linearGradient
-       id="linearGradient8924">
-      <stop
-         id="stop8926"
-         offset="0"
-         style="stop-color:#cee14b" />
-      <stop
-         id="stop8928"
-         offset="1"
-         style="stop-color:#9db029" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4873"
-       collect="always">
-      <stop
-         id="stop4875"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop4877"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       y2="-1.9899801"
-       x2="59.919094"
-       y1="-12.742159"
-       x1="63.397362"
-       gradientTransform="matrix(1.4292867,0,0,1.429254,-54.902217,39.017879)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3084"
-       xlink:href="#linearGradient4873" />
-  </defs>
   <g
-     id="layer1">
-    <g
-       transform="matrix(1.3379362,0,0,1.3015298,2.3082316e-2,1.7239512)"
-       id="g3305"
-       style="opacity:0.3;display:inline">
-      <rect
-         width="2.9601951"
-         height="15.366531"
-         x="-3.6903627"
-         y="-47.848343"
-         transform="scale(-1,-1)"
-         id="rect2484"
-         style="opacity:1;fill:url(#radialGradient3940);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1" />
-      <rect
-         width="40.41172"
-         height="15.366531"
-         x="3.6903627"
-         y="32.481812"
-         id="rect2486"
-         style="opacity:1;fill:url(#linearGradient3942);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1" />
-      <rect
-         width="2.9601951"
-         height="15.366531"
-         x="44.110001"
-         y="-47.848343"
-         transform="scale(1,-1)"
-         id="rect3444"
-         style="opacity:1;fill:url(#radialGradient3944);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:1.20000057;stroke-opacity:1;display:inline" />
-    </g>
-    <path
-       d="M 11.893351,11.664497 L 51.46167,11.664497 C 53.771545,11.664497 54.811047,11.283746 55.474546,12.993238 L 59.501079,23.623172 L 59.501079,57.73717 C 59.501079,59.801109 59.63915,59.485762 57.329264,59.485762 L 6.6707391,59.485762 C 4.3608542,59.485762 4.4989233,59.801109 4.4989233,57.73717 L 4.4989233,23.623172 L 8.5254578,12.993238 C 9.1704464,11.318277 9.5834655,11.664497 11.893351,11.664497 z"
-       id="path2488"
-       style="fill:url(#linearGradient3972);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3974);stroke-width:0.99420083;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
+     style="opacity:0.6"
+     id="g3712-8-2-4-4"
+     transform="matrix(1.5789502,0,0,0.7142857,-5.894751,27.928572)">
     <rect
-       width="54"
-       height="35"
-       x="5"
-       y="24"
-       id="rect3209"
-       style="fill:url(#radialGradient3969);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.69999993;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 13.150874,13.010441 L 50.244505,13.010441 C 52.409922,13.010441 53.7501,13.749934 54.657077,15.782233 L 57.781124,24.312384 L 57.781124,55.065522 C 57.781124,57.006384 56.682838,57.983552 54.517416,57.983552 L 9.2676127,57.983552 C 7.1021954,57.983552 6.2189051,56.90883 6.2189051,54.967967 L 6.2189051,24.312384 L 9.2421727,15.599346 C 9.8468262,14.024266 10.985452,13.010441 13.150874,13.010441 z"
-       id="path2490"
-       style="opacity:0.50549454;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3966);stroke-width:0.74211526;stroke-linecap:butt;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:block;overflow:visible" />
-    <path
-       d="M 4.5001475,23.5 L 59.499853,23.5"
-       id="path3273"
-       style="opacity:0.3;fill:none;fill-rule:evenodd;stroke:url(#linearGradient3960);stroke-width:0.99999994px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
-    <path
-       d="M 29,11 C 30.999999,11 33.000001,11 35,11 C 35,17.333333 35,23.666666 35,30 C 34.409407,30 33.818813,30 33.22822,30 C 32.623532,30 32.018844,30 31.414157,30 C 30.927363,30 30.440572,30 29.95378,30 C 29.635853,30 29.317926,30 29,30 C 29,23.666666 29,17.333333 29,11 z"
-       id="rect3326"
-       style="opacity:0.4;fill:url(#linearGradient3963);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none"
+       id="rect2801-5-5-7-9"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4159);fill-opacity:1;stroke:none"
+       id="rect3700-5-6-8-4"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
-  <g
-     transform="matrix(1.188001,0,0,1.188001,5.1459705,5.0699615)"
-     id="g6811">
-    <path
-       id="path2555"
-       d="m 33.989397,20.50005 c -7.450694,0 -13.489348,6.038648 -13.489348,13.489346 0,7.450698 6.038654,13.510556 13.489348,13.510555 7.450695,0 13.510565,-6.059857 13.510552,-13.510555 0,-7.450698 -6.059857,-13.489346 -13.510552,-13.489346 z"
-       style="fill:url(#radialGradient5565);fill-opacity:1;stroke:#204a87;stroke-width:0.841833;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <path
-       d="m 29.307194,37.292135 -0.386077,-0.785014 -0.723266,-0.167999 -0.385743,-1.064472 -0.964265,0.111792 -0.819519,-0.616061 -0.868407,0.784404 0,0.123717 c -0.262694,-0.07787 -0.585616,-0.0885 -0.819517,-0.236193 l -0.19304,-0.560204 0,-0.616746 -0.578519,0.05586 c 0.04829,-0.392542 0.09619,-0.784404 0.144812,-1.176879 l -0.33785,0 -0.337189,0.448409 -0.337849,0.167656 -0.482332,-0.279453 -0.04829,-0.616744 0.09652,-0.672613 0.7236,-0.5602 0.578515,0 0.09619,-0.33661 0.723263,0.167655 0.530558,0.673293 0.09652,-1.121698 0.9163,-0.784402 0.337519,-0.840951 0.675039,-0.280068 0.385745,-0.560201 0.867746,-0.168957 0.43437,-0.671925 c -0.434039,0 -0.868077,0 -1.302116,0 l 0.819784,-0.392541 0.578187,0 0.820117,-0.280747 0.09652,-0.335318 -0.289558,-0.280749 -0.337518,-0.112409 0.09652,-0.335998 -0.241,-0.50427 -0.578848,0.223524 0.09652,-0.448067 -0.675039,-0.392541 -0.530225,0.952335 0.04796,0.336609 -0.530227,0.224885 -0.337851,0.728473 -0.144478,-0.672608 -0.916304,-0.392542 -0.144816,-0.504272 1.205598,-0.729152 0.530561,-0.504272 0.04829,-0.616406 -0.289228,-0.168338 -0.385745,-0.05621 -0.240995,0.616747 c 0,0 -0.40326,0.08114 -0.506945,0.107435 -1.324137,1.253111 -3.999613,3.958199 -4.621183,9.065006 0.02461,0.118402 0.450555,0.804979 0.450555,0.804979 l 1.012559,0.616064 1.012554,0.280746 0.434372,0.560816 0.674706,0.504267 0.385743,-0.05586 0.289228,0.13373 0,0.09047 -0.38548,1.064815 -0.289561,0.448403 0.09652,0.224886 -0.241002,0.83959 0.868079,1.625966 0.867741,0.785018 0.386081,0.560197 -0.04856,1.177564 0.28956,0.671929 -0.28956,1.289352 c 0,0 -0.02268,-0.008 0.01427,0.121063 0.03728,0.129098 1.545037,0.988649 1.640891,0.915482 0.09552,-0.07453 0.177184,-0.139728 0.177184,-0.139728 l -0.09619,-0.279455 0.38548,-0.392543 0.144814,-0.392544 0.627076,-0.224885 0.482001,-1.233422 -0.144481,-0.335316 0.336854,-0.504273 0.723596,-0.16895 0.386076,-0.896816 -0.09652,-1.120335 0.578523,-0.840946 0.09651,-0.840951 C 30.877968,38.122254 30.092813,37.707092 29.307061,37.292 M 35.602388,21.466328 34.194838,20.9 l -1.622789,0.188545 -2.003001,0.565948 -0.3788,0.377781 1.244727,0.880346 0,0.503253 -0.487125,0.503252 0.649946,1.321974 0.431886,-0.252393 0.542367,-0.880345 c 0.836073,-0.265465 1.585709,-0.566331 2.38039,-0.943809 l 0.649949,-1.698303 M 46.9,32.125914 c 0,0.184413 0,0 0,0 l -0.372466,0.43327 C 46.299228,32.28288 46.042896,32.05052 45.782602,31.807843 l -0.57138,0.08635 -0.52203,-0.606032 0,0.750008 0.447248,0.347558 0.297686,0.346223 0.397829,-0.462054 c 0.100136,0.192629 0.198911,0.385255 0.298368,0.577885 l 0,0.577247 -0.447932,0.519618 -0.819711,0.577879 -0.620805,0.636218 -0.397827,-0.463457 0.198913,-0.519611 -0.397208,-0.462057 -0.670836,-1.472573 -0.571381,-0.663594 -0.149561,0.172762 0.224273,0.837761 0.421888,0.490833 c 0.240953,0.714348 0.479306,1.397109 0.795723,2.079936 0.490651,0 0.953211,-0.05349 1.440514,-0.116531 l 0,0.404493 -0.596125,1.501704 -0.546705,0.634813 -0.447249,0.983072 c 0,0.538851 0,1.077702 0,1.616483 l 0.149565,0.636218 -0.248334,0.287957 -0.547389,0.346855 -0.571379,0.490834 0.472607,0.548468 -0.646161,0.578584 0.124132,0.374304 -0.969273,1.127052 -0.645475,0 -0.546708,0.346856 -0.348473,0 0,-0.462054 -0.148192,-0.925508 c -0.192286,-0.579988 -0.392497,-1.155837 -0.596126,-1.73168 0,-0.425059 0.02468,-0.845973 0.04942,-1.270963 l 0.249019,-0.577248 -0.348474,-0.69378 0.02536,-0.952886 -0.472607,-0.548471 0.236301,-0.793884 -0.384497,-0.448013 -0.67152,0 -0.223588,-0.259808 -0.670837,0.433622 -0.273008,-0.318427 -0.621485,0.548752 C 35.497283,36.428367 35.074714,35.937532 34.652211,35.4467 l -0.496668,-1.213398 0.447247,-0.692379 -0.248335,-0.28859 0.546022,-1.329295 c 0.448613,-0.573106 0.917186,-1.12291 1.391164,-1.674749 l 0.845071,-0.231028 0.943913,-0.115195 0.646164,0.173465 0.919168,0.952182 0.323115,-0.375003 0.446563,-0.05756 0.845076,0.288588 0.64616,0 0.447246,-0.404487 0.198913,-0.288592 -0.447935,-0.288589 -0.745612,-0.05757 c -0.206915,-0.294768 -0.399195,-0.604629 -0.644862,-0.866539 l -0.249018,0.115195 -0.09946,0.751344 -0.447246,-0.519616 -0.09877,-0.578583 -0.496669,-0.403082 -0.199598,0 0.497283,0.577247 -0.198912,0.519618 -0.397212,0.115198 0.248336,-0.51962 -0.447932,-0.230322 -0.396528,-0.462054 -0.746299,0.17276 -0.09878,0.230324 -0.447242,0.289292 -0.248338,0.635518 -0.6208,0.31737 -0.273693,-0.31737 -0.297685,0 0,-1.039936 0.646157,-0.346855 0.496669,0 -0.100137,-0.403787 -0.396532,-0.404487 0.670223,-0.144683 0.372468,-0.432567 0.297686,-0.520321 0.547384,0 -0.149559,-0.403786 0.348474,-0.231027 0,0.462056 0.744934,0.172757 0.744933,-0.634813 0.05003,-0.289291 0.645477,-0.4617 c -0.233636,0.02983 -0.467272,0.05174 -0.695578,0.115549 l 0,-0.52025 0.248333,-0.577601 -0.248333,0 -0.545746,0.519615 -0.149563,0.288941 0.149563,0.404841 -0.249021,0.692375 -0.397207,-0.231025 -0.347111,-0.403784 -0.547388,0.403784 -0.19891,-0.923754 0.943914,-0.635164 0,-0.346855 0.596741,-0.404138 0.943912,-0.231378 0.646163,0.231378 1.19218,0.231027 -0.297687,0.346226 -0.64616,0 0.64616,0.693078 0.496668,-0.577255 0.15086,-0.25398 c 0,0 1.905122,1.753584 2.993882,3.671779 1.08877,1.918835 1.600063,4.18045 1.600063,4.639765 z"
-       style="fill:url(#radialGradient5562);fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path6566" />
-    <path
-       id="path8655"
-       d="m 46.499829,33.999553 c 0,6.903687 -5.596778,12.500274 -12.499671,12.500274 -6.903524,0 -12.499985,-5.596653 -12.499985,-12.500274 0,-6.903366 5.596461,-12.499381 12.499985,-12.499381 6.902893,0 12.499671,5.596015 12.499671,12.499381 l 0,0 z"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3084);stroke-width:0.84204072;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="4"
+     rx="4"
+     height="55"
+     width="55" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="5.5784316"
+     x="5.5784316"
+     ry="3"
+     rx="3"
+     height="52.84314"
+     width="52.84314" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21.054333,34 c -1.798584,0.002 -2.725002,2.14207 -1.49112,3.444654 l 10.945669,11.916229 c 0.809764,0.852155 2.172472,0.852155 2.982237,0 L 44.436786,37.444654 C 45.670668,36.14207 44.744251,34.001939 42.945667,34 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="M 27.800781,19 C 26.803581,19 26,19.669 26,20.5 V 32 h -4.945312 c -1.798584,0.002 -2.72607,2.142728 -1.492188,3.445312 l 10.947266,11.916016 c 0.809764,0.852154 2.170703,0.852154 2.980468,0 L 44.4375,35.445312 C 45.671382,34.142728 44.743897,32.001939 42.945312,32 H 38 V 20.5 C 38,19.669 37.196419,19 36.199219,19 Z" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21,32 c -1.740217,4.4e-5 -2.650323,2.068577 -1.474609,3.351562 l 11,12 c 0.792776,0.865044 2.156442,0.865044 2.949218,0 l 11,-12 C 45.650323,34.068577 44.740217,32.000044 43,32 Z"
+     id="path6081"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="12"
+     height="15"
+     x="26"
+     y="19"
+     rx="1.8"
+     ry="1.5" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient3751);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.8;marker:none"
+     id="path10689"
+     d="m 63.999999,61 c 0,1.656855 -6.044156,3 -13.499999,3 C 43.044156,64 37,62.656855 37,61 c 0,-1.656854 6.044156,-3 13.5,-3 7.455843,0 13.499999,1.343146 13.499999,3 z" />
+  <path
+     style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2840);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2842);stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect2576"
+     d="m 48.453704,37.499999 c -0.721008,0 -1.324074,0.572974 -1.324074,1.293981 v 1.685186 c -0.455869,0.152991 -0.898205,0.330687 -1.324075,0.541666 l -1.173612,-1.173611 c -0.50983,-0.509829 -1.325819,-0.509829 -1.835648,0 l -2.949074,2.918982 c -0.50983,0.509829 -0.509827,1.32582 0,1.835648 l 1.173611,1.173611 c -0.216018,0.433268 -0.385794,0.889712 -0.541666,1.354167 h -1.655093 c -0.721008,0 -1.324076,0.572974 -1.324074,1.293981 v 4.152778 c -1e-6,0.721007 0.603069,1.293983 1.324074,1.293981 h 1.655093 c 0.155872,0.464455 0.325648,0.920899 0.541666,1.354167 l -1.173611,1.173611 c -0.50983,0.509829 -0.509831,1.325819 0,1.835648 l 2.949074,2.918982 c 0.509828,0.509829 1.32582,0.509827 1.835648,0 l 1.173612,-1.173611 c 0.42587,0.210979 0.868206,0.388674 1.324075,0.541666 v 1.685185 c -10e-7,0.721007 0.60307,1.293984 1.324074,1.293982 h 4.122685 c 0.721008,0 1.293981,-0.572977 1.293981,-1.293982 v -1.685185 c 0.464455,-0.155873 0.920899,-0.325648 1.354167,-0.541666 l 1.17361,1.173611 c 0.50983,0.509829 1.325818,0.509829 1.835648,0 l 2.949074,-2.918982 c 0.50983,-0.509829 0.509826,-1.325821 0,-1.835648 l -1.203703,-1.203704 c 0.210979,-0.425869 0.388674,-0.868205 0.541666,-1.324074 h 1.685185 c 0.721008,0 1.293982,-0.572976 1.293982,-1.293981 V 48.42361 C 63.5,47.702603 62.92702,47.129629 62.206017,47.129629 H 60.520832 C 60.36784,46.67376 60.190145,46.231424 59.979166,45.805554 l 1.203703,-1.203703 c 0.50983,-0.509829 0.509829,-1.325819 0,-1.835648 l -2.949074,-2.918982 c -0.509828,-0.509829 -1.325821,-0.509829 -1.835648,0 l -1.17361,1.173611 C 54.791269,40.804814 54.334825,40.635038 53.87037,40.479166 V 38.79398 c 10e-7,-0.721007 -0.572978,-1.293981 -1.293981,-1.293981 z M 50.5,47.129629 c 1.860444,0 3.37037,1.509925 3.37037,3.37037 0,1.860444 -1.509926,3.37037 -3.37037,3.37037 -1.860446,0 -3.37037,-1.509926 -3.37037,-3.37037 -10e-7,-1.860445 1.509925,-3.37037 3.37037,-3.37037 z" />
+  <path
+     style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+     d="m 50.499999,42.999999 c -4.135568,0 -7.5,3.364432 -7.5,7.5 0,4.135569 3.364432,7.5 7.5,7.5 4.135568,0 7.5,-3.364431 7.5,-7.5 0,-4.135568 -3.364432,-7.5 -7.5,-7.5 z m 0,4.6875 c 1.553301,0 2.8125,1.259199 2.8125,2.8125 0,1.553301 -1.259199,2.8125 -2.8125,2.8125 -1.553301,0 -2.8125,-1.259199 -2.8125,-2.8125 0,-1.553301 1.259199,-2.8125 2.8125,-2.8125 z"
+     id="path3315" />
+  <path
+     style="fill:none;stroke:url(#linearGradient2836);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none"
+     id="path28"
+     d="m 50.499998,42.499999 c -4.411202,0 -7.999999,3.588799 -7.999999,7.999999 0,4.411201 3.588797,8.000001 7.999999,8.000001 4.411203,0 8.000001,-3.5888 8.000001,-8.000001 0,-4.4112 -3.588798,-7.999999 -8.000001,-7.999999 z" />
+  <path
+     style="display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3688);stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 48.440658,38.499512 c -0.613009,0.13376 -0.269659,0.929213 -0.359321,1.386352 0.04442,0.571822 0.0114,1.32914 -0.658754,1.518176 -0.733243,0.153911 -1.577181,0.975646 -2.275698,0.299436 -0.484464,-0.408423 -0.850558,-1.014601 -1.422312,-1.279153 -0.518099,0.263694 -0.892292,0.839277 -1.356292,1.231835 -0.626722,0.64966 -1.319339,1.246849 -1.904342,1.929729 -0.03648,0.516166 0.589949,0.774771 0.868877,1.160575 0.479801,0.363876 0.87895,1.013653 0.482716,1.58951 -0.325623,0.632157 -0.372263,1.74265 -1.309872,1.745487 -0.630706,0.05069 -1.311127,-0.109017 -1.906609,0.09455 -0.212934,0.594664 -0.04711,1.289486 -0.0996,1.925981 0.01704,0.856315 -0.03434,1.719419 0.02612,2.571427 0.361347,0.374657 0.981024,0.127497 1.460628,0.199012 0.61207,-0.08979 1.363652,0.116955 1.473439,0.823463 0.167873,0.682869 0.890389,1.493101 0.243754,2.140951 -0.40278,0.479575 -1.005948,0.842244 -1.266429,1.405944 0.273335,0.575122 0.883831,0.943913 1.300572,1.430633 0.61791,0.604946 1.243075,1.242339 1.853809,1.828304 0.528247,0.03944 0.792852,-0.594661 1.184958,-0.88073 0.364208,-0.480828 1.01577,-0.879371 1.591741,-0.481465 0.622272,0.327641 1.713019,0.383788 1.71329,1.308626 0.05341,0.631485 -0.114738,1.322139 0.0996,1.911667 0.681103,0.202258 1.44608,0.04465 2.162255,0.09455 0.779879,-0.01426 1.564057,0.02857 2.341243,-0.02144 0.361888,-0.347628 0.114979,-0.966367 0.187842,-1.435374 -0.0528,-0.5538 0.02235,-1.269444 0.658754,-1.447711 0.745062,-0.142545 1.599003,-0.978638 2.305641,-0.299436 0.484464,0.408423 0.850558,1.0146 1.422311,1.279153 0.5181,-0.263695 0.892293,-0.839277 1.356294,-1.231835 0.626721,-0.64966 1.319339,-1.246848 1.904341,-1.929729 0.03648,-0.516166 -0.589949,-0.774771 -0.868877,-1.160576 -0.485471,-0.373471 -0.922327,-1.02719 -0.511405,-1.621694 0.327639,-0.622277 0.383786,-1.713031 1.308618,-1.713302 0.636249,-0.04522 1.316831,0.09723 1.921579,-0.08463 0.183492,-0.703222 0.03824,-1.482971 0.08463,-2.217766 -0.01374,-0.766415 0.02785,-1.536998 -0.02144,-2.300733 -0.347625,-0.361895 -0.96636,-0.114984 -1.435363,-0.187847 -0.616061,0.08609 -1.385145,-0.09648 -1.500947,-0.814949 -0.180478,-0.673052 -0.889387,-1.477505 -0.246188,-2.119522 0.417691,-0.44287 0.890601,-0.840321 1.274025,-1.311376 0.02469,-0.520415 -0.59361,-0.774231 -0.87758,-1.158585 -0.750993,-0.737311 -1.510823,-1.50645 -2.254454,-2.224864 -0.528247,-0.03944 -0.792851,0.594662 -1.184957,0.880731 -0.363873,0.479803 -1.013645,0.878956 -1.589499,0.482718 -0.632152,-0.325625 -1.742638,-0.372265 -1.745475,-1.30988 -0.04522,-0.636252 0.09723,-1.31684 -0.08463,-1.92159 -0.703216,-0.183497 -1.482961,-0.03824 -2.217749,-0.08463 -0.709748,0 -1.419496,0 -2.129243,0 z"
+     id="path2901" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:url(#linearGradient3698);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3690"
+     d="m 54.999998,50.501944 a 4.4999998,4.4999955 0 1 1 -8.999999,0 4.4999998,4.4999955 0 1 1 8.999999,0 z" />
 </svg>

--- a/elementary-xfce/apps/96/software-properties.svg
+++ b/elementary-xfce/apps/96/software-properties.svg
@@ -1,0 +1,362 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="96"
+   height="96"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="software-properties.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234045"
+     inkscape:cx="68.877591"
+     inkscape:cy="70.868273"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="1024"
+     inkscape:window-y="79"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0810811,0,0,2.0810811,-1.9459378,-1.9459246)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3013"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3015"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       cx="4.9929786"
+       cy="43.5"
+       fx="4.9929786"
+       fy="43.5"
+       r="2.5" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="47.851692"
+       x2="12.168998"
+       y2="0.32248196"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.025641,0,0,2.025641,-0.6153847,-2.641025)" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309-1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311-5"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313-0"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10691">
+      <stop
+         id="stop10693"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop10695"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="86.132919"
+       y1="105.105"
+       x2="84.63858"
+       y2="20.895"
+       id="linearGradient2512"
+       xlink:href="#linearGradient5128-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.27640914,0,0,0.27640914,58.309864,58.586226)" />
+    <linearGradient
+       id="linearGradient5128-3">
+      <stop
+         id="stop5130-6"
+         style="stop-color:#e5e5e5;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5132-7"
+         style="stop-color:#ababab;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.758585"
+       y1="1"
+       x2="20.758585"
+       y2="45.017357"
+       id="linearGradient2515"
+       xlink:href="#linearGradient3309-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.90697464,0,0,0.90697464,54.232605,55.139537)" />
+    <linearGradient
+       x1="37.201294"
+       y1="1"
+       x2="37.201294"
+       y2="45"
+       id="linearGradient2517"
+       xlink:href="#linearGradient3397"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.90697464,0,0,0.90697464,54.232605,55.139537)" />
+    <linearGradient
+       id="linearGradient3397">
+      <stop
+         id="stop3399"
+         style="stop-color:#aaaaaa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3401"
+         style="stop-color:#8c8c8c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient2436"
+       xlink:href="#linearGradient10691"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.882353,0,0,0.47058774,-41.882358,88.82353)" />
+    <linearGradient
+       id="linearGradient8265-821-176-38-919-66-249-7-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop2687-1-9" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop2689-5-4" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient918"
+       x1="70.178734"
+       y1="75.425247"
+       x2="70.178734"
+       y2="60.497593"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.93333357,0,0,0.93333357,12.533268,12.533311)" />
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3014"
+       gradientUnits="userSpaceOnUse"
+       x1="12.47939"
+       y1="2"
+       x2="12.47939"
+       y2="22.006775"
+       gradientTransform="matrix(1.9364459,0,0,1.9366989,52.765065,52.759574)" />
+  </defs>
+  <metadata
+     id="metadata3663">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="M 96,91.000001 C 96,93.761426 87.045695,96 76.000001,96 64.954307,96 56,93.761426 56,91.000001 56,88.238576 64.954307,86 76.000001,86 87.045695,86 96,88.238576 96,91.000001 Z"
+       id="path8836"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2436);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999985;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none" />
+    <g
+       style="opacity:0.4;stroke-width:0.5"
+       id="g3712"
+       transform="matrix(2.3157904,0,0,1.1428572,-7.578968,36.285712)">
+      <rect
+         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:0.5"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:0.5"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:0.5"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+    <rect
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+       id="rect5505-21"
+       y="8.5"
+       x="8.5"
+       ry="6"
+       rx="6"
+       height="79"
+       width="79" />
+    <path
+       style="color:#000000;fill:#010000;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 41.552367,29.000001 c -1.404454,0 -2.552734,1.14235 -2.552734,2.544922 v 17.455072 h -7.417602 c -1.547424,0.0017 -2.758287,0.939904 -3.283203,2.154297 -0.524916,1.214394 -0.378667,2.740232 0.683594,3.863281 l 16.412109,17.894532 c 0.002,0.002 0.0039,0.004 0.0059,0.0059 1.407411,1.483256 3.791807,1.483256 5.199218,0 0.002,-0.0019 0.004,-0.0039 0.0059,-0.0059 L 67.017578,55.017573 c 1.062261,-1.123048 1.20851,-2.648889 0.683594,-3.863281 -0.524916,-1.214392 -1.73578,-2.152626 -3.283203,-2.154297 H 57.000367 V 31.544923 c 0,-1.402572 -1.14828,-2.544922 -2.552734,-2.544922 z"
+       id="path13703"
+       sodipodi:nodetypes="ssccsccccccsccsss" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="rect6741"
+       y="9.5"
+       x="9.5"
+       ry="5"
+       rx="5"
+       height="77"
+       width="77" />
+    <path
+       style="color:#000000;opacity:1;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+       d="m 41.552125,27.500098 c -1.136947,0 -2.052251,0.912429 -2.052251,2.045804 V 47.6 h -7.91804 c -2.697822,0.0029 -4.087422,3.575797 -2.236634,5.532496 L 45.763368,71.03268 c 1.214623,1.280078 3.258644,1.280078 4.473267,0 L 66.654803,53.132496 C 68.505591,51.175797 67.115991,47.602913 64.41817,47.6 H 56.500126 V 29.545902 c 0,-1.133375 -0.915304,-2.045804 -2.052251,-2.045804 z"
+       id="path12165"
+       sodipodi:nodetypes="ssccccccccsss" />
+    <path
+       style="color:#000000;opacity:1;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 42,28.000001 c -1.108,0 -2,0.892 -2,2 v 18 h -8.000156 c -2.629134,0.0028 -3.983354,3.145704 -2.179688,5.058594 l 16.000156,17.499406 c 1.183698,1.251418 3.175678,1.251418 4.359376,0 L 66.179844,53.058595 c 1.803666,-1.91289 0.449446,-5.055746 -2.179688,-5.058594 H 56 v -18 c 0,-1.108 -0.892,-2 -2,-2 z"
+       id="path887"
+       sodipodi:nodetypes="ssccccccccsss" />
+    <path
+       d="m 73.307411,56.499999 c -0.767418,0 -1.388805,0.636611 -1.388805,1.417148 v 2.749266 c -1.372198,0.365607 -2.683338,0.917846 -3.882985,1.615549 l -1.955664,-1.955664 c -0.275956,-0.275961 -0.606539,-0.422118 -0.96366,-0.425144 -0.357113,-0.0029 -0.720673,0.125478 -0.992004,0.396802 l -3.8263,3.826299 c -0.542642,0.542646 -0.523578,1.40374 0.0283,1.955663 l 1.955665,1.955664 c -0.6977,1.199644 -1.249939,2.510786 -1.615549,3.882986 h -2.749267 c -0.780532,0 -1.417143,0.621385 -1.417143,1.388805 v 5.385161 c 0,0.76742 0.636611,1.388806 1.417143,1.388806 h 2.749267 c 0.36561,1.3722 0.917849,2.683341 1.615549,3.882985 l -1.955665,1.955664 c -0.551921,0.551922 -0.570986,1.413016 -0.0283,1.955664 l 3.8263,3.826299 c 0.542652,0.542646 1.403743,0.523577 1.955664,-0.02835 l 1.955664,-1.955664 c 1.199647,0.697704 2.510787,1.249942 3.882985,1.615549 v 2.749267 c 0,0.780536 0.621387,1.417148 1.388805,1.417148 h 5.385162 c 0.767418,0 1.388805,-0.636612 1.388805,-1.417148 v -2.749267 c 1.372207,-0.365607 2.683348,-0.917845 3.882985,-1.615549 l 1.955664,1.955664 c 0.551931,0.551922 1.413022,0.57099 1.955664,0.02835 l 3.8263,-3.826299 c 0.542652,-0.542647 0.523587,-1.403742 -0.0283,-1.955664 l -1.955664,-1.955664 c 0.697709,-1.199644 1.249947,-2.510785 1.615549,-3.882985 h 2.749276 c 0.780533,0 1.417148,-0.621386 1.417148,-1.388806 v -5.385161 c 0,-0.767419 -0.636615,-1.388805 -1.417148,-1.388805 h -2.749275 c -0.365602,-1.3722 -0.91784,-2.683342 -1.615549,-3.882986 l 1.955664,-1.955664 c 0.55193,-0.551922 0.570995,-1.413017 0.0283,-1.955663 l -3.826301,-3.826299 c -0.542642,-0.542647 -1.403742,-0.52358 -1.955664,0.02835 l -1.955664,1.955664 c -1.199637,-0.697711 -2.510778,-1.24995 -3.882985,-1.615557 v -2.749266 c 0,-0.780537 -0.621377,-1.417148 -1.388805,-1.417148 z m 2.692582,13.60462 c 3.254224,0 5.895335,2.64111 5.895335,5.895335 0,3.254225 -2.641111,5.895335 -5.895335,5.895335 -3.254225,0 -5.895336,-2.64111 -5.895336,-5.895335 0,-3.254225 2.641111,-5.895335 5.895336,-5.895335 z"
+       id="rect3267"
+       style="display:block;overflow:visible;visibility:visible;fill:url(#linearGradient2515);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2517);stroke-width:0.999998;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate" />
+    <path
+       d="m 76.000042,64.499999 c -6.3411,0 -11.5,5.158899 -11.5,11.5 0,6.3411 5.1589,11.5 11.5,11.5 6.341109,0 11.5,-5.1589 11.5,-11.5 0,-6.341101 -5.158891,-11.5 -11.5,-11.5 z"
+       id="path28-5"
+       style="fill:none;stroke:url(#linearGradient2512);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       d="m 76.000042,64.999999 c -6.065502,0 -11,4.934498 -11,11 0,6.065502 4.934498,11 11,11 6.065502,-10e-7 11,-4.934498 11,-11 0,-6.065502 -4.934498,-11 -11,-11 z m 0,5.076923 c 3.269539,0 5.923077,2.653539 5.923077,5.923077 0,3.269538 -2.653538,5.923077 -5.923077,5.923077 -3.269538,0 -5.923077,-2.653539 -5.923077,-5.923077 0,-3.269538 2.653539,-5.923077 5.923077,-5.923077 z"
+       id="path3315-3"
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999561;stroke-miterlimit:4;stroke-dasharray:none" />
+    <path
+       d="m 75.999997,68.999996 c -3.859801,0 -7.000002,3.1402 -7.000002,7.000002 0,3.859801 3.140201,7.000002 7.000002,7.000002 3.859806,0 7.000001,-3.140201 7.000001,-7.000002 0,-3.859802 -3.140195,-7.000002 -7.000001,-7.000002 z"
+       id="path874"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient918);stroke-width:0.999996;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="color:#000000;display:block;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3014);stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3799"
+       d="m 73.097747,57.540802 c -0.143637,0.752831 -0.01829,1.745176 -0.06051,2.588267 0.125276,1.506903 -1.491598,2.039061 -2.649606,2.356208 -1.059285,0.602769 -2.612257,1.301264 -3.557191,0.104982 -0.573509,-0.573576 -1.147019,-1.14716 -1.720527,-1.720747 -0.83602,0.5552 -1.519643,1.47837 -2.296691,2.17595 -0.618625,0.698378 -1.463056,1.303213 -1.939284,2.060577 0.788171,0.94924 2.030394,1.622165 2.373691,2.860451 -0.04775,1.546384 -1.04599,2.961634 -1.573143,4.390542 -0.971753,1.092976 -2.546508,0.543572 -3.823215,0.677373 -0.667236,-0.02496 -0.136194,1.135579 -0.3056,1.599148 0.0023,1.442809 -0.0047,2.885891 0.0035,4.328518 1.25009,0.12433 2.627732,-0.291629 3.767344,0.347962 1.075912,1.121762 1.308329,2.854935 1.949558,4.238983 0.08089,1.457828 -1.418082,2.181559 -2.225628,3.178385 -0.420959,0.527569 0.74607,0.976381 0.999052,1.453234 0.98314,0.983267 1.96628,1.966532 2.949416,2.949799 1.011719,-0.590439 1.626087,-1.915317 2.799002,-2.33361 1.578477,-0.206553 2.931175,1.058304 4.422512,1.421492 1.260032,0.875548 0.703953,2.537899 0.826838,3.825277 -0.171394,0.810461 1.02217,0.251521 1.489055,0.415543 1.479241,-0.0023 2.958771,0.0047 4.437837,-0.0035 0.12431,-1.250256 -0.29159,-2.628074 0.347917,-3.767833 1.121615,-1.076054 2.854564,-1.308501 4.23843,-1.949814 1.457639,-0.08091 2.181273,1.418268 3.17797,2.225918 0.5275,0.421014 0.976251,-0.746167 1.453046,-0.999185 0.983135,-0.983267 1.966273,-1.96653 2.94941,-2.949797 -0.59036,-1.011853 -1.915066,-1.626301 -2.333305,-2.799373 -0.206517,-1.578678 1.058169,-2.931557 1.421306,-4.423085 0.875433,-1.260199 2.537572,-0.704046 3.82478,-0.826947 0.810356,0.171415 0.251484,-1.022306 0.415485,-1.489248 -0.0023,-1.479438 0.0047,-2.959159 -0.0035,-4.438422 -1.250092,-0.124331 -2.627731,0.291632 -3.767346,-0.347962 -1.075893,-1.121745 -1.30831,-2.85492 -1.949539,-4.238966 -0.08089,-1.457829 1.418084,-2.181557 2.225626,-3.178387 0.420952,-0.527571 -0.746076,-0.97638 -0.999061,-1.453232 -0.983137,-0.983271 -1.966275,-1.966538 -2.949414,-2.949802 -1.011721,0.590441 -1.626087,1.915319 -2.799004,2.33361 -1.578473,0.206553 -2.931176,-1.058305 -4.422506,-1.421489 -1.260036,-0.875545 -0.703956,-2.537903 -0.826842,-3.825279 0.171394,-0.810462 -1.022172,-0.251521 -1.489052,-0.415541 -1.460265,0 -2.920535,0 -4.380798,0 z" />
+  </g>
+</svg>


### PR DESCRIPTION
This was a PR to update all software icons, but I'm splitting the PRs and leaving only the `software-properties` proposal here as there is some discussion on it below.

---

Update the `software-properties` icon to match software installer icons. Uses newer elementary borders, gradients, and arrow style.

Current (left) and Proposed (right):
![software-properties](https://github.com/shimmerproject/elementary-xfce/assets/1984060/7c4f4cc1-477b-4abf-81d6-85c7eb44c8a7)
