### PR TITLE
Add gtk-copy, remove large gtk- icons

### DIFF
--- a/elementary-xfce/actions/128/gtk-about.svg
+++ b/elementary-xfce/actions/128/gtk-about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/128/gtk-cancel.svg
+++ b/elementary-xfce/actions/128/gtk-cancel.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/128/gtk-delete.svg
+++ b/elementary-xfce/actions/128/gtk-delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/128/gtk-execute.svg
+++ b/elementary-xfce/actions/128/gtk-execute.svg
@@ -1,1 +1,0 @@
-system-run.svg

--- a/elementary-xfce/actions/128/gtk-find.svg
+++ b/elementary-xfce/actions/128/gtk-find.svg
@@ -1,1 +1,0 @@
-edit-find.svg

--- a/elementary-xfce/actions/128/gtk-help.svg
+++ b/elementary-xfce/actions/128/gtk-help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/128/gtk-info.svg
+++ b/elementary-xfce/actions/128/gtk-info.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/128/gtk-media-record.svg
+++ b/elementary-xfce/actions/128/gtk-media-record.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/128/gtk-media-stop.svg
+++ b/elementary-xfce/actions/128/gtk-media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/128/gtk-new.svg
+++ b/elementary-xfce/actions/128/gtk-new.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/128/gtk-open.svg
+++ b/elementary-xfce/actions/128/gtk-open.svg
@@ -1,1 +1,0 @@
-document-open.svg

--- a/elementary-xfce/actions/128/gtk-paste.svg
+++ b/elementary-xfce/actions/128/gtk-paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/128/gtk-properties.svg
+++ b/elementary-xfce/actions/128/gtk-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/128/gtk-remove.svg
+++ b/elementary-xfce/actions/128/gtk-remove.svg
@@ -1,1 +1,0 @@
-list-remove.svg

--- a/elementary-xfce/actions/128/gtk-stop.svg
+++ b/elementary-xfce/actions/128/gtk-stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/16/gtk-copy.svg
+++ b/elementary-xfce/actions/16/gtk-copy.svg
@@ -1,0 +1,1 @@
+edit-copy.svg

--- a/elementary-xfce/actions/22/gtk-copy.svg
+++ b/elementary-xfce/actions/22/gtk-copy.svg
@@ -1,0 +1,1 @@
+edit-copy.svg

--- a/elementary-xfce/actions/24/gtk-copy.svg
+++ b/elementary-xfce/actions/24/gtk-copy.svg
@@ -1,0 +1,1 @@
+edit-copy.svg

--- a/elementary-xfce/actions/32/gtk-copy.svg
+++ b/elementary-xfce/actions/32/gtk-copy.svg
@@ -1,0 +1,1 @@
+edit-copy.svg

--- a/elementary-xfce/actions/48/gtk-copy.svg
+++ b/elementary-xfce/actions/48/gtk-copy.svg
@@ -1,0 +1,1 @@
+edit-copy.svg

--- a/elementary-xfce/actions/64/gtk-about.svg
+++ b/elementary-xfce/actions/64/gtk-about.svg
@@ -1,1 +1,0 @@
-help-about.svg

--- a/elementary-xfce/actions/64/gtk-cancel.svg
+++ b/elementary-xfce/actions/64/gtk-cancel.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/64/gtk-delete.svg
+++ b/elementary-xfce/actions/64/gtk-delete.svg
@@ -1,1 +1,0 @@
-edit-delete.svg

--- a/elementary-xfce/actions/64/gtk-execute.svg
+++ b/elementary-xfce/actions/64/gtk-execute.svg
@@ -1,1 +1,0 @@
-system-run.svg

--- a/elementary-xfce/actions/64/gtk-find.svg
+++ b/elementary-xfce/actions/64/gtk-find.svg
@@ -1,1 +1,0 @@
-edit-find.svg

--- a/elementary-xfce/actions/64/gtk-help.svg
+++ b/elementary-xfce/actions/64/gtk-help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/64/gtk-info.svg
+++ b/elementary-xfce/actions/64/gtk-info.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/actions/64/gtk-media-record.svg
+++ b/elementary-xfce/actions/64/gtk-media-record.svg
@@ -1,1 +1,0 @@
-media-record.svg

--- a/elementary-xfce/actions/64/gtk-media-stop.svg
+++ b/elementary-xfce/actions/64/gtk-media-stop.svg
@@ -1,1 +1,0 @@
-media-playback-stop.svg

--- a/elementary-xfce/actions/64/gtk-new.svg
+++ b/elementary-xfce/actions/64/gtk-new.svg
@@ -1,1 +1,0 @@
-document-new.svg

--- a/elementary-xfce/actions/64/gtk-open.svg
+++ b/elementary-xfce/actions/64/gtk-open.svg
@@ -1,1 +1,0 @@
-document-open.svg

--- a/elementary-xfce/actions/64/gtk-paste.svg
+++ b/elementary-xfce/actions/64/gtk-paste.svg
@@ -1,1 +1,0 @@
-edit-paste.svg

--- a/elementary-xfce/actions/64/gtk-properties.svg
+++ b/elementary-xfce/actions/64/gtk-properties.svg
@@ -1,1 +1,0 @@
-document-properties.svg

--- a/elementary-xfce/actions/64/gtk-remove.svg
+++ b/elementary-xfce/actions/64/gtk-remove.svg
@@ -1,1 +1,0 @@
-list-remove.svg

--- a/elementary-xfce/actions/64/gtk-revert-to-saved-ltr.svg
+++ b/elementary-xfce/actions/64/gtk-revert-to-saved-ltr.svg
@@ -1,1 +1,0 @@
-document-revert.svg

--- a/elementary-xfce/actions/64/gtk-revert-to-saved-rtl.svg
+++ b/elementary-xfce/actions/64/gtk-revert-to-saved-rtl.svg
@@ -1,1 +1,0 @@
-document-revert.svg

--- a/elementary-xfce/actions/64/gtk-stop.svg
+++ b/elementary-xfce/actions/64/gtk-stop.svg
@@ -1,1 +1,0 @@
-process-stop.svg

--- a/elementary-xfce/actions/96/gtk-execute.svg
+++ b/elementary-xfce/actions/96/gtk-execute.svg
@@ -1,1 +1,0 @@
-system-run.svg

--- a/elementary-xfce/actions/96/gtk-find.svg
+++ b/elementary-xfce/actions/96/gtk-find.svg
@@ -1,1 +1,0 @@
-edit-find.svg

--- a/elementary-xfce/actions/96/gtk-help.svg
+++ b/elementary-xfce/actions/96/gtk-help.svg
@@ -1,1 +1,0 @@
-help-contents.svg

--- a/elementary-xfce/actions/96/gtk-info.svg
+++ b/elementary-xfce/actions/96/gtk-info.svg
@@ -1,1 +1,0 @@
-help-info.svg

--- a/elementary-xfce/apps/128/gtk-help.svg
+++ b/elementary-xfce/apps/128/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/128/gtk-info.svg
+++ b/elementary-xfce/apps/128/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/128/gtk-info.svg

--- a/elementary-xfce/apps/16/gtk-help.svg
+++ b/elementary-xfce/apps/16/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/16/gtk-info.svg
+++ b/elementary-xfce/apps/16/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/16/gtk-info.svg

--- a/elementary-xfce/apps/22/gtk-help.svg
+++ b/elementary-xfce/apps/22/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/22/gtk-info.svg
+++ b/elementary-xfce/apps/22/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/22/gtk-info.svg

--- a/elementary-xfce/apps/24/gtk-help.svg
+++ b/elementary-xfce/apps/24/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/24/gtk-info.svg
+++ b/elementary-xfce/apps/24/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/24/gtk-info.svg

--- a/elementary-xfce/apps/32/gtk-help.svg
+++ b/elementary-xfce/apps/32/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/32/gtk-info.svg
+++ b/elementary-xfce/apps/32/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/32/gtk-info.svg

--- a/elementary-xfce/apps/48/gtk-help.svg
+++ b/elementary-xfce/apps/48/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/48/gtk-info.svg
+++ b/elementary-xfce/apps/48/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/48/gtk-info.svg

--- a/elementary-xfce/apps/64/gtk-help.svg
+++ b/elementary-xfce/apps/64/gtk-help.svg
@@ -1,1 +1,0 @@
-help-browser.svg

--- a/elementary-xfce/apps/64/gtk-info.svg
+++ b/elementary-xfce/apps/64/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/64/gtk-info.svg

--- a/elementary-xfce/apps/96/gtk-help.svg
+++ b/elementary-xfce/apps/96/gtk-help.svg
@@ -1,1 +1,0 @@
-../../actions/96/help-contents.svg

--- a/elementary-xfce/apps/96/gtk-info.svg
+++ b/elementary-xfce/apps/96/gtk-info.svg
@@ -1,1 +1,0 @@
-../../actions/96/help-info.svg


### PR DESCRIPTION
Adds missing gtk-copy (symlinked to edit-copy)

Since gtk- prefixed icons seem to only be used at menu and button sizes, this removes 64px and above gtk- prefixed icon symlinks. Also removes a few gtk- prefixed icon duplicates in /apps.

Fixes #359