### PR TITLE
Devices: Disc - improve borders, remove symlinks

### DIFF
--- a/elementary-xfce/devices/128/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/128/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/128/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/128/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-cd.svg
+++ b/elementary-xfce/devices/128/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-cdr.svg
+++ b/elementary-xfce/devices/128/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/128/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/128/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/128/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/128/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/128/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/128/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical-dvd.svg
+++ b/elementary-xfce/devices/128/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/128/media-optical.svg
+++ b/elementary-xfce/devices/128/media-optical.svg
@@ -1,35 +1,70 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="128"
    height="128"
    id="svg4201"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="media-optical.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview76"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="3.6875"
+     inkscape:cx="-16.271186"
+     inkscape:cy="68.474576"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4203">
     <linearGradient
-       x1="18.775953"
-       y1="4.0378027"
-       x2="18.203465"
-       y2="45.962208"
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.33000001;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
        id="linearGradient2651"
        xlink:href="#linearGradient6036"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0859888,0,0,-1.0859883,37.559418,27.149721)" />
+       gradientTransform="matrix(1.0859888,0,0,-1.0859883,37.559432,27.149712)" />
     <linearGradient
        id="linearGradient6036">
       <stop
          id="stop6038"
-         style="stop-color:#ffffff;stop-opacity:1"
+         style="stop-color:#000000;stop-opacity:0.28;"
          offset="0" />
       <stop
          id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
+         style="stop-color:#000000;stop-opacity:0.23999999;"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -206,26 +241,6 @@
        gradientUnits="userSpaceOnUse"
        spreadMethod="reflect" />
     <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient2654"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.5381093,0,0,2.5381093,3.0853666,-60.914613)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        x1="12.2744"
        y1="32.4165"
        x2="35.391201"
@@ -255,26 +270,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient2660"
-       xlink:href="#linearGradient3772-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7073165,0,0,2.7073165,135.10782,-64.975588)" />
-    <linearGradient
-       id="linearGradient3772-6">
-      <stop
-         id="stop3774-6"
-         style="stop-color:#b4b4b4;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3776-4"
-         style="stop-color:#969696;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient23419">
       <stop
          id="stop23421"
@@ -295,6 +290,24 @@
        gradientUnits="userSpaceOnUse"
        id="radialGradient4199"
        xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="74.129532"
+       y1="-56"
+       x2="74.129532"
+       y2="56"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4206">
@@ -304,7 +317,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -316,17 +328,9 @@
        id="path23417"
        style="opacity:0.3;fill:url(#radialGradient4199);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
     <path
-       d="m 119.49998,9e-6 c 0,-30.763132 -24.736865,-55.499989 -55.499992,-55.499989 C 33.236854,-55.49998 8.5,-30.763121 8.5,9e-6 8.4999946,30.763139 33.236857,55.5 63.999988,55.5 94.763112,55.49999 119.49998,30.763141 119.49998,9e-6 z m -35.195118,0 c 0,11.176154 -8.905094,20.304874 -20.304874,20.304874 -11.623403,0 -20.304874,-9.354626 -20.304874,-20.304874 0,-11.173915 8.234215,-20.304874 20.304874,-20.304874 12.07066,0 20.304874,9.352343 20.304874,20.304874 z"
        id="path2781"
-       style="fill:url(#linearGradient2658);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2660);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
-    <path
-       d="m 63.999988,-20.999991 c -11.592,0 -21,9.408 -21,21 0,11.592001 9.408,21 21,21 11.592,0 21,-9.407999 21,-21 0,-11.592 -9.408,-21 -21,-21 z m 0,10.500001 c 5.796,0 10.5,4.703999 10.5,10.499999 0,5.796 -4.704,10.5 -10.5,10.5 -5.796,0 -10.5,-4.704 -10.5,-10.5 0,-5.796 4.704,-10.499999 10.5,-10.499999 z"
-       id="path2474"
-       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 63.999988,-20.304865 c -11.20829,0 -20.304874,9.096584 -20.304874,20.304874 0,11.20829 9.096584,20.304874 20.304874,20.304874 11.20829,0 20.304874,-9.096584 20.304874,-20.304874 0,-11.20829 -9.096584,-20.304874 -20.304874,-20.304874 z m 0,10.152436 c 5.604145,0 10.152437,4.548293 10.152437,10.152438 0,5.604145 -4.548292,10.152436 -10.152437,10.152436 -5.604145,0 -10.152437,-4.548291 -10.152437,-10.152436 0,-5.604145 4.548292,-10.152438 10.152437,-10.152438 z"
-       id="path3418"
-       style="fill:none;stroke:url(#linearGradient2654);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#linearGradient2658);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 64 -55.5 C 33.236897 -55.5 8.5 -30.763099 8.5 0 C 8.4999946 30.763099 33.2369 55.5 64 55.5 C 94.763093 55.49999 119.5 30.763101 119.5 0 C 119.5 -30.763101 94.763096 -55.5 64 -55.5 z M 64 -21 A 21 20.99999 0 0 1 85 0 A 21 20.99999 0 0 1 64 21 A 21 20.99999 0 0 1 43 0 A 21 20.99999 0 0 1 64 -21 z " />
     <g
        transform="matrix(2.7320403,0,0,2.7320403,-1.0900842,-65.074256)"
        id="g3527">
@@ -381,9 +385,29 @@
        style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient4064);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="path8655"
        d="m 118.49999,-0.001923 c 0,30.100492 -24.402273,54.501933 -54.499313,54.501933 -30.099783,0 -54.500684,-24.401718 -54.500684,-54.501933 0,-30.099098 24.400901,-54.498065 54.500684,-54.498065 30.09704,0 54.499313,24.398967 54.499313,54.498065 l 0,0 z" />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:0.999998;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="63.999989"
+       cy="9.9999997e-06"
+       r="9.5" />
+    <circle
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="64"
+       cy="0"
+       r="55.5" />
     <path
-       d="m 63.99999,21.500009 c -11.917147,0 -21.500003,-9.582855 -21.500003,-21.5 0,-11.917145 9.582856,-21.5 21.500003,-21.5 11.917144,0 21.499999,9.582855 21.499999,21.5 0,11.917145 -9.582855,21.5 -21.499999,21.5 l 0,0 0,0 z"
+       d="m 64,-21 c -11.592,0 -21,9.408 -21,21 0,11.592001 9.408,21 21,21 11.592,0 21,-9.407999 21,-21 0,-11.592 -9.408,-21 -21,-21 z m 0,10.500001 C 69.796001,-10.499999 74.5,-5.796 74.5,0 74.5,5.7960003 69.796001,10.5 64,10.5 58.204,10.5 53.5,5.7960003 53.5,0 c 0,-5.796 4.704,-10.499999 10.5,-10.499999 z"
+       id="path2474"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 63.999999,22.500002 C 51.52857,22.500002 41.5,12.471432 41.5,2e-7 41.5,-12.471432 51.52857,-22.500002 63.999999,-22.500002 76.471435,-22.500002 86.5,-12.471432 86.5,2e-7 86.5,12.471432 76.471435,22.500002 63.999999,22.500002 Z"
+       id="path7063"
+       style="opacity:1;fill:none;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.5" />
+    <path
+       d="M 63.999999,21.5 C 52.082857,21.5 42.500001,11.917145 42.500001,1.5e-7 42.500001,-11.917145 52.082857,-21.5 63.999999,-21.5 c 11.91715,0 21.5,9.582855 21.5,21.50000015 C 85.499999,11.917145 75.917149,21.5 63.999999,21.5 Z"
        id="path3281"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+       style="opacity:1;fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
   </g>
 </svg>

--- a/elementary-xfce/devices/16/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/16/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/16/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/16/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-cd.svg
+++ b/elementary-xfce/devices/16/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-cdr.svg
+++ b/elementary-xfce/devices/16/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/16/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/16/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/16/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/16/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/16/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/16/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical-dvd.svg
+++ b/elementary-xfce/devices/16/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/16/media-optical.svg
+++ b/elementary-xfce/devices/16/media-optical.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg4087">
+   id="svg4087"
+   sodipodi:docname="media-optical.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview23023"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="59"
+     inkscape:cx="7.4830508"
+     inkscape:cy="9.1101695"
+     inkscape:window-width="1326"
+     inkscape:window-height="823"
+     inkscape:window-x="584"
+     inkscape:window-y="153"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4089">
     <linearGradient
@@ -57,7 +80,7 @@
          offset="0" />
       <stop
          id="stop6040"
-         style="stop-color:#ffffff;stop-opacity:0"
+         style="stop-color:#ffffff;stop-opacity:0.2;"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -226,17 +249,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        x1="12.2744"
        y1="32.4165"
        x2="35.391201"
@@ -246,14 +258,48 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0,0.4285752,-0.4285752,0,17.900088,-2.2858061)" />
     <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient4085"
-       xlink:href="#linearGradient3772"
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="74.129532"
+       y1="-56"
+       x2="74.129532"
+       y2="56"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3658536,0,0,0.3658536,17.609167,-0.78048667)" />
+       gradientTransform="matrix(0.13513514,0,0,0.13513514,-0.64864946,7.9999993)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.31;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-9"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2631579,0,0,0.2631579,-8.8421021,7.9999987)" />
+    <linearGradient
+       id="linearGradient6036-9">
+      <stop
+         id="stop6038-1"
+         style="stop-color:#000000;stop-opacity:0.33000001;"
+         offset="0" />
+      <stop
+         id="stop6040-2"
+         style="stop-color:#000000;stop-opacity:0.31999999;"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata4092">
@@ -263,16 +309,15 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
      id="layer1">
     <path
-       d="m 15.5,8.0000004 c 0,-4.1571805 -3.34282,-7.49999949 -7.5000007,-7.49999949 -4.1571809,0 -7.49999939,3.34281929 -7.49999939,7.49999949 C 0.49999911,12.15718 3.8428187,15.5 7.9999993,15.5 12.157179,15.499999 15.5,12.15718 15.5,8.0000004 z m -5,0 C 10.5,9.2939445 9.5060913,10.5 7.9999993,10.5 6.4939073,10.5 5.5,9.1934915 5.5,8.0000004 c 0,-1.2270178 1.0349902,-2.5 2.4999993,-2.5 1.4985143,0 2.5000007,1.2056213 2.5000007,2.5 z"
        id="path2781"
-       style="fill:url(#linearGradient4083);fill-rule:nonzero;stroke:url(#linearGradient4085);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:url(#linearGradient4083);fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 8 0.5 C 3.8428233 0.5 0.5 3.842824 0.5 8 C 0.4999992 12.157175 3.8428236 15.5 8 15.5 C 12.157176 15.499999 15.5 12.157175 15.5 8 C 15.5 3.8428237 12.157177 0.5 8 0.5 z M 8 5 A 3 3 0 0 1 11 8 A 3 3 0 0 1 8 11 A 3 3 0 0 1 5 8 A 3 3 0 0 1 8 5 z " />
     <g
        transform="matrix(0.3357395,0,0,0.3357395,-0.1714995,-0.39196467)"
        id="g3527">
@@ -299,29 +344,30 @@
          style="opacity:0.8;fill:url(#linearGradient3320);fill-opacity:1;fill-rule:nonzero;stroke:none" />
     </g>
     <g
-       transform="matrix(-0.3507965,0,0,-0.3507965,16.408914,16.448702)"
-       id="g3297">
+       transform="matrix(-0.34797631,0,0,-0.34797631,16.395856,16.437447)"
+       id="g3297"
+       style="stroke-width:1.0081">
       <path
-         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 l 10e-7,0 z"
-         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z"
+         transform="rotate(1.618417,24.093743,24.175959)"
          id="path3299"
-         style="opacity:0.8;fill:url(#linearGradient3301);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+         style="opacity:0.8;fill:url(#linearGradient3301);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
       <path
-         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 l 0,0 z"
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
          id="path3301"
-         style="opacity:0.8;fill:url(#linearGradient3303);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+         style="opacity:0.8;fill:url(#linearGradient3303);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
       <path
-         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
          id="path3303"
-         style="opacity:0.8;fill:url(#linearGradient3305);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+         style="opacity:0.8;fill:url(#linearGradient3305);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
       <path
-         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
          id="path3305"
-         style="opacity:0.8;fill:url(#linearGradient3307);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+         style="opacity:0.8;fill:url(#linearGradient3307);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
       <path
-         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z"
          id="path3307"
-         style="opacity:0.8;fill:url(#linearGradient3309);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+         style="opacity:0.8;fill:url(#linearGradient3309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
     </g>
     <path
        d="M 7.9999996,11.5 C 6.0599997,11.5 4.5,9.9400008 4.5,8.000001 4.5,6.0600013 6.0599997,4.5000015 7.9999996,4.5000015 9.9399998,4.5000015 11.5,6.0600013 11.5,8.000001 11.5,9.9400008 9.9399998,11.5 7.9999996,11.5 l 0,0 0,0 0,0 z"
@@ -331,5 +377,17 @@
        d="M 14.5,7.9997706 C 14.5,11.589738 11.589638,14.5 8.0000825,14.5 4.4102002,14.5 1.5,11.589704 1.5,7.9997706 c 0,-3.5898007 2.9102002,-6.49977 6.5000825,-6.49977 3.5895555,0 6.4999175,2.9099693 6.4999175,6.49977 l 0,0 z"
        id="path8655"
        style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3194);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="8"
+       cy="8"
+       r="2.5" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999998;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="8"
+       cy="8"
+       r="7.5000005" />
   </g>
 </svg>

--- a/elementary-xfce/devices/22/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/22/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/22/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/22/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-cd.svg
+++ b/elementary-xfce/devices/22/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-cdr.svg
+++ b/elementary-xfce/devices/22/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/22/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/22/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/22/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/22/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/22/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/22/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/22/media-optical-dvd.svg
+++ b/elementary-xfce/devices/22/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/24/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/24/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/24/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-cd.svg
+++ b/elementary-xfce/devices/24/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-cdr.svg
+++ b/elementary-xfce/devices/24/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/24/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/24/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/24/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/24/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/24/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/24/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical-dvd.svg
+++ b/elementary-xfce/devices/24/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/24/media-optical.svg
+++ b/elementary-xfce/devices/24/media-optical.svg
@@ -1,37 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg4250">
+   id="svg4250"
+   sodipodi:docname="media-optical.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20733"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="39.333333"
+     inkscape:cx="9.2161017"
+     inkscape:cy="11.491525"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="826"
+     inkscape:window-y="503"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4252">
-    <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient3068"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4374999,0,0,0.4374999,1.5,9.4999996)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        x1="18.775953"
        y1="4.0378027"
@@ -233,7 +236,7 @@
        id="linearGradient3072"
        xlink:href="#linearGradient3263"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,0.54545936,-0.54545936,0,24.600113,6.908972)" />
+       gradientTransform="matrix(0,0.54286194,-0.54286195,0,24.540113,6.9713107)" />
     <linearGradient
        x1="12.2744"
        y1="32.4165"
@@ -252,26 +255,6 @@
       <stop
          id="stop3269"
          style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient3074"
-       xlink:href="#linearGradient3772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4656319,0,0,0.4656319,24.22985,8.8248332)" />
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -295,6 +278,58 @@
        xlink:href="#linearGradient23419"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.48613589,0,0,0.1546652,0.65624961,21.060353)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="74.129532"
+       y1="-56"
+       x2="74.129532"
+       y2="56"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17117118,0,0,0.17117118,1.045044,20)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
+       id="linearGradient2651"
+       xlink:href="#linearGradient5804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17678888,0,0,-0.1767888,7.6957213,24.419722)" />
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5804"
+       id="linearGradient21339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08839444,0,0,-0.0883944,9.847861,22.209859)"
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591" />
   </defs>
   <metadata
      id="metadata4255">
@@ -304,7 +339,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -316,13 +350,19 @@
        id="path23417"
        style="opacity:0.3;fill:url(#radialGradient4248);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
     <path
-       d="M 21.545454,20 C 21.545454,14.709042 17.290956,10.454545 12,10.454545 6.709042,10.454545 2.4545455,14.709043 2.4545455,20 2.4545444,25.290957 6.7090425,29.545454 12,29.545454 17.290956,29.545453 21.545454,25.290957 21.545454,20 z M 15.5,20 c 0,1.791874 -1.745436,3.5 -3.5,3.5 -1.792116,0 -3.5,-1.822747 -3.5,-3.5 0,-1.714806 1.648901,-3.5 3.5,-3.5 1.888644,0 3.5,1.670604 3.5,3.5 z"
+       d="M 21.5,20.000001 C 21.5,14.734238 17.265761,10.5 12,10.5 6.734237,10.5 2.4999998,14.734239 2.4999998,20.000001 2.4999987,25.265762 6.7342375,29.5 12,29.5 c 5.265761,-1e-6 9.5,-4.234238 9.5,-9.499999 z m -6.016667,0 c 0,1.783341 -1.737124,3.483333 -3.483333,3.483333 -1.783582,0 -3.4833334,-1.814067 -3.4833334,-3.483333 0,-1.706641 1.6410484,-3.483334 3.4833334,-3.483334 1.87965,0 3.483333,1.662649 3.483333,3.483334 z"
        id="path2781"
-       style="fill:url(#linearGradient3072);fill-rule:nonzero;stroke:url(#linearGradient3074);stroke-width:1.00000012;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:url(#linearGradient3072);fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999999;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="12"
+       cy="20"
+       r="9.5" />
     <path
-       d="m 12,16.441 c -1.964568,0 -3.5590002,1.594432 -3.5590002,3.559 0,1.964568 1.5944322,3.559 3.5590002,3.559 1.964568,0 3.559,-1.594432 3.559,-3.559 0,-1.964568 -1.594432,-3.559 -3.559,-3.559 z m 0,1.7795 c 0.982284,0 1.7795,0.797216 1.7795,1.7795 0,0.982284 -0.797216,1.7795 -1.7795,1.7795 -0.982284,0 -1.7795,-0.797216 -1.7795,-1.7795 0,-0.982284 0.797216,-1.7795 1.7795,-1.7795 z"
        id="path2474"
-       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="M 12 17 C 10.344002 17 9 18.344002 9 20 C 9 21.655998 10.344002 23 12 23 C 13.655997 23 15 21.655998 15 20 C 15 18.344002 13.655997 17 12 17 z M 12 18.125 A 1.875 1.875 0 0 1 13.875 20 A 1.875 1.875 0 0 1 12 21.875 A 1.875 1.875 0 0 1 10.125 20 A 1.875 1.875 0 0 1 12 18.125 z " />
     <g
        transform="matrix(0.444875,0,0,0.444875,1.323,9.3229999)"
        id="g3527">
@@ -382,8 +422,12 @@
        id="path3281"
        style="opacity:0.4;fill:none;stroke:url(#linearGradient3065);stroke-width:0.99999976;stroke-miterlimit:4;stroke-opacity:1" />
     <path
-       d="m 11.999999,16.499999 c -1.932,0 -3.4999993,1.568 -3.4999993,3.500001 0,1.932 1.5679993,3.499999 3.4999993,3.499999 1.932001,0 3.5,-1.567999 3.5,-3.499999 0,-1.932001 -1.567999,-3.500001 -3.5,-3.500001 z m 0,1.750002 c 0.966001,0 1.75,0.783999 1.75,1.749999 0,0.966 -0.783999,1.75 -1.75,1.75 -0.965999,0 -1.749998,-0.784 -1.749998,-1.75 0,-0.965999 0.783999,-1.749999 1.749998,-1.749999 z"
-       id="path3418"
-       style="fill:none;stroke:url(#linearGradient3068);stroke-width:1.00000024;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 12,21.75 c -0.97,0 -1.75,-0.78 -1.75,-1.75 0,-0.970001 0.78,-1.75 1.75,-1.75 0.970001,0 1.75,0.779999 1.75,1.75 0,0.97 -0.779999,1.75 -1.75,1.75 z"
+       id="path21337"
+       style="fill:none;stroke:url(#linearGradient21339);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="m 12,23.500001 c -1.94,0 -3.5,-1.559999 -3.5,-3.5 0,-1.94 1.56,-3.5 3.5,-3.5 1.940001,0 3.5,1.56 3.5,3.5 0,1.940001 -1.559999,3.5 -3.5,3.5 z"
+       id="path3281-7"
+       style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
   </g>
 </svg>

--- a/elementary-xfce/devices/32/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/32/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/32/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/32/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-cd.svg
+++ b/elementary-xfce/devices/32/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-cdr.svg
+++ b/elementary-xfce/devices/32/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/32/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/32/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/32/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/32/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/32/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/32/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical-dvd.svg
+++ b/elementary-xfce/devices/32/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/32/media-optical.svg
+++ b/elementary-xfce/devices/32/media-optical.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="32px"
    height="32px"
    id="svg4106"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="media-optical.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview15024"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="41.7193"
+     inkscape:cx="14.873212"
+     inkscape:cy="14.190075"
+     inkscape:window-width="1326"
+     inkscape:window-height="990"
+     inkscape:window-x="997"
+     inkscape:window-y="76"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4108">
     <linearGradient
@@ -20,7 +43,7 @@
        id="linearGradient3406"
        xlink:href="#linearGradient6036"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3283222,0,0,-0.3283221,8.0063392,24.208052)" />
+       gradientTransform="matrix(0.3283222,0,0,-0.3283221,8.0063395,24.208052)" />
     <linearGradient
        id="linearGradient6036">
       <stop
@@ -59,46 +82,6 @@
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
          id="stop4019" />
-    </linearGradient>
-    <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient3427"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6875,0,0,0.6875,-0.5000014,-0.5000005)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="20.018932"
-       y1="3"
-       x2="20.018932"
-       y2="45.17627"
-       id="linearGradient3409"
-       xlink:href="#linearGradient3772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6585366,0,0,0.6585366,0.195122,0.195122)" />
-    <linearGradient
-       id="linearGradient3772">
-      <stop
-         id="stop3774"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3776"
-         style="stop-color:#969696;stop-opacity:1"
-         offset="1" />
     </linearGradient>
     <linearGradient
        x1="20.580074"
@@ -295,6 +278,57 @@
        gradientUnits="userSpaceOnUse"
        id="radialGradient4104"
        xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="74.129532"
+       y1="-56"
+       x2="74.129532"
+       y2="56"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324325,0,0,0.24324325,0.43243062,16.000001)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
+       id="linearGradient2651"
+       xlink:href="#linearGradient5804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13890557,0,0,-0.1389055,12.618067,19.472637)" />
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
+       id="linearGradient2651-6"
+       xlink:href="#linearGradient5804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2778111,0,0,-0.27781097,9.236133,22.945276)" />
   </defs>
   <metadata
      id="metadata4111">
@@ -304,7 +338,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -319,9 +352,9 @@
        id="path2781"
        style="fill:url(#linearGradient3431);fill-rule:nonzero;stroke:none" />
     <path
-       d="m 16,10.731707 c -2.908097,0 -5.268293,2.360196 -5.268293,5.268293 0,2.908098 2.360196,5.268293 5.268293,5.268293 2.908098,0 5.268293,-2.360195 5.268293,-5.268293 0,-2.908097 -2.360195,-5.268293 -5.268293,-5.268293 z m 0,2.634147 c 1.454049,0 2.634147,1.180098 2.634147,2.634146 0,1.454049 -1.180098,2.634147 -2.634147,2.634147 -1.454048,0 -2.634146,-1.180098 -2.634146,-2.634147 0,-1.454048 1.180098,-2.634146 2.634146,-2.634146 z"
        id="path2474"
-       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="M 16 11 C 13.240007 11 11 13.240007 11 16 C 11 18.759994 13.240007 21 16 21 C 18.759994 21 21 18.759994 21 16 C 21 13.240007 18.759994 11 16 11 z M 16 12.75 A 3.25 3.25 0 0 1 19.25 16 A 3.25 3.25 0 0 1 16 19.25 A 3.25 3.25 0 0 1 12.75 16 A 3.25 3.25 0 0 1 16 12.75 z " />
     <g
        transform="matrix(0.6585366,0,0,0.6585366,0.195122,0.195122)"
        id="g3527">
@@ -374,20 +407,26 @@
          style="opacity:0.8;fill:url(#linearGradient3444);fill-opacity:1;fill-rule:nonzero;stroke:none" />
     </g>
     <path
-       d="M 16,2.5 C 8.5170743,2.5 2.5,8.5170756 2.5,16 2.5,23.482926 8.517075,29.5 16,29.5 23.482925,29.5 29.499999,23.482926 29.499999,16 29.499998,8.5170763 23.482926,2.5 16,2.5 z"
-       id="path3287"
-       style="fill:none;stroke:url(#linearGradient3409);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
-    <path
-       d="M 15.999999,10.5 C 12.964,10.5 10.5,12.964001 10.5,16 c 0,3.036 2.464,5.5 5.499999,5.5 3.036,0 5.5,-2.464 5.5,-5.5 0,-3.035999 -2.464,-5.5 -5.5,-5.5 z m 0,2.75 c 1.518001,0 2.75,1.232001 2.75,2.75 0,1.518001 -1.231999,2.75 -2.75,2.75 -1.517999,0 -2.75,-1.231999 -2.75,-2.75 0,-1.517999 1.232001,-2.75 2.75,-2.75 z"
-       id="path3418"
-       style="fill:none;stroke:url(#linearGradient3427);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 16,18.75 c -1.524286,0 -2.75,-1.225715 -2.75,-2.750001 C 13.25,14.475713 14.475714,13.25 16,13.25 c 1.524286,0 2.75,1.225714 2.75,2.749999 C 18.75,17.524285 17.524286,18.75 16,18.75 Z"
+       id="path3281-7"
+       style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
     <path
        style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3199);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
        id="path8655"
        d="M 28.5,15.999557 C 28.5,22.903339 22.903147,28.5 16.000158,28.5 9.096537,28.5 3.5,22.903276 3.5,15.999557 3.5,9.0960941 9.096537,3.5000011 16.000158,3.5000011 22.903147,3.5000011 28.5,9.0960941 28.5,15.999557 l 0,0 z" />
     <path
-       d="M 15.999999,22.5 C 12.397142,22.5 9.5,19.602858 9.5,16.000001 c 0,-3.602858 2.897142,-6.5000015 6.499999,-6.5000015 3.60286,0 6.5,2.8971435 6.5,6.5000015 0,3.602857 -2.89714,6.499999 -6.5,6.499999 l 0,0 0,0 z"
+       d="m 16,22.5 c -3.602857,0 -6.4999998,-2.897142 -6.4999998,-6.499999 0,-3.602858 2.8971428,-6.5000015 6.4999998,-6.5000015 3.602859,0 6.5,2.8971435 6.5,6.5000015 C 22.5,19.602858 19.602859,22.5 16,22.5 Z"
        id="path3281"
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3406);stroke-width:0.99999994;stroke-miterlimit:4;stroke-opacity:1" />
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3406);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999997;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="16"
+       cy="16"
+       r="13.500001" />
+    <path
+       d="m 16,21.5 c -3.048572,0 -5.5,-2.451428 -5.5,-5.5 0,-3.048572 2.451428,-5.5 5.5,-5.5 3.048573,0 5.5,2.451428 5.5,5.5 0,3.048572 -2.451427,5.5 -5.5,5.5 z"
+       id="path3281-7-1"
+       style="fill:none;stroke:url(#linearGradient2651-6);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
   </g>
 </svg>

--- a/elementary-xfce/devices/48/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/48/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/48/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/48/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-cd.svg
+++ b/elementary-xfce/devices/48/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-cdr.svg
+++ b/elementary-xfce/devices/48/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/48/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/48/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/48/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/48/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/48/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/48/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical-dvd.svg
+++ b/elementary-xfce/devices/48/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/48/media-optical.svg
+++ b/elementary-xfce/devices/48/media-optical.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg4033">
+   id="svg4033"
+   sodipodi:docname="media-optical.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview14513"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="7.3220339"
+     inkscape:cy="24.101695"
+     inkscape:window-width="1920"
+     inkscape:window-height="1031"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4033" />
   <defs
      id="defs4035">
     <linearGradient
@@ -264,7 +287,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>

--- a/elementary-xfce/devices/64/media-optical-cd-r.svg
+++ b/elementary-xfce/devices/64/media-optical-cd-r.svg
@@ -1,1 +1,0 @@
-media-cdr.svg

--- a/elementary-xfce/devices/64/media-optical-cd-rw.svg
+++ b/elementary-xfce/devices/64/media-optical-cd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-cd.svg
+++ b/elementary-xfce/devices/64/media-optical-cd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-cdr.svg
+++ b/elementary-xfce/devices/64/media-optical-cdr.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-dvd-r-plus.svg
+++ b/elementary-xfce/devices/64/media-optical-dvd-r-plus.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-dvd-r.svg
+++ b/elementary-xfce/devices/64/media-optical-dvd-r.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-dvd-ram.svg
+++ b/elementary-xfce/devices/64/media-optical-dvd-ram.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-dvd-rom.svg
+++ b/elementary-xfce/devices/64/media-optical-dvd-rom.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-dvd-rw.svg
+++ b/elementary-xfce/devices/64/media-optical-dvd-rw.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical-dvd.svg
+++ b/elementary-xfce/devices/64/media-optical-dvd.svg
@@ -1,1 +1,0 @@
-media-optical.svg

--- a/elementary-xfce/devices/64/media-optical.svg
+++ b/elementary-xfce/devices/64/media-optical.svg
@@ -1,17 +1,51 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="64px"
    height="64px"
    id="svg4132"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="media-optical.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview4604"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="14.75"
+     inkscape:cx="26.542373"
+     inkscape:cy="30.644068"
+     inkscape:window-width="1326"
+     inkscape:window-height="414"
+     inkscape:window-x="602"
+     inkscape:window-y="618"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs4134">
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
     <linearGradient
        xlink:href="#linearGradient6036"
        id="linearGradient3064"
@@ -206,26 +240,6 @@
        gradientUnits="userSpaceOnUse"
        spreadMethod="reflect" />
     <linearGradient
-       xlink:href="#linearGradient3428"
-       id="linearGradient3067"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3125,0,0,1.3125,0.5000004,0.4999996)"
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        xlink:href="#linearGradient3263-6"
        id="linearGradient3070"
        gradientUnits="userSpaceOnUse"
@@ -255,26 +269,6 @@
          id="stop3269-2" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3772-6"
-       id="linearGradient3072"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3414634,0,0,1.3414634,67.233617,-0.1951219)"
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898" />
-    <linearGradient
-       id="linearGradient3772-6">
-      <stop
-         offset="0"
-         style="stop-color:#b4b4b4;stop-opacity:1;"
-         id="stop3774-6" />
-      <stop
-         offset="1"
-         style="stop-color:#969696;stop-opacity:1;"
-         id="stop3776-4" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient23419">
       <stop
          id="stop23421"
@@ -295,6 +289,58 @@
        gradientUnits="userSpaceOnUse"
        id="radialGradient4130"
        xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="74.129532"
+       y1="-56"
+       x2="74.129532"
+       y2="56"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4954955,0,0,0.4954955,0.2882874,32)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
+       id="linearGradient2651"
+       xlink:href="#linearGradient5804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53036665,0,0,-0.53036641,19.087164,45.259163)" />
+    <linearGradient
+       id="linearGradient6036-9">
+      <stop
+         id="stop6038-1"
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="0" />
+      <stop
+         id="stop6040-2"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-9"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55263156,0,0,0.55263156,-3.3684128,31.999996)" />
   </defs>
   <metadata
      id="metadata4137">
@@ -304,7 +350,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -315,13 +360,9 @@
        id="path23417"
        d="M 61,53.499999 C 61.001449,58.194291 48.017314,62 32,62 15.982686,62 2.9985065,58.194291 3.0000001,53.499999 2.9985065,48.805709 15.982686,45 32,45 c 16.017314,0 29.001493,3.805709 29,8.499999 l 0,0 z" />
     <path
-       style="fill:url(#linearGradient3070);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3072);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
        id="path2781"
-       d="M 59.5,31.999999 C 59.5,16.757004 47.242994,4.5 32,4.5 16.757002,4.5 4.5,16.757005 4.5,31.999999 c -2.6e-6,15.242995 12.257004,27.5 27.5,27.5 15.242992,-3e-6 27.5,-12.257003 27.5,-27.5 z m -17,0 C 42.5,37.537735 37.64854,42.5 32,42.5 26.240655,42.5 21.5,37.425799 21.5,31.999999 21.5,26.463373 26.019041,21.5 32,21.5 c 5.980959,0 10.5,5.073069 10.5,10.499999 z" />
-    <path
-       style="fill:#ffffff;fill-opacity:0.49803922;stroke:url(#linearGradient3067);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3418"
-       d="m 31.999999,21.499999 c -5.795999,0 -10.5,4.703999 -10.5,10.499999 0,5.795999 4.704001,10.5 10.5,10.5 5.795999,0 10.499999,-4.704001 10.499999,-10.5 0,-5.796 -4.704,-10.499999 -10.499999,-10.499999 z m 0,5.249999 c 2.898,0 5.249999,2.352 5.249999,5.25 0,2.898 -2.351999,5.249999 -5.249999,5.249999 -2.898,0 -5.25,-2.351999 -5.25,-5.249999 0,-2.898 2.352,-5.25 5.25,-5.25 z" />
+       style="fill:url(#linearGradient3070);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 32 4.5 C 16.757017 4.5 4.5 16.757021 4.5 32 C 4.4999974 47.24298 16.757019 59.5 32 59.5 C 47.242977 59.499997 59.5 47.242982 59.5 32 C 59.5 16.75702 47.242979 4.5 32 4.5 z M 32 22 A 10 10 0 0 1 42 32 A 10 10 0 0 1 32 42 A 10 10 0 0 1 22 32 A 10 10 0 0 1 32 22 z " />
     <g
        id="g3527"
        transform="matrix(1.3333334,0,0,1.3333334,-1.6000002e-6,0.0588927)">
@@ -380,5 +421,31 @@
        style="opacity:0.4;fill:none;stroke:url(#linearGradient3064);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1"
        id="path3281"
        d="m 31.999999,43.500001 c -6.374286,0 -11.5,-5.125713 -11.5,-11.5 0,-6.374285 5.125714,-11.500001 11.5,-11.500001 6.374289,0 11.5,5.125716 11.5,11.500001 0,6.374287 -5.125711,11.5 -11.5,11.5 l 0,0 0,0 0,0 z" />
+    <path
+       id="path3418"
+       style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.498039;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="M 32 22 C 26.480013 22 22 26.480012 22 32 C 22 37.519987 26.480013 42 32 42 C 37.519987 42 42 37.519987 42 32 C 42 26.480012 37.519987 22 32 22 z M 32 26 A 6 6 0 0 1 38 32 A 6 6 0 0 1 32 38 A 6 6 0 0 1 26 32 A 6 6 0 0 1 32 26 z " />
+    <path
+       d="m 32,42.5 c -5.82,0 -10.5,-4.679998 -10.5,-10.5 0,-5.820001 4.68,-10.5 10.5,-10.5 5.820003,0 10.5,4.679999 10.5,10.5 0,5.820002 -4.679997,10.5 -10.5,10.5 z"
+       id="path3281-7"
+       style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-opacity:0.5;stop-color:#000000"
+       id="circle10638"
+       cx="32"
+       cy="32"
+       r="6.25" />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="32"
+       cy="32"
+       r="5.25" />
   </g>
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999999;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path3554"
+     cx="32"
+     cy="32"
+     r="27.5" />
 </svg>

--- a/elementary-xfce/devices/96/media-optical.svg
+++ b/elementary-xfce/devices/96/media-optical.svg
@@ -5,7 +5,7 @@
    id="svg4201"
    version="1.1"
    sodipodi:docname="media-optical.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,15 +23,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="18.031223"
-     inkscape:cx="50.440284"
-     inkscape:cy="49.414286"
+     inkscape:zoom="25.5"
+     inkscape:cx="43.470588"
+     inkscape:cy="44.607843"
      inkscape:window-width="1920"
-     inkscape:window-height="999"
+     inkscape:window-height="1031"
      inkscape:window-x="0"
-     inkscape:window-y="25"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4203">
     <linearGradient
@@ -228,26 +230,6 @@
        gradientUnits="userSpaceOnUse"
        spreadMethod="reflect" />
     <linearGradient
-       x1="21.448364"
-       y1="15.5"
-       x2="21.448364"
-       y2="32.509201"
-       id="linearGradient2654"
-       xlink:href="#linearGradient3428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8750001,0,0,1.8750001,3.0000004,-61.000001)" />
-    <linearGradient
-       id="linearGradient3428">
-      <stop
-         id="stop3430"
-         style="stop-color:#aaaaaa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3432"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        x1="12.2744"
        y1="32.4165"
        x2="35.391201"
@@ -277,26 +259,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="-21.915663"
-       y1="3"
-       x2="-21.915663"
-       y2="45.032898"
-       id="linearGradient2660"
-       xlink:href="#linearGradient3772-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0243898,0,0,2.0243898,101.17072,-64.585357)" />
-    <linearGradient
-       id="linearGradient3772-6">
-      <stop
-         id="stop3774-6"
-         style="stop-color:#b4b4b4;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3776-4"
-         style="stop-color:#969696;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient23419">
       <stop
          id="stop23421"
@@ -317,6 +279,58 @@
        gradientUnits="userSpaceOnUse"
        id="radialGradient4199"
        xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="74.129532"
+       y1="-56"
+       x2="74.129532"
+       y2="56"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74774775,0,0,0.74774775,0.14414456,-16.000002)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.33000001;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
+       id="linearGradient2651-3"
+       xlink:href="#linearGradient6036-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75766665,0,0,-0.7576663,29.553091,2.9416607)" />
+    <linearGradient
+       id="linearGradient6036-6">
+      <stop
+         id="stop6038-7"
+         style="stop-color:#000000;stop-opacity:0.28;"
+         offset="0" />
+      <stop
+         id="stop6040-5"
+         style="stop-color:#000000;stop-opacity:0.23999999;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-6"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73684212,0,0,0.73684212,0.84211142,-16.000007)" />
   </defs>
   <metadata
      id="metadata4206">
@@ -337,17 +351,23 @@
        id="path23417"
        style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4199);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
     <path
-       d="m 89.499993,-16.000001 c 0,-23.003062 -18.496935,-41.499991 -41.499994,-41.499991 -23.003064,0 -41.4999915,18.49693 -41.4999915,41.499991 -4.1e-6,23.0030612 18.4969295,41.499994 41.4999915,41.499994 23.003057,-8e-6 41.499994,-18.4969313 41.499994,-41.499994 z m -26.31707,0 c 0,8.356944 -6.658764,15.18292384 -15.182924,15.18292384 -8.691373,0 -15.182924,-6.99490054 -15.182924,-15.18292384 0,-8.355269 6.157116,-15.182923 15.182924,-15.182923 9.025809,0 15.182924,6.993193 15.182924,15.182923 z"
        id="path2781"
-       style="fill:url(#linearGradient2658);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2660);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+       style="fill:url(#linearGradient2658);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 48 -57.5 C 24.996959 -57.5 6.5 -39.003038 6.5 -16 C 6.4999959 7.0030382 24.996961 25.5 48 25.5 C 71.003034 25.499992 89.5 7.0030397 89.5 -16 C 89.5 -39.003039 71.003036 -57.5 48 -57.5 z M 48 -30.5 A 14.5 14.5 0 0 1 62.5 -16 A 14.5 14.5 0 0 1 48 -1.5 A 14.5 14.5 0 0 1 33.5 -16 A 14.5 14.5 0 0 1 48 -30.5 z " />
     <path
-       d="m 47.999991,-31.749993 c -8.694,0 -15.75,7.056 -15.75,15.75 0,8.6940005 7.056,15.74999995 15.75,15.74999995 8.694,0 15.75,-7.05599945 15.75,-15.74999995 0,-8.694 -7.056,-15.75 -15.75,-15.75 z m 0,7.875001 c 4.347,0 7.875,3.527999 7.875,7.874999 0,4.347 -3.528,7.8749998 -7.875,7.8749998 -4.347,0 -7.875,-3.5279998 -7.875,-7.8749998 0,-4.347 3.528,-7.874999 7.875,-7.874999 z"
        id="path2474"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999997;marker:none;enable-background:accumulate" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999994;marker:none;enable-background:accumulate"
+       d="M 48 -30.5 C 39.996008 -30.5 33.5 -24.003992 33.5 -16 C 33.5 -7.9960075 39.996008 -1.5 48 -1.5 C 56.003992 -1.5 62.5 -7.9960075 62.5 -16 C 62.5 -24.003992 56.003992 -30.5 48 -30.5 z M 48 -24 A 7.9999995 7.9999995 0 0 1 56 -16 A 7.9999995 7.9999995 0 0 1 48 -8 A 7.9999995 7.9999995 0 0 1 40 -16 A 7.9999995 7.9999995 0 0 1 48 -24 z " />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="48"
+       cy="-16"
+       r="7" />
     <path
-       d="m 48,-31.000001 c -8.279999,0 -15,6.72 -15,15 0,8.2800008 6.720002,15.00000115 15,15.00000115 8.28,0 15,-6.72000035 15,-15.00000115 0,-8.28 -6.72,-15 -15,-15 z m 0,7.499999 c 4.14,0 7.5,3.360001 7.5,7.500001 0,4.139999 -3.36,7.5000003 -7.5,7.5000003 -4.14,0 -7.5,-3.3600013 -7.5,-7.5000003 0,-4.14 3.36,-7.500001 7.5,-7.500001 z"
-       id="path3418"
-       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient2654);stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       d="M 47.999999,-0.99999915 C 39.685714,-0.99999915 33,-7.6857123 33,-16 33,-24.314288 39.685714,-31.000001 47.999999,-31.000001 56.314291,-31.000001 63,-24.314288 63,-16 63,-7.6857123 56.314291,-0.99999915 47.999999,-0.99999915 Z"
+       id="path3281-3"
+       style="fill:none;stroke:url(#linearGradient2651-3);stroke-width:0.999997;stroke-miterlimit:4;stroke-opacity:1" />
     <g
        transform="matrix(2.0490302,0,0,2.0490302,-0.8175631,-64.805692)"
        id="g3527"
@@ -408,5 +428,11 @@
        d="M 47.999992,7.0593023e-6 C 39.131418,7.0593023e-6 31.99999,-7.1314201 31.99999,-15.999993 c 0,-8.868573 7.131428,-16 16.000002,-16 8.868573,0 16,7.131427 16,16 0,8.8685729 -7.131427,16.0000000593023 -16,16.0000000593023 z"
        id="path3281"
        style="opacity:0.4;fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="48"
+       cy="-16"
+       r="41.5" />
   </g>
 </svg>


### PR DESCRIPTION
Updates the disc borders to make them sharper. Removes symlinks I'm pretty certain aren't used anymore (details below). If I need to split these up I can do that.

Thanks!

---

Updated
- Use semi-transparent borders for `media-optical` making them sharper, especially in dark themes.

Removed
- All `media-optical-*` symlinks.

All `media-optical-*` icons are symlinked to `media-optical`, none are unique icons so they shouldn't be needed. These special icon names (like `media-optical-cd-r`) are defined in udisks2[1], but they are not FreeDesktop.org names, and every app I can find (even udisks2 frontends like gnome-disk-utility) seems to enable fallbacks to use simply media-optical for all disc media.

[1] https://github.com/max2344/udisks2/blob/4d165214f81e71b7ff10b02cdea0a1d915dd8c7f/udisks/udisksobjectinfo.c#L177

---

![disc-borders](https://user-images.githubusercontent.com/1984060/232219621-6678ecd0-56a7-4fd5-a605-14ec2572f977.png)
