### PR TITLE
Update Ubiquity and USB Creator icon

### DIFF
--- a/elementary-xfce/apps/128/ubiquity.svg
+++ b/elementary-xfce/apps/128/ubiquity.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="128"
    height="128"
-   id="svg3367">
+   id="svg3367"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview90"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.9111844"
+     inkscape:cx="110.06896"
+     inkscape:cy="102.01513"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="424"
+     inkscape:window-y="71"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3367" />
   <metadata
      id="metadata49726">
     <rdf:RDF>
@@ -18,276 +40,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3369">
-    <linearGradient
-       id="linearGradient23419">
-      <stop
-         id="stop23421"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop23423"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3265"
-         style="stop-color:#dedbde;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3267"
-         style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6036">
-      <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3519">
-      <stop
-         id="stop3521"
-         style="stop-color:#fcd9cd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3523"
-         style="stop-color:#fcd9cd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3511">
-      <stop
-         id="stop3513"
-         style="stop-color:#ebeec7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3515"
-         style="stop-color:#ebeec7;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3503">
-      <stop
-         id="stop3505"
-         style="stop-color:#c4ebdd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3507"
-         style="stop-color:#c4ebdd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3495">
-      <stop
-         id="stop3497"
-         style="stop-color:#c1cbe4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3499"
-         style="stop-color:#c1cbe4;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3487">
-      <stop
-         id="stop3489"
-         style="stop-color:#e6cde2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3491"
-         style="stop-color:#e6cde2;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.334524"
-       cy="41.63604"
-       r="22.627417"
-       fx="23.334524"
-       fy="41.63604"
-       id="radialGradient2584"
-       xlink:href="#linearGradient23419"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6516504,0,0,0.7954211,2.1249955,72.881817)" />
-    <linearGradient
-       x1="10.50172"
-       y1="3.6100161"
-       x2="48.798885"
-       y2="54.698483"
-       id="linearGradient2642"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7528548,0,0,2.7528545,-3.0237572,-4.8213527)" />
-    <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
-       id="linearGradient2651"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0859888,0,0,1.0859883,37.559418,36.850296)" />
-    <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient2654"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.5381093,0,0,2.5381093,3.0853666,3.0853861)" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient2658"
-       xlink:href="#linearGradient3263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.1714559,-3.1714559,0,137.26064,-12.114951)" />
-    <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient2660"
-       xlink:href="#linearGradient3772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7073165,0,0,2.7073165,135.10782,-0.9755887)" />
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient2672"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient2674"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient2676"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient2678"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient2680"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient2682"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient2684"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient2686"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient2688"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient2690"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
     <linearGradient
        id="linearGradient3707-319-631-407-324-3-8-4">
       <stop
@@ -341,7 +98,7 @@
        xlink:href="#linearGradient4011-2"
        id="linearGradient3122"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7027027,0,0,1.7027027,-29.140852,49.824176)"
+       gradientTransform="matrix(1.7027027,0,0,1.7027027,-34.140852,45.824176)"
        x1="71.204407"
        y1="6.2375584"
        x2="71.204407"
@@ -350,7 +107,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-5"
        id="radialGradient3125"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.5498531,-3.7553211,-9.6621544e-8,124.73176,34.366627)"
+       gradientTransform="matrix(0,3.5498531,-3.7553211,-9.6621544e-8,119.73176,30.366627)"
        cx="6.0693989"
        cy="8.4497671"
        fx="6.0693989"
@@ -360,100 +117,269 @@
        xlink:href="#linearGradient3707-319-631-407-324-3-8-4"
        id="linearGradient3127"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.6668213,0,0,1.6668213,52.99631,52.996277)"
+       gradientTransform="matrix(1.6668213,0,0,1.6668213,47.99631,48.996277)"
        x1="24"
        y1="44"
        x2="24"
        y2="3.8990016" />
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7339903,0,0,3.0819181,-140.98913,-3.5238899)"
+       x1="118.57409"
+       y1="3.7037382"
+       x2="118.79462"
+       y2="32.292839" />
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.01900466"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.4795045,0,0,2.1356709,24.785117,-2.8194939)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.769231,0,0,3.1538457,-144.7081,2.1651309)"
+       x1="116.83477"
+       y1="-38.101143"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03153139" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.5999998,0,0,2.6000002,-20.400398,-3.7999923)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(1.2816215,0,0,0.2871899,13.094313,106.54209)"
+       r="22.627001">
+      <stop
+         id="stop23421-3"
+         offset="0" />
+      <stop
+         id="stop23423-6"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient7374-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(1.14904,0,0,0.37565594,61.188003,102.85861)"
+       r="22.627001">
+      <stop
+         id="stop23421-3-6"
+         offset="0" />
+      <stop
+         id="stop23423-6-7"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
   </defs>
   <path
-     d="M 124,105.99999 C 124.00309,115.94084 97.139272,124 64,124 C 30.860727,124 3.9969077,115.94084 3.999998,105.99999 C 3.9969077,96.059149 30.860727,88 64,88 C 97.139272,88 124.00309,96.059149 124,105.99999 L 124,105.99999 z"
      id="path23417"
-     style="opacity:0.3;fill:url(#radialGradient2584);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     d="m 71.999999,118.49998 a 29,6.4982711 0 1 1 -57.999998,0 29,6.4982711 0 1 1 57.999998,0 z" />
   <path
-     d="M 119.49998,64.000008 C 119.49998,33.236876 94.763115,8.5000192 63.999988,8.5000192 C 33.236854,8.5000192 8.5,33.236878 8.5,64.000008 C 8.4999946,94.763138 33.236857,119.5 63.999988,119.5 C 94.763112,119.49999 119.49998,94.76314 119.49998,64.000008 z M 84.304862,64.000008 C 84.304862,75.176162 75.399768,84.304882 63.999988,84.304882 C 52.376585,84.304882 43.695114,74.950256 43.695114,64.000008 C 43.695114,52.826093 51.929329,43.695134 63.999988,43.695134 C 76.070648,43.695134 84.304862,53.047477 84.304862,64.000008 L 84.304862,64.000008 z"
-     id="path2781"
-     style="fill:url(#linearGradient2658);fill-rule:nonzero;stroke:url(#linearGradient2660);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+     id="path23417-5"
+     style="opacity:0.15;fill:url(#radialGradient7374-3);fill-rule:evenodd;stroke-width:0.999999"
+     d="m 114,118.5 a 26,8.5 0 1 1 -52,0 26,8.5 0 1 1 52,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.293023"
+     transform="scale(1,-1)"
+     rx="1.0000001"
+     ry="1.0000001"
+     height="39"
+     width="39"
+     y="-119.49999"
+     x="22.499596" />
   <path
-     d="M 63.999988,43.000008 C 52.407988,43.000008 42.999988,52.408008 42.999988,64.000008 C 42.999988,75.592009 52.407988,85.000008 63.999988,85.000008 C 75.591988,85.000008 84.999988,75.592009 84.999988,64.000008 C 84.999988,52.408008 75.591988,43.000008 63.999988,43.000008 L 63.999988,43.000008 z M 63.999988,53.500009 C 69.795988,53.500009 74.499988,58.204008 74.499988,64.000008 C 74.499988,69.796008 69.795988,74.500008 63.999988,74.500008 C 58.203988,74.500008 53.499988,69.796008 53.499988,64.000008 C 53.499988,58.204008 58.203988,53.500009 63.999988,53.500009 L 63.999988,53.500009 z"
-     id="path2474"
-     style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 22.999597,96.000001 h 38"
+     id="path4538" />
   <path
-     d="M 63.999988,43.695134 C 52.791698,43.695134 43.695114,52.791718 43.695114,64.000008 C 43.695114,75.208298 52.791698,84.304882 63.999988,84.304882 C 75.208278,84.304882 84.304862,75.208298 84.304862,64.000008 C 84.304862,52.791718 75.208278,43.695134 63.999988,43.695134 L 63.999988,43.695134 z M 63.999988,53.84757 C 69.604133,53.84757 74.152425,58.395863 74.152425,64.000008 C 74.152425,69.604153 69.604133,74.152444 63.999988,74.152444 C 58.395843,74.152444 53.847551,69.604153 53.847551,64.000008 C 53.847551,58.395863 58.395843,53.84757 63.999988,53.84757 L 63.999988,53.84757 z"
-     id="path3418"
-     style="fill:none;stroke:url(#linearGradient2654);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g
-     transform="matrix(2.7320403,0,0,2.7320403,-1.0900842,-1.0742573)"
-     id="g3527">
-    <path
-       d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
-       transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
-       id="path3296"
-       style="opacity:0.8;fill:url(#linearGradient2672);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
-       id="path3308"
-       style="opacity:0.8;fill:url(#linearGradient2674);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-       id="path3310"
-       style="opacity:0.8;fill:url(#linearGradient2676);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-       id="path3312"
-       style="opacity:0.8;fill:url(#linearGradient2678);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-       id="path3314"
-       style="opacity:0.8;fill:url(#linearGradient2680);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  </g>
+     style="opacity:0.35;fill:#000000;fill-opacity:0.335988;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.674419"
+     d="m 28.499597,104.5 v 7 h 9 v -7 z"
+     id="rect3450" />
+  <rect
+     id="rect3458"
+     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="37"
+     width="37"
+     y="-118.49999"
+     x="23.499596" />
+  <rect
+     ry="2.5"
+     id="rect5391"
+     style="fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="2.5000002"
+     height="90"
+     width="54"
+     y="6"
+     x="14.999598" />
+  <rect
+     ry="3"
+     id="rect5391-2"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="2.9999998"
+     height="91.000076"
+     width="55.000076"
+     y="5.4999609"
+     x="14.499559" />
+  <rect
+     rx="2.0000002"
+     id="rect5391-2-0"
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     ry="2"
+     height="89"
+     width="53"
+     y="6.5"
+     x="15.499598" />
   <path
-     d="M 64.000005,9.5000009 C 33.791433,9.5000009 9.5,33.791433 9.5,64.000001 C 9.5,94.208571 33.791433,118.5 64.000005,118.5 C 94.208577,118.5 118.5,94.208571 118.5,64.000001 C 118.5,33.791433 94.208577,9.5000009 64.000005,9.5000009 L 64.000005,9.5000009 L 64.000005,9.5000009 z"
-     id="path3272"
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient2642);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1" />
-  <g
-     transform="matrix(-2.7073165,0,0,-2.7073165,128.97558,128.95078)"
-     id="g3297">
-    <path
-       d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
-       transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
-       id="path3299"
-       style="opacity:0.8;fill:url(#linearGradient2682);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
-       id="path3301"
-       style="opacity:0.8;fill:url(#linearGradient2684);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-       id="path3303"
-       style="opacity:0.8;fill:url(#linearGradient2686);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-       id="path3305"
-       style="opacity:0.8;fill:url(#linearGradient2688);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-       id="path3307"
-       style="opacity:0.8;fill:url(#linearGradient2690);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  </g>
+     style="fill:#ffffff;fill-opacity:1;stroke-width:1"
+     d="m 41.750966,17.001953 -4.619141,7.998048 h 3.294922 V 65.88086 l -8.410156,-7.958984 c -0.543003,-0.677435 -0.924212,-1.56479 -0.945312,-2.476563 0,-3.688487 5.5e-5,-5.879274 -0.002,-6.685546 1.557124,-0.546519 2.679688,-2.014547 2.679688,-3.759766 0,-2.207818 -1.791383,-3.998047 -4,-3.998047 -2.209577,0 -4,1.790069 -4,3.998047 0,1.745219 1.123888,3.213247 2.679688,3.759766 l -0.002,6.607422 c 0,1.790615 0.983061,3.667104 2.134766,4.861328 v 0.002 c 0.02845,0.02526 8.921875,8.445312 8.921875,8.445312 0.542204,0.675996 0.92162,1.561522 0.943359,2.472657 v 7.029296 a 5,5 0 0 0 -3.677642,4.822219 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -3.681641,-4.818359 v -6.953125 c 0,-0.01164 6.39e-4,-0.02334 0,-0.03516 V 61.144532 c 0.02317,-0.909374 0.40247,-1.795346 0.945313,-2.470703 0,0 8.893103,-8.417303 8.921875,-8.443359 1.151544,-1.194222 2.134766,-3.072347 2.134765,-4.863281 l -0.002,-6.367188 h 2.681641 v -8 h -8 v 8 H 52.4267 c 0,0 -0.002,1.677211 -0.002,6.445312 -0.02093,0.911933 -0.402309,1.799448 -0.945312,2.476563 l -8.41211,7.960937 V 25.000001 h 3.300782 z"
+     id="path4696" />
   <path
-     d="M 63.99999,42.500008 C 52.082843,42.500008 42.499987,52.082863 42.499987,64.000008 C 42.499987,75.917153 52.082843,85.500008 63.99999,85.500008 C 75.917134,85.500008 85.499989,75.917153 85.499989,64.000008 C 85.499989,52.082863 75.917134,42.500008 63.99999,42.500008 L 63.99999,42.500008 L 63.99999,42.500008 L 63.99999,42.500008 z"
-     id="path3281"
-     style="opacity:0.8;fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+     id="path1334"
+     d="m 41.750966,16.001953 -4.619141,7.998048 h 3.294922 V 64.88086 l -8.410156,-7.958984 c -0.543003,-0.677435 -0.924212,-1.56479 -0.945312,-2.476563 0,-3.688487 5.5e-5,-5.879274 -0.002,-6.685546 1.557124,-0.546519 2.679688,-2.014547 2.679688,-3.759766 0,-2.207818 -1.791383,-3.998047 -4,-3.998047 -2.209577,0 -4,1.790069 -4,3.998047 0,1.745219 1.123888,3.213247 2.679688,3.759766 l -0.002,6.607422 c 0,1.790615 0.983061,3.667104 2.134766,4.861328 v 0.002 c 0.02845,0.02526 8.921875,8.445312 8.921875,8.445312 0.542204,0.675996 0.92162,1.561522 0.943359,2.472657 v 7.029296 a 5,5 0 0 0 -3.677642,4.822219 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -3.681641,-4.818359 v -6.953125 c 0,-0.01164 6.39e-4,-0.02334 0,-0.03516 V 60.144532 c 0.02317,-0.909374 0.40247,-1.795346 0.945313,-2.470703 0,0 8.893103,-8.417303 8.921875,-8.443359 1.151544,-1.194222 2.134766,-3.072347 2.134765,-4.863281 l -0.002,-6.367188 h 2.681641 v -8 h -8 v 8 H 52.4267 c 0,0 -0.002,1.677211 -0.002,6.445312 -0.02093,0.911933 -0.402309,1.799448 -0.945312,2.476563 l -8.41211,7.960937 V 24.000001 h 3.300782 z"
+     style="fill:#aaaaaa;fill-opacity:1;stroke-width:1" />
   <path
-     d="m 93,60.5 c -17.93239,0 -32.5,14.567615 -32.5,32.5 0,17.93239 14.56761,32.5 32.5,32.5 17.93238,0 32.5,-14.56761 32.5,-32.5 0,-17.932385 -14.56762,-32.5 -32.5,-32.5 z"
+     id="path4655"
+     d="m 46.499597,104.5 v 7 h 9 v -7 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.335988;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.674419" />
+  <path
+     id="path4661"
+     d="m 27.999597,112.5 h 10"
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     style="opacity:0.2;fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 45.999597,112.5 h 10"
+     id="path4663" />
+  <rect
+     rx="0.5"
+     ry="0.5"
+     y="100"
+     x="31.999596"
+     height="1"
+     width="2"
+     id="rect4665"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     rx="0.5"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4667"
+     width="2"
+     height="1"
+     x="49.999599"
+     y="100"
+     ry="0.5" />
+  <rect
+     rx="0.5"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4669"
+     width="2"
+     height="1"
+     x="31.999596"
+     y="101"
+     ry="0.5" />
+  <rect
+     ry="0.5"
+     y="101"
+     x="49.999599"
+     height="1"
+     width="2"
+     id="rect4671"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="0.5" />
+  <path
+     d="m 88,56.5 c -17.93239,0 -32.5,14.567615 -32.5,32.5 0,17.93239 14.56761,32.5 32.5,32.5 17.93238,0 32.5,-14.56761 32.5,-32.5 0,-17.932385 -14.56762,-32.5 -32.5,-32.5 z"
      id="path2555-7-1"
-     style="color:#000000;fill:url(#radialGradient3125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3127);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3125);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3127);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 124.5,92.998872 C 124.5,110.39642 110.39593,124.5 93.0004,124.5 75.60328,124.5 61.5,110.39626 61.5,92.998872 c 0,-17.396721 14.10328,-31.498873 31.5004,-31.498873 17.39553,0 31.4996,14.102152 31.4996,31.498873 l 0,0 z"
+     d="M 119.5,88.998872 C 119.5,106.39642 105.39593,120.5 88.0004,120.5 70.60328,120.5 56.5,106.39626 56.5,88.998872 c 0,-17.396721 14.10328,-31.498873 31.5004,-31.498873 17.39553,0 31.4996,14.102152 31.4996,31.498873 z"
      id="path8655-6-6"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3122);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3122);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 78,94.999998 93,110.3 108,94.999998 z"
+     d="M 73,90.999998 88,106.3 103,90.999998 Z"
      id="rect3005-5-5"
-     style="color:#000000;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 90,75.999998 0,18 -12,0 15,15.300002 15,-15.300002 -12,0 0,-18 z"
+     d="m 85,71.999998 v 18 H 73 L 88,105.3 103,89.999998 H 91 v -18 z"
      id="rect3005-5"
-     style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/apps/16/ubiquity.svg
+++ b/elementary-xfce/apps/16/ubiquity.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="16"
    height="16"
-   id="svg3540">
+   id="svg3540"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview84"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.125"
+     inkscape:cx="-5.7627119"
+     inkscape:cy="11.615819"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3540" />
   <metadata
      id="metadata4201">
     <rdf:RDF>
@@ -23,229 +45,6 @@
   </metadata>
   <defs
      id="defs3542">
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient3296"
-       xlink:href="#linearGradient3772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3658536,0,0,0.3658536,17.609167,-0.7804871)" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3265"
-         style="stop-color:#dedbde;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3267"
-         style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3294"
-       xlink:href="#linearGradient3263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.4285752,-0.4285752,0,17.900088,-2.2858065)" />
-    <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
-       id="linearGradient3287"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.1767888,0,0,0.1767887,3.6957217,3.5802806)" />
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient3320"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient3318"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient3316"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient3314"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient3312"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient6036">
-      <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.50172"
-       y1="3.6100161"
-       x2="48.798885"
-       y2="54.698483"
-       id="linearGradient3278"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3283221,0,0,0.3283221,6.3406987e-3,-0.20805)" />
-    <linearGradient
-       id="linearGradient3519">
-      <stop
-         id="stop3521"
-         style="stop-color:#fcd9cd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3523"
-         style="stop-color:#fcd9cd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient3309"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3511">
-      <stop
-         id="stop3513"
-         style="stop-color:#ebeec7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3515"
-         style="stop-color:#ebeec7;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient3307"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3503">
-      <stop
-         id="stop3505"
-         style="stop-color:#c4ebdd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3507"
-         style="stop-color:#c4ebdd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient3305"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3495">
-      <stop
-         id="stop3497"
-         style="stop-color:#c1cbe4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3499"
-         style="stop-color:#c1cbe4;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient3303"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3487">
-      <stop
-         id="stop3489"
-         style="stop-color:#e6cde2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3491"
-         style="stop-color:#e6cde2;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient3301"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
       <stop
@@ -342,72 +141,157 @@
        x2="12"
        y2="6"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.163584,0,0,0.34628289,-12.263087,0.37367311)"
+       x1="118.57409"
+       y1="4.5651455"
+       x2="118.57409"
+       y2="30.817942" />
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28675946,0,0,0.27673617,3.098382,-0.65332472)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3-0"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14345115,0,0,0.17047815,-10.138461,19.022438)"
+       x1="116.7913"
+       y1="-35.32711"
+       x2="116.7913"
+       y2="-28.483252" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.09812192" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763-1"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33333333,0,0,0.33333333,-2.999999,25.333294)" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
   </defs>
-  <g
-     id="layer1">
-    <path
-       d="M 15.5,8 C 15.5,3.8428195 12.15718,0.50000048 7.9999993,0.50000048 C 3.8428184,0.50000048 0.49999991,3.8428198 0.49999991,8 C 0.49999911,12.15718 3.8428187,15.5 7.9999993,15.5 C 12.157179,15.499999 15.5,12.15718 15.5,8 z M 10.5,8 C 10.5,9.2939441 9.5060913,10.5 7.9999993,10.5 C 6.4939073,10.5 5.5,9.1934911 5.5,8 C 5.5,6.7729822 6.5349902,5.5 7.9999993,5.5 C 9.4985136,5.5 10.5,6.7056213 10.5,8 z"
-       id="path2781"
-       style="fill:url(#linearGradient3294);fill-rule:nonzero;stroke:url(#linearGradient3296);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
-    <path
-       d="M 7.9999996,4.5000011 C 6.0599997,4.5000011 4.5,6.0600007 4.5,8.0000005 C 4.5,9.9400002 6.0599997,11.5 7.9999996,11.5 C 9.9399998,11.5 11.5,9.9400002 11.5,8.0000005 C 11.5,6.0600007 9.9399998,4.5000011 7.9999996,4.5000011 L 7.9999996,4.5000011 L 7.9999996,4.5000011 L 7.9999996,4.5000011 z"
-       id="path3281"
-       style="opacity:0.8;fill:none;stroke:url(#linearGradient3287);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
-    <g
-       transform="matrix(0.3357395,0,0,0.3357395,-0.1714995,-0.3919651)"
-       id="g3527">
-      <path
-         d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
-         transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
-         id="path3296"
-         style="opacity:0.8;fill:url(#linearGradient3312);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
-         id="path3308"
-         style="opacity:0.8;fill:url(#linearGradient3314);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-         id="path3310"
-         style="opacity:0.8;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-         id="path3312"
-         style="opacity:0.8;fill:url(#linearGradient3318);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-         id="path3314"
-         style="opacity:0.8;fill:url(#linearGradient3320);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    </g>
-    <path
-       d="M 8.0000005,1.5000013 C 4.3971432,1.5000013 1.4999999,4.3971448 1.4999999,8.0000015 C 1.4999999,11.602858 4.3971432,14.500001 8.0000005,14.500001 C 11.602858,14.500001 14.500001,11.602858 14.500001,8.0000015 C 14.500001,4.3971448 11.602858,1.5000013 8.0000005,1.5000013 L 8.0000005,1.5000013 L 8.0000005,1.5000013 z"
-       id="path3272"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3278);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
-    <g
-       transform="matrix(-0.3507965,0,0,-0.3507965,16.408914,16.448702)"
-       id="g3297">
-      <path
-         d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
-         transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
-         id="path3299"
-         style="opacity:0.8;fill:url(#linearGradient3301);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
-         id="path3301"
-         style="opacity:0.8;fill:url(#linearGradient3303);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-         id="path3303"
-         style="opacity:0.8;fill:url(#linearGradient3305);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-         id="path3305"
-         style="opacity:0.8;fill:url(#linearGradient3307);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-         id="path3307"
-         style="opacity:0.8;fill:url(#linearGradient3309);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    </g>
-  </g>
+  <rect
+     x="2.500001"
+     y="10.499961"
+     width="5"
+     height="5"
+     ry="0.5"
+     rx="0.5"
+     style="fill:url(#linearGradient4763-1);fill-opacity:1;stroke:none;stroke-width:1"
+     id="rect3448-7-9" />
+  <rect
+     x="2.500001"
+     y="10.499961"
+     width="5"
+     height="5"
+     ry="0.5"
+     rx="0.5"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-opacity:1"
+     id="rect3448-9-2" />
+  <path
+     id="rect3450-0"
+     d="m 3.500001,12.49996 v -1 h 1 v 1 z m 2,0 v -1 h 1 v 1 z"
+     style="opacity:0.35;fill:#000000;fill-opacity:0.335988;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     x="3.500001"
+     y="12.5"
+     width="3"
+     height="2"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458-2" />
+  <rect
+     id="rect5391-3"
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999924;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="0.99999994"
+     ry="1"
+     height="12.000078"
+     width="7.0000782"
+     y="0.49996099"
+     x="1.499962" />
+  <rect
+     x="2.000001"
+     y="0.99996102"
+     width="6"
+     height="11"
+     rx="0.5"
+     style="fill:url(#linearGradient5466-8-3-0);fill-opacity:1;stroke:none;stroke-width:0.999918;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-5-7"
+     ry="0.5" />
+  <rect
+     x="2.500001"
+     y="1.499952"
+     width="5"
+     height="10"
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient3730-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2-0-5" />
   <path
      style="color:#000000;fill:url(#radialGradient3161);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3163);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
      id="path3364"

--- a/elementary-xfce/apps/22/ubiquity.svg
+++ b/elementary-xfce/apps/22/ubiquity.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="22"
    height="22"
-   id="svg2890">
+   id="svg2890"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview90"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="11.377991"
+     inkscape:cx="2.5927248"
+     inkscape:cy="12.831791"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="108"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2890" />
   <metadata
      id="metadata38397">
     <rdf:RDF>
@@ -18,65 +40,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs2892">
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3265"
-         style="stop-color:#dedbde;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3267"
-         style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6036">
-      <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient3519">
       <stop
@@ -193,96 +161,6 @@
          id="stop3762-8-4-8" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient6036"
-       id="linearGradient3258"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4820056,0,0,0.4820056,-0.73539134,-1.0501373)"
-       x1="10.50172"
-       y1="3.6100161"
-       x2="48.798885"
-       y2="54.698483" />
-    <linearGradient
-       xlink:href="#linearGradient6036"
-       id="linearGradient3267"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2272999,0,0,0.2272999,5.4659273,5.3175017)"
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208" />
-    <linearGradient
-       xlink:href="#linearGradient3428"
-       id="linearGradient3270"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4374999,0,0,0.4374999,0.50000036,0.50000024)"
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201" />
-    <linearGradient
-       xlink:href="#linearGradient3263"
-       id="linearGradient3274"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.6000053,-0.6000053,0,24.860125,-3.4001308)"
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033" />
-    <linearGradient
-       xlink:href="#linearGradient3772"
-       id="linearGradient3276"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5121951,0,0,0.5121951,24.452835,-1.2926834)"
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898" />
-    <linearGradient
-       xlink:href="#linearGradient3487"
-       id="linearGradient3281"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112" />
-    <linearGradient
-       xlink:href="#linearGradient3495"
-       id="linearGradient3283"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104" />
-    <linearGradient
-       xlink:href="#linearGradient3503"
-       id="linearGradient3285"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353" />
-    <linearGradient
-       xlink:href="#linearGradient3511"
-       id="linearGradient3287"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712" />
-    <linearGradient
-       xlink:href="#linearGradient3519"
-       id="linearGradient3289"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect"
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656" />
-    <linearGradient
        xlink:href="#linearGradient3487"
        id="linearGradient3313"
        gradientUnits="userSpaceOnUse"
@@ -364,52 +242,176 @@
        y1="15.85593"
        x2="7.8555918"
        y2="-0.12225635" />
+    <linearGradient
+       x1="22.553417"
+       y1="6.6305909"
+       x2="22.553417"
+       y2="41.943768"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21462027,0,0,0.39741647,5.2504798,-0.63796629)" />
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3-0"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47793243,0,0,0.40252535,2.8306345,-1.4047796)" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.33471938,0,0,0.59667354,-29.328651,2.3563865)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0.03140453"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.26516308,0,0,0.06026566,48.916692,28.466026)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
   </defs>
-  <path
-     style="fill:url(#linearGradient3274);fill-rule:nonzero;stroke:url(#linearGradient3276);stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1"
-     id="path2781"
-     d="M 21.5,11 C 21.5,5.1799464 16.820052,0.49999964 11,0.49999964 5.1799464,0.49999964 0.50000006,5.1799469 0.50000006,11 0.49999896,16.820053 5.1799469,21.5 11,21.5 c 5.820052,-1e-6 10.5,-4.679947 10.5,-10.5 z m -7,0 c 0,1.971062 -1.56998,3.5 -3.5,3.5 -1.971328,0 -3.5,-1.655022 -3.5,-3.5 0,-1.8862861 1.463791,-3.5000001 3.5,-3.5000001 2.077509,0 3.5,1.487665 3.5,3.5000001 z" />
-  <path
-     style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path2474"
-     d="m 11,7.0850999 c -2.1610248,0 -3.9149,1.7538752 -3.9149,3.9149001 0,2.161025 1.7538752,3.9149 3.9149,3.9149 2.161025,0 3.9149,-1.753875 3.9149,-3.9149 0,-2.1610249 -1.753875,-3.9149001 -3.9149,-3.9149001 z m 0,1.95745 c 1.080512,0 1.95745,0.876938 1.95745,1.9574501 0,1.080512 -0.876938,1.95745 -1.95745,1.95745 C 9.919488,12.95745 9.04255,12.080512 9.04255,11 9.04255,9.9194879 9.919488,9.0425499 11,9.0425499 z" />
-  <path
-     style="fill:none;stroke:url(#linearGradient3270);stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path3418"
-     d="m 11,7.5 c -1.932,0 -3.4999998,1.5679999 -3.4999998,3.5 0,1.932 1.5679998,3.5 3.4999998,3.5 1.932,0 3.5,-1.568 3.5,-3.5 0,-1.9320001 -1.568,-3.5 -3.5,-3.5 l 0,0 z m 0,1.7500009 c 0.966,0 1.75,0.7840001 1.75,1.7499991 0,0.966 -0.784,1.75 -1.75,1.75 -0.965999,0 -1.749999,-0.784 -1.749999,-1.75 0,-0.965999 0.784,-1.7499991 1.749999,-1.7499991 z" />
-  <path
-     style="opacity:0.8;fill:none;stroke:url(#linearGradient3267);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1"
-     id="path3281"
-     d="m 11,6.4999996 c -2.494286,0 -4.5000002,2.005714 -4.5000002,4.5000004 0,2.494285 2.0057142,4.5 4.5000002,4.5 2.494287,0 4.5,-2.005715 4.5,-4.5 0,-2.4942864 -2.005713,-4.5000004 -4.5,-4.5000004 l 0,0 0,0 0,0 z" />
   <g
-     id="g3527"
-     transform="matrix(0.4893625,0,0,0.4893625,-0.74470004,-0.74470006)">
+     id="g4579"
+     transform="translate(-49.104077,-10.339226)">
     <path
-       style="opacity:0.8;fill:url(#linearGradient3281);fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path3296"
-       transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
-       d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 l 10e-7,0 z" />
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3283);fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path3308"
-       d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 l 0,0 z" />
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3285);fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path3310"
-       d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z" />
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3287);fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path3312"
-       d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z" />
-    <path
-       style="opacity:0.8;fill:url(#linearGradient3289);fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="path3314"
-       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z" />
+       id="path23417"
+       style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+       d="m 61.104077,30.975341 a 6.0000001,1.3636364 0 1 1 -12,0 6.0000001,1.3636364 0 1 1 12,0 z" />
   </g>
+  <rect
+     x="1.4999998"
+     y="-21.5"
+     width="9"
+     height="9"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.302326"
+     id="rect3448" />
+  <g
+     id="g4576"
+     style="opacity:0.2;stroke-width:0.999997"
+     transform="translate(-6.0000002,-1)">
+    <rect
+       y="20"
+       x="9"
+       height="2"
+       width="2"
+       id="rect4570"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+       id="rect4572"
+       width="2"
+       height="2"
+       x="13"
+       y="20" />
+  </g>
+  <rect
+     x="2.4944272"
+     y="-20.472153"
+     width="7"
+     height="7"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
+  <rect
+     ry="0.47058824"
+     id="rect5391-5-7"
+     style="fill:url(#linearGradient5466-8-3-0);fill-opacity:1;stroke:none;stroke-width:0.999926;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="0.5"
+     height="16"
+     width="10"
+     y="1.0000001"
+     x="0.99999952" />
+  <rect
+     ry="0.94444466"
+     rx="1"
+     y="0.49996099"
+     x="0.49996051"
+     height="17.000078"
+     width="11.000078"
+     id="rect901"
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <rect
+     y="1.499961"
+     x="1.4999998"
+     height="15"
+     width="9"
+     id="rect901-3"
+     style="vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   <path
-     style="opacity:0.5;fill:none;stroke:url(#linearGradient3258);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
-     id="path3272"
-     d="m 11,1.4574316 c -5.2893093,0 -9.542569,4.25326 -9.542569,9.5425684 0,5.28931 4.2532597,9.542568 9.542569,9.542568 5.28931,0 9.542569,-4.253258 9.542569,-9.542568 C 20.542569,5.7106916 16.28931,1.4574316 11,1.4574316 l 0,0 0,0 z" />
+     d="m 4.8407228,15.425961 c 0,-0.812844 0.270159,-1.023722 0.601081,-1.307524 0.265666,-0.128245 0.308115,-0.215797 0.304622,-0.628246 -0.0038,-0.455788 -0.04748,-0.403723 -0.892257,-1.137052 C 3.5643339,11.233523 3.3908715,10.963529 3.2394258,9.8400312 3.1277126,9.0114062 3.2060696,9.6984202 2.8853867,9.3796832 2.2951365,8.7930346 2.3962616,7.9326767 3.0989188,7.5629073 3.7319229,7.229803 4.4817838,7.5840843 4.7130238,8.3255447 4.8269958,8.6909683 4.5537578,9.3220324 4.1868588,9.5407382 3.8511069,9.7408952 3.7118159,9.407192 3.7885949,10.144999 c 0.04249,0.408357 0.14605,0.373299 0.2301219,0.538935 0.144387,0.284464 1.5583,1.623587 1.712099,1.623587 V 5.9999146 h -0.783763 l 1.06712,-2.5039139 1.11847,2.5041685 h -0.76181 v 4.7546638 c 0.105957,0 1.129458,-1.0236788 1.478993,-1.4983141 0.151025,-0.2050753 0.242676,-0.4962648 0.242676,-0.7710368 0,-0.4144014 0.136657,-0.50154 -0.17942,-0.50154 H 7.5763378 V 6.0421279 H 9.4845545 V 7.9839421 H 9.1758725 C 8.9004443,8.0161921 8.7035843,8.1565775 8.6515893,8.6160753 8.5740393,9.3013354 8.2958478,9.7205022 7.2157418,10.809259 l -0.844915,0.911155 v 2.24934 l 0.249682,0.149014 c 0.169778,0.08196 0.403596,0.346791 0.519598,0.58852 0.412977,0.862221 -0.161626,1.788713 -1.109116,1.788713 -0.686597,-0.02546 -1.190568,-0.377978 -1.190568,-1.069028 z"
+     style="opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path3690-3" />
+  <path
+     d="m 4.8407228,14.425793 c 0,-0.812844 0.270159,-1.023722 0.601081,-1.307524 0.265666,-0.128245 0.308115,-0.215797 0.304622,-0.628246 -0.0038,-0.455788 -0.04748,-0.403723 -0.892257,-1.137052 C 3.5643339,10.233355 3.3908715,9.9633612 3.2394258,8.8398637 3.1277126,8.0112387 3.2060696,8.6982526 2.8853867,8.3795157 2.2951365,7.7928671 2.3962616,6.9325092 3.0989188,6.5627398 c 0.6330041,-0.3331043 1.382865,0.021177 1.614105,0.7626374 0.113972,0.3654236 -0.159266,0.9964877 -0.526165,1.2151934 -0.3357519,0.200157 -0.4750429,-0.1335461 -0.3982639,0.604262 0.04249,0.4083566 0.14605,0.3732976 0.2301219,0.5389336 0.144387,0.284464 1.5583,1.6235868 1.712099,1.6235868 V 4.9997471 h -0.783763 l 1.06712,-2.5039139 1.11847,2.5041685 h -0.76181 v 4.7546635 c 0.105957,0 1.129458,-1.023678 1.478993,-1.4983138 0.151025,-0.2050753 0.242676,-0.4962648 0.242676,-0.7710368 0,-0.4144014 0.136657,-0.50154 -0.17942,-0.50154 H 7.5763378 V 5.0419604 H 9.4845545 V 6.9837746 H 9.1758725 C 8.9004443,7.0160246 8.7035843,7.15641 8.6515893,7.6159078 8.5740393,8.3011679 8.2958478,8.720335 7.2157418,9.8090912 l -0.844915,0.9111548 v 2.24934 l 0.249682,0.149014 c 0.169778,0.08196 0.403596,0.346791 0.519598,0.58852 0.412977,0.862221 -0.161626,1.788713 -1.109116,1.788713 -0.686597,-0.02546 -1.190568,-0.377978 -1.190568,-1.069028 z"
+     style="opacity:0.95;fill:#969696;fill-opacity:1;stroke-width:0.636327"
+     id="path3690" />
   <g
      id="g3301"
      transform="translate(-21,0)">

--- a/elementary-xfce/apps/24/ubiquity.svg
+++ b/elementary-xfce/apps/24/ubiquity.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="24"
    height="24"
-   id="svg2890">
+   id="svg2890"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview95"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="12.949153"
+     inkscape:cy="11.661017"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="736"
+     inkscape:window-y="55"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2890" />
   <metadata
      id="metadata38397">
     <rdf:RDF>
@@ -23,270 +45,6 @@
   </metadata>
   <defs
      id="defs2892">
-    <linearGradient
-       id="linearGradient23419">
-      <stop
-         id="stop23421"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop23423"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.334524"
-       cy="41.63604"
-       r="22.627417"
-       fx="23.334524"
-       fy="41.63604"
-       id="radialGradient2888"
-       xlink:href="#linearGradient23419"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4861359,0,0,0.1546652,0.6562496,13.060353)" />
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient2885"
-       xlink:href="#linearGradient3772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5121951,0,0,0.5121951,25.452835,-0.2926833)" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3265"
-         style="stop-color:#dedbde;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3267"
-         style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient2883"
-       xlink:href="#linearGradient3263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.6000053,-0.6000053,0,25.860125,-2.4001307)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient2879"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4374999,0,0,0.4374999,1.5000004,1.5000003)" />
-    <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
-       id="linearGradient2876"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2272999,0,0,0.2272999,6.4659273,6.3175018)" />
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient2488"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient2486"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient2484"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient2482"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient2480"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient6036">
-      <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.50172"
-       y1="3.6100161"
-       x2="48.798885"
-       y2="54.698483"
-       id="linearGradient2867"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4820056,0,0,0.4820056,0.2646087,-5.013717e-2)" />
-    <linearGradient
-       id="linearGradient3519">
-      <stop
-         id="stop3521"
-         style="stop-color:#fcd9cd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3523"
-         style="stop-color:#fcd9cd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient2500"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3511">
-      <stop
-         id="stop3513"
-         style="stop-color:#ebeec7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3515"
-         style="stop-color:#ebeec7;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient2498"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3503">
-      <stop
-         id="stop3505"
-         style="stop-color:#c4ebdd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3507"
-         style="stop-color:#c4ebdd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient2496"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3495">
-      <stop
-         id="stop3497"
-         style="stop-color:#c1cbe4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3499"
-         style="stop-color:#c1cbe4;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient2494"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3487">
-      <stop
-         id="stop3489"
-         style="stop-color:#e6cde2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3491"
-         style="stop-color:#e6cde2;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient2492"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
     <linearGradient
        id="linearGradient3707-319-631-407-324-3-8">
       <stop
@@ -351,7 +109,7 @@
        xlink:href="#linearGradient3707-319-631-407-324-3-8-2"
        id="linearGradient3115"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(9,10.155436)"
+       gradientTransform="translate(8.0000001,10.155436)"
        x1="7.8555918"
        y1="15.85593"
        x2="7.8555918"
@@ -360,7 +118,7 @@
        xlink:href="#linearGradient4011"
        id="linearGradient3118"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.29729731,0,0,0.29729731,-4.3261833,9.4613611)"
+       gradientTransform="matrix(0.29729731,0,0,0.29729731,-5.3261832,9.4613611)"
        x1="71.204407"
        y1="6.2375584"
        x2="71.204407"
@@ -369,7 +127,7 @@
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
        id="radialGradient3121"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.77906898,-0.82416206,-1.4353423e-8,23.964014,4.8539399)"
+       gradientTransform="matrix(0,0.77906898,-0.82416206,-1.4353423e-8,22.964014,4.8539399)"
        cx="5.7800279"
        cy="8.4497671"
        fx="5.7800279"
@@ -379,103 +137,195 @@
        xlink:href="#linearGradient3707-319-631-407-324-3-8"
        id="linearGradient3123"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33336426,0,0,0.33336425,8.9992583,8.9992576)"
+       gradientTransform="matrix(0.33336426,0,0,0.33336425,7.9992584,8.9992576)"
        x1="24"
        y1="44"
        x2="24"
        y2="3.8990016" />
+    <linearGradient
+       x1="22.553417"
+       y1="6.6305909"
+       x2="22.553417"
+       y2="41.943768"
+       id="linearGradient4161-4"
+       xlink:href="#linearGradient4075"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.21462027,0,0,0.42391297,6.2504806,-0.78050729)" />
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         id="stop4077"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4079"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4081"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop4083"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3-0"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.47793243,0,0,0.42768318,3.8306353,-1.5550797)" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.33471938,0,0,0.59667354,-28.328651,0.35638599)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0.03140453"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.26516308,0,0,0.06026566,48.916692,28.466026)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421-3" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423-6" />
+    </radialGradient>
   </defs>
   <g
-     id="layer1">
+     id="g4579"
+     transform="translate(-48.104077,-8.3392265)">
     <path
-       d="M 23,19.499999 C 23.000566,21.432943 18.075533,23 12,23 C 5.924467,23 0.9994335,21.432943 1,19.499999 C 0.9994335,17.567056 5.924467,16 12,16 C 18.075533,16 23.000566,17.567056 23,19.499999 z"
        id="path23417"
-       style="opacity:0.3;fill:url(#radialGradient2888);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 22.5,12 C 22.5,6.1799465 17.820052,1.4999997 12,1.4999997 C 6.1799464,1.4999997 1.5000001,6.179947 1.5000001,12 C 1.499999,17.820053 6.1799469,22.5 12,22.5 C 17.820052,22.499999 22.5,17.820053 22.5,12 z M 15.5,12 C 15.5,13.971062 13.93002,15.5 12,15.5 C 10.028672,15.5 8.5,13.844978 8.5,12 C 8.5,10.113714 9.963791,8.5 12,8.5 C 14.077509,8.5 15.5,9.987665 15.5,12 z"
-       id="path2781"
-       style="fill:url(#linearGradient2883);fill-rule:nonzero;stroke:url(#linearGradient2885);stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1" />
-    <path
-       d="M 12,8.0851 C 9.8389752,8.0851 8.0851,9.8389752 8.0851,12 C 8.0851,14.161025 9.8389752,15.9149 12,15.9149 C 14.161025,15.9149 15.9149,14.161025 15.9149,12 C 15.9149,9.8389752 14.161025,8.0851 12,8.0851 z M 12,10.04255 C 13.080512,10.04255 13.95745,10.919488 13.95745,12 C 13.95745,13.080512 13.080512,13.95745 12,13.95745 C 10.919488,13.95745 10.04255,13.080512 10.04255,12 C 10.04255,10.919488 10.919488,10.04255 12,10.04255 z"
-       id="path2474"
-       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 12,8.5000001 C 10.068,8.5000001 8.5000002,10.068 8.5000002,12 C 8.5000002,13.932 10.068,15.5 12,15.5 C 13.932,15.5 15.5,13.932 15.5,12 C 15.5,10.068 13.932,8.5000001 12,8.5000001 L 12,8.5000001 z M 12,10.250001 C 12.966,10.250001 13.75,11.034001 13.75,12 C 13.75,12.966 12.966,13.75 12,13.75 C 11.034001,13.75 10.250001,12.966 10.250001,12 C 10.250001,11.034001 11.034001,10.250001 12,10.250001 z"
-       id="path3418"
-       style="fill:none;stroke:url(#linearGradient2879);stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:round;marker:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 12,7.4999997 C 9.505714,7.4999997 7.4999998,9.5057137 7.4999998,12 C 7.4999998,14.494285 9.505714,16.5 12,16.5 C 14.494287,16.5 16.5,14.494285 16.5,12 C 16.5,9.5057137 14.494287,7.4999997 12,7.4999997 L 12,7.4999997 L 12,7.4999997 L 12,7.4999997 z"
-       id="path3281"
-       style="opacity:0.8;fill:none;stroke:url(#linearGradient2876);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
-    <g
-       transform="matrix(0.4893625,0,0,0.4893625,0.2553,0.2553)"
-       id="g3527">
-      <path
-         d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
-         transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
-         id="path3296"
-         style="opacity:0.8;fill:url(#linearGradient2480);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
-         id="path3308"
-         style="opacity:0.8;fill:url(#linearGradient2482);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-         id="path3310"
-         style="opacity:0.8;fill:url(#linearGradient2484);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-         id="path3312"
-         style="opacity:0.8;fill:url(#linearGradient2486);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-         id="path3314"
-         style="opacity:0.8;fill:url(#linearGradient2488);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    </g>
-    <path
-       d="M 12,2.4574317 C 6.7106907,2.4574317 2.457431,6.7106917 2.457431,12 C 2.457431,17.28931 6.7106907,21.542568 12,21.542568 C 17.28931,21.542568 21.542569,17.28931 21.542569,12 C 21.542569,6.7106917 17.28931,2.4574317 12,2.4574317 L 12,2.4574317 L 12,2.4574317 z"
-       id="path3272"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2867);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
-    <g
-       transform="matrix(-0.4893625,0,0,-0.4893625,23.7447,23.740214)"
-       id="g3297">
-      <path
-         d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
-         transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
-         id="path3299"
-         style="opacity:0.8;fill:url(#linearGradient2492);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
-         id="path3301"
-         style="opacity:0.8;fill:url(#linearGradient2494);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-         id="path3303"
-         style="opacity:0.8;fill:url(#linearGradient2496);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-         id="path3305"
-         style="opacity:0.8;fill:url(#linearGradient2498);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-         id="path3307"
-         style="opacity:0.8;fill:url(#linearGradient2500);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    </g>
+       style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+       d="m 61.104077,30.975341 a 6.0000001,1.3636364 0 1 1 -12,0 6.0000001,1.3636364 0 1 1 12,0 z" />
   </g>
+  <rect
+     x="2.5"
+     y="-23.500002"
+     width="9"
+     height="9"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.302326"
+     id="rect3448" />
+  <g
+     id="g4576"
+     style="opacity:0.2"
+     transform="translate(-4.9999994)">
+    <rect
+       y="20"
+       x="9"
+       height="2"
+       width="2"
+       id="rect4570"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
+    <rect
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+       id="rect4572"
+       width="2"
+       height="2"
+       x="13"
+       y="20" />
+  </g>
+  <rect
+     x="3.4944277"
+     y="-22.472155"
+     width="7"
+     height="7"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
+  <rect
+     ry="0.5"
+     id="rect5391-5-7"
+     style="fill:url(#linearGradient5466-8-3-0);fill-opacity:1;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="0.5"
+     height="17"
+     width="10"
+     y="0.99999887"
+     x="2" />
+  <rect
+     ry="1"
+     rx="1"
+     y="0.49995977"
+     x="1.499961"
+     height="18.000078"
+     width="11.000078"
+     id="rect901"
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <rect
+     y="1.4999597"
+     x="2.5"
+     height="16.000078"
+     width="9"
+     id="rect901-3"
+     style="vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   <path
-     d="M 17.000001,10.5 C 13.413525,10.5 10.5,13.413524 10.5,17 c 0,3.586476 2.913525,6.500001 6.500001,6.5 3.586474,0 6.500003,-2.913524 6.499999,-6.5 0,-3.586476 -2.913525,-6.5 -6.499999,-6.5 z"
+     d="m 5.8407236,15.425961 c 0,-0.812845 0.270159,-1.023723 0.601081,-1.307525 0.265666,-0.128245 0.308115,-0.215797 0.304622,-0.628246 -0.0038,-0.455788 -0.04748,-0.403723 -0.892257,-1.137052 C 4.5643347,11.233522 4.3908723,10.963528 4.2394266,9.8400298 4.1277134,9.0114048 4.2060704,9.6984187 3.8853875,9.3796818 3.2951373,8.7930332 3.3962624,7.9326753 4.0989196,7.5629059 4.7319237,7.2298016 5.4817846,7.5840829 5.7130246,8.3255433 5.8269966,8.6909669 5.5537586,9.322031 5.1868596,9.5407367 4.8511077,9.7408937 4.7118167,9.4071906 4.7885957,10.144998 c 0.04249,0.408357 0.14605,0.373299 0.2301219,0.538935 0.144387,0.284464 1.5583,1.623587 1.712099,1.623587 V 5.9999132 h -0.783763 l 1.0671196,-2.5039139 1.11847,2.5041685 h -0.76181 v 4.7546642 c 0.105957,0 1.129458,-1.0236787 1.478993,-1.4983145 0.1510249,-0.2050753 0.2426759,-0.4962648 0.2426759,-0.7710368 0,-0.4144014 0.136657,-0.50154 -0.1794199,-0.50154 H 8.5763382 V 6.0421265 H 10.484554 V 7.9839407 H 10.175873 C 9.9004451,8.0161907 9.7035851,8.1565761 9.6515901,8.6160739 9.5740401,9.301334 9.2958481,9.7205011 8.2157422,10.809258 l -0.844915,0.911155 v 2.24934 l 0.249682,0.149014 c 0.169778,0.08196 0.403596,0.346791 0.519598,0.58852 0.412977,0.862222 -0.161626,1.788714 -1.109116,1.788714 -0.6865966,-0.02546 -1.1905676,-0.377978 -1.1905676,-1.069028 z"
+     style="opacity:0.3;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path3690-3" />
+  <path
+     d="m 5.8407236,14.425792 c 0,-0.812844 0.270159,-1.023722 0.601081,-1.307524 0.265666,-0.128245 0.308115,-0.215797 0.304622,-0.628246 -0.0038,-0.455788 -0.04748,-0.403723 -0.892257,-1.137052 C 4.5643347,10.233354 4.3908723,9.9633603 4.2394266,8.8398623 4.1277134,8.0112373 4.2060704,8.6982512 3.8853875,8.3795143 3.2951373,7.7928657 3.3962624,6.9325078 4.0989196,6.5627384 c 0.6330041,-0.3331043 1.382865,0.021177 1.614105,0.7626374 0.113972,0.3654236 -0.159266,0.9964877 -0.526165,1.2151934 -0.3357519,0.200157 -0.4750429,-0.1335461 -0.3982639,0.604262 0.04249,0.408357 0.14605,0.3732981 0.2301219,0.5389341 0.144387,0.284464 1.5583,1.6235867 1.712099,1.6235867 V 4.9997457 h -0.783763 l 1.0671196,-2.5039139 1.11847,2.5041685 h -0.76181 v 4.754664 c 0.105957,0 1.129458,-1.0236785 1.478993,-1.4983143 0.1510249,-0.2050753 0.2426759,-0.4962648 0.2426759,-0.7710368 0,-0.4144014 0.136657,-0.50154 -0.1794199,-0.50154 H 8.5763382 V 5.041959 H 10.484554 V 6.9837732 H 10.175873 C 9.9004451,7.0160232 9.7035851,7.1564086 9.6515901,7.6159064 9.5740401,8.3011665 9.2958481,8.7203336 8.2157422,9.8090903 l -0.844915,0.9111547 v 2.24934 l 0.249682,0.149014 c 0.169778,0.08196 0.403596,0.346791 0.519598,0.58852 0.412977,0.862221 -0.161626,1.788714 -1.109116,1.788714 -0.6865966,-0.02546 -1.1905676,-0.377978 -1.1905676,-1.069029 z"
+     style="opacity:0.95;fill:#969696;fill-opacity:1;stroke-width:0.636327"
+     id="path3690" />
+  <path
+     d="m 16.000001,10.5 c -3.586476,0 -6.5000009,2.913524 -6.5000009,6.5 0,3.586476 2.9135249,6.500001 6.5000009,6.5 3.586474,0 6.500003,-2.913524 6.499999,-6.5 0,-3.586476 -2.913525,-6.5 -6.499999,-6.5 z"
      id="path2555-7"
-     style="color:#000000;fill:url(#radialGradient3121);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3123);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3121);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3123);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 22.5,16.999804 C 22.5,20.03747 20.037384,22.5 17.000069,22.5 13.962476,22.5 11.5,20.037441 11.5,16.999804 11.5,13.962282 13.962476,11.5 17.000069,11.5 20.037384,11.5 22.5,13.962282 22.5,16.999804 l 0,0 z"
+     d="M 21.5,16.999804 C 21.5,20.03747 19.037384,22.5 16.000069,22.5 12.962476,22.5 10.5,20.037441 10.5,16.999804 10.5,13.962282 12.962476,11.5 16.000069,11.5 19.037384,11.5 21.5,13.962282 21.5,16.999804 Z"
      id="path8655-6"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3118);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3118);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 16,14 0,4 -3,0 4,4 4,-4 -3,0 0,-4 z"
+     d="m 15,14 v 4 h -3 l 4,4 4,-4 h -3 v -4 z"
      id="rect3005-8"
-     style="color:#000000;fill:url(#linearGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   <path
-     d="m 16,13 0,4 -3,0 4,4 4,-4 -3,0 0,-4 z"
+     d="m 15,13 v 4 h -3 l 4,4 4,-4 h -3 v -4 z"
      id="rect3005"
-     style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/apps/32/ubiquity.svg
+++ b/elementary-xfce/apps/32/ubiquity.svg
@@ -1,300 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg4106">
+   id="svg4106"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview102"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="22.125"
+     inkscape:cx="12.542373"
+     inkscape:cy="14.734463"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="542"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4106" />
   <defs
      id="defs4108">
-    <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
-       id="linearGradient3406"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3283222,0,0,-0.3283221,8.0063392,24.208052)" />
-    <linearGradient
-       id="linearGradient6036">
-      <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3199"
-       xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.67567564,0,0,0.67567564,-32.468594,-1.1332689)" />
-    <linearGradient
-       id="linearGradient4011">
-      <stop
-         id="stop4013"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
-      <stop
-         id="stop4017"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
-      <stop
-         id="stop4019"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient3427"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6875,0,0,0.6875,-0.5000014,-0.5000005)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.018932"
-       y1="3"
-       x2="20.018932"
-       y2="45.17627"
-       id="linearGradient3409"
-       xlink:href="#linearGradient3772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6585366,0,0,0.6585366,0.195122,0.195122)" />
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient3436"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3487">
-      <stop
-         id="stop3489"
-         style="stop-color:#e6cde2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3491"
-         style="stop-color:#e6cde2;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient3438"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3495">
-      <stop
-         id="stop3497"
-         style="stop-color:#c1cbe4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3499"
-         style="stop-color:#c1cbe4;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient3440"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3503">
-      <stop
-         id="stop3505"
-         style="stop-color:#c4ebdd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3507"
-         style="stop-color:#c4ebdd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient3442"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3511">
-      <stop
-         id="stop3513"
-         style="stop-color:#ebeec7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3515"
-         style="stop-color:#ebeec7;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient3444"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3519">
-      <stop
-         id="stop3521"
-         style="stop-color:#fcd9cd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3523"
-         style="stop-color:#fcd9cd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient3446"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient3448"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient3450"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient3452"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient3454"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3431"
-       xlink:href="#linearGradient3263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.7714354,-0.7714354,0,33.82016,-2.5144531)" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3265"
-         style="stop-color:#dedbde;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3267"
-         style="stop-color:#e6e6e6;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient23419">
-      <stop
-         id="stop23421"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop23423"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.334524"
-       cy="41.63604"
-       r="22.627417"
-       fx="23.334524"
-       fy="41.63604"
-       id="radialGradient4104"
-       xlink:href="#linearGradient23419"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.61871843,0,0,0.19951815,1.5624994,18.177856)" />
     <linearGradient
        x1="24"
        y1="44"
@@ -392,6 +131,97 @@
        xlink:href="#linearGradient3707-319-631-407-324-3-8-2"
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(0,1.155436)" />
+    <linearGradient
+       gradientTransform="matrix(0.26232885,0,0,0.42474288,12.083588,5.1837041)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4075"
+       id="linearGradient4161-4"
+       y2="41.946075"
+       x2="11.11739"
+       y1="-7.4956021"
+       x1="11.11739" />
+    <linearGradient
+       id="linearGradient4075">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4077" />
+      <stop
+         offset="0.03367912"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4079" />
+      <stop
+         offset="0.99223143"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4081" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4083" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-5.0000001)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.996155"
+       x2="16.875002"
+       y1="0"
+       x1="17"
+       id="linearGradient4616"
+       xlink:href="#linearGradient3600-8" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.43035349,0,0,0.7671517,-35.42096,-0.12117437)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         id="stop4606"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4608"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03140453" />
+      <stop
+         id="stop4610"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop4612"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374-3"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.39774462,0,0,0.0903985,0.7189239,26.190573)"
+       r="22.627001">
+      <stop
+         id="stop23421-6"
+         offset="0" />
+      <stop
+         id="stop23423-7"
+         style="stop-opacity:0"
+         offset="1" />
+    </radialGradient>
   </defs>
   <metadata
      id="metadata4111">
@@ -401,110 +231,82 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374-3);fill-rule:evenodd;stroke-width:1"
+     d="m 19,29.954546 c 0,2.727271 -18,2.727271 -18,0 0,-2.727271 18,-2.727271 18,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.302326"
+     transform="scale(1,-1)"
+     rx="1"
+     ry="1"
+     height="11"
+     width="11"
+     y="-30.5"
+     x="4.5" />
+  <path
+     style="opacity:0.4;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4"
+     d="m 6.9999999,27 v 2 H 9 V 27 Z M 11,27 v 2 h 2 V 27 Z M 7.4999999,27.5 H 8.5 v 1 H 7.4999999 Z M 11.5,27.5 h 1 v 1 h -1 z"
+     id="rect4570" />
+  <rect
+     id="rect3458"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="9"
+     width="9"
+     y="-29.472153"
+     x="5.4944277" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4616);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-opacity:0.265116;marker:none;enable-background:accumulate"
+     id="rect2990"
+     d="M 2.4999999,2.0000004 2.5113079,23.5 c -0.033435,1.036496 0.9417175,0.991663 0.9417175,0.991663 H 16.352955 C 17.422887,24.525103 17.488695,23.5 17.488695,23.5 l 0.01131,-21.4999996 c 0,0 -0.01961,-1.50000003 -1.5,-1.50000003 H 3.9999999 c -0.8333333,0 -1.5004383,0.66666683 -1.5,1.50000003 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient4161-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path4034"
+     d="m 3.9999999,1.4687504 c 0,0 -0.5258824,0.039485 -0.5,0.53125 V 23.5 H 16.5 V 2.0000004 C 16.47393,1.4516682 16,1.4687504 16,1.4687504 Z" />
+  <path
+     d="m 8.482844,21.17785 c 0,-1.045085 0.347347,-1.316215 0.772817,-1.681103 C 9.597233,19.331861 9.65181,19.219293 9.647319,18.689003 9.642419,18.102991 9.586269,18.16993 8.500131,17.227079 6.8417729,15.787573 6.6187489,15.440438 6.4240339,13.995941 c -0.143632,-1.065375 -0.04289,-0.83098 -0.455194,-1.240783 -0.758893,-0.754263 -0.628875,-1.860432 0.274541,-2.335847 0.813864,-0.4282766 1.7779701,0.02723 2.0752791,0.980526 0.146537,0.46983 -0.20477,1.281198 -0.6764981,1.562391 -0.431681,0.257344 -0.610771,-0.171702 -0.512054,0.776908 0.05464,0.52503 0.187778,1.128862 0.295869,1.341822 0.185643,0.365739 2.0035301,2.087469 2.2012731,2.087469 V 6.6722428 H 8.619554 C 9.085891,5.8639263 9.539955,5.0421923 9.991565,4.228476 L 11.4296,6.6725701 H 10.45013 V 13.8864 c 0.136226,0 1.471823,-1.355485 1.921223,-1.965731 0.194177,-0.263668 0.312012,-0.638055 0.312012,-0.991329 0,-0.532798 0.175703,-0.644833 -0.230681,-0.644833 H 12.019728 V 7.7878886 h 2.45342 v 2.4966184 h -0.396876 c -0.354121,0.04146 -0.607227,0.221959 -0.674078,0.812735 -0.0997,0.881048 -0.477046,1.459305 -1.865755,2.859133 l -1.086318,1.171487 v 4.177721 l 0.32102,0.19159 c 0.218286,0.105375 0.518909,0.445875 0.668055,0.756668 0.53097,1.108572 -0.207806,2.299775 -1.426007,2.299775 C 9.130422,22.520896 8.48246,22.067644 8.48246,21.17915 Z"
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke-width:1"
+     id="path4625" />
+  <path
+     id="path3690"
+     style="fill:#aaaaaa;stroke-width:1"
+     d="m 8.482844,20.17785 c 0,-1.045085 0.347347,-1.316215 0.772817,-1.681103 C 9.597233,18.331861 9.65181,18.219293 9.647319,17.689003 9.642419,17.102991 9.586269,17.16993 8.500131,16.227079 6.8417729,14.787573 6.6187489,14.440438 6.4240339,12.995941 6.2804019,11.930566 6.3811439,12.164961 5.9688399,11.755158 5.2099469,11.000895 5.3399649,9.8947264 6.2433809,9.4193114 7.0572449,8.991034 8.021351,9.4465414 8.31866,10.399837 c 0.146537,0.46983 -0.20477,1.281198 -0.6764981,1.562391 -0.431681,0.257344 -0.610771,-0.171702 -0.512054,0.776908 0.05464,0.52503 0.187778,1.128862 0.295869,1.341822 0.185643,0.365739 2.0035301,2.087469 2.2012731,2.087469 V 5.6722428 H 8.619554 C 9.085891,4.8639263 9.539955,4.0421923 9.991565,3.228476 L 11.4296,5.6725701 H 10.45013 V 12.8864 c 0.136226,0 1.471823,-1.355485 1.921223,-1.965731 0.194177,-0.263668 0.312012,-0.638055 0.312012,-0.9913286 0,-0.532798 0.175703,-0.644833 -0.230681,-0.644833 H 12.019728 V 6.7878886 h 2.45342 v 2.4966188 h -0.396876 c -0.354121,0.04146 -0.607227,0.221959 -0.674078,0.8127346 -0.0997,0.881048 -0.477046,1.459305 -1.865755,2.859133 l -1.086318,1.171487 v 4.177721 l 0.32102,0.19159 c 0.218286,0.105375 0.518909,0.445875 0.668055,0.756668 0.53097,1.108572 -0.207806,2.299775 -1.426007,2.299775 C 9.130422,21.520896 8.48246,21.067644 8.48246,20.17915 Z" />
   <g
-     id="layer1">
+     id="g4622"
+     style="opacity:0.2"
+     transform="translate(-2.0000001,7.0000004)">
     <path
-       d="M 30,26.484999 C 30.000722,28.978497 23.732497,31 16,31 8.2675033,31 1.999279,28.978497 2.0000001,26.484999 1.999279,23.991503 8.2675033,21.97 16,21.97 c 7.732497,0 14.000722,2.021503 14,4.514999 z"
-       id="path23417"
-       style="opacity:0.3;fill:url(#radialGradient4104);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 29.5,16 C 29.5,8.5170745 23.482924,2.5 16,2.5 8.5170738,2.5 2.5,8.5170751 2.5,16 c -1.3e-6,7.482925 6.0170745,13.5 13.5,13.5 7.482924,-1e-6 13.5,-6.017074 13.5,-13.5 z m -8.231707,0 c 0,3.044415 -2.223878,5.268293 -5.268293,5.268293 -3.044414,0 -5.268293,-2.223878 -5.268293,-5.268293 0,-3.044414 2.223879,-5.268293 5.268293,-5.268293 3.044415,0 5.268293,2.223879 5.268293,5.268293 z"
-       id="path2781"
-       style="fill:url(#linearGradient3431);fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 16,10.731707 c -2.908097,0 -5.268293,2.360196 -5.268293,5.268293 0,2.908098 2.360196,5.268293 5.268293,5.268293 2.908098,0 5.268293,-2.360195 5.268293,-5.268293 0,-2.908097 -2.360195,-5.268293 -5.268293,-5.268293 z m 0,2.634147 c 1.454049,0 2.634147,1.180098 2.634147,2.634146 0,1.454049 -1.180098,2.634147 -2.634147,2.634147 -1.454048,0 -2.634146,-1.180098 -2.634146,-2.634147 0,-1.454048 1.180098,-2.634146 2.634146,-2.634146 z"
-       id="path2474"
-       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <g
-       transform="matrix(0.6585366,0,0,0.6585366,0.195122,0.195122)"
-       id="g3527">
-      <path
-         d="m 24,3.5 c -2.975804,0 -5.797406,0.6208152 -8.34375,1.75 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 l 0,-12.125 C 24.06248,3.4998614 24.0313,3.5 24,3.5 z"
-         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
-         id="path3296"
-         style="opacity:0.8;fill:url(#linearGradient3446);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="m 19.597283,3.9975155 c -2.9067,0.6375811 -5.529765,1.8485223 -7.775043,3.4970525 l 7.230257,9.771547 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.688856,3.9774292 c -0.03058,0.00656 -0.061,0.013379 -0.09157,0.020086 z"
-         id="path3308"
-         style="opacity:0.8;fill:url(#linearGradient3448);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 14.558173,5.8448691 C 11.915535,7.2130345 9.6952631,9.061613 7.9531621,11.235092 l 9.5129549,7.567261 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.641427,5.8017664 c -0.02783,0.014254 -0.05545,0.02871 -0.08325,0.043103 z"
-         id="path3310"
-         style="opacity:0.8;fill:url(#linearGradient3450);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 10.168897,8.9334932 C 7.970412,10.939005 6.3042413,13.299243 5.1840387,15.849551 L 16.331399,20.69683 c 0.455898,-1.036579 1.119019,-1.993675 2.009011,-2.805547 0.02369,-0.02161 0.0454,-0.0419 0.06926,-0.06318 L 10.238158,8.8703115 c -0.0232,0.020972 -0.04613,0.042084 -0.06926,0.063182 z"
-         id="path3312"
-         style="opacity:0.8;fill:url(#linearGradient3452);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="m 6.78125,12.96875 c -0.016978,0.02626 -0.045621,0.06739 -0.0625,0.09375 -1.1482224,1.793482 -1.9616625,3.681269 -2.5,5.625 l 11.75,3.125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 6.78125,12.96875 z"
-         id="path3314"
-         style="opacity:0.8;fill:url(#linearGradient3454);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    </g>
-    <g
-       transform="matrix(-0.6585366,0,0,-0.6585366,31.804879,31.804879)"
-       id="g3642"
-       style="opacity:0.8">
-      <path
-         d="m 24,3.5 c -2.975804,0 -5.797406,0.6208152 -8.34375,1.75 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 l 0,-12.125 C 24.06248,3.4998614 24.0313,3.5 24,3.5 z"
-         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
-         id="path3644"
-         style="opacity:0.8;fill:url(#linearGradient3436);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="m 19.597283,3.9975155 c -2.9067,0.6375811 -5.529765,1.8485223 -7.775043,3.4970525 l 7.230257,9.771547 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.688856,3.9774292 c -0.03058,0.00656 -0.061,0.013379 -0.09157,0.020086 z"
-         id="path3646"
-         style="opacity:0.8;fill:url(#linearGradient3438);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 14.558173,5.8448691 C 11.915535,7.2130345 9.6952631,9.061613 7.9531621,11.235092 l 9.5129549,7.567261 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.641427,5.8017664 c -0.02783,0.014254 -0.05545,0.02871 -0.08325,0.043103 z"
-         id="path3648"
-         style="opacity:0.8;fill:url(#linearGradient3440);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="M 10.168897,8.9334932 C 7.970412,10.939005 6.3042413,13.299243 5.1840387,15.849551 L 16.331399,20.69683 c 0.455898,-1.036579 1.119019,-1.993675 2.009011,-2.805547 0.02369,-0.02161 0.0454,-0.0419 0.06926,-0.06318 L 10.238158,8.8703115 c -0.0232,0.020972 -0.04613,0.042084 -0.06926,0.063182 z"
-         id="path3650"
-         style="opacity:0.8;fill:url(#linearGradient3442);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      <path
-         d="m 6.78125,12.96875 c -0.016978,0.02626 -0.045621,0.06739 -0.0625,0.09375 -1.1482224,1.793482 -1.9616625,3.681269 -2.5,5.625 l 11.75,3.125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 6.78125,12.96875 z"
-         id="path3652"
-         style="opacity:0.8;fill:url(#linearGradient3444);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    </g>
-    <path
-       d="M 16,2.5 C 8.5170743,2.5 2.5,8.5170756 2.5,16 2.5,23.482926 8.517075,29.5 16,29.5 23.482925,29.5 29.499999,23.482926 29.499999,16 29.499998,8.5170763 23.482926,2.5 16,2.5 z"
-       id="path3287"
-       style="fill:none;stroke:url(#linearGradient3409);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
-    <path
-       d="M 15.999999,10.5 C 12.964,10.5 10.5,12.964001 10.5,16 c 0,3.036 2.464,5.5 5.499999,5.5 3.036,0 5.5,-2.464 5.5,-5.5 0,-3.035999 -2.464,-5.5 -5.5,-5.5 z m 0,2.75 c 1.518001,0 2.75,1.232001 2.75,2.75 0,1.518001 -1.231999,2.75 -2.75,2.75 -1.517999,0 -2.75,-1.231999 -2.75,-2.75 0,-1.517999 1.232001,-2.75 2.75,-2.75 z"
-       id="path3418"
-       style="fill:none;stroke:url(#linearGradient3427);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 28.5,15.999557 C 28.5,22.903339 22.903147,28.5 16.000158,28.5 9.096537,28.5 3.5,22.903276 3.5,15.999557 3.5,9.0960941 9.096537,3.5000011 16.000158,3.5000011 22.903147,3.5000011 28.5,9.0960941 28.5,15.999557 l 0,0 z"
-       id="path8655"
-       style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3199);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="M 15.999999,22.5 C 12.397142,22.5 9.5,19.602858 9.5,16.000001 c 0,-3.602858 2.897142,-6.5000015 6.499999,-6.5000015 3.60286,0 6.5,2.8971435 6.5,6.5000015 0,3.602857 -2.89714,6.499999 -6.5,6.499999 l 0,0 0,0 z"
-       id="path3281"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3406);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1" />
+       id="rect4618"
+       d="m 9.5,20.5 v 1 h 1 v -1 z m 4,0 v 1 h 1 v -1 z"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.4" />
   </g>
+  <path
+     id="path4666"
+     d="M 4.9999999,25 H 15"
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <g
-     transform="translate(16,16)"
+     transform="translate(15,16)"
      id="layer1-5">
     <path
-       d="m 8.000001,0.49999997 c -4.138241,0 -7.50000103,3.36175853 -7.50000103,7.49999993 C 0.49999997,12.138242 3.86176,15.500001 8.000001,15.5 12.13824,15.5 15.500004,12.138242 15.5,7.9999999 15.5,3.8617585 12.13824,0.49999997 8.000001,0.49999997 z"
+       d="m 8.000001,0.49999997 c -4.138241,0 -7.50000103,3.36175853 -7.50000103,7.49999993 C 0.49999997,12.138242 3.86176,15.500001 8.000001,15.5 12.13824,15.5 15.500004,12.138242 15.5,7.9999999 15.5,3.8617585 12.13824,0.49999997 8.000001,0.49999997 Z"
        id="path2555-7"
-       style="color:#000000;fill:url(#radialGradient3119);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3121);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3119);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3121);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 14.5,7.999769 C 14.5,11.589737 11.589636,14.5 8.0000824,14.5 4.4101993,14.5 1.5,11.589703 1.5,7.999769 1.5,4.4099697 4.4101993,1.5000003 8.0000824,1.5000003 11.589636,1.5000003 14.5,4.4099697 14.5,7.999769 l 0,0 z"
+       d="M 14.5,7.999769 C 14.5,11.589737 11.589636,14.5 8.0000824,14.5 4.4101993,14.5 1.5,11.589703 1.5,7.999769 1.5,4.4099697 4.4101993,1.5000003 8.0000824,1.5000003 11.589636,1.5000003 14.5,4.4099697 14.5,7.999769 Z"
        id="path8655-6"
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3071);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3071);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 7,5 7,9 4,9 8,13 12,9 9,9 9,5 z"
+       d="M 7,5 V 9 H 4 l 4,4 4,-4 H 9 V 5 Z"
        id="rect3005-8"
-       style="color:#000000;fill:url(#linearGradient4037-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4037-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 7,4 7,8 4,8 8,12 12,8 9,8 9,4 z"
+       d="M 7,4 V 8 H 4 l 4,4 4,-4 H 9 V 4 Z"
        id="rect3005"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   </g>
 </svg>

--- a/elementary-xfce/apps/48/ubiquity.svg
+++ b/elementary-xfce/apps/48/ubiquity.svg
@@ -1,260 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg4033">
+   id="svg4033"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview94"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.85965"
+     inkscape:cx="18.240958"
+     inkscape:cy="19.127838"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="449"
+     inkscape:window-y="59"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4033" />
   <defs
      id="defs4035">
-    <linearGradient
-       id="linearGradient6036">
-      <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4011">
-      <stop
-         id="stop4013"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4015"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
-      <stop
-         id="stop4017"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
-      <stop
-         id="stop4019"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient3311"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3487">
-      <stop
-         id="stop3489"
-         style="stop-color:#e6cde2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3491"
-         style="stop-color:#e6cde2;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient3313"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3495">
-      <stop
-         id="stop3497"
-         style="stop-color:#c1cbe4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3499"
-         style="stop-color:#c1cbe4;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient3315"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3503">
-      <stop
-         id="stop3505"
-         style="stop-color:#c4ebdd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3507"
-         style="stop-color:#c4ebdd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient3317"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3511">
-      <stop
-         id="stop3513"
-         style="stop-color:#ebeec7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3515"
-         style="stop-color:#ebeec7;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient3319"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3519">
-      <stop
-         id="stop3521"
-         style="stop-color:#fcd9cd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3523"
-         style="stop-color:#fcd9cd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient3346"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient3348"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient3350"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient3352"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient3354"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263"
-       gradientUnits="userSpaceOnUse">
-      <stop
-         id="stop3265"
-         style="stop-color:#dedcde;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3267"
-         style="stop-color:#f0f0f0;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient23419">
-      <stop
-         id="stop23421"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop23423"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
-       id="linearGradient3054"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4293444,0,0,-0.4293442,13.546752,34.733607)" />
-    <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3057"
-       xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611003,-2.7278988)" />
-    <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3076"
-       xlink:href="#linearGradient3263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1714389,-1.1714389,0,51.060244,-4.11454)" />
-    <radialGradient
-       cx="23.334524"
-       cy="41.63604"
-       r="22.627417"
-       fx="23.334524"
-       fy="41.63604"
-       id="radialGradient3081"
-       xlink:href="#linearGradient23419"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9722718,0,0,0.2872354,1.3124992,27.540524)" />
     <radialGradient
        cx="62.625"
        cy="4.625"
@@ -353,6 +132,117 @@
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
+    <linearGradient
+       y2="31.67935"
+       x2="118.57409"
+       y1="3.7037382"
+       x1="118.57409"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-49.600004,-1.1041808)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3730"
+       xlink:href="#linearGradient3742" />
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         id="stop3734"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.01900466" />
+      <stop
+         id="stop3738"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop3740"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.95586485,0,0,0.83020854,9.661268,-2.9598958)" />
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.80846"
+       x1="116.7913"
+       gradientTransform="matrix(0.62162171,0,0,1.108108,-49.600004,-1.1041032)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-44.395805"
+       x2="25"
+       y1="-35"
+       x1="25"
+       id="linearGradient4763"
+       xlink:href="#linearGradient7056"
+       gradientTransform="translate(-8,3.8794814e-5)" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.48613231,0,0,0.11048705,4.656462,39.898148)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421-3" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423-6" />
+    </radialGradient>
   </defs>
   <metadata
      id="metadata4038">
@@ -362,109 +252,104 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 46,39.499867 c 0.0011,3.589753 -9.848934,6.500001 -22,6.500001 -12.151066,0 -22.001133,-2.910248 -21.9999999,-6.500001 C 1.998867,35.910116 11.848934,32.999868 24,32.999868 c 12.151066,0 22.001133,2.910248 22,6.499999 l 0,0 z"
-     id="path23417"
-     style="opacity:0.3;fill:url(#radialGradient3081);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
+     d="m 27,44.49856 a 11,2.5 0 1 1 -22,0 11,2.5 0 1 1 22,0 z"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     id="path23417" />
+  <rect
+     x="8.5"
+     y="-44.499962"
+     width="15"
+     height="15"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:none"
+     id="rect3448" />
+  <rect
+     x="8.5"
+     y="-44.499962"
+     width="15"
+     height="15"
+     ry="1"
+     rx="1"
+     transform="scale(1,-1)"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-opacity:1"
+     id="rect3448-9" />
   <path
-     d="M 44.5,24 C 44.5,12.637039 35.362959,3.5 24,3.5 12.637038,3.5 3.5000001,12.63704 3.5000001,24 3.4999981,35.36296 12.637039,44.5 24,44.5 35.362958,44.499998 44.5,35.362961 44.5,24 z m -13,0 c 0,4.12813 -3.28927,7.5 -7.5,7.5 -4.29333,0 -7.5,-3.455313 -7.5,-7.5 0,-4.127303 3.041467,-7.5 7.5,-7.5 4.458533,0 7.5,3.45447 7.5,7.5 z"
-     id="path2781"
-     style="fill:url(#linearGradient3076);fill-rule:nonzero;stroke:none" />
+     id="rect3450"
+     d="m 11.5,38.49996 v 3 h 3 v -3 z m 6,0 v 3 h 3 v -3 z"
+     style="opacity:0.25;fill:#000000;fill-opacity:0.335988;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     x="9.5"
+     y="-43.499962"
+     width="13"
+     height="13"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458" />
+  <rect
+     x="6"
+     y="1.9999611"
+     width="20"
+     height="33"
+     ry="1.5"
+     rx="1.5"
+     style="fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391" />
+  <rect
+     x="5.5"
+     y="1.499961"
+     width="21"
+     height="34"
+     ry="2"
+     rx="2"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2" />
+  <rect
+     x="6.4999609"
+     y="2.499922"
+     width="19.000078"
+     height="32.000076"
+     ry="1"
+     rx="1"
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2-0" />
   <path
-     d="m 24,16 c -4.416,0 -8,3.584 -8,8 0,4.416 3.584,8 8,8 4.416,0 8,-3.584 8,-8 0,-4.416 -3.584,-8 -8,-8 z m 0,4 c 2.208,0 4,1.792 4,4 0,2.208 -1.792,4 -4,4 -2.208,0 -4,-1.792 -4,-4 0,-2.208 1.792,-4 4,-4 z"
-     id="path2474"
-     style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 14.678,29.36637 c 0,-1.2774 0.42456,-1.6088 0.94461,-2.0548 0.4175,-0.20154 0.38288,-0.33913 0.37739,-0.9873 -0.006,-0.71628 0.02671,-0.63446 -1.30087,-1.7869 -2.027,-1.7595 -2.2996,-2.1838 -2.5376,-3.9494 -0.17556,-1.3022 -0.05242,-1.0157 -0.55638,-1.5166 -0.92759,-0.92193 -0.76867,-2.274 0.33557,-2.8551 0.99478,-0.52348 2.1732,0.03328 2.5366,1.1985 0.17911,0.57427 -0.25029,1.566 -0.82688,1.9097 -0.52764,0.31455 -0.74654,-0.20987 -0.62588,0.94961 0.06678,0.64174 0.22952,1.3798 0.36164,1.6401 0.22691,0.44704 2.3721,2.5515 2.6138,2.5515 v -12.432 H 14 L 16.5221,8 19,12.03408 h -1.999995 v 8.42 c 0.16651,0 1.881595,-1.6568 2.430895,-2.4027 0.23734,-0.32228 0.38137,-0.77989 0.38137,-1.2117 0,-0.65124 0.21476,-0.78818 -0.28196,-0.78818 h -0.5292 v -3.0516 h 2.9988 v 3.0516 h -0.4851 c -0.43284,0.05068 -0.74221,0.2713 -0.82392,0.99341 -0.12186,1.0769 -0.58309,1.7837 -2.2805,3.4947 l -1.410395,1.4319 5e-6,5.1064 0.47497,0.23418 c 0.26681,0.1288 0.63426,0.54499 0.81656,0.92487 0.649,1.355 -0.254,2.811 -1.743,2.811 -1.079,-0.04 -1.871,-0.594 -1.871,-1.68 z"
+     style="opacity:0.3;fill:#ffffff"
+     id="path3690-6"
+     sodipodi:nodetypes="cccccccccsccccccccssscccccscccccccc" />
   <path
-     d="m 24,20.25 c 2.07,0 3.75,1.68 3.75,3.75 0,2.07 -1.68,3.75 -3.75,3.75 -2.07,0 -3.75,-1.68 -3.75,-3.75 0,-2.07 1.68,-3.75 3.75,-3.75 z"
-     id="path3418"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 14.678,28.36643 c 0,-1.2774 0.42456,-1.6088 0.94461,-2.0548 0.4175,-0.20154 0.48421,-0.33913 0.47872,-0.9873 -0.006,-0.71628 -0.07462,-0.63446 -1.4022,-1.7869 -2.027,-1.7595 -2.2996,-2.1838 -2.5376,-3.9494 -0.17556,-1.3022 -0.05242,-1.0157 -0.55638,-1.5166 -0.92759,-0.92193 -0.76867,-2.274 0.33557,-2.8551 0.99478,-0.52348 2.1732,0.03328 2.5366,1.1985 0.17911,0.57427 -0.25029,1.566 -0.82688,1.9097 -0.52764,0.31455 -0.74654,-0.20987 -0.62588,0.94961 0.06678,0.64174 0.22952,1.3798 0.36164,1.6401 0.22691,0.44704 2.3721,2.5515 2.6138,2.5515 V 10.9998 H 14 L 16.5221,7.5 19,11.0002 h -1.999995 v 8.45394 c 0.16651,0 1.881595,-1.6568 2.430895,-2.4027 0.23734,-0.32228 0.38137,-0.77989 0.38137,-1.2117 0,-0.65124 0.21476,-0.78818 -0.28196,-0.78818 h -0.5292 v -3.0516 h 2.9988 v 3.0516 h -0.4851 c -0.43284,0.05068 -0.74221,0.2713 -0.82392,0.99341 -0.12186,1.0769 -0.58309,1.7837 -2.2805,3.4947 l -1.410395,1.4319 5e-6,5.1064 0.47497,0.23418 c 0.26681,0.1288 0.63426,0.54499 0.81656,0.92487 0.649,1.355 -0.254,2.811 -1.743,2.811 -1.079,-0.04 -1.871,-0.594 -1.871,-1.68 z"
+     style="opacity:0.95;fill:#aaaaaa"
+     id="path3690"
+     sodipodi:nodetypes="cccccccccsccccccccssscccccscccccccc" />
   <g
-     id="g3527">
-    <path
-       d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 l 10e-7,0 z"
-       transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
-       id="path3296"
-       style="opacity:0.8;fill:url(#linearGradient3346);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 l 0,0 z"
-       id="path3308"
-       style="opacity:0.8;fill:url(#linearGradient3348);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-       id="path3310"
-       style="opacity:0.8;fill:url(#linearGradient3350);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-       id="path3312"
-       style="opacity:0.8;fill:url(#linearGradient3352);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-       id="path3314"
-       style="opacity:0.8;fill:url(#linearGradient3354);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  </g>
-  <g
-     transform="matrix(-1,0,0,-1,47.999999,47.990833)"
-     id="g3297">
-    <path
-       d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 l 10e-7,0 z"
-       transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
-       id="path3299"
-       style="opacity:0.8;fill:url(#linearGradient3311);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 l 0,0 z"
-       id="path3301"
-       style="opacity:0.8;fill:url(#linearGradient3313);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-       id="path3303"
-       style="opacity:0.8;fill:url(#linearGradient3315);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-       id="path3305"
-       style="opacity:0.8;fill:url(#linearGradient3317);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <path
-       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-       id="path3307"
-       style="opacity:0.8;fill:url(#linearGradient3319);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  </g>
-  <path
-     d="M 43.5,23.99931 C 43.5,34.76921 34.76891,43.5 24.000247,43.5 13.230598,43.5 4.5,34.769111 4.5,23.99931 4.5,13.229908 13.230598,4.5000024 24.000247,4.5000024 34.76891,4.5000024 43.5,13.229908 43.5,23.99931 l 0,0 z"
-     id="path8655"
-     style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3057);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="m 24,32.5 c -4.711429,0 -8.5,-3.788571 -8.5,-8.5 0,-4.711429 3.788571,-8.500001 8.5,-8.500001 4.711431,0 8.5,3.788572 8.5,8.500001 0,4.711429 -3.788569,8.5 -8.5,8.5 l 0,0 0,0 0,0 z"
-     id="path3281"
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3054);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
-  <path
-     d="M 44.5,24 C 44.5,12.637039 35.362959,3.5 24,3.5 12.637038,3.5 3.5000001,12.63704 3.5000001,24 3.4999981,35.36296 12.637039,44.5 24,44.5 35.362958,44.499998 44.5,35.362961 44.5,24 z m -13,0 c 0,4.12813 -3.28927,7.5 -7.5,7.5 -4.29333,0 -7.5,-3.455313 -7.5,-7.5 0,-4.127303 3.041467,-7.5 7.5,-7.5 4.458533,0 7.5,3.45447 7.5,7.5 z"
-     id="path2781-3"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
-  <g
-     transform="translate(25,32)"
+     transform="translate(22,31)"
      id="layer1-5">
     <path
-       d="m 23,13 c 0,1.65685 -4.92486,3 -11,3 -6.07514,0 -11,-1.34315 -11,-3 0,-1.65685 4.92486,-3 11,-3 6.07514,0 11,1.34315 11,3 l 0,0 z"
+       d="m 23,13 c 0,1.65685 -4.92486,3 -11,3 -6.07514,0 -11,-1.34315 -11,-3 0,-1.65685 4.92486,-3 11,-3 6.07514,0 11,1.34315 11,3 z"
        id="path8836"
-       style="opacity:0.3;fill:url(#radialGradient12301);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient12301);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
     <path
-       d="M 12,-6.4999997 C 6.20646,-6.4999997 1.5,-1.79354 1.5,4 1.5,9.79354 6.20646,14.5 12,14.5 17.79354,14.5 22.5,9.79354 22.5,4 22.5,-1.79354 17.79354,-6.4999997 12,-6.4999997 z"
+       d="M 12,-6.4999997 C 6.20646,-6.4999997 1.5,-1.79354 1.5,4 1.5,9.79354 6.20646,14.5 12,14.5 17.79354,14.5 22.5,9.79354 22.5,4 22.5,-1.79354 17.79354,-6.4999997 12,-6.4999997 Z"
        id="path2555-7-1"
-       style="color:#000000;fill:url(#radialGradient6358);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6360);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient6358);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6360);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
-       d="M 21.5,3.99966 C 21.5,9.24654 17.24639,13.5 12.00012,13.5 6.75337,13.5 2.5,9.24649 2.5,3.99966 c 0,-5.24663 4.25337,-9.4996597 9.50012,-9.4996597 5.24627,0 9.49988,4.2530297 9.49988,9.4996597 l 0,0 z"
+       d="M 21.5,3.99966 C 21.5,9.24654 17.24639,13.5 12.00012,13.5 6.75337,13.5 2.5,9.24649 2.5,3.99966 c 0,-5.24663 4.25337,-9.4996597 9.50012,-9.4996597 5.24627,0 9.49988,4.2530297 9.49988,9.4996597 z"
        id="path8655-6-6"
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient6351);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient6351);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
     <path
        d="m 7,5.5 5,5.1 5,-5.1 z"
        id="rect3005-5-5"
-       style="color:#000000;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
     <path
-       d="m 11,-1.5 0,6 -4,0 5,5.1 5,-5.1 -4,0 0,-6 z"
+       d="m 11,-1.5 v 6 H 7 l 5,5.1 5,-5.1 h -4 v -6 z"
        id="rect3005-5"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
   </g>
 </svg>

--- a/elementary-xfce/apps/64/ubiquity.svg
+++ b/elementary-xfce/apps/64/ubiquity.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="64"
    height="64"
-   id="svg3554">
+   id="svg3554"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview90"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="15.644738"
+     inkscape:cx="15.308662"
+     inkscape:cy="21.988224"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="567"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3554" />
   <defs
      id="defs3556">
     <linearGradient
@@ -20,7 +42,7 @@
        id="linearGradient3162"
        xlink:href="#linearGradient4011-7"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972967,0,0,0.72972967,-4.346076,29.49607)" />
+       gradientTransform="matrix(0.72972967,0,0,0.72972967,-7.3460756,29.49607)" />
     <linearGradient
        id="linearGradient4011-7">
       <stop
@@ -49,7 +71,7 @@
        id="radialGradient3165"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(4.5367027e-8,1.7632481,-1.8653063,0,63.761488,20.748948)" />
+       gradientTransform="matrix(4.5367027e-8,1.7632481,-1.8653063,0,60.761488,20.748948)" />
     <linearGradient
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
       <stop
@@ -77,7 +99,7 @@
        id="linearGradient3167"
        xlink:href="#linearGradient3707-319-631-407-324-3-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.74365873,0,0,0.74365873,30.152194,30.15219)" />
+       gradientTransform="matrix(0.74365873,0,0,0.74365873,27.152194,30.15219)" />
     <linearGradient
        id="linearGradient3707-319-631-407-324-3-8">
       <stop
@@ -98,7 +120,7 @@
        id="radialGradient3170"
        xlink:href="#linearGradient8838"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5058824,0,0,0.37647,-46.305886,58.258824)" />
+       gradientTransform="matrix(1.5058824,0,0,0.37647,-49.305886,58.258824)" />
     <linearGradient
        id="linearGradient8838">
       <stop
@@ -110,244 +132,117 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="23.334524"
-       cy="41.63604"
-       r="22.627417"
-       fx="23.334524"
-       fy="41.63604"
-       id="radialGradient4130"
-       xlink:href="#linearGradient23419"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.281631,0,0,0.3756156,2.0937489,37.860857)" />
     <linearGradient
-       id="linearGradient23419">
+       xlink:href="#linearGradient3742"
+       id="linearGradient3730"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81791996,0,0,1.4890166,-64.315479,0.65699801)"
+       x1="118.57409"
+       y1="3.7037382"
+       x2="118.57409"
+       y2="31.67935" />
+    <linearGradient
+       id="linearGradient3742">
       <stop
-         id="stop23421"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3734" />
       <stop
-         id="stop23423"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         offset="0.01900466"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3736" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3738" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3740" />
     </linearGradient>
     <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3070"
-       xlink:href="#linearGradient3263-6"
+       gradientTransform="matrix(1.2289726,0,0,1.0632918,13.850178,-0.19950599)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.5714424,-1.5714424,0,68.300327,-5.7146267)" />
+       xlink:href="#linearGradient3600-8"
+       id="linearGradient5466-8-3"
+       y2="45.68882"
+       x2="11.098394"
+       y1="5.9702148"
+       x1="11.098394" />
     <linearGradient
-       x1="12.2744"
-       y1="32.4165"
-       x2="35.391201"
-       y2="14.2033"
-       id="linearGradient3263-6"
-       gradientUnits="userSpaceOnUse">
+       id="linearGradient3600-8">
       <stop
-         id="stop3265-8"
-         style="stop-color:#dedcde;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-2" />
       <stop
-         id="stop3267-9"
-         style="stop-color:#f0f0f0;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3269-2"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-5" />
     </linearGradient>
     <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient3072"
-       xlink:href="#linearGradient3772-6"
+       xlink:href="#linearGradient4614"
+       id="linearGradient4604"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3414634,0,0,1.3414634,67.233617,-0.1951219)" />
+       gradientTransform="matrix(0.81288992,0,0,1.4490643,-63.784659,-4.059263)"
+       x1="116.7913"
+       y1="-37.80846"
+       x2="116.7913"
+       y2="-26.979191" />
     <linearGradient
-       id="linearGradient3772-6">
+       id="linearGradient4614">
       <stop
-         id="stop3774-6"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776-4"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient3067"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3125,0,0,1.3125,0.5000004,0.4999996)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.580074"
-       y1="10.774516"
-       x2="24.27351"
-       y2="9.8622112"
-       id="linearGradient2477"
-       xlink:href="#linearGradient3487"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3487">
-      <stop
-         id="stop3489"
-         style="stop-color:#e6cde2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3491"
-         style="stop-color:#e6cde2;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="17.494959"
-       y1="11.200086"
-       x2="21.047453"
-       y2="9.7956104"
-       id="linearGradient2479"
-       xlink:href="#linearGradient3495"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3495">
-      <stop
-         id="stop3497"
-         style="stop-color:#c1cbe4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3499"
-         style="stop-color:#c1cbe4;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="14.084608"
-       y1="13.045606"
-       x2="16.994024"
-       y2="10.732353"
-       id="linearGradient2481"
-       xlink:href="#linearGradient3503"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3503">
-      <stop
-         id="stop3505"
-         style="stop-color:#c4ebdd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3507"
-         style="stop-color:#c4ebdd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="12.371647"
-       y1="16.188046"
-       x2="14.609327"
-       y2="13.461712"
-       id="linearGradient2483"
-       xlink:href="#linearGradient3511"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3511">
-      <stop
-         id="stop3513"
-         style="stop-color:#ebeec7;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3515"
-         style="stop-color:#ebeec7;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="10.609375"
-       y1="17.886322"
-       x2="9.7297754"
-       y2="20.612656"
-       id="linearGradient2485"
-       xlink:href="#linearGradient3519"
-       gradientUnits="userSpaceOnUse"
-       spreadMethod="reflect" />
-    <linearGradient
-       id="linearGradient3519">
-      <stop
-         id="stop3521"
-         style="stop-color:#fcd9cd;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3523"
-         style="stop-color:#fcd9cd;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3227"
-       xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4324324,-70.753407,-4.322531)" />
-    <linearGradient
-       id="linearGradient4011">
-      <stop
-         id="stop4013"
+         id="stop4606"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015"
+         id="stop4608"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
+         offset="0" />
       <stop
-         id="stop4017"
+         id="stop4610"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
+         offset="0.9812181" />
       <stop
-         id="stop4019"
+         id="stop4612"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient6036">
+       gradientTransform="matrix(1.2666667,0,0,1.2666667,-8.4000383,-4.133335)"
+       xlink:href="#linearGradient7056"
+       id="linearGradient4763"
+       x1="25"
+       y1="-35"
+       x2="25"
+       y2="-44.395805"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient7056">
       <stop
-         id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         id="stop7064" />
+      <stop
+         offset="1"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         id="stop7060" />
+    </linearGradient>
+    <radialGradient
+       id="radialGradient7374"
+       gradientUnits="userSpaceOnUse"
+       cy="41.636002"
+       cx="23.334999"
+       gradientTransform="matrix(0.61871386,0,0,0.14061988,8.5627314,53.961715)"
+       r="22.627001">
+      <stop
+         id="stop23421-3"
          offset="0" />
       <stop
-         id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop23423-6"
+         style="stop-opacity:0"
          offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
-       id="linearGradient3552"
-       xlink:href="#linearGradient6036"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5808777,0,0,-0.5808775,17.85737,46.52194)" />
+    </radialGradient>
   </defs>
   <metadata
      id="metadata3559">
@@ -357,79 +252,93 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       id="layer1-6">
-      <path
-         d="M 61,53.499999 C 61.001449,58.194291 48.017314,62 32,62 15.982686,62 2.9985065,58.194291 3.0000001,53.499999 2.9985065,48.805709 15.982686,45 32,45 c 16.017314,0 29.001493,3.805709 29,8.499999 l 0,0 z"
-         id="path23417"
-         style="opacity:0.3;fill:url(#radialGradient4130);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="M 59.5,31.999999 C 59.5,16.757004 47.242994,4.5 32,4.5 16.757002,4.5 4.5,16.757005 4.5,31.999999 c -2.6e-6,15.242995 12.257004,27.5 27.5,27.5 15.242992,-3e-6 27.5,-12.257003 27.5,-27.5 z m -17,0 C 42.5,37.537735 37.64854,42.5 32,42.5 26.240655,42.5 21.5,37.425799 21.5,31.999999 21.5,26.463373 26.019041,21.5 32,21.5 c 5.980959,0 10.5,5.073069 10.5,10.499999 z"
-         id="path2781"
-         style="fill:url(#linearGradient3070);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3072);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
-      <path
-         d="m 31.999999,21.499999 c -5.795999,0 -10.5,4.703999 -10.5,10.499999 0,5.795999 4.704001,10.5 10.5,10.5 5.795999,0 10.499999,-4.704001 10.499999,-10.5 0,-5.796 -4.704,-10.499999 -10.499999,-10.499999 z m 0,5.249999 c 2.898,0 5.249999,2.352 5.249999,5.25 0,2.898 -2.351999,5.249999 -5.249999,5.249999 -2.898,0 -5.25,-2.351999 -5.25,-5.249999 0,-2.898 2.352,-5.25 5.25,-5.25 z"
-         id="path3418"
-         style="fill:#ffffff;fill-opacity:0.49803922;stroke:url(#linearGradient3067);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <g
-         transform="matrix(1.3333334,0,0,1.3333334,-1.6000002e-6,0.0588927)"
-         id="g3527">
-        <path
-           d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 l 10e-7,0 z"
-           transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
-           id="path3296"
-           style="opacity:0.8;fill:url(#linearGradient2477);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 l 0,0 z"
-           id="path3308"
-           style="opacity:0.8;fill:url(#linearGradient2479);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
-           id="path3310"
-           style="opacity:0.8;fill:url(#linearGradient2481);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
-           id="path3312"
-           style="opacity:0.8;fill:url(#linearGradient2483);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
-           id="path3314"
-           style="opacity:0.8;fill:url(#linearGradient2485);fill-opacity:1;fill-rule:nonzero;stroke:none" />
-      </g>
-      <path
-         d="M 58.500001,31.999061 C 58.500001,46.63508 46.634673,58.5 32.000336,58.5 17.364659,58.5 5.5000001,46.634945 5.5000001,31.999061 c 0,-14.635341 11.8646589,-26.4990586 26.5003359,-26.4990586 14.634337,0 26.499665,11.8637176 26.499665,26.4990586 l 0,0 z"
-         id="path8655"
-         style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3227);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 31.999999,43.500001 c -6.374286,0 -11.5,-5.125713 -11.5,-11.5 0,-6.374285 5.125714,-11.500001 11.5,-11.500001 6.374289,0 11.5,5.125716 11.5,11.500001 0,6.374287 -5.125711,11.5 -11.5,11.5 l 0,0 0,0 0,0 z"
-         id="path3281"
-         style="opacity:0.4;fill:none;stroke:url(#linearGradient3552);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
-    </g>
-    <path
-       d="m 64,60 c 0,2.209139 -7.163445,4 -16.000001,4 -8.836555,0 -16,-1.790861 -16,-4 0,-2.209139 7.163445,-4 16,-4 C 56.836555,56 64,57.790861 64,60 l 0,0 z"
-       id="path8836"
-       style="opacity:0.3;fill:url(#radialGradient3170);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="m 48.000003,33.499999 c -8.000599,0 -14.500001,6.499399 -14.500001,14.5 0,8.000601 6.499402,14.500003 14.500001,14.500001 8.000597,0 14.500006,-6.4994 14.499999,-14.500001 0,-8.000601 -6.499402,-14.5 -14.499999,-14.5 z"
-       id="path2555-7"
-       style="color:#000000;fill:url(#radialGradient3165);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3167);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 61.500002,47.999522 c 0,7.456084 -6.044601,13.500478 -13.499829,13.500478 -7.455911,0 -13.500171,-6.044463 -13.500171,-13.500478 0,-7.455739 6.04426,-13.49952 13.500171,-13.49952 7.455228,0 13.499829,6.043781 13.499829,13.49952 l 0,0 z"
-       id="path8655-6"
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3162);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 42,50 6,6 6,-6 z"
-       id="rect3005-5-0"
-       style="color:#000000;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 47,42 0,7 -5,0 6,6 6,-6 -5,0 0,-7 z"
-       id="rect3005-5"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
+  <path
+     id="path23417"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:1"
+     d="m 36.999961,59.816785 a 14.000001,3.1818183 0 1 1 -28.0000006,0 14.000001,3.1818183 0 1 1 28.0000006,0 z" />
+  <rect
+     id="rect3448"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.293023"
+     transform="scale(1,-1)"
+     rx="1.0000001"
+     ry="1.0000001"
+     height="19"
+     width="19"
+     y="-60.500004"
+     x="12.499962" />
+  <path
+     style="opacity:0.1;fill:none;fill-rule:evenodd;stroke:#000000;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 12.999961,49.500001 h 18"
+     id="path4538" />
+  <path
+     style="opacity:0.35;fill:#000000;fill-opacity:0.335988;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.674419"
+     d="m 15.499961,53.500001 v 4 h 4 v -4 z m 9,0 v 4 h 4 v -4 z"
+     id="rect3450" />
+  <rect
+     id="rect3458"
+     style="opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     transform="scale(1,-1)"
+     height="17"
+     width="17"
+     y="-59.5"
+     x="13.499962" />
+  <rect
+     ry="2.5"
+     id="rect5391"
+     style="fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="2.5"
+     height="44"
+     width="26"
+     y="5.000001"
+     x="8.9999609" />
+  <rect
+     ry="3"
+     id="rect5391-2"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     rx="3"
+     height="45.000076"
+     width="27.000078"
+     y="4.4999609"
+     x="8.4999609" />
+  <rect
+     rx="2.0000002"
+     id="rect5391-2-0"
+     style="fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     ry="2"
+     height="43"
+     width="25"
+     y="5.500001"
+     x="9.4999609" />
+  <path
+     d="m 18.961894,41.867924 c 0,-1.858009 0.617533,-2.340038 1.373958,-2.988756 0.607264,-0.293144 0.704295,-0.493272 0.69631,-1.436051 -0.0087,-1.041847 -0.108537,-0.922837 -2.039534,-2.599089 -2.94832,-2.559235 -3.344823,-3.176389 -3.691,-5.744497 -0.255356,-1.894081 -0.07625,-1.47736 -0.809268,-2.205931 -1.349202,-1.340969 -1.118049,-3.307588 0.488095,-4.152812 1.446931,-0.761414 3.160971,0.04841 3.689545,1.743247 0.26052,0.83529 -0.364053,2.277785 -1.202717,2.777705 -0.767465,0.45752 -1.08586,-0.305261 -0.910357,1.38123 0.09713,0.933427 0.333842,2.006953 0.526014,2.385565 0.330046,0.650231 3.561984,3.711218 3.913542,3.711218 l 0.0035,-17.739752 h -1.791537 c 0.829079,-1.43707 1.63634,-3.425076 2.439237,-4.871745 l 2.556617,4.872327 h -1.741356 l -0.0035,13.904202 c 0.242192,0 2.616688,-2.409856 3.415658,-3.494785 0.345217,-0.468764 0.304712,-1.635494 0.304712,-2.263572 0,-0.947244 0.312374,-1.146427 -0.410117,-1.146427 h -0.769714 v -5 h 5 v 5 h -1.343763 c -0.629576,0.07372 -1.079562,0.833238 -1.198411,1.883564 -0.177248,1.566377 -0.598118,2.656935 -3.067042,5.145625 l -1.931317,2.082733 v 5.427381 l 0.570726,0.340621 c 0.388082,0.187343 0.922547,0.792701 1.187706,1.345245 0.943986,1.97088 -0.369449,4.088667 -2.535235,4.088667 -1.569431,-0.05818 -2.721414,-0.863987 -2.721414,-2.4436 z"
+     style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke-width:1"
+     id="path4540" />
+  <path
+     id="path3690"
+     style="opacity:0.95;fill:#aaaaaa;stroke-width:1"
+     d="m 18.961894,40.867924 c 0,-1.858009 0.617533,-2.340038 1.373958,-2.988756 0.607264,-0.293144 0.704295,-0.493272 0.69631,-1.436051 -0.0087,-1.041847 -0.108537,-0.922837 -2.039534,-2.599089 -2.94832,-2.559235 -3.344823,-3.176389 -3.691,-5.744497 -0.255356,-1.894081 -0.07625,-1.47736 -0.809268,-2.205931 -1.349202,-1.340969 -1.118049,-3.307588 0.488095,-4.152812 1.446931,-0.761414 3.160971,0.04841 3.689545,1.743247 0.26052,0.83529 -0.364053,2.277785 -1.202717,2.777705 -0.767465,0.45752 -1.08586,-0.305261 -0.910357,1.38123 0.09713,0.933427 0.333842,2.006953 0.526014,2.385565 0.330046,0.650231 3.561984,3.711218 3.913542,3.711218 l 0.0035,-17.739752 H 18.5 L 21.65,11 25,16.000583 h -2.537057 l -0.0035,13.904202 c 0.242192,0 2.616688,-2.409856 3.415658,-3.494785 0.345217,-0.468764 0.304712,-1.635494 0.304712,-2.263572 0,-0.947244 0.312374,-1.146427 -0.410117,-1.146427 h -0.769714 v -5 h 5 v 5 h -1.343763 c -0.629576,0.07372 -1.079562,0.833238 -1.198411,1.883564 -0.177248,1.566377 -0.598118,2.656935 -3.067042,5.145625 l -1.931317,2.082733 v 5.427381 l 0.570726,0.340621 c 0.388082,0.187343 0.922547,0.792701 1.187706,1.345245 0.943986,1.97088 -0.369449,4.088667 -2.535235,4.088667 -1.569431,-0.05818 -2.721414,-0.863987 -2.721414,-2.4436 z"
+     sodipodi:nodetypes="cccccccccsccccccccssscccccscccccccc" />
+  <path
+     d="m 61,60 c 0,2.209139 -7.163445,4 -16.000001,4 -8.836555,0 -16,-1.790861 -16,-4 0,-2.209139 7.163445,-4 16,-4 C 53.836555,56 61,57.790861 61,60 Z"
+     id="path8836"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3170);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 45.000003,33.499999 c -8.000599,0 -14.500001,6.499399 -14.500001,14.5 0,8.000601 6.499402,14.500003 14.500001,14.500001 8.000597,0 14.500006,-6.4994 14.499999,-14.500001 0,-8.000601 -6.499402,-14.5 -14.499999,-14.5 z"
+     id="path2555-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3165);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3167);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 58.500002,47.999522 c 0,7.456084 -6.044601,13.500478 -13.499829,13.500478 -7.455911,0 -13.500171,-6.044463 -13.500171,-13.500478 0,-7.455739 6.04426,-13.49952 13.500171,-13.49952 7.455228,0 13.499829,6.043781 13.499829,13.49952 z"
+     id="path8655-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3162);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 39,50 6,6 6,-6 z"
+     id="rect3005-5-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 44,42 v 7 h -5 l 6,6 6,-6 h -5 v -7 z"
+     id="rect3005-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/apps/96/ubiquity.svg
+++ b/elementary-xfce/apps/96/ubiquity.svg
@@ -1,0 +1,391 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 96 96"
+   version="1.0"
+   width="96"
+   height="96"
+   id="svg11300"
+   sodipodi:docname="ubiquity.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     id="namedview38"
+     showgrid="false"
+     inkscape:zoom="13.906434"
+     inkscape:cx="36.350081"
+     inkscape:cy="32.790577"
+     inkscape:window-x="601"
+     inkscape:window-y="129"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300"
+     inkscape:pagecheckerboard="0" />
+  <metadata
+     id="metadata49">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4614">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4606" />
+      <stop
+         offset="0.02750255"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4608" />
+      <stop
+         offset="0.9812181"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4610" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4612" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3742">
+      <stop
+         id="stop3734"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.01900466" />
+      <stop
+         id="stop3738"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9812181" />
+      <stop
+         id="stop3740"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627001"
+       gradientTransform="matrix(0.97226462,0,0,0.2209741,10.312924,80.797776)"
+       cx="23.334999"
+       cy="41.636002"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient7374">
+      <stop
+         offset="0"
+         id="stop23421" />
+      <stop
+         offset="1"
+         style="stop-opacity:0"
+         id="stop23423" />
+    </radialGradient>
+    <linearGradient
+       id="linearGradient3600-8">
+      <stop
+         id="stop3602-2"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="11.098394"
+       y1="5.9702148"
+       x2="11.098394"
+       y2="45.68882"
+       id="linearGradient5466-8-3"
+       xlink:href="#linearGradient3600-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0073162,0,0,1.7107328,19.688663,-7.2203116)" />
+    <linearGradient
+       y2="31.67935"
+       x2="118.57409"
+       y1="3.7037382"
+       x1="118.57409"
+       gradientTransform="matrix(1.3413942,0,0,2.3201011,-108.55791,-4.0467514)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3730"
+       xlink:href="#linearGradient3742" />
+    <linearGradient
+       y2="-26.979191"
+       x2="116.7913"
+       y1="-37.973656"
+       x1="116.7913"
+       gradientTransform="matrix(1.3866946,0,0,2.4719333,-113.33848,5.0753801)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4604"
+       xlink:href="#linearGradient4614" />
+    <linearGradient
+       id="linearGradient7056">
+      <stop
+         id="stop7064"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop7060"
+         style="stop-color:#c8c8c8;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-44.395805"
+       x2="25"
+       y1="-35"
+       x1="25"
+       id="linearGradient4763"
+       xlink:href="#linearGradient7056"
+       gradientTransform="matrix(2,0,0,2,-15,-1.0014)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient12301"
+       xlink:href="#linearGradient8838"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8823529,0,0,0.564705,-113.54336,22.532308)" />
+    <linearGradient
+       id="linearGradient8838">
+      <stop
+         id="stop8840"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8842"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="6.0693989"
+       cy="8.4497671"
+       r="19.99999"
+       fx="6.0693989"
+       fy="8.4497671"
+       id="radialGradient6358"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.3483643,-2.4842893,-6.3918866e-8,25.330764,-32.644165)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8-5">
+      <stop
+         id="stop3750-8-9-1"
+         style="stop-color:#90dbec;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3752-3-2-2"
+         style="stop-color:#42baea;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3754-7-2-5"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop3756-9-3-2"
+         style="stop-color:#2b63a0;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="24"
+       y1="44"
+       x2="24"
+       y2="3.8990016"
+       id="linearGradient6360"
+       xlink:href="#linearGradient3707-319-631-407-324-3-8-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1026664,0,0,1.1026664,-22.124997,-20.319934)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-3-8-4">
+      <stop
+         id="stop3760-7-3-4"
+         style="stop-color:#185f9a;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3762-8-4-6"
+         style="stop-color:#599ec9;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient6351"
+       xlink:href="#linearGradient4011-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.108108,0,0,1.108108,-75.149507,-21.954485)" />
+    <linearGradient
+       id="linearGradient4011-2">
+      <stop
+         id="stop4013-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-9"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     d="m 55,89.9986 a 22,5 0 1 1 -44,0 22,5 0 1 1 44,0 z"
+     style="opacity:0.3;fill:url(#radialGradient7374);fill-rule:evenodd;stroke-width:2"
+     id="path23417"
+     inkscape:connector-curvature="0" />
+  <rect
+     x="18"
+     y="-90.001404"
+     width="30"
+     height="30"
+     ry="1.5"
+     rx="1.5"
+     transform="scale(1,-1)"
+     style="fill:url(#linearGradient4763);fill-opacity:1;stroke:none;stroke-width:2"
+     id="rect3448" />
+  <rect
+     x="17.5"
+     y="-90.5"
+     width="31"
+     height="30.999998"
+     ry="2"
+     rx="2"
+     transform="scale(1,-1)"
+     style="opacity:0.4;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect3448-9" />
+  <path
+     id="rect3450"
+     d="m 23.5,78.5 v 5 h 7 v -5 z m 12,0 v 5 h 7 v -5 z"
+     style="opacity:1;fill:#bfbfbf;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.25"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccc" />
+  <rect
+     x="18.5"
+     y="-89.5"
+     width="29"
+     height="29"
+     transform="scale(1,-1)"
+     style="opacity:0.6;fill:none;fill-opacity:1;stroke:url(#linearGradient4604);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect3458"
+     rx="1.0357143"
+     ry="1.0357143" />
+  <rect
+     x="12"
+     y="3.0000002"
+     width="42"
+     height="68"
+     ry="2.5"
+     rx="2.5"
+     style="opacity:1;fill:url(#linearGradient5466-8-3);fill-opacity:1;stroke:none;stroke-width:1.99984;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391" />
+  <rect
+     x="11.5"
+     y="2.5"
+     width="43"
+     height="69"
+     ry="3"
+     rx="3"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect5391-2" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient3730);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="m 14.657896,3.5 c -1.195474,0 -2.157895,0.9338125 -2.157895,2.09375 v 62.8125 c 0,1.159937 0.962421,2.09375 2.157895,2.09375 h 36.684211 c 1.195474,0 2.157895,-0.933813 2.157895,-2.09375 V 5.59375 C 53.500002,4.4338125 52.537581,3.5 51.342107,3.5 Z"
+     id="rect5391-2-0"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 29.356342,57.63682 c 0,-2.5548 0.84912,-3.2176 1.88922,-4.1096 0.835,-0.40308 0.96842,-0.67826 0.95744,-1.9746 -0.012,-1.43256 -0.14924,-1.26892 -2.8044,-3.5738 -4.054,-3.519 -4.5992,-4.3676 -5.0752,-7.8988 -0.35112,-2.6044 -0.10484,-2.0314 -1.11276,-3.0332 -1.85518,-1.84386 -1.53734,-4.548 0.67114,-5.7102 1.98956,-1.04696 4.3464,0.06656 5.0732,2.397 0.35822,1.14854 -0.50058,3.132 -1.65376,3.8194 -1.05528,0.6291 -1.49308,-0.41974 -1.25176,1.89922 0.13356,1.28348 0.45904,2.7596 0.72328,3.2802 0.45382,0.89408 4.8978,5.103 5.3812,5.103 v -24.864 h -2.4634 c 1.14,-1.976 2.25,-3.9848 3.354,-5.974 l 3.5154,5.9748 h -2.3944 v 16.84 c 0.33302,0 3.598,-3.3136 4.6966,-4.8054 0.47468,-0.64456 0.76274,-1.55978 0.76274,-2.4234 0,-1.30248 0.42952,-1.57636 -0.56392,-1.57636 h -1.0584 v -6.1032 h 5.9976 v 6.1032 h -0.9702 c -0.86568,0.10136 -1.48442,0.5426 -1.64784,1.98682 -0.24372,2.1538 -1.16618,3.5674 -4.561,6.9894 l -2.6556,2.8638 v 10.2128 l 0.78476,0.46836 c 0.53362,0.2576 1.26852,1.08998 1.63312,1.84974 1.298,2.71 -0.508,5.622 -3.486,5.622 -2.158,-0.08 -3.742,-1.188 -3.742,-3.36 z"
+     style="opacity:0.3;fill:#ffffff;stroke-width:2"
+     id="path3690-6"
+     inkscape:connector-curvature="0" />
+  <path
+     d="m 29.356342,55.63694 c 0,-2.5548 0.84912,-3.2176 1.88922,-4.1096 0.835,-0.40308 0.96842,-0.67826 0.95744,-1.9746 -0.012,-1.43256 -0.14924,-1.26892 -2.8044,-3.5738 -4.054,-3.519 -4.5992,-4.3676 -5.0752,-7.8988 -0.35112,-2.6044 -0.10484,-2.0314 -1.11276,-3.0332 -1.85518,-1.84386 -1.53734,-4.548 0.67114,-5.7102 1.98956,-1.04696 4.3464,0.06656 5.0732,2.397 0.35822,1.14854 -0.50058,3.132 -1.65376,3.8194 -1.05528,0.6291 -1.49308,-0.41974 -1.25176,1.89922 0.13356,1.28348 0.45904,2.7596 0.72328,3.2802 0.45382,0.89408 4.8978,5.103 5.3812,5.103 v -24.864 H 29.25 l 3.875,-5.974 3.875,5.9748 h -2.834458 v 16.84 c 0.33302,0 3.598,-3.3136 4.6966,-4.8054 0.47468,-0.64456 0.76274,-1.55978 0.76274,-2.4234 0,-1.30248 0.42952,-1.57636 -0.56392,-1.57636 h -1.0584 V 22.904 h 5.9976 v 6.1032 h -0.9702 c -0.86568,0.10136 -1.48442,0.5426 -1.64784,1.98682 -0.24372,2.1538 -1.16618,3.5674 -4.561,6.9894 l -2.6556,2.8638 v 10.2128 l 0.78476,0.46836 c 0.53362,0.2576 1.26852,1.08998 1.63312,1.84974 1.298,2.71 -0.508,5.622 -3.486,5.622 -2.158,-0.08 -3.742,-1.188 -3.742,-3.36 z"
+     style="opacity:0.95;fill:#aaaaaa;stroke-width:2"
+     id="path3690"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccccccsccccccccssscccccscccccccc" />
+  <g
+     transform="translate(63.661016,64.855932)"
+     id="layer1-5">
+    <path
+       d="m 24.338984,25.144068 c 0,3.3137 -8.954291,6 -20,6 -11.0457093,0 -20,-2.6863 -20,-6 0,-3.3137 8.9542907,-6 20,-6 11.045709,0 20,2.6863 20,6 z"
+       id="path8836"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient12301);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;marker:none" />
+    <path
+       d="m 4.338983,-15.355932 c -11.862962,0 -21.499999,9.6370359 -21.499999,21.499999 0,11.862962 9.637037,21.499999 21.499999,21.499999 11.862963,0 21.5,-9.637037 21.5,-21.499999 0,-11.8629631 -9.637037,-21.499999 -21.5,-21.499999 z"
+       id="path2555-7-1"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient6358);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient6360);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 24.838984,6.143333 c 0,11.322215 -9.178843,20.500734 -20.4997412,20.500734 -11.3219343,0 -20.5002588,-9.178627 -20.5002588,-20.500734 0,-11.3216751 9.1783245,-20.499265 20.5002588,-20.499265 11.3208982,0 20.4997412,9.1775899 20.4997412,20.499265 z"
+       id="path8655-6-6"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient6351);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m -6.161016,9.144068 10.499999,11 10.500001,-11 z"
+       id="rect3005-5-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#3077ac;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cccc" />
+    <path
+       d="m 2.338984,-4.855932 v 12 h -8.5 l 10.499999,11 10.500001,-11 h -8.5 v -12 z"
+       id="rect3005-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <rect
+     y="75"
+     x="26"
+     height="1"
+     width="2"
+     id="rect4665"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect4669"
+     width="2"
+     height="1"
+     x="26"
+     y="76" />
+  <rect
+     y="75"
+     x="38"
+     height="1"
+     width="2"
+     id="rect2757"
+     style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:0.4;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect2759"
+     width="2"
+     height="1"
+     x="38"
+     y="76" />
+</svg>

--- a/elementary-xfce/apps/96/usb-creator-gtk.svg
+++ b/elementary-xfce/apps/96/usb-creator-gtk.svg
@@ -1,0 +1,1 @@
+ubiquity.svg

--- a/elementary-xfce/apps/96/usb-creator-kde.svg
+++ b/elementary-xfce/apps/96/usb-creator-kde.svg
@@ -1,0 +1,1 @@
+ubiquity.svg


### PR DESCRIPTION
Use the USB removable media icon instead of the CD icon for the Ubiquity and USB Creator icons.

For USB Creator, the icon now matches the application name.

For Ubiquity, when trying Xubuntu Live this icon will be seen as the "Install Xubuntu" icon on the desktop. USB media is likely what most people use now as disc drives have become more rare (and the live image size is greater than that of a CD now).

I know (as mentioned in #341) that this type of icon can become antiquated, so if there is a better solution (or if the CD still works just fine) let me know.

Thanks.