### PR TITLE
Devices: Sharpen printer icons, add sizes

### DIFF
--- a/elementary-xfce/actions/16/document-print.svg
+++ b/elementary-xfce/actions/16/document-print.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="16"
    height="16"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="document-print.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview78204"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="1.7966102"
+     inkscape:cy="8.0338983"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata24649">
     <rdf:RDF>
@@ -32,17 +55,6 @@
       <stop
          id="stop6664"
          style="stop-color:#787878;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -135,15 +147,6 @@
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.34883886,0,0,0.37500427,-0.37213199,-0.1876208)" />
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2877"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.34883886,0,0,0.37500427,-0.37213192,-0.18761334)" />
   </defs>
   <rect
      width="10.999916"
@@ -153,23 +156,23 @@
      x="2.500042"
      y="3.5000422"
      id="rect2315"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
   <g
      transform="matrix(0.69407228,0,0,0.73253891,2.4439816,0.13360126)"
      id="layer1">
     <path
        d="m 1.4976268,0.49762721 13.0047472,0.002374 c 0,3.90746299 0,11.09490679 0,15.00237279 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031634 0,-15.00474638 z"
        id="rect2594"
-       style="fill:#f4f4f4;fill-opacity:1;stroke:#b5b6b2;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:#f4f4f4;fill-opacity:1;stroke:#000000;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   </g>
   <path
      d="m 1.5050189,12.499854 c 0.025372,0.518058 -0.0657,1.075536 0.080353,1.555513 0.2739839,0.609191 0.8786674,0.408878 1.2830134,0.44374 0.0073,0.359613 0.029665,0.914771 0.3421077,0.991264 3.3005711,0.01952 6.2780675,0.0028 9.579015,0.0084 0.340644,0.01588 0.35312,-0.580789 0.342108,-0.959421 0.11125,-0.09326 0.427435,-0.01386 0.581072,-0.04021 0.38015,0.0815 0.844967,-0.329793 0.78162,-1.013691 0,-0.328519 0,-0.657045 0,-0.985562 -4.329764,0 -8.6595258,0 -12.9892892,0 z"
      id="rect6333"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
   <path
      d="m 1.2251892,7.4999662 13.5496198,0 c 0.401775,0 0.725226,0.3477098 0.725226,0.7796206 l 0,5.2204472 -15.00006986,0 0,-5.2204472 c 0,-0.4319108 0.32345002,-0.7796206 0.72522406,-0.7796206 z"
      id="rect2313"
-     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:url(#linearGradient2877);stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:#000000;stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none" />
   <path
      d="m 1.8170282,8.4999529 12.3659448,0 c 0.164502,0 0.317074,0.1374829 0.317074,0.2857221 l 0,3.714372 -13.0000942,0 0,-3.714372 c 0,-0.1482392 0.1525713,-0.2857221 0.3170754,-0.2857221 z"
      id="rect2374"

--- a/elementary-xfce/actions/24/document-print-preview.svg
+++ b/elementary-xfce/actions/24/document-print-preview.svg
@@ -5,7 +5,7 @@
    height="24"
    id="svg11300"
    sodipodi:docname="document-print-preview.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -24,14 +24,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="20.093618"
-     inkscape:cx="-2.0155653"
+     inkscape:cx="13.287801"
      inkscape:cy="16.721727"
      inkscape:window-width="1317"
      inkscape:window-height="890"
      inkscape:window-x="601"
-     inkscape:window-y="140"
+     inkscape:window-y="115"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg11300" />
+     inkscape:current-layer="svg11300"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <metadata
      id="metadata39193">
     <rdf:RDF>
@@ -45,17 +47,6 @@
   </metadata>
   <defs
      id="defs3">
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient6842">
       <stop
@@ -169,15 +160,6 @@
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.4883737,0,0,0.5000043,0.2790318,1.2498788)" />
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2922"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4883737,0,0,0.5000043,0.2790319,1.2498888)" />
     <radialGradient
        cx="24"
        cy="41.875"
@@ -233,23 +215,23 @@
      x="4.500042"
      y="5.500042"
      id="rect2315"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
   <g
      transform="translate(4,0.9999992)"
      id="layer1">
     <path
        d="m 1.4976268,0.49762721 13.0047472,0.002374 c 0,3.90746299 0,11.09490679 0,15.00237279 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031634 0,-15.00474638 z"
        id="rect2594"
-       style="fill:#f4f4f4;fill-opacity:1;stroke:#b5b6b2;stroke-width:0.9952535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:#f4f4f4;fill-opacity:1;stroke:#000000;stroke-width:0.9952535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   </g>
   <path
      d="m 2.5074017,19.499855 c 0.037084,0.51806 -0.096022,1.075538 0.1174382,1.555517 0.4004353,0.609192 1.2841971,0.408879 1.8751601,0.44374 0.010664,0.359614 0.043357,0.914773 0.5,0.991267 4.8238775,0.01951 9.175572,0.0028 14,0.0084 0.49786,0.01588 0.516095,-0.580789 0.5,-0.959423 0.162596,-0.09327 0.624708,-0.01381 0.849253,-0.0402 0.5556,0.08151 1.234943,-0.329792 1.142361,-1.013692 0,-0.328521 0,-0.657046 0,-0.985565 -6.328071,0 -12.6561415,0 -18.9842123,0 z"
      id="rect6333"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:0.99970871;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970871;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
   <path
      d="m 2.5152783,11.499966 18.9694417,0 c 0.562484,0 1.015314,0.463613 1.015314,1.039492 l 0,6.960576 -21.000068,0 0,-6.960576 c 0,-0.575879 0.4528294,-1.039492 1.0153123,-1.039492 z"
      id="rect2313"
-     style="fill:url(#linearGradient2920);fill-opacity:1;stroke:url(#linearGradient2922);stroke-width:0.99993205;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2920);fill-opacity:1;stroke:#000000;stroke-width:0.99993205;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none" />
   <path
      d="m 2.9633695,12.499953 18.0732605,0 c 0.240428,0 0.463417,0.206223 0.463417,0.428579 l 0,5.571515 -19.0000942,0 0,-5.571515 c 0,-0.222356 0.2229882,-0.428579 0.4634167,-0.428579 z"
      id="rect2374"

--- a/elementary-xfce/actions/24/document-print.svg
+++ b/elementary-xfce/actions/24/document-print.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="24"
    height="24"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="document-print.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview78982"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="2.6949153"
+     inkscape:cy="12.050847"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g5529" />
   <metadata
      id="metadata36249">
     <rdf:RDF>
@@ -32,17 +55,6 @@
       <stop
          id="stop6664"
          style="stop-color:#787878;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -158,15 +170,6 @@
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.4883737,0,0,0.5000043,0.2790318,1.2498788)" />
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient5583"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4883737,0,0,0.5000043,0.2790319,1.2498888)" />
     <radialGradient
        cx="24"
        cy="41.875"
@@ -200,23 +203,23 @@
        x="4.500042"
        y="5.500042"
        id="rect2315"
-       style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+       style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
     <g
        transform="translate(4,0.9999992)"
        id="layer1">
       <path
          d="m 1.4976268,0.49762721 13.0047472,0.002374 c 0,3.90746299 0,11.09490679 0,15.00237279 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031634 0,-15.00474638 z"
          id="rect2594"
-         style="fill:#f4f4f4;fill-opacity:1;stroke:#b5b6b2;stroke-width:0.9952535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+         style="fill:#f4f4f4;fill-opacity:1;stroke:#000000;stroke-width:0.9952535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
     </g>
     <path
        d="m 2.5074017,19.499855 c 0.037084,0.51806 -0.096022,1.075538 0.1174382,1.555517 0.4004353,0.609192 1.2841971,0.408879 1.8751601,0.44374 0.010664,0.359614 0.043357,0.914773 0.5,0.991267 4.8238775,0.01951 9.175572,0.0028 14,0.0084 0.49786,0.01588 0.516095,-0.580789 0.5,-0.959423 0.162596,-0.09327 0.624708,-0.01381 0.849253,-0.0402 0.5556,0.08151 1.234943,-0.329792 1.142361,-1.013692 0,-0.328521 0,-0.657046 0,-0.985565 -6.328071,0 -12.6561415,0 -18.9842123,0 z"
        id="rect6333"
-       style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:0.99970871;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970871;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
     <path
        d="m 2.5152783,11.499966 18.9694417,0 c 0.562484,0 1.015314,0.463613 1.015314,1.039492 l 0,6.960576 -21.000068,0 0,-6.960576 c 0,-0.575879 0.4528294,-1.039492 1.0153123,-1.039492 z"
        id="rect2313"
-       style="fill:url(#linearGradient5581);fill-opacity:1;stroke:url(#linearGradient5583);stroke-width:0.99993205;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:url(#linearGradient5581);fill-opacity:1;stroke:#000000;stroke-width:0.99993205;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none" />
     <path
        d="m 2.9633695,12.499953 18.0732605,0 c 0.240428,0 0.463417,0.206223 0.463417,0.428579 l 0,5.571515 -19.0000942,0 0,-5.571515 c 0,-0.222356 0.2229882,-0.428579 0.4634167,-0.428579 z"
        id="rect2374"

--- a/elementary-xfce/actions/48/document-print-preview.svg
+++ b/elementary-xfce/actions/48/document-print-preview.svg
@@ -5,7 +5,7 @@
    height="48"
    id="svg11300"
    sodipodi:docname="document-print-preview.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -24,14 +24,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="14.208333"
-     inkscape:cx="23.964809"
-     inkscape:cy="24"
+     inkscape:cx="17.454546"
+     inkscape:cy="24.000001"
      inkscape:window-width="1317"
      inkscape:window-height="890"
      inkscape:window-x="558"
-     inkscape:window-y="283"
+     inkscape:window-y="115"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg11300" />
+     inkscape:current-layer="g3998"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <metadata
      id="metadata3848">
     <rdf:RDF>
@@ -54,17 +56,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -212,15 +203,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9705882,0,0,0.8,0.7058824,10.1)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient3635"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.5,1.5)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -256,15 +238,6 @@
        xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.7142849,0,0,0.6998651,6.857167,1.4502166)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3649"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5767828,0,0,0.6549695,49.293,0.6702317)" />
     <radialGradient
        cx="3.7590685"
        cy="11.918329"
@@ -285,30 +258,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-2.5e-7,1.999981)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient3657"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,2)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
        y2="18.919773"
        id="linearGradient3660"
        xlink:href="#linearGradient6828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient3662"
-       xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
     <radialGradient
@@ -321,167 +276,6 @@
        xlink:href="#linearGradient7612"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.254902,0,0,0.339869,-6.1176472,27.267974)" />
-    <linearGradient
-       id="linearGradient11114-516">
-      <stop
-         id="stop3372"
-         style="stop-color:#242424;stop-opacity:0.99215686"
-         offset="0" />
-      <stop
-         id="stop3374"
-         style="stop-color:#656565;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3277-442">
-      <stop
-         id="stop3378"
-         style="stop-color:#575757;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3380"
-         style="stop-color:#333;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient12093-170">
-      <stop
-         id="stop3384"
-         style="stop-color:white;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3386"
-         style="stop-color:white;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4454-600">
-      <stop
-         id="stop3408"
-         style="stop-color:#a1a1a1;stop-opacity:0.20784314"
-         offset="0" />
-      <stop
-         id="stop3410"
-         style="stop-color:#a1a1a1;stop-opacity:0.67843139"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4467-402">
-      <stop
-         id="stop3390"
-         style="stop-color:white;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3392"
-         style="stop-color:white;stop-opacity:0.24761905"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2300-465">
-      <stop
-         id="stop3396"
-         style="stop-color:#343434;stop-opacity:0.97647059"
-         offset="0" />
-      <stop
-         id="stop3398"
-         style="stop-color:#929292;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient11104-770">
-      <stop
-         id="stop3402"
-         style="stop-color:#333;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3404"
-         style="stop-color:#333;stop-opacity:0.6122449"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6209-717">
-      <stop
-         id="stop3366"
-         style="stop-color:#979797;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3368"
-         style="stop-color:black;stop-opacity:0.34117648"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-172.65306"
-       y1="99.667191"
-       x2="-164.71831"
-       y2="91.972626"
-       id="linearGradient3982"
-       xlink:href="#linearGradient11114-516"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3936567,0,0,0.38976,148.37527,-5.4329178)" />
-    <linearGradient
-       x1="32.892574"
-       y1="27.988184"
-       x2="31.364458"
-       y2="29.484051"
-       id="linearGradient3984"
-       xlink:href="#linearGradient3277-442"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0113456,0,0,1.0013346,46.849579,0.6207219)" />
-    <linearGradient
-       x1="277.573"
-       y1="146.1507"
-       x2="201.87128"
-       y2="67.350082"
-       id="linearGradient3986"
-       xlink:href="#linearGradient12093-170"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3936567,0,0,0.38976,-3.211595,-1.6662606)" />
-    <radialGradient
-       cx="18.240929"
-       cy="21.817987"
-       r="8.3085051"
-       fx="18.240929"
-       fy="21.817987"
-       id="radialGradient3988"
-       xlink:href="#linearGradient4454-600"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       cx="15.414371"
-       cy="13.078408"
-       r="6.65625"
-       fx="15.414371"
-       fy="13.078408"
-       id="radialGradient3990"
-       xlink:href="#linearGradient4467-402"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.0710057,0,0,2.3628614,13.986567,-22.539066)" />
-    <linearGradient
-       x1="173.09576"
-       y1="75.31868"
-       x2="173.09576"
-       y2="11.949074"
-       id="linearGradient3992"
-       xlink:href="#linearGradient2300-465"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4037708,0,0,0.399774,-4.836512,-1.5263508)" />
-    <linearGradient
-       x1="41.541653"
-       y1="68.291702"
-       x2="41.485142"
-       y2="4.5362983"
-       id="linearGradient3994"
-       xlink:href="#linearGradient11104-770"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4037708,0,0,0.399774,47.537071,1.4823095)" />
-    <linearGradient
-       x1="173.09576"
-       y1="75.31868"
-       x2="173.09576"
-       y2="11.949074"
-       id="linearGradient3996"
-       xlink:href="#linearGradient6209-717"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3845313,0,0,0.3807249,-1.399825,-0.9351299)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient15780"
@@ -570,11 +364,11 @@
        x="9.4979439"
        y="10.497924"
        id="rect2315"
-       style="fill:url(#linearGradient3660);fill-opacity:1;stroke:url(#linearGradient3662);stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+       style="fill:url(#linearGradient3660);fill-opacity:1;stroke:#000000;stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
     <path
        d="m 4.5789659,22.499981 4.9210339,0 1.0000002,1 27,0 1,-1 4.921034,0 c 1.151747,0 2.078966,0.927219 2.078966,2.078966 l 0,13.921034 -43.0000002,0 0,-13.921034 c 0,-1.151747 0.9272188,-2.078966 2.0789661,-2.078966 z"
        id="rect2313"
-       style="fill:url(#linearGradient3655);fill-opacity:1;stroke:url(#linearGradient3657);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:url(#linearGradient3655);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
     <path
        d="m 4.4999997,23.499981 39.0000003,0 c 0.518817,0 1,0.481183 1,1 l 0,13 -41.0000002,0 0,-13 c 0,-0.518817 0.4811833,-1 0.9999999,-1 z"
        id="rect2374"
@@ -582,7 +376,7 @@
     <path
        d="m 11.499989,2.4999892 c 5.728776,0 11.457549,0 17.186322,0 1.00495,0.3397 6.403888,4.2097834 7.8137,6.88944 0,8.2015158 0,6.9090548 0,15.1105708 -8.333341,0 -16.66668,0 -25.000022,0 0,-10.497995 0,-11.502016 0,-22.0000108 z"
        id="rect2594"
-       style="fill:url(#linearGradient3647);fill-opacity:1;stroke:url(#linearGradient3649);stroke-width:0.99997759;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:url(#linearGradient3647);fill-opacity:1;stroke:#000000;stroke-width:0.99997759;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
     <path
        d="m 28.172621,2.503731 c 0.461632,3.1311527 0.441325,6.8576695 0.441325,6.8576695 0,0 3.526294,-0.084635 7.882281,0.450826 C 32.950272,6.1780173 30.465386,4.662651 28.172621,2.503731 z"
        id="path8596"
@@ -601,7 +395,7 @@
     <path
        d="M 3.5,38.5 C 3.580089,39.536507 3.2926219,40.651877 3.7536297,41.61219 4.6184456,42.831026 6.2237037,42.430252 7.5,42.5 c 0.023032,0.719497 -0.2134627,1.830225 0.7727435,1.983266 10.4180765,0.03903 20.8392415,0.0056 31.2585065,0.01673 1.075221,0.03177 1.003507,-1.16201 0.96875,-1.919563 0.351156,-0.186608 1.047908,-0.02762 1.532856,-0.08044 1.19992,0.163086 2.667095,-0.659828 2.467144,-2.028135 0,-0.657288 0,-1.314577 0,-1.971865 -13.666667,0 -27.333333,0 -41,0 z"
        id="rect6333"
-       style="fill:url(#linearGradient3633);fill-opacity:1;stroke:url(#linearGradient3635);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:url(#linearGradient3633);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
     <rect
        width="25"
        height="9"

--- a/elementary-xfce/actions/48/document-print.svg
+++ b/elementary-xfce/actions/48/document-print.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="48"
    height="48"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="document-print.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview79827"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="5.3898305"
+     inkscape:cy="24.101695"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g6448" />
   <metadata
      id="metadata851">
     <rdf:RDF>
@@ -43,17 +66,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -201,15 +213,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9705882,0,0,0.8,0.7058824,10.1)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient5555"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.5,1.5)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -245,15 +248,6 @@
        xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.7142849,0,0,0.6998651,6.857167,1.4502166)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient5569"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5767828,0,0,0.6549695,49.293,0.6702317)" />
     <radialGradient
        cx="3.7590685"
        cy="11.918329"
@@ -274,30 +268,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-2.5e-7,1.999981)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient5577"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,2)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
        y2="18.919773"
        id="linearGradient5580"
        xlink:href="#linearGradient6828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient5582"
-       xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
     <radialGradient
@@ -333,11 +309,11 @@
        x="9.4979439"
        y="10.497924"
        id="rect2315"
-       style="fill:url(#linearGradient5580);fill-opacity:1;stroke:url(#linearGradient5582);stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+       style="fill:url(#linearGradient5580);fill-opacity:1;stroke:#000000;stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
     <path
        d="m 4.5789659,22.499981 4.9210339,0 1.0000002,1 27,0 1,-1 4.921034,0 c 1.151747,0 2.078966,0.927219 2.078966,2.078966 l 0,13.921034 -43.0000002,0 0,-13.921034 c 0,-1.151747 0.9272188,-2.078966 2.0789661,-2.078966 z"
        id="rect2313"
-       style="fill:url(#linearGradient5575);fill-opacity:1;stroke:url(#linearGradient5577);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:url(#linearGradient5575);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
     <path
        d="m 4.4999997,23.499981 39.0000003,0 c 0.518817,0 1,0.481183 1,1 l 0,13 -41.0000002,0 0,-13 c 0,-0.518817 0.4811833,-1 0.9999999,-1 z"
        id="rect2374"
@@ -345,7 +321,7 @@
     <path
        d="m 11.499989,2.4999892 c 5.728776,0 11.457549,0 17.186322,0 1.00495,0.3397 6.403888,4.2097834 7.8137,6.88944 0,8.2015158 0,6.9090548 0,15.1105708 -8.333341,0 -16.66668,0 -25.000022,0 0,-10.497995 0,-11.502016 0,-22.0000108 z"
        id="rect2594"
-       style="fill:url(#linearGradient5567);fill-opacity:1;stroke:url(#linearGradient5569);stroke-width:0.99997759;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:url(#linearGradient5567);fill-opacity:1;stroke:#000000;stroke-width:0.99997759;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
     <path
        d="m 28.172621,2.503731 c 0.461632,3.1311527 0.441325,6.8576695 0.441325,6.8576695 0,0 3.526294,-0.084635 7.882281,0.450826 C 32.950272,6.1780173 30.465386,4.662651 28.172621,2.503731 z"
        id="path8596"
@@ -364,7 +340,7 @@
     <path
        d="M 3.5,38.5 C 3.580089,39.536507 3.2926219,40.651877 3.7536297,41.61219 4.6184456,42.831026 6.2237037,42.430252 7.5,42.5 c 0.023032,0.719497 -0.2134627,1.830225 0.7727435,1.983266 10.4180765,0.03903 20.8392415,0.0056 31.2585065,0.01673 1.075221,0.03177 1.003507,-1.16201 0.96875,-1.919563 0.351156,-0.186608 1.047908,-0.02762 1.532856,-0.08044 1.19992,0.163086 2.667095,-0.659828 2.467144,-2.028135 0,-0.657288 0,-1.314577 0,-1.971865 -13.666667,0 -27.333333,0 -41,0 z"
        id="rect6333"
-       style="fill:url(#linearGradient5553);fill-opacity:1;stroke:url(#linearGradient5555);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:url(#linearGradient5553);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
     <rect
        width="25"
        height="9"

--- a/elementary-xfce/apps/16/system-config-printer.svg
+++ b/elementary-xfce/apps/16/system-config-printer.svg
@@ -1,0 +1,1 @@
+../../devices/16/printer.svg

--- a/elementary-xfce/apps/24/system-config-printer.svg
+++ b/elementary-xfce/apps/24/system-config-printer.svg
@@ -1,0 +1,1 @@
+../../devices/24/printer.svg

--- a/elementary-xfce/apps/32/system-config-printer.svg
+++ b/elementary-xfce/apps/32/system-config-printer.svg
@@ -1,0 +1,1 @@
+../../devices/32/printer.svg

--- a/elementary-xfce/apps/48/system-config-printer.svg
+++ b/elementary-xfce/apps/48/system-config-printer.svg
@@ -1,0 +1,1 @@
+../../devices/48/printer.svg

--- a/elementary-xfce/apps/64/system-config-printer.svg
+++ b/elementary-xfce/apps/64/system-config-printer.svg
@@ -1,0 +1,1 @@
+../../devices/64/printer.svg

--- a/elementary-xfce/devices/16/gnome-dev-printer-new.svg
+++ b/elementary-xfce/devices/16/gnome-dev-printer-new.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="16"
    height="16"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="gnome-dev-printer-new.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview64077"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="-4.5084746"
+     inkscape:cy="8"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="39"
+     inkscape:window-y="292"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata24649">
     <rdf:RDF>
@@ -18,23 +41,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3">
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient6842">
       <stop
@@ -116,15 +127,6 @@
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.34883886,0,0,0.37500427,-0.37213199,-0.1876208)" />
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2877"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.34883886,0,0,0.37500427,-0.37213192,-0.18761334)" />
     <radialGradient
        cx="64.575233"
        cy="48.605404"
@@ -163,23 +165,23 @@
      x="2.500042"
      y="3.5000422"
      id="rect2315"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
   <g
      transform="matrix(0.69407228,0,0,0.73253891,2.4439816,0.13360126)"
      id="layer1">
     <path
        d="m 1.4976268,0.49762721 13.0047472,0.002374 c 0,3.90746299 0,11.09490679 0,15.00237279 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031634 0,-15.00474638 z"
        id="rect2594"
-       style="fill:#f4f4f4;fill-opacity:1;stroke:#b5b6b2;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:#f4f4f4;fill-opacity:1;stroke:#000000;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   </g>
   <path
      d="m 1.5050189,12.499854 c 0.025372,0.518058 -0.0657,1.075536 0.080353,1.555513 0.2739839,0.609191 0.8786674,0.408878 1.2830134,0.44374 0.0073,0.359613 0.029665,0.914771 0.3421077,0.991264 3.3005711,0.01952 6.2780675,0.0028 9.579015,0.0084 0.340644,0.01588 0.35312,-0.580789 0.342108,-0.959421 0.11125,-0.09326 0.427435,-0.01386 0.581072,-0.04021 0.38015,0.0815 0.844967,-0.329793 0.78162,-1.013691 0,-0.328519 0,-0.657045 0,-0.985562 -4.329764,0 -8.6595258,0 -12.9892892,0 z"
      id="rect6333"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
   <path
      d="m 1.2251892,7.4999662 13.5496198,0 c 0.401775,0 0.725226,0.3477098 0.725226,0.7796206 l 0,5.2204472 -15.00006986,0 0,-5.2204472 c 0,-0.4319108 0.32345002,-0.7796206 0.72522406,-0.7796206 z"
      id="rect2313"
-     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:url(#linearGradient2877);stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:#000000;stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.30000001;stroke-dasharray:none" />
   <path
      d="m 1.8170282,8.4999529 12.3659448,0 c 0.164502,0 0.317074,0.1374829 0.317074,0.2857221 l 0,3.714372 -13.0000942,0 0,-3.714372 c 0,-0.1482392 0.1525713,-0.2857221 0.3170754,-0.2857221 z"
      id="rect2374"

--- a/elementary-xfce/devices/16/printer.svg
+++ b/elementary-xfce/devices/16/printer.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="16"
    height="16"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="printer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview38557"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="29.5"
+     inkscape:cx="4.5254237"
+     inkscape:cy="3.6949153"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="677"
+     inkscape:window-y="243"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata24649">
     <rdf:RDF>
@@ -18,23 +41,11 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
      id="defs3">
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient6842">
       <stop
@@ -116,15 +127,6 @@
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.34883886,0,0,0.37500427,-0.37213199,-0.1876208)" />
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2877"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.34883886,0,0,0.37500427,-0.37213192,-0.18761334)" />
   </defs>
   <rect
      width="10.999916"
@@ -134,23 +136,23 @@
      x="2.500042"
      y="3.5000422"
      id="rect2315"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.69999999;stroke-dasharray:none;display:inline" />
   <g
      transform="matrix(0.69407228,0,0,0.73253891,2.4439816,0.13360126)"
      id="layer1">
     <path
        d="m 1.4976268,0.49762721 13.0047472,0.002374 c 0,3.90746299 0,11.09490679 0,15.00237279 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031634 0,-15.00474638 z"
        id="rect2594"
-       style="fill:#f4f4f4;fill-opacity:1;stroke:#b5b6b2;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:#fafafa;fill-opacity:1;stroke:#000000;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   </g>
   <path
      d="m 1.5050189,12.499854 c 0.025372,0.518058 -0.0657,1.075536 0.080353,1.555513 0.2739839,0.609191 0.8786674,0.408878 1.2830134,0.44374 0.0073,0.359613 0.029665,0.914771 0.3421077,0.991264 3.3005711,0.01952 6.2780675,0.0028 9.579015,0.0084 0.340644,0.01588 0.35312,-0.580789 0.342108,-0.959421 0.11125,-0.09326 0.427435,-0.01386 0.581072,-0.04021 0.38015,0.0815 0.844967,-0.329793 0.78162,-1.013691 0,-0.328519 0,-0.657045 0,-0.985562 -4.329764,0 -8.6595258,0 -12.9892892,0 z"
      id="rect6333"
-     style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.69999999;stroke-dasharray:none" />
   <path
      d="m 1.2251892,7.4999662 13.5496198,0 c 0.401775,0 0.725226,0.3477098 0.725226,0.7796206 l 0,5.2204472 -15.00006986,0 0,-5.2204472 c 0,-0.4319108 0.32345002,-0.7796206 0.72522406,-0.7796206 z"
      id="rect2313"
-     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:url(#linearGradient2877);stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:#000000;stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.30000001;stroke-dasharray:none" />
   <path
      d="m 1.8170282,8.4999529 12.3659448,0 c 0.164502,0 0.317074,0.1374829 0.317074,0.2857221 l 0,3.714372 -13.0000942,0 0,-3.714372 c 0,-0.1482392 0.1525713,-0.2857221 0.3170754,-0.2857221 z"
      id="rect2374"
@@ -166,4 +168,11 @@
      d="m 13,14 0,0.875 C 13,14.94425 12.93031,15 12.843749,15 l -9.687506,0 c -0.086562,0 -0.15625,-0.05575 -0.15625,-0.125 l 0,-0.875 L 13,14 z"
      id="rect6331"
      style="fill:#e6e6e6;fill-opacity:1;stroke:none" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.7;stop-color:#000000"
+     id="rect40418"
+     width="8"
+     height="1"
+     x="4"
+     y="1" />
 </svg>

--- a/elementary-xfce/devices/16/system-config-printer.svg
+++ b/elementary-xfce/devices/16/system-config-printer.svg
@@ -1,1 +1,0 @@
-printer.svg

--- a/elementary-xfce/devices/24/printer.svg
+++ b/elementary-xfce/devices/24/printer.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="24"
    height="24"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="printer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview51587"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="19.666667"
+     inkscape:cx="6.2542372"
+     inkscape:cy="7.8813558"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="0"
+     inkscape:window-y="219"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g5529" />
   <metadata
      id="metadata162459">
     <rdf:RDF>
@@ -23,17 +46,6 @@
   </metadata>
   <defs
      id="defs3">
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient6842">
       <stop
@@ -147,15 +159,6 @@
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.4883737,0,0,0.5000043,0.2790318,1.2498788)" />
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient5583"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4883737,0,0,0.5000043,0.2790319,1.2498888)" />
     <radialGradient
        cx="24"
        cy="41.875"
@@ -188,11 +191,11 @@
        id="linearGradient4559">
       <stop
          id="stop4561"
-         style="stop-color:silver;stop-opacity:1"
+         style="stop-color:#000000;stop-opacity:0.2;"
          offset="0" />
       <stop
          id="stop4563"
-         style="stop-color:#949492;stop-opacity:1"
+         style="stop-color:#000000;stop-opacity:0.40000001;"
          offset="1" />
     </linearGradient>
   </defs>
@@ -210,14 +213,14 @@
        x="4.500042"
        y="5.500042"
        id="rect2315"
-       style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+       style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.69999999;stroke-dasharray:none;display:inline" />
     <g
        transform="translate(4,0.9999992)"
        id="layer1">
       <path
          d="m 1.4976268,0.49762721 c 2.980045,0 4.9376418,0 7.9176887,0 0.522766,0.16184396 4.3536885,2.61362219 5.0870585,3.89029659 0,3.907463 0,7.2069842 0,11.1144502 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031638 0,-15.00474679 z"
          id="rect2594"
-         style="fill:#f4f4f4;fill-opacity:1;stroke:#b5b6b2;stroke-width:0.9952535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+         style="fill:#f4f4f4;fill-opacity:1;stroke:#000000;stroke-width:0.9952535;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
       <path
          d="M 9.5,0.4979205 C 9.5,2.041279 9.5,4.5 9.5,4.5 c 0,0 4.080603,0 5.00208,0 0,-1.9018156 -3.00574,-4.0020795 -5.00208,-4.0020795 z"
          id="path12038"
@@ -226,11 +229,11 @@
     <path
        d="m 2.5074017,19.499855 c 0.037084,0.51806 -0.096022,1.075538 0.1174382,1.555517 0.4004353,0.609192 1.2841971,0.408879 1.8751601,0.44374 0.010664,0.359614 0.043357,0.914773 0.5,0.991267 4.8238775,0.01951 9.175572,0.0028 14,0.0084 0.49786,0.01588 0.516095,-0.580789 0.5,-0.959423 0.162596,-0.09327 0.624708,-0.01381 0.849253,-0.0402 0.5556,0.08151 1.234943,-0.329792 1.142361,-1.013692 0,-0.328521 0,-0.657046 0,-0.985565 -6.328071,0 -12.6561415,0 -18.9842123,0 z"
        id="rect6333"
-       style="fill:#505050;fill-opacity:1;stroke:#3c3d3a;stroke-width:0.99970871;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970871;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.69999999;stroke-dasharray:none" />
     <path
        d="m 2.5152783,11.499966 18.9694417,0 c 0.562484,0 1.015314,0.463613 1.015314,1.039492 l 0,6.960576 -21.000068,0 0,-6.960576 c 0,-0.575879 0.4528294,-1.039492 1.0153123,-1.039492 z"
        id="rect2313"
-       style="fill:url(#linearGradient5581);fill-opacity:1;stroke:url(#linearGradient5583);stroke-width:0.99993205;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:url(#linearGradient5581);fill-opacity:1;stroke:#000000;stroke-width:0.99993205;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none" />
     <path
        d="m 2.9633695,12.499953 18.0732605,0 c 0.240428,0 0.463417,0.206223 0.463417,0.428579 l 0,5.571515 -19.0000942,0 0,-5.571515 c 0,-0.222356 0.2229882,-0.428579 0.4634167,-0.428579 z"
        id="rect2374"

--- a/elementary-xfce/devices/24/system-config-printer.svg
+++ b/elementary-xfce/devices/24/system-config-printer.svg
@@ -1,1 +1,0 @@
-printer.svg

--- a/elementary-xfce/devices/32/printer.svg
+++ b/elementary-xfce/devices/32/printer.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.0"
-   width="64"
-   height="64"
+   width="32"
+   height="32"
    id="svg11300"
    sodipodi:docname="printer.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
@@ -15,24 +15,26 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview57994"
+     id="namedview85"
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:showpageshadow="2"
+     inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="10.429825"
-     inkscape:cx="24.017661"
-     inkscape:cy="34.132883"
-     inkscape:window-width="1326"
-     inkscape:window-height="414"
-     inkscape:window-x="109"
-     inkscape:window-y="813"
+     width="32px"
+     inkscape:zoom="11.313709"
+     inkscape:cx="9.4133586"
+     inkscape:cy="20.196737"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="639"
+     inkscape:window-y="651"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg11300" />
+     inkscape:current-layer="svg11300"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <metadata
      id="metadata109152">
     <rdf:RDF>
@@ -153,7 +155,7 @@
        id="linearGradient2444"
        xlink:href="#linearGradient6828"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2857143,0,0,1,1.1428571,17)" />
+       gradientTransform="matrix(0.64285715,0,0,0.5,0.57142852,8)" />
     <linearGradient
        x1="21.0625"
        y1="38"
@@ -162,7 +164,7 @@
        id="linearGradient2447"
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.25,0,0,1,2,17)" />
+       gradientTransform="matrix(0.625,0,0,0.75,1,-1.5)" />
     <radialGradient
        cx="11.537243"
        cy="15.279687"
@@ -172,16 +174,16 @@
        id="radialGradient2456"
        xlink:href="#linearGradient2463"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.24,0,0,0.51282052,2.2399998,24.653853)" />
+       gradientTransform="matrix(0.6,0,0,0.21367526,1.5999999,13.230771)" />
     <linearGradient
-       x1="7.5170455"
-       y1="31.15625"
+       x1="7.4545455"
+       y1="32.028358"
        x2="7.4545455"
        y2="40.875"
        id="linearGradient2459"
        xlink:href="#linearGradient6828"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2062953,0,0,1.0661658,3.0475908,13.651113)" />
+       gradientTransform="matrix(0.59055834,0,0,0.59134552,1.8434598,4.507236)" />
     <linearGradient
        x1="21.919418"
        y1="21"
@@ -190,7 +192,7 @@
        id="linearGradient2464"
        xlink:href="#linearGradient6828"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2222222,0,0,1.2727273,2.6666664,4.1363638)" />
+       gradientTransform="matrix(0.62962962,0,0,0.63636394,0.8888888,1.8181753)" />
     <linearGradient
        x1="15.600636"
        y1="33"
@@ -199,7 +201,7 @@
        id="linearGradient2466"
        xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2222222,0,0,1.2727273,2.6666664,4.1363638)" />
+       gradientTransform="matrix(0.62962962,0,0,0.63636394,0.8888888,1.8181753)" />
     <radialGradient
        cx="3.7590685"
        cy="11.918329"
@@ -209,7 +211,7 @@
        id="radialGradient2478"
        xlink:href="#linearGradient6842"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2436834,0.02546538,-0.01570664,0.91310691,2.334362,21.984542)" />
+       gradientTransform="matrix(0.60964873,0.01072227,-0.00769933,0.38446612,1.4580206,12.493489)" />
     <linearGradient
        x1="11.519291"
        y1="20"
@@ -218,7 +220,7 @@
        id="linearGradient2481"
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2325581,0,0,1.3125,2.4186055,3.5937499)" />
+       gradientTransform="matrix(0.627907,0,0,0.62500001,0.9302317,2.6874999)" />
     <linearGradient
        x1="21.586424"
        y1="9.5515556"
@@ -227,7 +229,7 @@
        id="linearGradient2486"
        xlink:href="#linearGradient6828"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1819384,0,0,1.1284132,3.6334807,4.9064115)" />
+       gradientTransform="matrix(0.57575761,0,0,0.56410276,2.181818,2.7051246)" />
     <radialGradient
        cx="24"
        cy="41.875"
@@ -237,12 +239,12 @@
        id="radialGradient2491"
        xlink:href="#linearGradient7612"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5163399,0,0,0.339869,-4.3921567,42.267974)" />
+       gradientTransform="matrix(0.75816995,0,0,0.1699345,-2.1960784,21.133986)" />
     <filter
-       x="-0.14846255"
-       y="-0.16434373"
-       width="1.2969251"
-       height="1.3286875"
+       x="-0.11751037"
+       y="-0.13261381"
+       width="1.2350207"
+       height="1.2652276"
        color-interpolation-filters="sRGB"
        id="filter3212">
       <feGaussianBlur
@@ -308,7 +310,7 @@
        xlink:href="#linearGradient6393"
        id="radialGradient3082"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9585208,-0.09966997,0.1135695,1.0921915,11.11858,19.720617)"
+       gradientTransform="matrix(1.0370399,-0.10773965,0.12287276,1.1806197,7.6470038,17.228763)"
        cx="40.092358"
        cy="31.496664"
        fx="40.092358"
@@ -318,16 +320,16 @@
        xlink:href="#linearGradient8589"
        id="linearGradient3085"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6371285,0,0,0.6445638,20.829693,3.744518)"
-       x1="32.892288"
-       y1="8.0590115"
+       gradientTransform="matrix(0.31856425,0,0,0.3215793,9.914846,2.3812579)"
+       x1="30.238829"
+       y1="11.518704"
        x2="36.358372"
        y2="5.4565363" />
     <linearGradient
        xlink:href="#linearGradient3211"
        id="linearGradient3089"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.87878591,0,0,0.6279076,10.909113,3.930216)"
+       gradientTransform="matrix(0.39393857,0,0,0.30232592,6.5454756,2.7441968)"
        x1="24"
        y1="1.9999999"
        x2="24"
@@ -336,7 +338,7 @@
        xlink:href="#XMLID_8_"
        id="radialGradient3092"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.31914906,0,0,-0.2542968,11.574481,35.288672)"
+       gradientTransform="matrix(0.14893625,0,0,-0.1271484,6.4680847,18.144336)"
        cx="102"
        cy="112.3047"
        r="139.55859" />
@@ -344,93 +346,99 @@
        xlink:href="#linearGradient3600"
        id="linearGradient3095"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88571451,0,0,0.6301241,10.742862,2.9103522)"
+       gradientTransform="matrix(0.42857269,0,0,0.30419872,5.7142606,1.7325614)"
        x1="25.132275"
        y1="0.98520643"
        x2="25.132275"
        y2="47.013336" />
   </defs>
   <path
-     d="M 61,56.499999 C 61,60.08985 48.016257,63 32,63 15.983742,63 3,60.08985 3,56.499999 c 0,-3.589851 12.983742,-6.500001 29,-6.500001 16.016257,0 29,2.91015 29,6.500001 l 0,0 z"
+     d="M 30.5,28.249999 C 30.5,30.044924 24.008128,31.5 16,31.5 7.991871,31.5 1.5,30.044924 1.5,28.249999 c 0,-1.794926 6.491871,-3.250001 14.5,-3.250001 8.008128,0 14.5,1.455075 14.5,3.250001 z"
      id="path3087"
-     style="opacity:0.5;fill:url(#radialGradient2491);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none;visibility:visible;display:inline;overflow:visible" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:url(#radialGradient2491);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;marker:none" />
   <rect
-     width="39.003963"
-     height="22.004059"
-     rx="0.75817347"
-     ry="0.72383887"
-     x="12.498018"
-     y="14.497924"
+     width="19"
+     height="11.000004"
+     rx="0.36932904"
+     ry="0.36185282"
+     x="6.5"
+     y="7.4999981"
      id="rect2315"
-     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:#000000;stroke-width:0.99603379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
+     style="display:inline;fill:url(#linearGradient2486);fill-opacity:1;stroke:#000000;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.69999999" />
   <path
-     style="fill:url(#linearGradient3095);fill-opacity:1;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     style="display:inline;fill:url(#linearGradient3095);fill-opacity:1;stroke:#000000;stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34999999"
      id="path4160"
-     d="m 16.499972,4.499961 c 7.10369,0 16.396332,0 23.500028,0 1.24614,0.3128 5.751882,3.876424 7.500052,6.343886 0,7.552064 0,15.104128 0,22.656193 -10.333361,0 -20.66672,0 -31.00008,0 0,-9.666694 0,-19.333388 0,-29.000079 z" />
+     d="m 8.4999665,2.499961 c 3.4372785,0 7.9337305,0 11.3710115,0 0.602973,0.1510073 2.783176,1.8713825 3.629067,3.0625745 0,3.6458345 0,7.2916685 0,10.9375035 -5.000027,0 -10.000052,0 -15.0000785,0 0,-4.666693 0,-9.3333862 0,-14.000078 z" />
   <path
-     style="fill:url(#radialGradient3092);fill-opacity:1"
+     style="fill:url(#radialGradient3092);fill-opacity:1;stroke-width:1"
      id="path4191"
-     d="m 17.319163,33 c -0.175852,0 -0.31915,-0.114179 -0.31915,-0.254297 l 0,-27.464043 c 0,-0.140371 0.143298,-0.254296 0.31915,-0.254296 6.602729,0.07029 13.919724,-0.105144 20.514427,0.0175 l 9.072918,5.769515 0.0935,21.931323 C 47.000018,32.885821 46.857038,33 46.680869,33 l -29.361706,0 z" />
+     d="M 9.1489367,17 C 9.0668727,17 9,16.94291 9,16.872851 V 3.1408302 c 0,-0.070185 0.066872,-0.127148 0.1489367,-0.127148 3.0812743,0.035145 6.4958723,-0.052572 9.5734013,0.00875 l 4.234029,2.8847575 0.04363,10.9656613 C 23.000005,16.94291 22.933281,17 22.851069,17 Z" />
   <path
-     style="opacity:0.6;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     style="display:inline;opacity:0.6;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="path2435"
-     d="m 46.499974,11.138976 c 0,7.031232 0,14.329829 0,21.361064 -9.666665,0 -19.333331,0 -29,0 0,-9.000029 0,-18.000054 0,-27.000079 6.645372,0 14.854653,0 21.500026,0" />
+     d="M 22.500002,6 V 16.500039 H 9.5 V 3.5 H 20"
+     sodipodi:nodetypes="ccccc" />
   <path
-     style="opacity:0.4;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline;filter:url(#filter3212)"
+     style="display:inline;opacity:0.4;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.33937;filter:url(#filter3212)"
      id="path2600"
-     transform="matrix(0.6385981,0,0,0.6193639,20.725089,4.429406)"
-     d="m 28.617256,0.92125832 c 4.282522,0 3.131838,8.07279828 3.131838,8.07279828 0,0 9.379054,-1.3919737 9.379054,3.2291174 0,-2.6097233 -11.302304,-10.7285956 -12.510892,-11.30191568 z" />
+     transform="matrix(0.25306435,0,0,0.28559035,11.728034,3.2673527)"
+     d="m 28.73564,-0.93614052 c 4.282522,0 3.013454,9.93019712 3.013454,9.93019712 0,0 12.792802,-0.5452127 12.792802,4.0758784 0,-2.609723 -15.250534,-12.16829994 -15.806256,-14.00607552 z"
+     sodipodi:nodetypes="cccc" />
   <path
-     style="fill:url(#linearGradient3085);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline"
+     style="display:inline;fill:url(#linearGradient3085);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1"
      id="path4474"
-     d="m 39,5 c 2.034888,0 2,4 2,4 0,0 5.989445,0.137864 5.989445,3 0,-0.697366 0.05487,-1.196763 -0.08543,-1.414376 C 45.89611,9.022238 41.57209,5.459808 40,5 c -0.117643,-0.03441 -0.40795,-4e-6 -1,0 z" />
+     d="m 19,3 c 1.017444,0 0,3 0,3 0,0 3.994723,-0.9279477 3.994723,0.5000002 C 22.994723,6.1520773 23.07015,5.6085693 23,5.5 22.496052,4.7200112 20.786045,3.2294028 20,3 19.94118,2.982833 19.296025,2.9999981 19,3 Z"
+     sodipodi:nodetypes="ccccsc" />
   <path
-     d="m 8.0624473,30.5 6.0654597,0 1.232559,1.3125 33.279068,0 1.232559,-1.3125 6.06546,0 c 1.419595,0 2.562446,1.216975 2.562446,2.728643 l 0,18.271357 -52.9999982,0 0,-18.271357 C 5.5000008,31.716975 6.6428519,30.5 8.0624473,30.5 l 0,0 z"
+     d="M 3.8053965,15.5 H 6.5 l 1,1 h 17 l 1,-1 h 2.694603 c 0.72319,0 1.305398,0.579512 1.305398,1.299354 V 25.5 H 2.4999992 V 16.799354 C 2.4999992,16.079512 3.0822065,15.5 3.8053965,15.5 Z"
      id="rect2313"
-     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
+     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:#000000;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999"
+     sodipodi:nodetypes="sccccssccss" />
   <path
-     d="m 7.7439025,31.500002 48.5121955,0 c 0.645358,0 1.243902,0.653034 1.243902,1.357143 l 0,17.642857 -50.9999998,0 0,-17.642857 c 0,-0.704109 0.5985451,-1.357143 1.2439022,-1.357143 l 0,0 z"
+     d="M 4.1097562,16.499999 H 27.890244 c 0.316352,0 0.609756,0.274962 0.609756,0.571429 V 24.5 H 3.5000001 v -7.428572 c 0,-0.296467 0.2934045,-0.571429 0.6097561,-0.571429 z"
      id="rect2374"
-     style="opacity:0.9;fill:none;stroke:url(#radialGradient2478);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
+     style="display:inline;opacity:0.9;fill:none;stroke:url(#radialGradient2478);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
   <rect
-     width="33"
-     height="14"
-     x="15.5"
-     y="31.5"
+     width="17"
+     height="7.0000033"
+     x="7.5"
+     y="15.499998"
      id="rect2319"
-     style="fill:url(#linearGradient2464);fill-opacity:1;stroke:url(#linearGradient2466);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2464);fill-opacity:1;stroke:url(#linearGradient2466);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <path
-     d="m 6.5202591,51.499997 c 0.099539,1.381361 -0.2577398,2.867822 0.3152236,4.147638 1.0748362,1.624352 3.0699301,1.090238 4.6561763,1.183191 0.02862,0.958879 -0.265303,2.439154 0.960403,2.643113 12.948104,0.05202 25.900046,0.0075 38.849626,0.0223 1.336338,0.04234 1.247209,-1.548619 1.204012,-2.558215 0.436434,-0.248694 1.302391,-0.03681 1.905109,-0.107203 1.49132,0.217346 3.314798,-0.879358 3.066289,-2.70291 0,-0.875973 0,-1.751946 0,-2.627919 -16.985613,0 -33.971225,0 -50.9568389,0 l 0,9e-6 z"
+     d="m 3.5,25.500001 c 0,0 -0.082628,1.290154 0.197874,1.999999 0.5262008,0.900942 1.122198,1 2.2794947,1 0.014011,0.53184 -0.1298827,1.886875 0.4701784,2 H 25.466912 c 0.654221,0.02349 0.555962,-1.44003 0.534813,-2 h 0.987299 C 28.01585,28.5 28.5,28.050857 28.5,27 v -1.499942 z"
      id="rect6333"
-     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:#000000;stroke-width:0.999995;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.69999999"
+     sodipodi:nodetypes="cccccccccc" />
   <rect
-     width="31"
-     height="12"
-     x="16.5"
-     y="32.499996"
+     width="15"
+     height="5.000001"
+     x="8.5"
+     y="16.499998"
      id="rect2459"
-     style="opacity:0.3;fill:none;stroke:url(#radialGradient2456);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="display:inline;opacity:0.3;fill:none;stroke:url(#radialGradient2456);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <g
      id="g3076"
-     transform="translate(0,-3)">
+     transform="matrix(1.4441954,0,0,1.4442017,-50.26471,-49.93243)"
+     style="stroke-width:0.692426">
     <path
-       style="fill:none;stroke:url(#linearGradient3080);stroke-width:0.74988067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:none;stroke:url(#linearGradient3080);stroke-width:0.519236;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path2726"
        d="m 54.625413,50.50023 c 0,0.62148 -0.503786,1.125291 -1.125237,1.125291 -0.62145,0 -1.125236,-0.503811 -1.125236,-1.125291 0,-0.621481 0.503786,-1.125291 1.125236,-1.125291 0.621451,0 1.125237,0.50381 1.125237,1.125291 z" />
     <path
-       style="fill:url(#radialGradient3082);fill-opacity:1;stroke:none"
+       style="fill:url(#radialGradient3082);fill-opacity:1;stroke:none;stroke-width:0.692426"
        id="path2764"
-       d="m 54.299999,50.500001 c 3.88e-4,0.442102 -0.357898,0.800702 -0.8,0.800702 -0.442102,0 -0.800388,-0.3586 -0.8,-0.800702 -3.88e-4,-0.442102 0.357898,-0.800702 0.8,-0.800702 0.442102,0 0.800388,0.3586 0.8,0.800702 l 0,0 z" />
+       d="m 54.365711,50.500169 c 4.2e-4,0.477896 -0.387216,0.86553 -0.865534,0.86553 -0.478317,0 -0.865953,-0.387634 -0.865533,-0.86553 -4.2e-4,-0.477896 0.387216,-0.86553 0.865533,-0.86553 0.478318,0 0.865954,0.387634 0.865534,0.86553 z" />
   </g>
   <path
-     d="m 52,55 0,3.5 c 0,0.277 -0.27875,0.5 -0.625,0.5 l -38.75,0 C 12.27875,59 12,58.777 12,58.5 l 0,-3.5 40,0 z"
+     d="m 26,27 v 2.625 C 26,29.83275 25.860625,30 25.6875,30 H 6.3125 C 6.139375,30 6,29.83275 6,29.625 V 27 Z"
      id="rect6331"
-     style="fill:url(#linearGradient2447);fill-opacity:1;stroke:none" />
+     style="fill:url(#linearGradient2447);fill-opacity:1;stroke:none;stroke-width:1" />
   <rect
-     width="36"
-     height="2"
-     x="14"
-     y="55"
+     width="18"
+     height="1"
+     x="7"
+     y="27"
      id="rect6329"
-     style="fill:url(#linearGradient2444);fill-opacity:1;stroke:none" />
+     style="fill:url(#linearGradient2444);fill-opacity:1;stroke:none;stroke-width:0.999998" />
 </svg>

--- a/elementary-xfce/devices/48/gnome-dev-printer-new.svg
+++ b/elementary-xfce/devices/48/gnome-dev-printer-new.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="48"
    height="48"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="gnome-dev-printer-new.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview64798"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="5.3898305"
+     inkscape:cy="24.101695"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata10939">
     <rdf:RDF>
@@ -80,17 +103,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaaaaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -238,15 +250,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9705882,0,0,0.8,0.7058824,10.1)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient2461"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.5,1.5)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -284,30 +287,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-2.5e-7,1.999981)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2483"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,2)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
        y2="18.919773"
        id="linearGradient2486"
        xlink:href="#linearGradient6828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient2488"
-       xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
     <radialGradient
@@ -324,7 +309,7 @@
        height="1.3286875"
        y="-0.16434373"
        width="1.2969251"
-       x="-0.14846256"
+       x="-0.14846255"
        id="filter3212">
       <feGaussianBlur
          id="feGaussianBlur3214"
@@ -440,15 +425,6 @@
        xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.6571436,0,0,0.6301241,0.2285531,-8.9647831e-2)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2620"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5306412,0,0,0.5897023,39.269605,-0.7919081)" />
     <radialGradient
        cx="102"
        cy="112.3047"
@@ -488,7 +464,7 @@
      x="9.4979439"
      y="10.497924"
      id="rect2315"
-     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:url(#linearGradient2488);stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline" />
+     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:#000000;stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.75;display:inline" />
   <g
      transform="translate(8.0000133,1.9999996)"
      id="layer1">
@@ -510,7 +486,7 @@
     <path
        d="M 4.499961,1.4999609 C 9.7704453,1.4999609 15.04093,1.4999609 20.311419,1.4999609 C 21.235975,1.8127611 26.20301,5.3763851 27.50004,7.8438467 C 27.50004,15.395911 27.50004,22.947975 27.50004,30.50004 C 19.833346,30.50004 12.166654,30.50004 4.499961,30.50004 C 4.499961,20.833346 4.499961,11.166652 4.499961,1.4999609 z"
        id="path4160"
-       style="fill:url(#linearGradient2618);fill-opacity:1;stroke:url(#linearGradient2620);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;display:inline" />
+       style="fill:url(#linearGradient2618);fill-opacity:1;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34999999;display:inline" />
     <path
        d="M 5.2340427,30 C 5.1050853,30 5,29.885821 5,29.745703 L 5,2.2816602 C 5,2.141289 5.1050853,2.0273644 5.2340427,2.0273644 C 10.076044,2.0976535 15.441839,1.9222203 20.277954,2.0448649 L 26.931426,7.8143805 L 27,29.745703 C 27,29.885821 26.895148,30 26.765957,30 L 5.2340427,30 z"
        id="path4191"
@@ -532,7 +508,7 @@
   <path
      d="M 4.5789659,22.499981 L 9.4999998,22.499981 L 10.5,23.499981 L 37.5,23.499981 L 38.5,22.499981 L 43.421034,22.499981 C 44.572781,22.499981 45.5,23.4272 45.5,24.578947 L 45.5,38.499981 L 2.4999998,38.499981 L 2.4999998,24.578947 C 2.4999998,23.4272 3.4272186,22.499981 4.5789659,22.499981 L 4.5789659,22.499981 z"
      id="rect2313"
-     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:url(#linearGradient2483);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
   <path
      d="M 4.4999997,23.499981 L 43.5,23.499981 C 44.018817,23.499981 44.5,23.981164 44.5,24.499981 L 44.5,37.499981 L 3.4999998,37.499981 L 3.4999998,24.499981 C 3.4999998,23.981164 3.9811831,23.499981 4.4999997,23.499981 L 4.4999997,23.499981 z"
      id="rect2374"
@@ -547,7 +523,7 @@
   <path
      d="M 3.5,38.5 C 3.580089,39.536507 3.2926219,40.651877 3.7536297,41.61219 C 4.6184456,42.831026 6.2237037,42.430252 7.5,42.5 C 7.523032,43.219497 7.2865373,44.330225 8.2727435,44.483266 C 18.69082,44.522296 29.111985,44.488866 39.53125,44.499996 C 40.606471,44.531766 40.534757,43.337986 40.5,42.580433 C 40.851156,42.393825 41.547908,42.552813 42.032856,42.499993 C 43.232776,42.663079 44.699951,41.840165 44.5,40.471858 C 44.5,39.81457 44.5,39.157281 44.5,38.499993 C 30.833333,38.499993 17.166667,38.499993 3.5,38.499993 L 3.5,38.5 z"
      id="rect6333"
-     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:url(#linearGradient2461);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.75" />
   <rect
      width="25"
      height="9"

--- a/elementary-xfce/devices/48/printer-network.svg
+++ b/elementary-xfce/devices/48/printer-network.svg
@@ -5,7 +5,7 @@
    height="48"
    id="svg11300"
    sodipodi:docname="printer-network.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,15 +23,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="14.208333"
-     inkscape:cx="24"
-     inkscape:cy="23.964809"
-     inkscape:window-width="1920"
-     inkscape:window-height="1028"
-     inkscape:window-x="0"
+     inkscape:zoom="20.093617"
+     inkscape:cx="36.454363"
+     inkscape:cy="39.788755"
+     inkscape:window-width="958"
+     inkscape:window-height="1005"
+     inkscape:window-x="960"
      inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg11300" />
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g7753"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <metadata
      id="metadata14477">
     <rdf:RDF>
@@ -46,6 +48,25 @@
   <defs
      id="defs3">
     <linearGradient
+       id="linearGradient18589">
+      <stop
+         id="stop18581"
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="0" />
+      <stop
+         id="stop18583"
+         style="stop-color:#000000;stop-opacity:0.5;"
+         offset="0.1" />
+      <stop
+         id="stop18585"
+         style="stop-color:#000000;stop-opacity:0.5;"
+         offset="0.89999998" />
+      <stop
+         id="stop18587"
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient6393">
       <stop
          id="stop6395"
@@ -54,17 +75,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -201,15 +211,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9705882,0,0,0.8,0.7058824,3.0971914)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient2895"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.5,-5.5028087)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -235,7 +236,7 @@
        id="linearGradient2903"
        xlink:href="#linearGradient8589"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7828347,0,0,0.8639232,4.8577161,-0.34021445)" />
+       gradientTransform="matrix(0.7828347,0,0,0.8639232,4.8577161,-1.3371883)" />
     <linearGradient
        x1="25.132275"
        y1="6.7287393"
@@ -244,16 +245,7 @@
        id="linearGradient2907"
        xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.7142849,0,0,0.6998651,6.857167,0.44723296)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2909"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5767828,0,0,0.6549695,49.293,-0.33275185)" />
+       gradientTransform="matrix(0.7142849,0,0,0.6998651,6.857167,-0.5497409)" />
     <radialGradient
        cx="3.7590685"
        cy="11.918329"
@@ -274,15 +266,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-2.5e-7,-5.0028277)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2917"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,-5.0028087)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
@@ -290,16 +273,7 @@
        id="linearGradient2920"
        xlink:href="#linearGradient6828"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,-6.0963961)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient2922"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,-6.0963961)" />
+       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,-4.0934964)" />
     <linearGradient
        x1="23.100046"
        y1="38.296745"
@@ -326,25 +300,6 @@
       <stop
          id="stop9355"
          style="stop-color:#878787;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient272-6">
-      <stop
-         id="stop273-1"
-         style="stop-color:#474747;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop275-8"
-         style="stop-color:#474747;stop-opacity:1"
-         offset="0.1" />
-      <stop
-         id="stop276-3"
-         style="stop-color:#474747;stop-opacity:1"
-         offset="0.89999998" />
-      <stop
-         id="stop274-5"
-         style="stop-color:#474747;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -393,7 +348,7 @@
        x2="5.0856376"
        y2="372.57819"
        id="linearGradient3480"
-       xlink:href="#linearGradient272-6"
+       xlink:href="#linearGradient18589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(9.3885424,0,0,0.2235366,29.130395,-51.784906)" />
     <linearGradient
@@ -402,7 +357,7 @@
        x2="5.0856376"
        y2="372.57819"
        id="linearGradient3482"
-       xlink:href="#linearGradient272-6"
+       xlink:href="#linearGradient18589"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(9.3885418,0,0,0.2235361,29.130383,-45.865211)" />
     <linearGradient
@@ -424,7 +379,7 @@
        x="22.749998"
        y="35.500599"
        id="rect8955"
-       style="fill:#d9d9d9;fill-opacity:1;stroke:#828282;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+       style="fill:#d9d9d9;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none" />
     <path
        d="m 45.24996,45.000414 a 20.999994,3 0 0 1 -41.9999874,0 20.999994,3.0000005 0 1 1 41.9999874,0 z"
        id="path6774"
@@ -439,14 +394,14 @@
          x="34.877113"
          y="31"
          id="rect8601"
-         style="opacity:0.65;fill:url(#linearGradient3480);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible" />
+         style="opacity:1;fill:url(#linearGradient3480);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible" />
       <rect
          width="41.999989"
          height="1"
          x="34.877102"
          y="29"
          id="rect8603"
-         style="opacity:0.65;fill:url(#linearGradient3482);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible" />
+         style="opacity:1;fill:url(#linearGradient3482);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible" />
       <rect
          width="41.5"
          height="1"
@@ -462,7 +417,7 @@
     <path
        d="m 22.028715,40.500491 -3.233398,0 c -0.582372,0 -1.045288,0.42704 -1.045288,0.964275 l 0,4.071083 c 0,0.53723 0.462916,0.964574 1.045288,0.964574 l 10.909354,0 c 0.582367,0 1.04529,-0.427345 1.04529,-0.964574 l 0,-4.071083 c 0,-0.537235 -0.462923,-0.964275 -1.04529,-0.964275 l -2.821165,0 -4.854791,0 z"
        id="path8607"
-       style="fill:url(#linearGradient3331);fill-opacity:1;fill-rule:nonzero;stroke:#5a5c58;stroke-width:1.00006688;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:new" />
+       style="fill:url(#linearGradient3331);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00006688;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:new" />
     <rect
        width="8"
        height="1.5"
@@ -483,29 +438,29 @@
      rx="0.56379259"
      ry="0.72383887"
      x="9.4979439"
-     y="3.4951172"
+     y="5.4980168"
      id="rect2315"
-     style="fill:url(#linearGradient2920);fill-opacity:1;stroke:url(#linearGradient2922);stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="display:inline;fill:url(#linearGradient2920);fill-opacity:1;stroke:#000000;stroke-width:0.996034;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.75" />
   <path
      d="m 4.5789659,15.497169 4.9210339,0 1.0000002,1 27,0 1,-1 4.921034,0 c 1.151747,0 2.078966,0.927219 2.078966,2.078966 l 0,13.921034 -43.0000002,0 0,-13.921034 c 0,-1.151747 0.9272188,-2.078966 2.0789661,-2.078966 z"
      id="rect2313"
-     style="fill:url(#linearGradient2915);fill-opacity:1;stroke:url(#linearGradient2917);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+     style="fill:url(#linearGradient2915);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
   <path
      d="m 4.4999997,16.497169 39.0000003,0 c 0.518817,0 1,0.481183 1,1 l 0,13 -41.0000002,0 0,-13 c 0,-0.518817 0.4811833,-1 0.9999999,-1 z"
      id="rect2374"
      style="opacity:0.9;fill:none;stroke:url(#radialGradient2912);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;display:inline" />
   <path
-     d="m 11.499989,1.4970055 c 5.728776,0 11.457549,0 17.186322,0 1.00495,0.3397 6.403888,4.2097833 7.8137,6.8894401 0,8.2015104 0,6.9090514 0,15.1105654 -8.333341,0 -16.66668,0 -25.000022,0 0,-10.497992 0,-11.502013 0,-22.0000055 z"
+     d="m 11.499989,0.50003164 c 5.728776,0 11.457549,0 17.186322,0 1.00495,0.3397 6.403888,4.20978326 7.8137,6.88944006 0,8.2015103 0,6.9090513 0,15.1105653 -8.333341,0 -16.66668,0 -25.000022,0 0,-10.497992 0,-11.502013 0,-22.00000536 z"
      id="rect2594"
-     style="fill:url(#linearGradient2907);fill-opacity:1;stroke:url(#linearGradient2909);stroke-width:0.99997759;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+     style="display:inline;fill:url(#linearGradient2907);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34999999" />
   <path
-     d="m 28.172621,1.5007473 c 0.461632,3.1311526 0.441325,6.8576696 0.441325,6.8576696 0,0 3.526294,-0.084635 7.882281,0.450826 C 32.950272,5.1750335 30.465386,3.6596674 28.172621,1.5007473 z"
+     d="M 28.172621,0.50377344 C 28.634253,3.634926 28.613946,7.361443 28.613946,7.361443 c 0,0 3.526294,-0.084635 7.882281,0.450826 C 32.950272,4.1780596 30.465386,2.6626935 28.172621,0.50377344 Z"
      id="path8596"
-     style="fill:black;fill-opacity:0.32663317;fill-rule:evenodd;stroke:black;stroke-width:1.00754702;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.16582917;stroke-dasharray:none;display:inline" />
+     style="display:inline;fill:#000000;fill-opacity:0.326633;fill-rule:evenodd;stroke:#000000;stroke-width:1.00755;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.165829" />
   <path
-     d="m 28,0.99697386 c 1.10808,3.34664984 1.01618,6.70605204 1.01618,6.70605204 0,0 6.146086,0.444304 7.98382,1.293948 0,-1.389106 -7.295193,-7.9762865 -9,-8.00000004 z"
+     d="m 28,0 c 1.10808,3.3466498 1.01618,6.706052 1.01618,6.706052 0,0 6.146086,0.444304 7.98382,1.293948 0,-1.389106 -7.295193,-7.97628646 -9,-8 z"
      id="path12038"
-     style="fill:url(#linearGradient2903);fill-opacity:1;fill-rule:evenodd;stroke:none;display:inline" />
+     style="display:inline;fill:url(#linearGradient2903);fill-opacity:1;fill-rule:evenodd;stroke:none" />
   <rect
      width="27"
      height="11"
@@ -516,7 +471,7 @@
   <path
      d="m 3.5,31.497188 c 0.080089,1.036507 -0.2073781,2.151877 0.2536297,3.11219 0.8648159,1.218836 2.470074,0.818062 3.7463703,0.88781 0.023032,0.719497 -0.2134627,1.830225 0.7727435,1.983266 10.4180765,0.03903 20.8392415,0.0056 31.2585065,0.01673 1.075221,0.03177 1.003507,-1.16201 0.96875,-1.919563 0.351156,-0.186608 1.047908,-0.02762 1.532856,-0.08044 1.19992,0.163086 2.667095,-0.659828 2.467144,-2.028135 0,-0.657288 0,-1.314577 0,-1.971865 -13.666667,0 -27.333333,0 -41,0 z"
      id="rect6333"
-     style="fill:url(#linearGradient2893);fill-opacity:1;stroke:url(#linearGradient2895);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2893);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
   <rect
      width="25"
      height="9"

--- a/elementary-xfce/devices/48/printer.svg
+++ b/elementary-xfce/devices/48/printer.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="48"
    height="48"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="printer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1441"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="6.9532168"
+     inkscape:cx="11.433557"
+     inkscape:cy="15.388561"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="376"
+     inkscape:window-y="348"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata109152">
     <rdf:RDF>
@@ -32,17 +55,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaaaaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -190,15 +202,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.9705882,0,0,0.8,0.7058824,10.1)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient2461"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.5,1.5)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -236,30 +239,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(-2.5e-7,1.999981)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2483"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,2)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
        y2="18.919773"
        id="linearGradient2486"
        xlink:href="#linearGradient6828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient2488"
-       xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
     <radialGradient
@@ -273,7 +258,7 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.254902,0,0,0.339869,-6.1176472,27.267974)" />
     <filter
-       x="-0.14846256"
+       x="-0.14846255"
        y="-0.16434373"
        width="1.2969251"
        height="1.3286875"
@@ -393,15 +378,6 @@
        xlink:href="#linearGradient3600"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.6571436,0,0,0.6301241,0.2285531,-0.08964783)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2620"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5306412,0,0,0.5897023,39.269605,-0.7919081)" />
     <radialGradient
        cx="102"
        cy="112.3047"
@@ -441,7 +417,7 @@
      x="9.4979439"
      y="10.497924"
      id="rect2315"
-     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:url(#linearGradient2488);stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:#000000;stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
   <g
      transform="translate(8.0000133,1.9999996)"
      id="layer1">
@@ -463,7 +439,7 @@
     <path
        d="m 4.499961,1.4999609 c 5.2704843,0 10.540969,0 15.811458,0 0.924556,0.3128002 5.891591,3.8764242 7.188621,6.3438858 0,7.5520643 0,15.1041283 0,22.6561933 -7.666694,0 -15.333386,0 -23.000079,0 0,-9.666694 0,-19.333388 0,-29.0000791 z"
        id="path4160"
-       style="fill:url(#linearGradient2618);fill-opacity:1;stroke:url(#linearGradient2620);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:url(#linearGradient2618);fill-opacity:1;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
     <path
        d="M 5.2340427,30 C 5.1050853,30 5,29.885821 5,29.745703 L 5,2.2816602 C 5,2.141289 5.1050853,2.0273644 5.2340427,2.0273644 10.076044,2.0976535 15.441839,1.9222203 20.277954,2.0448649 L 26.931426,7.8143805 27,29.745703 C 27,29.885821 26.895148,30 26.765957,30 L 5.2340427,30 z"
        id="path4191"
@@ -485,7 +461,7 @@
   <path
      d="m 4.5789659,22.499981 4.9210339,0 1.0000002,1 27,0 1,-1 4.921034,0 c 1.151747,0 2.078966,0.927219 2.078966,2.078966 l 0,13.921034 -43.0000002,0 0,-13.921034 c 0,-1.151747 0.9272188,-2.078966 2.0789661,-2.078966 l 0,0 z"
      id="rect2313"
-     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:url(#linearGradient2483);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
   <path
      d="m 4.4999997,23.499981 39.0000003,0 c 0.518817,0 1,0.481183 1,1 l 0,13 -41.0000002,0 0,-13 c 0,-0.518817 0.4811833,-1 0.9999999,-1 l 0,0 z"
      id="rect2374"
@@ -498,9 +474,10 @@
      id="rect2319"
      style="fill:url(#linearGradient2464);fill-opacity:1;stroke:url(#linearGradient2466);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
   <path
-     d="M 3.5,38.5 C 3.580089,39.536507 3.2926219,40.651877 3.7536297,41.61219 4.6184456,42.831026 6.2237037,42.430252 7.5,42.5 c 0.023032,0.719497 -0.2134627,1.830225 0.7727435,1.983266 10.4180765,0.03903 20.8392415,0.0056 31.2585065,0.01673 1.075221,0.03177 1.003507,-1.16201 0.96875,-1.919563 0.351156,-0.186608 1.047908,-0.02762 1.532856,-0.08044 1.19992,0.163086 2.667095,-0.659828 2.467144,-2.028135 0,-0.657288 0,-1.314577 0,-1.971865 -13.666667,0 -27.333333,0 -41,0 l 0,7e-6 z"
+     d="M 3.5,38.5 V 41 c 0,1.109497 0.8467674,1.5 2,1.5 h 2 c 0.023032,0.719497 -0.2134627,1.830225 0.7727435,1.983266 l 31.2585065,0.01673 c 1.075221,0.03177 1.003507,-1.16201 0.96875,-1.919563 0.351156,-0.186608 1.515052,-0.02762 2,-0.08044 1.273093,0 2,-0.508744 2,-1.999993 v -2.000007 z"
      id="rect6333"
-     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:url(#linearGradient2461);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.75"
+     sodipodi:nodetypes="ccscccccccc" />
   <rect
      width="25"
      height="9"

--- a/elementary-xfce/devices/48/system-config-printer.svg
+++ b/elementary-xfce/devices/48/system-config-printer.svg
@@ -1,1 +1,0 @@
-printer.svg

--- a/elementary-xfce/devices/64/gnome-dev-printer-new.svg
+++ b/elementary-xfce/devices/64/gnome-dev-printer-new.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="64"
    height="64"
-   id="svg11300">
+   id="svg11300"
+   sodipodi:docname="gnome-dev-printer-new.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65640"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="3.6875"
+     inkscape:cx="7.1864407"
+     inkscape:cy="32.135593"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata109152">
     <rdf:RDF>
@@ -18,7 +41,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -33,17 +55,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaaaaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -172,15 +183,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.2062953,0,0,1.0661658,3.0475908,13.651113)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient2461"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2428497,0,0,1.3327072,2.7917099,2.1898305)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -218,30 +220,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.2325581,0,0,1.3125,2.4186055,3.5937499)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2483"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2325581,0,0,1.3125,2.4186059,3.5937748)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
        y2="18.919773"
        id="linearGradient2486"
        xlink:href="#linearGradient6828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1819384,0,0,1.1284132,3.6334807,4.9064115)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient2488"
-       xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.1819384,0,0,1.1284132,3.6334807,4.9064115)" />
     <radialGradient
@@ -255,7 +239,7 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.5163399,0,0,0.339869,-4.3921567,42.267974)" />
     <filter
-       x="-0.14846256"
+       x="-0.14846255"
        y="-0.16434373"
        width="1.2969251"
        height="1.3286875"
@@ -366,15 +350,6 @@
        x2="25.132275"
        y2="47.013336" />
     <linearGradient
-       xlink:href="#linearGradient3104"
-       id="linearGradient3097"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71521142,0,0,0.5897023,63.363364,2.2080919)"
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471" />
-    <linearGradient
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3245"
        id="linearGradient3255"
@@ -456,9 +431,9 @@
      x="12.498018"
      y="14.497924"
      id="rect2315"
-     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:url(#linearGradient2488);stroke-width:0.99603379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:#000000;stroke-width:0.99603379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
   <path
-     style="fill:url(#linearGradient3095);fill-opacity:1;stroke:url(#linearGradient3097);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     style="fill:url(#linearGradient3095);fill-opacity:1;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
      id="path4160"
      d="m 16.499972,4.499961 c 7.10369,0 16.396332,0 23.500028,0 1.24614,0.3128 5.751882,3.876424 7.500052,6.343886 0,7.552064 0,15.104128 0,22.656193 -10.333361,0 -20.66672,0 -31.00008,0 0,-9.666694 0,-19.333388 0,-29.000079 z" />
   <path
@@ -481,7 +456,7 @@
   <path
      d="m 8.0624473,30.5 6.0654597,0 1.232559,1.3125 33.279068,0 1.232559,-1.3125 6.06546,0 c 1.419595,0 2.562446,1.216975 2.562446,2.728643 l 0,18.271357 -52.9999982,0 0,-18.271357 C 5.5000008,31.716975 6.6428519,30.5 8.0624473,30.5 l 0,0 z"
      id="rect2313"
-     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:url(#linearGradient2483);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
   <path
      d="m 7.7439025,31.500002 48.5121955,0 c 0.645358,0 1.243902,0.653034 1.243902,1.357143 l 0,17.642857 -50.9999998,0 0,-17.642857 c 0,-0.704109 0.5985451,-1.357143 1.2439022,-1.357143 l 0,0 z"
      id="rect2374"
@@ -496,7 +471,7 @@
   <path
      d="m 6.5202591,51.499997 c 0.099539,1.381361 -0.2577398,2.867822 0.3152236,4.147638 1.0748362,1.624352 3.0699301,1.090238 4.6561763,1.183191 0.02862,0.958879 -0.265303,2.439154 0.960403,2.643113 12.948104,0.05202 25.900046,0.0075 38.849626,0.0223 1.336338,0.04234 1.247209,-1.548619 1.204012,-2.558215 0.436434,-0.248694 1.302391,-0.03681 1.905109,-0.107203 1.49132,0.217346 3.314798,-0.879358 3.066289,-2.70291 0,-0.875973 0,-1.751946 0,-2.627919 -16.985613,0 -33.971225,0 -50.9568389,0 l 0,9e-6 z"
      id="rect6333"
-     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:url(#linearGradient2461);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
   <rect
      width="31"
      height="12"

--- a/elementary-xfce/devices/64/printer-network.svg
+++ b/elementary-xfce/devices/64/printer-network.svg
@@ -5,7 +5,7 @@
    height="64"
    id="svg11300"
    sodipodi:docname="printer-network.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -24,14 +24,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="10.65625"
-     inkscape:cx="32"
-     inkscape:cy="31.953079"
-     inkscape:window-width="1920"
-     inkscape:window-height="1028"
+     inkscape:cx="39.131965"
+     inkscape:cy="58.979472"
+     inkscape:window-width="1155"
+     inkscape:window-height="1005"
      inkscape:window-x="0"
      inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg11300" />
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g3331"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <metadata
      id="metadata109152">
     <rdf:RDF>
@@ -46,6 +48,25 @@
   <defs
      id="defs3">
     <linearGradient
+       id="linearGradient59327">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop59319" />
+      <stop
+         offset="0.1"
+         style="stop-color:#000000;stop-opacity:0.5;"
+         id="stop59321" />
+      <stop
+         offset="0.89999998"
+         style="stop-color:#000000;stop-opacity:0.5;"
+         id="stop59323" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;"
+         id="stop59325" />
+    </linearGradient>
+    <linearGradient
        id="linearGradient6393">
       <stop
          id="stop6395"
@@ -54,17 +75,6 @@
       <stop
          id="stop6397"
          style="stop-color:#6efb27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaaaaa;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -182,15 +192,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.2062953,0,0,1.0661658,3.0475908,6.6511125)" />
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient2461"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2428497,0,0,1.3327072,2.7917099,-4.81017)" />
-    <linearGradient
        x1="21.919418"
        y1="21"
        x2="22.007805"
@@ -228,30 +229,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.2325581,0,0,1.3125,2.4186055,-3.4062506)" />
     <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2483"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2325581,0,0,1.3125,2.4186059,-3.4062257)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
        y2="18.919773"
        id="linearGradient2486"
        xlink:href="#linearGradient6828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1819384,0,0,1.1284132,3.6334807,-2.093589)" />
-    <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient2488"
-       xlink:href="#linearGradient2366"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.1819384,0,0,1.1284132,3.6334807,-2.093589)" />
     <filter
@@ -366,15 +349,6 @@
        x2="25.132275"
        y2="47.013336" />
     <linearGradient
-       xlink:href="#linearGradient3104"
-       id="linearGradient3097"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.71521142,0,0,0.5897023,63.363364,-0.7919086)"
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471" />
-    <linearGradient
        id="linearGradient9347">
       <stop
          offset="0"
@@ -413,25 +387,6 @@
          id="stop182-0" />
     </linearGradient>
     <linearGradient
-       id="linearGradient272-6">
-      <stop
-         offset="0"
-         style="stop-color:#474747;stop-opacity:0"
-         id="stop273-1" />
-      <stop
-         offset="0.1"
-         style="stop-color:#474747;stop-opacity:1"
-         id="stop275-8" />
-      <stop
-         offset="0.89999998"
-         style="stop-color:#474747;stop-opacity:1"
-         id="stop276-3" />
-      <stop
-         offset="1"
-         style="stop-color:#474747;stop-opacity:0"
-         id="stop274-5" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient10997">
       <stop
          offset="0"
@@ -453,7 +408,7 @@
        fy="394.78125"
        r="20.625" />
     <linearGradient
-       xlink:href="#linearGradient272-6"
+       xlink:href="#linearGradient59327"
        id="linearGradient3342"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(12.518056,0,0,0.2235366,40.705591,-79.555719)"
@@ -462,7 +417,7 @@
        x2="5.0856376"
        y2="372.57819" />
     <linearGradient
-       xlink:href="#linearGradient272-6"
+       xlink:href="#linearGradient59327"
        id="linearGradient3344"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(12.518055,0,0,0.2235361,40.705575,-73.63602)"
@@ -497,9 +452,9 @@
      x="12.498018"
      y="7.4979234"
      id="rect2315"
-     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:url(#linearGradient2488);stroke-width:0.99603379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline" />
+     style="fill:url(#linearGradient2486);fill-opacity:1;stroke:#000000;stroke-width:0.99603379;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
   <path
-     style="fill:url(#linearGradient3095);fill-opacity:1;stroke:url(#linearGradient3097);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     style="fill:url(#linearGradient3095);fill-opacity:1;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
      id="path4160"
      d="m 16.499972,1.4999605 c 7.10369,0 16.396332,0 23.500028,0 1.24614,0.3128 5.751882,3.876424 7.500052,6.343886 0,7.5520645 0,15.1041285 0,22.6561935 -10.333361,0 -20.66672,0 -31.00008,0 0,-9.666694 0,-19.333388 0,-29.0000795 z" />
   <path
@@ -522,7 +477,7 @@
   <path
      d="m 8.0624473,23.5 6.0654597,0 1.232559,1.3125 33.279068,0 1.232559,-1.3125 6.06546,0 c 1.419595,0 2.562446,1.216975 2.562446,2.728643 l 0,18.271357 -52.9999982,0 0,-18.271357 C 5.5000008,24.716975 6.6428519,23.5 8.0624473,23.5 l 0,0 z"
      id="rect2313"
-     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:url(#linearGradient2483);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+     style="fill:url(#linearGradient2481);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
   <path
      d="m 7.7439025,24.500002 48.5121955,0 c 0.645358,0 1.243902,0.653034 1.243902,1.357143 l 0,17.642857 -50.9999998,0 0,-17.642857 c 0,-0.704109 0.5985451,-1.357143 1.2439022,-1.357143 l 0,0 z"
      id="rect2374"
@@ -538,7 +493,7 @@
      id="g3331"
      transform="translate(-44.2012,56)">
     <rect
-       style="fill:#d9d9d9;fill-opacity:1;stroke:#828282;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:#d9d9d9;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none"
        id="rect8955"
        y="-6.270812"
        x="74.867531"
@@ -549,14 +504,14 @@
        id="path6774"
        d="m 104.36752,4.229188 c 0,2.209147 -12.535986,4 -27.99999,4 -15.464005,0 -27.999991,-1.790853 -27.999991,-4 0,-2.209147 12.535986,-4 27.999991,-4 15.464004,0 27.99999,1.790853 27.99999,4 z" />
     <rect
-       style="opacity:0.65;fill:url(#linearGradient3342);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible"
+       style="opacity:1;fill:url(#linearGradient3342);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible"
        id="rect8601"
        y="3.229188"
        x="48.367882"
        height="1"
        width="55.999985" />
     <rect
-       style="opacity:0.65;fill:url(#linearGradient3344);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible"
+       style="opacity:1;fill:url(#linearGradient3344);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:block;overflow:visible"
        id="rect8603"
        y="1.2291918"
        x="48.367867"
@@ -570,7 +525,7 @@
        height="1"
        width="55.333332" />
     <path
-       style="fill:url(#linearGradient3348);fill-opacity:1;fill-rule:nonzero;stroke:#5a5c58;stroke-width:1.00006676;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:new"
+       style="fill:url(#linearGradient3348);fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1.00006676;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:block;overflow:visible;enable-background:new"
        id="path8607"
        d="m 73.804513,-0.270778 -3.730846,0 c -0.671968,0 -1.206102,0.42704 -1.206102,0.964275 l 0,4.071083 c 0,0.53723 0.534134,0.964575 1.206102,0.964575 l 12.587725,0 c 0.671963,0 1.206106,-0.427345 1.206106,-0.964575 l 0,-4.071083 c 0,-0.537235 -0.534143,-0.964275 -1.206106,-0.964275 l -3.255192,0 -5.601687,0 z" />
     <rect
@@ -586,7 +541,7 @@
   <path
      d="m 6.5202591,44.499997 c 0.099539,1.381361 -0.2577398,2.867822 0.3152236,4.147638 1.0748362,1.624352 3.0699301,1.090238 4.6561763,1.183191 0.02862,0.958879 -0.265303,2.439154 0.960403,2.643113 12.948104,0.05202 25.900046,0.0075 38.849626,0.0223 1.336338,0.04234 1.247209,-1.548619 1.204012,-2.558215 0.436434,-0.248694 1.302391,-0.03681 1.905109,-0.107203 1.49132,0.217346 3.314798,-0.879358 3.066289,-2.70291 0,-0.875973 0,-1.751946 0,-2.627919 -16.985613,0 -33.971225,0 -50.9568389,0 l 0,9e-6 z"
      id="rect6333"
-     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:url(#linearGradient2461);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2459);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
   <rect
      width="31"
      height="12"

--- a/elementary-xfce/devices/64/system-config-printer.svg
+++ b/elementary-xfce/devices/64/system-config-printer.svg
@@ -1,1 +1,0 @@
-printer.svg

--- a/elementary-xfce/status/16/printer-error.svg
+++ b/elementary-xfce/status/16/printer-error.svg
@@ -4,7 +4,7 @@
    width="16"
    height="16"
    id="svg11300"
-   sodipodi:docname="document-print-preview.svg"
+   sodipodi:docname="printer-error.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
@@ -15,27 +15,26 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview40"
+     id="namedview38557"
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1.0"
-     inkscape:pageshadow="2"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="30.140427"
-     inkscape:cx="7.1332765"
-     inkscape:cy="11.11464"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="300"
-     inkscape:window-y="115"
+     inkscape:zoom="20.85965"
+     inkscape:cx="8.4373419"
+     inkscape:cy="12.560134"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="562"
+     inkscape:window-y="68"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg11300"
-     inkscape:showpageshadow="2"
-     inkscape:deskcolor="#d1d1d1" />
+     inkscape:current-layer="svg11300" />
   <metadata
-     id="metadata26427">
+     id="metadata24649">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -137,23 +136,23 @@
      x="2.500042"
      y="3.5000422"
      id="rect2315"
-     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none;display:inline" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:1.00008368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.69999999;stroke-dasharray:none;display:inline" />
   <g
      transform="matrix(0.69407228,0,0,0.73253891,2.4439816,0.13360126)"
      id="layer1">
     <path
        d="m 1.4976268,0.49762721 13.0047472,0.002374 c 0,3.90746299 0,11.09490679 0,15.00237279 -4.334914,0 -8.6698338,0 -13.0047472,0 0,-5.001584 0,-10.0031634 0,-15.00474638 z"
        id="rect2594"
-       style="fill:#f4f4f4;fill-opacity:1;stroke:#000000;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+       style="fill:#fafafa;fill-opacity:1;stroke:#000000;stroke-width:1.39577675;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   </g>
   <path
      d="m 1.5050189,12.499854 c 0.025372,0.518058 -0.0657,1.075536 0.080353,1.555513 0.2739839,0.609191 0.8786674,0.408878 1.2830134,0.44374 0.0073,0.359613 0.029665,0.914771 0.3421077,0.991264 3.3005711,0.01952 6.2780675,0.0028 9.579015,0.0084 0.340644,0.01588 0.35312,-0.580789 0.342108,-0.959421 0.11125,-0.09326 0.427435,-0.01386 0.581072,-0.04021 0.38015,0.0815 0.844967,-0.329793 0.78162,-1.013691 0,-0.328519 0,-0.657045 0,-0.985562 -4.329764,0 -8.6595258,0 -12.9892892,0 z"
      id="rect6333"
-     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.75;stroke-dasharray:none" />
+     style="fill:#505050;fill-opacity:1;stroke:#000000;stroke-width:0.99970883;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:0.69999999;stroke-dasharray:none" />
   <path
      d="m 1.2251892,7.4999662 13.5496198,0 c 0.401775,0 0.725226,0.3477098 0.725226,0.7796206 l 0,5.2204472 -15.00006986,0 0,-5.2204472 c 0,-0.4319108 0.32345002,-0.7796206 0.72522406,-0.7796206 z"
      id="rect2313"
-     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:#000000;stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999;stroke-dasharray:none" />
+     style="fill:url(#linearGradient2875);fill-opacity:1;stroke:#000000;stroke-width:0.99993199;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.30000001;stroke-dasharray:none" />
   <path
      d="m 1.8170282,8.4999529 12.3659448,0 c 0.164502,0 0.317074,0.1374829 0.317074,0.2857221 l 0,3.714372 -13.0000942,0 0,-3.714372 c 0,-0.1482392 0.1525713,-0.2857221 0.3170754,-0.2857221 z"
      id="rect2374"
@@ -169,12 +168,32 @@
      d="m 13,14 0,0.875 C 13,14.94425 12.93031,15 12.843749,15 l -9.687506,0 c -0.086562,0 -0.15625,-0.05575 -0.15625,-0.125 l 0,-0.875 L 13,14 z"
      id="rect6331"
      style="fill:#e6e6e6;fill-opacity:1;stroke:none" />
+  <rect
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.7;stop-color:#000000"
+     id="rect40418"
+     width="8"
+     height="1"
+     x="4"
+     y="1" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-linejoin:round;stroke-opacity:0.75;stop-color:#000000"
+     id="path93713"
+     cx="11.5"
+     cy="11.5"
+     r="3" />
   <path
-     d="M 7.0856018,7.073826 C 7.0352698,7.092526 6.9878038,7.118421 6.945043,7.15051 L 6.0954713,7.6857103 C 5.966222,7.7616362 5.8755744,7.8847484 5.8486811,8.0208856 5.8217875,8.1570228 5.8615102,8.2917023 5.9568253,8.387554 l 5.1408727,5.015679 c 0.08856,0.09167 0.21845,0.140375 0.357259,0.133962 0.138811,-0.0064 0.27343,-0.06734 0.37025,-0.167573 l 0.880666,-0.910677 c 0.180174,-0.190375 0.179332,-0.465804 -0.002,-0.625159 L 7.5319933,7.1935832 C 7.4227821,7.0821421 7.253759,7.0367969 7.0856018,7.073826 Z"
-     id="path3220"
-     style="display:inline;fill:#f7d518;fill-opacity:1;fill-rule:evenodd;stroke:none" />
-  <path
-     d="M 7.5,4.9998137 C 7.5,6.9327074 5.9329969,8.499627 4.0000001,8.499627 2.0670035,8.499627 0.5,6.9327074 0.5,4.9998136 0.5,3.0669199 2.0670035,1.5 4.0000001,1.5 5.9329969,1.5 7.5,3.0669199 7.5,4.9998137 Z"
-     id="path2447"
-     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#2ca3ff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     class="error"
+     color="#bebebe"
+     d="m 11.500957,7.5000002 c -5.3346092,-0.00128 -5.3346092,7.9987288 0,8.0000038 5.332058,-0.0013 5.332058,-8.0012784 0,-8.0000038 z M 11,9 h 1 v 3 h -1 z m 0,4 h 1 v 1 h -1 z"
+     fill="#ef2929"
+     overflow="visible"
+     style="stroke-width:1;marker:none"
+     id="path10"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <circle
+     style="fill:none;fill-rule:evenodd;stroke:#7a0000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.75;stop-color:#000000"
+     id="path93296"
+     cx="11.5"
+     cy="11.5"
+     r="3.9999998" />
 </svg>

--- a/elementary-xfce/status/48/printer-error.svg
+++ b/elementary-xfce/status/48/printer-error.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.0"
    width="48"
    height="48"
-   id="svg2842">
+   id="svg2842"
+   sodipodi:docname="printer-error.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview72180"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13.906433"
+     inkscape:cx="38.363539"
+     inkscape:cy="29.302984"
+     inkscape:window-width="1920"
+     inkscape:window-height="1007"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2842" />
   <metadata
      id="metadata98">
     <rdf:RDF>
@@ -45,15 +68,6 @@
        fy="15.279687"
        r="13" />
     <linearGradient
-       x1="7.4375"
-       y1="14.105195"
-       x2="7.4375"
-       y2="8.9371939"
-       id="linearGradient2762"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.8789125,0,0,1.1284132,2.9061009,0.9064125)" />
-    <linearGradient
        x1="21.586424"
        y1="9.5515556"
        x2="21.686989"
@@ -73,7 +87,7 @@
        gradientTransform="matrix(0.6371285,0,0,0.6445638,7.7694385,1.6903004)" />
     <filter
        id="filter3212"
-       x="-0.14846256"
+       x="-0.14846255"
        width="1.2969251"
        y="-0.16434373"
        height="1.3286875">
@@ -145,26 +159,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.2340426,0,0,-0.2542968,7.9610355,33.234455)" />
     <linearGradient
-       id="linearGradient3104">
-      <stop
-         id="stop3106"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3108"
-         style="stop-color:#bebebe;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient2821"
-       xlink:href="#linearGradient3104"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5306412,0,0,0.5897023,46.209363,0.1538748)" />
-    <linearGradient
        id="linearGradient3600">
       <stop
          id="stop3602"
@@ -205,26 +199,6 @@
        xlink:href="#linearGradient7612"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.254902,0,0,0.339869,-6.1176472,27.267974)" />
-    <linearGradient
-       id="linearGradient6866">
-      <stop
-         id="stop6868"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6870"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.561552"
-       y1="36.999981"
-       x2="20.278992"
-       y2="19.999981"
-       id="linearGradient2757"
-       xlink:href="#linearGradient6866"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0,2)" />
     <linearGradient
        x1="11.519291"
        y1="20"
@@ -285,15 +259,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="9.5625"
-       y1="41.375"
-       x2="9.5"
-       y2="33.5"
-       id="linearGradient2735"
-       xlink:href="#linearGradient2366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.5,1.5)" />
-    <linearGradient
        x1="7.5170455"
        y1="31.15625"
        x2="7.4545455"
@@ -342,96 +307,79 @@
        xlink:href="#linearGradient6828"
        gradientUnits="userSpaceOnUse"
        gradientTransform="translate(0,2)" />
+    <radialGradient
+       gradientTransform="matrix(0.11151981,0,0,0.03548359,24.942029,39.166729)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient3108"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
     <linearGradient
-       id="linearGradient4873">
+       id="linearGradient3820-7-2-2">
       <stop
-         id="stop4875"
+         id="stop3822-2-6-36"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3864-8-7-6"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         offset="0.5" />
+      <stop
+         id="stop3824-1-2-4"
+         style="stop-color:#686868;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3208.0737"
+       x2="2035.1652"
+       y2="3241.9966"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8047894,0,0,0.60165743,-1604.8199,-1904.0804)" />
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient12398-3"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-0.836139,22.97872)" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4877"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4015-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="63.397362"
-       y1="-12.489107"
-       x2="63.397362"
-       y2="5.4675598"
-       id="linearGradient2491"
-       xlink:href="#linearGradient4873"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0862728,0,0,1.0862481,-55.56661,15.813638)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#dd3b27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143"
-       id="linearGradient2496"
-       xlink:href="#linearGradient2490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5160413,0,0,0.5160413,-0.384991,-0.3849911)" />
-    <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="23.895569"
-       cy="3.9900031"
-       r="20.397499"
-       fx="23.895569"
-       fy="3.9900031"
-       id="radialGradient2494"
-       xlink:href="#linearGradient3242"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.2316137,-1.6257082,0,18.486581,-28.720783)" />
-    <linearGradient
-       id="linearGradient8838">
-      <stop
-         id="stop8840"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8842"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       fx="62.625"
-       fy="4.625"
-       id="radialGradient2499"
-       xlink:href="#linearGradient8838"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,19.694118)" />
   </defs>
   <g
      id="layer1">
@@ -443,14 +391,14 @@
        x="9.4979439"
        y="10.497924"
        id="rect2315"
-       style="fill:url(#linearGradient2760);fill-opacity:1;stroke:url(#linearGradient2762);stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline" />
+       style="fill:url(#linearGradient2760);fill-opacity:1;stroke:#000000;stroke-width:0.99603385;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.75;display:inline" />
     <g
        transform="translate(1.0602415,1.0542161)"
        id="g2812">
       <path
          d="M 11.439719,2.4457438 C 16.710203,2.4457438 21.980688,2.4457438 27.251177,2.4457438 C 28.175733,2.758544 33.142768,6.322168 34.439798,8.7896296 C 34.439798,16.341694 34.439798,23.893758 34.439798,31.445823 C 26.773104,31.445823 19.106412,31.445823 11.439719,31.445823 C 11.439719,21.779129 11.439719,12.112435 11.439719,2.4457438 z"
          id="path4160"
-         style="fill:url(#linearGradient2819);fill-opacity:1;stroke:url(#linearGradient2821);stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;display:inline" />
+         style="fill:url(#linearGradient2819);fill-opacity:1;stroke:#000000;stroke-width:0.99992174;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34999999;display:inline" />
       <path
          d="M 12.173801,30.945783 C 12.044843,30.945783 11.939758,30.831604 11.939758,30.691486 L 11.939758,3.2274431 C 11.939758,3.0870719 12.044843,2.9731473 12.173801,2.9731473 C 17.015802,3.0434364 22.381597,2.8680032 27.217712,2.9906478 L 33.871184,8.7601634 L 33.939758,30.691486 C 33.939758,30.831604 33.834906,30.945783 33.705715,30.945783 L 12.173801,30.945783 z"
          id="path4191"
@@ -476,7 +424,7 @@
     <path
        d="M 4.5789659,22.499981 L 9.4999998,22.499981 L 10.5,23.499981 L 37.5,23.499981 L 38.5,22.499981 L 43.421034,22.499981 C 44.572781,22.499981 45.5,23.4272 45.5,24.578947 L 45.5,38.499981 L 2.4999998,38.499981 L 2.4999998,24.578947 C 2.4999998,23.4272 3.4272186,22.499981 4.5789659,22.499981 L 4.5789659,22.499981 z"
        id="rect2313"
-       style="fill:url(#linearGradient2755);fill-opacity:1;stroke:url(#linearGradient2757);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:url(#linearGradient2755);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:0.34999999" />
     <path
        d="M 4.4999997,23.499981 L 43.5,23.499981 C 44.018817,23.499981 44.5,23.981164 44.5,24.499981 L 44.5,37.499981 L 3.4999998,37.499981 L 3.4999998,24.499981 C 3.4999998,23.981164 3.9811831,23.499981 4.4999997,23.499981 L 4.4999997,23.499981 z"
        id="rect2374"
@@ -491,7 +439,7 @@
     <path
        d="M 3.5,38.5 C 3.580089,39.536507 3.2926219,40.651877 3.7536297,41.61219 C 4.6184456,42.831026 6.2237037,42.430252 7.5,42.5 C 7.523032,43.219497 7.2865373,44.330225 8.2727435,44.483266 C 18.69082,44.522296 29.111985,44.488866 39.53125,44.499996 C 40.606471,44.531766 40.534757,43.337986 40.5,42.580433 C 40.851156,42.393825 41.547908,42.552813 42.032856,42.499993 C 43.232776,42.663079 44.699951,41.840165 44.5,40.471858 C 44.5,39.81457 44.5,39.157281 44.5,38.499993 C 30.833333,38.499993 17.166667,38.499993 3.5,38.499993 L 3.5,38.5 z"
        id="rect6333"
-       style="fill:url(#linearGradient2733);fill-opacity:1;stroke:url(#linearGradient2735);stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:url(#linearGradient2733);fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.75" />
     <path
        d="M 40,40 L 40,43.5 C 40,43.777 39.777,44 39.5,44 L 8.5,44 C 8.223,44 8,43.777 8,43.5 L 8,40 L 40,40 z"
        id="rect6331"
@@ -503,30 +451,6 @@
        y="40"
        id="rect6329"
        style="fill:url(#linearGradient2718);fill-opacity:1;stroke:none" />
-    <g
-       transform="translate(24,24)"
-       id="g2938">
-      <path
-         d="M 24,21 C 24,22.656854 18.627417,24 12,24 C 5.3725828,24 -2.5e-07,22.656854 -2.5e-07,21 C -2.5e-07,19.343146 5.3725828,18 12,18 C 18.627417,18 24,19.343146 24,21 L 24,21 z"
-         id="path8836"
-         style="opacity:0.3;fill:url(#radialGradient2499);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="M 12.000002,1.501785 C 6.207449,1.501785 1.501785,6.2074466 1.501785,11.999999 C 1.501785,17.792553 6.207449,22.498218 12.000002,22.498215 C 17.792552,22.498215 22.498221,17.792553 22.498215,11.999999 C 22.498215,6.2074466 17.792552,1.501785 12.000002,1.501785 z"
-         id="path2555"
-         style="fill:url(#radialGradient2494);fill-opacity:1;stroke:url(#linearGradient2496);stroke-width:1.00365424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         d="M 21.499999,11.999663 C 21.499999,17.246537 17.24639,21.499999 12.00012,21.499999 C 6.7533674,21.499999 2.4999999,17.24649 2.4999999,11.999663 C 2.4999999,6.7530318 6.7533674,2.5000007 12.00012,2.5000007 C 17.24639,2.5000007 21.499999,6.7530318 21.499999,11.999663 L 21.499999,11.999663 z"
-         id="path2463"
-         style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2491);stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-      <path
-         d="M 4,13 C 9.333333,13 14.666667,13 20,13 C 20,12.000001 20,11 20,10 C 14.666667,10 9.333333,10 4,10 C 4,11 4,12.000001 4,13 z"
-         id="path3360"
-         style="font-size:89.63063812px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.7688275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;font-family:Georgia" />
-      <path
-         d="M 4,14 C 9.333333,14 14.666667,14 20,14 C 20,13.000001 20,12 20,11 C 14.666667,11 9.333333,11 4,11 C 4,12 4,13.000001 4,14 z"
-         id="path3271"
-         style="font-size:89.63063812px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-align:start;line-height:125%;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.7688275;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;font-family:Georgia" />
-    </g>
   </g>
   <rect
      style="opacity:0.29999999999999999;fill:none;stroke:url(#radialGradient2742);stroke-width:0.99999981999999998;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;display:inline"
@@ -535,4 +459,32 @@
      x="11.5"
      height="9"
      width="25" />
+  <path
+     style="fill:url(#radialGradient3108);fill-opacity:1;stroke:none"
+     id="path3818-0-2-5"
+     d="m 43,45.772727 a 7,2.2272727 0 0 1 -14,0 7,2.2272727 0 1 1 14,0 z" />
+  <path
+     d="m 36,25.5 c -5.79354,0 -10.5,4.70646 -10.5,10.5 0,5.79354 4.70646,10.5 10.5,10.5 5.79354,0 10.50001,-4.70646 10.5,-10.5 0,-5.79354 -4.70646,-10.5 -10.5,-10.5 z"
+     id="path2555-7-8-5-0-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.99;fill:url(#linearGradient11527-6-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 36,25.5 c -5.79354,0 -10.5,4.70646 -10.5,10.5 0,5.79354 4.70646,10.5 10.5,10.5 5.79354,0 10.50001,-4.70646 10.5,-10.5 0,-5.79354 -4.70646,-10.5 -10.5,-10.5 z"
+     id="path2555-7-8-5-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="M 45.49999,35.99966 C 45.49999,41.24654 41.24638,45.5 36.00011,45.5 30.75336,45.5 26.5,41.24649 26.5,35.99966 26.5,30.75303 30.75336,26.5 36.00011,26.5 c 5.24627,0 9.49988,4.25303 9.49988,9.49966 z"
+     id="path8655-6-0-9-5-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:url(#linearGradient12398-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="opacity:0.05;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:0.843237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path860-3-6-2"
+     d="m 36,29 c -1.274903,0 -2.427734,0.975373 -2.427734,2.285156 0,1.532001 0.486273,4.433996 0.960937,7.851563 A 1.0001,1.0001 0 0 0 35.523438,40 H 36 36.476562 a 1.0001,1.0001 0 0 0 0.990235,-0.863281 c 0.474664,-3.417568 0.960937,-6.319562 0.960937,-7.851563 C 38.427734,29.975372 37.274903,29 36,29 Z m 0,11 c -1.368867,0 -2.5,1.131132 -2.5,2.5 0,1.368868 1.131133,2.5 2.5,2.5 1.368867,0 2.5,-1.131133 2.5,-2.5 C 38.5,41.131133 37.368867,40 36,40 Z" />
+  <path
+     style="opacity:0.15;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:0.843237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     d="m 36,30 c -0.788978,0 -1.427734,0.575076 -1.427734,1.285156 0,1.285715 0.474981,4.286274 0.951172,7.714844 h 0.953124 c 0.476191,-3.428571 0.951172,-6.429129 0.951172,-7.714844 C 37.427734,30.575076 36.788977,30 36,30 Z m 0,11 c -0.828426,0 -1.5,0.671573 -1.5,1.5 0,0.828427 0.671574,1.5 1.5,1.5 0.828427,0 1.5,-0.671573 1.5,-1.5 C 37.5,41.671573 36.828427,41 36,41 Z"
+     id="path860-3-6" />
+  <path
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.498039"
+     d="m 36,29 c -0.788978,0 -1.427734,0.575076 -1.427734,1.285156 0,1.285715 0.474981,4.286274 0.951172,7.714844 h 0.953124 c 0.476191,-3.428571 0.951172,-6.429129 0.951172,-7.714844 C 37.427734,29.575076 36.788977,29 36,29 Z m 0,11 c -0.828426,0 -1.5,0.671573 -1.5,1.5 0,0.828427 0.671574,1.5 1.5,1.5 0.828427,0 1.5,-0.671573 1.5,-1.5 C 37.5,40.671573 36.828427,40 36,40 Z"
+     id="path860-3" />
 </svg>


### PR DESCRIPTION
Updated
- Use semi-transparent borders on all printer icons for a sharper look (especially in dark themes)
- Replaced printer error `-` emblem with newer `!` symbol
- Move `system-config-printer` symlinks to `apps` directory

Added
- `printer` 32px
- `printer-error` 16px