### PR TITLE
Actions: Update session icons

### DIFF
--- a/elementary-xfce/actions/16/system-lock-screen.svg
+++ b/elementary-xfce/actions/16/system-lock-screen.svg
@@ -1,1 +1,129 @@
-../../status/16/locked.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg4248"
+   sodipodi:docname="system-lock-screen.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1396"
+     inkscape:window-height="859"
+     id="namedview29"
+     showgrid="false"
+     inkscape:zoom="24.78125"
+     inkscape:cx="6.295082"
+     inkscape:cy="15.778058"
+     inkscape:window-x="576"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4248"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs4250">
+    <linearGradient
+       id="linearGradient4011-4">
+      <stop
+         id="stop4013-8"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019-1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.3513514,0,0,0.35135134,-17.203671,-0.90930007)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4011-4"
+       id="linearGradient3019"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
+    <linearGradient
+       gradientTransform="matrix(0,0.36585366,-0.36585366,0,16.780487,-0.78048733)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="81.658852"
+       y1="23.999998"
+       x1="-1.5996079"
+       id="linearGradient887"
+       xlink:href="#linearGradient947-5" />
+    <linearGradient
+       id="linearGradient947-5">
+      <stop
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         id="stop943-6" />
+      <stop
+         offset="1"
+         style="stop-color:#3a9104;stop-opacity:1"
+         id="stop945-2" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4253">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     id="path2555-3"
+     d="m 15.5,8.0000013 c 0,-4.1382414 -3.361758,-7.50000173 -7.4999999,-7.50000173 -4.1382408,0 -7.50000135,3.36176033 -7.50000035,7.50000173 0,4.1382387 3.36175955,7.5000027 7.50000035,7.4999987 C 12.138242,15.5 15.5,12.13824 15.5,8.0000013 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6"
+     d="M 14.500001,7.9997694 C 14.500001,11.589737 11.589637,14.5 8.0000818,14.5 4.4101998,14.5 1.499999,11.589703 1.499999,7.9997694 c 0,-3.5898004 2.9102008,-6.4997693 6.5000828,-6.4997693 3.5895552,0 6.4999192,2.9099689 6.4999192,6.4997693 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#206b00;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6-1"
+     d="M 8.000001,0.49999952 C 3.8617601,0.49999952 0.5,3.8617577 0.5,7.9999985 0.5,12.138241 3.8617601,15.5 8.000001,15.5 12.138241,15.5 15.500004,12.138241 15.5,7.9999985 15.5,3.8617577 12.138241,0.49999952 8.000001,0.49999952 Z" />
+  <path
+     id="path141573"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.500007,4 C 6.669008,4 6.000003,4.925336 6.000003,5.75 V 8 H 4.5 C 4.223001,8 4,8.223001 4,8.5 v 4 C 4,12.777 4.223001,13 4.5,13 h 7.000008 c 0.277,0 0.5,-0.223 0.5,-0.5 v -4 c 0,-0.276999 -0.223,-0.5 -0.5,-0.5 H 10.000006 V 5.75 C 10.000006,4.919001 9.331001,4 8.500002,4 Z m 0.165999,0.999598 h 0.667997 c 0.369068,0 0.665998,0.305736 0.665998,0.674804 V 8 H 7.000007 V 5.674402 c 0,-0.369068 0.29693,-0.674804 0.665999,-0.674804 z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
+  <path
+     id="path28609"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.250004,3 C 6.419005,3 6.000003,3.675336 6.000003,4.5 V 7 H 4.5 C 4.223001,7 4,7.223001 4,7.5 v 4 C 4,11.777 4.223001,12 4.5,12 h 7.000008 c 0.277,0 0.5,-0.223 0.5,-0.5 v -4 c 0,-0.276999 -0.223,-0.5 -0.5,-0.5 H 10.000006 V 4.5 C 10.000006,3.669001 9.581003,3 8.750004,3 Z m 0.416002,0.999598 h 0.667997 c 0.369068,0 0.665998,0.305736 0.665998,0.674804 V 7 H 7.000007 V 4.674402 c 0,-0.369068 0.29693,-0.674804 0.665999,-0.674804 z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.250004,3 C 6.419005,3 6.000003,3.675336 6.000003,4.5 V 7 H 4.5 C 4.223001,7 4,7.223001 4,7.5 v 4 C 4,11.777 4.223001,12 4.5,12 h 7.000008 c 0.277,0 0.5,-0.223 0.5,-0.5 v -4 c 0,-0.276999 -0.223,-0.5 -0.5,-0.5 H 10.000006 V 4.5 C 10.000006,3.669001 9.581003,3 8.750004,3 Z m 0.416002,0.999598 h 0.667997 c 0.369068,0 0.665998,0.305736 0.665998,0.674804 V 7 H 7.000007 V 4.674402 c 0,-0.369068 0.29693,-0.674804 0.665999,-0.674804 z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
+</svg>

--- a/elementary-xfce/actions/16/system-log-out.svg
+++ b/elementary-xfce/actions/16/system-log-out.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   width="16px"
+   height="16px"
+   id="svg3033"
    version="1.1"
-   width="16"
-   height="16"
-   id="svg4248"
-   sodipodi:docname="xfsm-logout.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="system-log-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -15,45 +15,44 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview28"
      pagecolor="#ffffff"
      bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
+     borderopacity="1.0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview29"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="35.04598"
-     inkscape:cx="9.016726"
-     inkscape:cy="6.4058702"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4248"
-     inkscape:pagecheckerboard="0" />
+     inkscape:zoom="30.140427"
+     inkscape:cx="8.2779186"
+     inkscape:cy="6.2374697"
+     inkscape:window-width="1284"
+     inkscape:window-height="867"
+     inkscape:window-x="428"
+     inkscape:window-y="126"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3033"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs3035">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011">
       <stop
-         id="stop4013-8"
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop4015-5"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop4015" />
       <stop
-         id="stop4017-6"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
          offset="0.83456558" />
       <stop
-         id="stop4019-1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -62,108 +61,67 @@
        x2="71.204407"
        y2="44.340794"
        id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
+       xlink:href="#linearGradient4011"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135138,0,0,0.35135138,-17.203669,-0.90930069)" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.4568977,-2.5991048,-6.9066326e-8,29.961873,-9.3717628)" />
+       gradientTransform="matrix(0.35135137,0,0,0.35135141,-17.203669,-0.9093021)" />
     <linearGradient
-       id="linearGradient3820-7-2-2">
-      <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
+       inkscape:collect="always"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
+       x1="12.000114"
+       y1="10.456168"
+       x2="12.000114"
+       y2="29.543833"
+       gradientTransform="matrix(0.71440716,0,0,0.71440716,-0.572886,-6.2881433)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
+       id="linearGradient26009">
       <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
+         id="stop26005"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
       <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
-         style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop26007"
+         offset="1"
+         style="stop-color:#f37329;stop-opacity:1" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata3038">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="M 8.000001,0.49999995 C 3.8617599,0.49999995 0.5,3.861758 0.5,7.9999994 0.5,12.138242 3.8617599,15.500002 8.000001,15.5 12.138241,15.5 15.500004,12.138242 15.5,7.9999994 15.5,3.861758 12.138241,0.49999995 8.000001,0.49999995 Z"
+     d="m 8,0.49999975 c -4.13824,0 -7.5,3.36175895 -7.5,7.49999975 C 0.5,12.138241 3.86176,15.500002 8,15.5 c 4.13824,0 7.500004,-3.361759 7.5,-7.5000005 C 15.5,3.8617587 12.13824,0.49999975 8,0.49999975 Z"
      id="path2555"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate" />
+     style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="M 8.000001,0.49999995 C 3.8617597,0.49999995 0.5,3.8617581 0.5,8 c 0,4.138241 3.3617597,7.500002 7.500001,7.5 C 12.13824,15.5 15.500004,12.138241 15.5,8 15.5,3.8617581 12.13824,0.49999995 8.000001,0.49999995 Z"
+     id="path1424"
+     style="font-variation-settings:normal;fill:none;fill-opacity:0.60000002;stroke:#a62100;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;stop-color:#000000"
+     d="m 7.3514124,13.25 c 0.3593481,0 0.6486431,-0.284449 0.6486431,-0.637778 V 9.9998897 H 12.351357 C 12.710706,9.9998897 13,9.7154401 13,9.3621102 V 8.6378891 C 13,8.2845592 12.710706,7.9997619 12.351357,8.0001108 H 8.0000555 V 5.387777 C 8.0000555,5.0344493 7.7107605,4.75 7.3514124,4.75 7.1577374,4.75 6.9848499,4.832756 6.8661955,4.9642528 l -3.688831,3.5902169 c -0.1096749,0.1142224 -0.1773643,0.267745 -0.1773643,0.4372274 0,0.1694837 0.067683,0.3230051 0.1773643,0.4372274 l 3.688831,3.6068225 C 6.9848499,13.16725 7.1577374,13.25 7.3514124,13.25 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     d="m 8.0000003,0.49999955 c -4.138241,0 -7.50000006,3.36175895 -7.50000006,7.50000005 0,4.1382414 3.36175906,7.5000024 7.50000006,7.5000004 C 12.13824,15.5 15.500004,12.138241 15.5,7.9999996 15.5,3.8617585 12.13824,0.49999955 8.0000003,0.49999955 Z"
      id="path2555-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
   <path
-     d="m 14.500001,7.9997701 c 0,3.5899669 -2.910364,6.5002309 -6.4999178,6.5002309 C 4.4101997,14.500001 1.5,11.589704 1.5,7.9997701 1.5,4.4099688 4.4101997,1.5 8.0000832,1.5 c 3.5895538,0 6.4999178,2.9099688 6.4999178,6.4997701 z"
+     d="m 14.500001,7.999769 c 0,3.589968 -2.910364,6.500233 -6.4999183,6.500233 -3.5898839,0 -6.5000833,-2.910299 -6.5000833,-6.500233 0,-3.5898016 2.9101994,-6.4997705 6.5000833,-6.4997705 3.5895543,0 6.4999183,2.9099689 6.4999183,6.4997705 z"
      id="path8655"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     d="M 7,3.9999924 2,8.5000075 7,13.5 V 11 h 5 V 6.4999924 H 7 Z"
-     id="path882"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ae2109;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none"
-     sodipodi:nodetypes="cccccccc" />
+     id="path138251"
+     style="font-variation-settings:normal;fill:#a62100;fill-opacity:0.60000002;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 7.3514124,13.25 c 0.3593481,0 0.6486431,-0.284449 0.6486431,-0.637778 V 9.9998897 H 12.351357 C 12.710706,9.9998897 13,9.7154401 13,9.3621102 V 8.6378891 C 13,8.2845592 12.710706,7.9997619 12.351357,8.0001108 H 8.0000555 V 5.387777 C 8.0000555,5.0344493 7.7107605,4.75 7.3514124,4.75 7.1577374,4.75 6.9848499,4.832756 6.8661955,4.9642528 l -3.688831,3.5902169 c -0.1096749,0.1142224 -0.1773643,0.267745 -0.1773643,0.4372274 0,0.1694837 0.067683,0.3230051 0.1773643,0.4372274 l 3.688831,3.6068225 C 6.9848499,13.16725 7.1577374,13.25 7.3514124,13.25 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="M 7,3.5 2.5,8 7,12.5 V 10 h 5 V 6 H 7 Z"
-     id="path4348"
-     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none"
-     sodipodi:nodetypes="cccccccc" />
-  <path
-     d="m 40.531397,-9.051989 a 0.97549411,0.97549411 0 0 0 -0.53125,0.25 l -8,7.03125 a 0.97549411,0.97549411 0 0 0 0,1.46875 l 8,6.96875 a 0.97549411,0.97549411 0 0 0 1.625,-0.75 v -4.03125 h 8.03125 a 0.97549411,0.97549411 0 0 0 0.96875,-0.96875 v -3.9375 a 0.97549411,0.97549411 0 0 0 -0.96875,-0.96875 h -8.03125 v -4.09375 a 0.97549411,0.97549411 0 0 0 -1.09375,-0.96875 z"
-     id="path4026-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#ae2109;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     d="m 40.635147,-8.083239 -8,7.027124 8,6.972876 v -5 h 9 v -3.927874 h -9 z"
-     id="path4348-5-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ae2109;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     d="m 40.635147,-9.083239 -8,7.027124 8,6.972876 v -5 h 9 v -3.927874 h -9 z"
-     id="path4348-7"
-     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     id="path873-5"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 7.3514124,12.25 c 0.3593481,0 0.6486431,-0.284449 0.6486431,-0.637778 V 8.9998897 H 12.351357 C 12.710706,8.9998897 13,8.7154401 13,8.3621102 V 7.6378891 C 13,7.2845592 12.710706,6.9997619 12.351357,7.0001108 H 8.0000555 V 4.387777 C 8.0000555,4.0344493 7.7107605,3.75 7.3514124,3.75 7.1577374,3.75 6.9848499,3.832756 6.8661955,3.9642528 l -3.688831,3.5902169 c -0.1096749,0.1142224 -0.1773643,0.267745 -0.1773643,0.4372274 0,0.1694837 0.067683,0.3230051 0.1773643,0.4372274 l 3.688831,3.6068225 C 6.9848499,12.16725 7.1577374,12.25 7.3514124,12.25 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/elementary-xfce/actions/16/system-reboot.svg
+++ b/elementary-xfce/actions/16/system-reboot.svg
@@ -1,1 +1,138 @@
-view-refresh.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16px"
+   height="16px"
+   id="svg3033"
+   version="1.1"
+   sodipodi:docname="system-reboot.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview28"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="8.5847183"
+     inkscape:cy="6.8942911"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="684"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3033"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs3035">
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop4015" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient3089"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135137,0,0,0.35135141,-17.203669,-0.9093021)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
+       gradientUnits="userSpaceOnUse"
+       x1="12.000114"
+       y1="10.18603"
+       x2="12.000114"
+       y2="29.734943"
+       gradientTransform="matrix(0.71440716,0,0,0.71440716,-0.572886,-6.2881433)" />
+    <linearGradient
+       id="linearGradient26009">
+      <stop
+         id="stop26005"
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         id="stop26007"
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3038">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 8,0.49999975 c -4.13824,0 -7.5,3.36175895 -7.5,7.49999975 C 0.5,12.138241 3.86176,15.500002 8,15.5 c 4.13824,0 7.500004,-3.361759 7.5,-7.5000005 C 15.5,3.8617587 12.13824,0.49999975 8,0.49999975 Z"
+     id="path2555"
+     style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 8.0000003,0.49999955 c -4.138241,0 -7.50000006,3.36175895 -7.50000006,7.50000005 0,4.1382414 3.36175906,7.5000024 7.50000006,7.5000004 C 12.13824,15.5 15.500004,12.138241 15.5,7.9999996 15.5,3.8617585 12.13824,0.49999955 8.0000003,0.49999955 Z"
+     id="path2555-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#002e99;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
+  <path
+     d="m 14.500001,7.999769 c 0,3.589968 -2.910364,6.500233 -6.4999183,6.500233 -3.5898839,0 -6.5000833,-2.910299 -6.5000833,-6.500233 0,-3.5898016 2.9101994,-6.4997705 6.5000833,-6.4997705 3.5895543,0 6.4999183,2.9099689 6.4999183,6.4997705 z"
+     id="path8655"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path11867"
+     style="font-variation-settings:normal;fill:none;fill-opacity:0.6;stroke:#002e99;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.1;marker:none;stop-color:#000000"
+     d="M 8.5507812,3.25 C 8.2455615,3.25 8,3.4334857 8,3.6621094 V 4.9003906 C 6.0153006,4.9470494 4.2278297,6.2887034 3.7460938,8.2597656 3.1940944,10.518316 4.5755121,12.814781 6.828125,13.46875 c 2.2526129,0.653969 4.664899,-0.50938 5.482422,-2.6875 A 0.99999499,0.99999499 0 0 0 11.726562,9.4921875 0.99999499,0.99999499 0 0 0 10.439453,10.078125 C 9.9959136,11.259844 8.6643565,11.918361 7.3847656,11.546875 6.1051747,11.175389 5.3911485,9.9549129 5.6894531,8.734375 5.9463413,7.6832962 6.8990672,6.9457431 8,6.9042969 V 8.3378906 C 8,8.566515 8.2455615,8.75 8.5507812,8.75 8.715282,8.75 8.8621024,8.6964185 8.9628906,8.6113281 L 11.984375,6.5507812 C 12.077532,6.4768722 12.2522,6.3655808 12.25,5.9941406 12.247743,5.6227005 12.077535,5.5231267 11.984375,5.4492188 L 8.9628906,3.3886719 C 8.8621094,3.3035899 8.715282,3.25 8.5507812,3.25 Z" />
+  <path
+     id="path9399"
+     style="font-variation-settings:normal;fill:#002e99;fill-opacity:0.5;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="M 8.5507812,3.25 C 8.2455615,3.25 8,3.4334857 8,3.6621094 V 4.9003906 C 6.0153006,4.9470494 4.2278297,6.2887034 3.7460938,8.2597656 3.1940944,10.518316 4.5755121,12.814781 6.828125,13.46875 c 2.2526129,0.653969 4.664899,-0.50938 5.482422,-2.6875 A 0.99999499,0.99999499 0 0 0 11.726562,9.4921875 0.99999499,0.99999499 0 0 0 10.439453,10.078125 C 9.9959136,11.259844 8.6643565,11.918361 7.3847656,11.546875 6.1051747,11.175389 5.3911485,9.9549129 5.6894531,8.734375 5.9463413,7.6832962 6.8990672,6.9457431 8,6.9042969 V 8.3378906 C 8,8.566515 8.2455615,8.75 8.5507812,8.75 8.715282,8.75 8.8621024,8.6964185 8.9628906,8.6113281 L 11.984375,6.5507812 C 12.077532,6.4768722 12.2522,6.3655808 12.25,5.9941406 12.247743,5.6227005 12.077535,5.5231267 11.984375,5.4492188 L 8.9628906,3.3886719 C 8.8621094,3.3035899 8.715282,3.25 8.5507812,3.25 Z" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 8.5509362,7.7500001 c -0.3052201,0 -0.5509367,-0.1840553 -0.5509367,-0.4126799 V 2.6626795 C 7.9999995,2.4340556 8.2457161,2.25 8.5509362,2.25 c 0.1645009,0 0.3113455,0.053552 0.4121268,0.1386341 l 3.021292,2.0613658 c 0.09316,0.073908 0.263366,0.1731877 0.265623,0.5446282 C 12.252178,5.3660686 12.077512,5.4760909 11.984355,5.55 L 8.963063,7.6113657 C 8.8622747,7.6964562 8.7154371,7.7500001 8.5509362,7.7500001 Z"
+     sodipodi:nodetypes="sccscczccs" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.99999;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     id="path54251"
+     sodipodi:type="arc"
+     sodipodi:cx="8.1045189"
+     sodipodi:cy="8.2749519"
+     sodipodi:rx="3.4803777"
+     sodipodi:ry="3.3750012"
+     sodipodi:start="0.34906585"
+     sodipodi:end="4.8869219"
+     sodipodi:arc-type="arc"
+     d="M 11.375004,9.4292703 A 3.4803777,3.3750012 0 0 1 7.1063353,11.508168 3.4803777,3.3750012 0 0 1 4.7179552,7.4966231 3.4803777,3.3750012 0 0 1 8.7088801,4.9512246"
+     sodipodi:open="true" />
+</svg>

--- a/elementary-xfce/actions/16/system-shutdown.svg
+++ b/elementary-xfce/actions/16/system-shutdown.svg
@@ -4,8 +4,8 @@
    height="16px"
    id="svg3033"
    version="1.1"
-   sodipodi:docname="system-shutdown-alt.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="system-shutdown.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,26 +23,19 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="42.625"
-     inkscape:cx="7.8123167"
-     inkscape:cy="7.9882698"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3033" />
+     inkscape:zoom="85.250001"
+     inkscape:cx="8.005865"
+     inkscape:cy="9.3020527"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="204"
+     inkscape:window-y="749"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3033"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3035">
-    <linearGradient
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407"
-       gradientTransform="matrix(0.35135136,0,0,0.35135136,-17.203671,-0.90930025)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3280"
-       xlink:href="#linearGradient4011" />
     <linearGradient
        id="linearGradient4011">
       <stop
@@ -63,85 +56,34 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#dd3b27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="20.397499"
-       fy="3.9900031"
-       fx="23.895569"
-       cy="3.9900031"
-       cx="23.895569"
-       gradientTransform="matrix(0,0.8796593,-1.1611346,0,12.632931,-21.08413)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient3089"
+       xlink:href="#linearGradient4011"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3029"
-       xlink:href="#linearGradient3242" />
-    <linearGradient
-       y2="3.0816143"
-       x2="18.379412"
-       y1="44.980297"
-       x1="18.379412"
-       gradientTransform="matrix(0.3685738,0,0,0.3685738,-0.84577,-0.84576985)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3031"
-       xlink:href="#linearGradient2490" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ef6555;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#c6272e;stop-opacity:1" />
-    </linearGradient>
+       gradientTransform="matrix(0.35135137,0,0,0.35135141,-17.203669,-0.9093021)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient885-7"
-       id="linearGradient905-6"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
        gradientUnits="userSpaceOnUse"
-       x1="12.089882"
-       y1="11.236414"
-       x2="12.089882"
-       y2="29.379152"
-       gradientTransform="matrix(0.71440714,0,0,0.71440714,-0.5728861,-6.2881432)" />
+       x1="12.000114"
+       y1="10.456168"
+       x2="12.000114"
+       y2="29.543833"
+       gradientTransform="matrix(0.71440716,0,0,0.71440716,-0.572886,-6.2881433)" />
     <linearGradient
-       id="linearGradient885-7">
+       id="linearGradient26009">
       <stop
-         id="stop881-5"
+         id="stop26005"
          offset="0"
-         style="stop-color:#f25a4a;stop-opacity:1" />
+         style="stop-color:#ed5353;stop-opacity:1" />
       <stop
-         id="stop883-3"
+         id="stop26007"
          offset="1"
-         style="stop-color:#c8252c;stop-opacity:1" />
+         style="stop-color:#c6262e;stop-opacity:1" />
     </linearGradient>
   </defs>
   <metadata
@@ -156,34 +98,40 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 8.0000008,0.5 c -4.138241,0 -7.5000009,3.3617589 -7.5000009,7.4999989 0,4.1382421 3.3617599,7.5000031 7.5000009,7.5000011 C 12.13824,15.5 15.500004,12.138241 15.5,7.9999989 15.5,3.8617589 12.13824,0.5 8.0000008,0.5 Z"
-     id="path2555-3-5"
-     style="fill:url(#linearGradient905-6);fill-opacity:1;stroke:none;stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 8,0.49999975 c -4.13824,0 -7.5,3.36175895 -7.5,7.49999975 C 0.5,12.138241 3.86176,15.500002 8,15.5 c 4.13824,0 7.500004,-3.361759 7.5,-7.5000005 C 15.5,3.8617587 12.13824,0.49999975 8,0.49999975 Z"
+     id="path2555"
+     style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 8.0000007,0.4999998 c -4.1382408,0 -7.5000006,3.3617588 -7.5000006,7.5000003 0,4.1382419 3.3617598,7.5000019 7.5000006,7.4999999 C 12.13824,15.5 15.500004,12.138242 15.5,8.0000001 15.5,3.8617586 12.13824,0.4999998 8.0000007,0.4999998 Z"
+     d="m 8.0000003,0.49999955 c -4.138241,0 -7.50000006,3.36175895 -7.50000006,7.50000005 0,4.1382414 3.36175906,7.5000024 7.50000006,7.5000004 C 12.13824,15.5 15.500004,12.138241 15.5,7.9999996 15.5,3.8617585 12.13824,0.49999955 8.0000003,0.49999955 Z"
      id="path2555-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#510606;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-  <g
-     id="layer1">
-    <path
-       style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3280);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path8655-6"
-       d="M 14.5,7.999769 C 14.5,11.589737 11.589636,14.5 8.0000824,14.5 4.4101993,14.5 1.5,11.589703 1.5,7.999769 1.5,4.4099697 4.4101993,1.5000003 8.0000824,1.5000003 11.589636,1.5000003 14.5,4.4099697 14.5,7.999769 l 0,0 z" />
-    <path
-       style="fill:none;stroke:#5d5d5d;stroke-width:2.83500004;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;opacity:0.5"
-       id="path7267"
-       d="M 5.6086174,3.9176445 C 1.6443539,6.0298403 3.4369833,12.0825 7.9690904,12.0825 c 4.4848986,0 6.4949576,-5.7382035 2.3604736,-8.1648555" />
-    <path
-       style="fill:none;stroke:#fafafa;stroke-width:1.55200005;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path10579"
-       d="M 5.6096392,3.8956539 C 1.5660167,6.0290201 3.394532,12.142345 8.0173656,12.142345 c 4.5746804,0 6.6249774,-5.795717 2.4077264,-8.2466911" />
-    <path
-       style="fill:none;stroke:#5d5d5d;stroke-width:2.88880062;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new;opacity:0.5"
-       id="path7269"
-       d="M 8.0225985,6.4556712 8.0223995,2.9444718" />
-    <path
-       style="fill:none;stroke:#fafafa;stroke-width:1.80499995;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path10581"
-       d="m 8.0224475,6.3976537 -1.98e-4,-3.395164" />
-  </g>
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
+  <path
+     d="m 14.500001,7.999769 c 0,3.589968 -2.910364,6.500233 -6.4999183,6.500233 -3.5898839,0 -6.5000833,-2.910299 -6.5000833,-6.500233 0,-3.5898016 2.9101994,-6.4997705 6.5000833,-6.4997705 3.5895543,0 6.4999183,2.9099689 6.4999183,6.4997705 z"
+     id="path8655"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:2.835;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none"
+     id="path7267"
+     d="M 5.6086174,3.9176445 C 1.6443539,6.0298403 3.4369833,12.0825 7.9690904,12.0825 c 4.4848986,0 6.4949576,-5.7382035 2.3604736,-8.1648555" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:3;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:new"
+     id="path7269"
+     d="M 8.000199,6 8,3" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path10581"
+     d="M 8.000198,6 8,3" />
+  <path
+     style="opacity:1;fill:none;fill-opacity:0.5;stroke:#ffffff;stroke-width:1.8;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="path143740"
+     sodipodi:type="arc"
+     sodipodi:cx="8"
+     sodipodi:cy="7.6966681"
+     sodipodi:rx="4.5015039"
+     sodipodi:ry="4.3738847"
+     sodipodi:start="5.3756141"
+     sodipodi:end="4.0491639"
+     sodipodi:open="true"
+     sodipodi:arc-type="arc"
+     d="M 10.771403,4.25 A 4.5015039,4.3738847 0 0 1 12.256256,9.1206658 4.5015039,4.3738847 0 0 1 8,12.070553 4.5015039,4.3738847 0 0 1 3.7437444,9.1206656 4.5015039,4.3738847 0 0 1 5.2285976,4.2499999" />
 </svg>

--- a/elementary-xfce/actions/16/system-suspend-hibernate.svg
+++ b/elementary-xfce/actions/16/system-suspend-hibernate.svg
@@ -5,7 +5,7 @@
    height="16"
    id="svg4248"
    sodipodi:docname="system-suspend-hibernate.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -27,14 +27,16 @@
      inkscape:window-height="859"
      id="namedview29"
      showgrid="false"
-     inkscape:zoom="8.7614951"
-     inkscape:cx="18.033452"
-     inkscape:cy="10.671695"
-     inkscape:window-x="327"
-     inkscape:window-y="169"
+     inkscape:zoom="17.52299"
+     inkscape:cx="15.379795"
+     inkscape:cy="15.351261"
+     inkscape:window-x="474"
+     inkscape:window-y="101"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg4248"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4250">
     <linearGradient
@@ -57,14 +59,23 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
+       gradientTransform="matrix(0.3513514,0,0,0.35135134,-17.203671,-0.90930007)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135138,0,0,0.35135138,-17.203669,-0.90930069)" />
+       xlink:href="#linearGradient4011-4"
+       id="linearGradient3019"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
+    <linearGradient
+       gradientTransform="matrix(0,0.36585365,-0.36585365,0,16.780487,-0.78048685)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887-3"
+       xlink:href="#linearGradient902" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient902">
@@ -77,15 +88,6 @@
          offset="1"
          id="stop900" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient902"
-       id="linearGradient1047"
-       x1="7.9701004"
-       y1="0.82754827"
-       x2="7.9701004"
-       y2="14.770559"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata4253">
@@ -99,20 +101,24 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="M 8.000001,0.49999995 C 3.8617599,0.49999995 0.5,3.861758 0.5,7.9999994 0.5,12.138242 3.8617599,15.500002 8.000001,15.5 12.138241,15.5 15.500004,12.138242 15.5,7.9999994 15.5,3.861758 12.138241,0.49999995 8.000001,0.49999995 Z"
-     id="path2555"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1047);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555-3"
+     d="m 15.5,8.0000013 c 0,-4.1382414 -3.361758,-7.50000173 -7.4999999,-7.50000173 -4.1382408,0 -7.50000135,3.36176033 -7.50000035,7.50000173 0,4.1382387 3.36175955,7.5000027 7.50000035,7.4999987 C 12.138242,15.5 15.5,12.13824 15.5,8.0000013 Z" />
   <path
-     d="M 8.000001,0.49999995 C 3.8617597,0.49999995 0.5,3.8617581 0.5,8 c 0,4.138241 3.3617597,7.500002 7.500001,7.5 C 12.13824,15.5 15.500004,12.138241 15.5,8 15.5,3.8617581 12.13824,0.49999995 8.000001,0.49999995 Z"
-     id="path2555-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#007293;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6"
+     d="M 14.500001,7.9997694 C 14.500001,11.589737 11.589637,14.5 8.0000818,14.5 4.4101998,14.5 1.499999,11.589703 1.499999,7.9997694 c 0,-3.5898004 2.9102008,-6.4997693 6.5000828,-6.4997693 3.5895552,0 6.4999192,2.9099689 6.4999192,6.4997693 z" />
   <path
-     d="m 14.500001,7.9997701 c 0,3.5899669 -2.910364,6.5002309 -6.4999178,6.5002309 C 4.4101997,14.500001 1.5,11.589704 1.5,7.9997701 1.5,4.4099688 4.4101997,1.5 8.0000832,1.5 c 3.5895538,0 6.4999178,2.9099688 6.4999178,6.4997701 z"
-     id="path8655"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     id="path22818"
+     style="color:#000000;fill:none;stroke-linecap:round;stroke:#0e141f;stroke-opacity:0.2;stroke-width:1;stroke-dasharray:none"
+     d="M 8 2.5 A 0.5 0.5 0 0 0 7.5 3 L 7.5 3.8652344 L 6.9414062 3.4804688 A 0.5 0.5 0 0 0 6.2460938 3.609375 A 0.5 0.5 0 0 0 6.3730469 4.3046875 L 7.5 5.0820312 L 7.5 7.1269531 L 5.7675781 6.1113281 L 5.6679688 4.7304688 A 0.5 0.5 0 0 0 5.1328125 4.2675781 A 0.5 0.5 0 0 0 4.6699219 4.8007812 L 4.7207031 5.4960938 L 3.9902344 5.0683594 A 0.5 0.5 0 0 0 3.3046875 5.2480469 A 0.5 0.5 0 0 0 3.484375 5.9316406 L 4.2324219 6.3710938 L 3.6054688 6.6796875 A 0.5 0.5 0 0 0 3.3789062 7.3476562 A 0.5 0.5 0 0 0 4.046875 7.5761719 L 5.265625 6.9765625 L 7.0117188 8 L 5.2617188 9.0253906 L 4.0175781 8.4355469 A 0.5 0.5 0 0 0 3.3515625 8.671875 A 0.5 0.5 0 0 0 3.5878906 9.3378906 L 4.21875 9.6367188 L 3.484375 10.068359 A 0.5 0.5 0 0 0 3.3046875 10.753906 A 0.5 0.5 0 0 0 3.9902344 10.931641 L 4.7070312 10.511719 L 4.6464844 11.207031 A 0.5 0.5 0 0 0 5.1035156 11.748047 A 0.5 0.5 0 0 0 5.6425781 11.291016 L 5.7617188 9.8925781 L 7.5 8.8730469 L 7.5 10.923828 L 6.3671875 11.728516 A 0.5 0.5 0 0 0 6.25 12.425781 A 0.5 0.5 0 0 0 6.9472656 12.542969 L 7.5 12.150391 L 7.5 13 A 0.5 0.5 0 0 0 8 13.5 A 0.5 0.5 0 0 0 8.5 13 L 8.5 12.150391 L 9.0527344 12.542969 A 0.5 0.5 0 0 0 9.75 12.425781 A 0.5 0.5 0 0 0 9.6328125 11.728516 L 8.5 10.923828 L 8.5 8.8730469 L 10.238281 9.8925781 L 10.357422 11.291016 A 0.5 0.5 0 0 0 10.896484 11.748047 A 0.5 0.5 0 0 0 11.353516 11.207031 L 11.292969 10.511719 L 12.009766 10.931641 A 0.5 0.5 0 0 0 12.695312 10.753906 A 0.5 0.5 0 0 0 12.515625 10.068359 L 11.78125 9.6367188 L 12.412109 9.3378906 A 0.5 0.5 0 0 0 12.648438 8.671875 A 0.5 0.5 0 0 0 11.982422 8.4355469 L 10.738281 9.0253906 L 8.9882812 8 L 10.734375 6.9765625 L 11.953125 7.5761719 A 0.5 0.5 0 0 0 12.621094 7.3476562 A 0.5 0.5 0 0 0 12.394531 6.6796875 L 11.767578 6.3710938 L 12.515625 5.9316406 A 0.5 0.5 0 0 0 12.695312 5.2480469 A 0.5 0.5 0 0 0 12.009766 5.0683594 L 11.279297 5.4960938 L 11.330078 4.8007812 A 0.5 0.5 0 0 0 10.867188 4.2675781 A 0.5 0.5 0 0 0 10.332031 4.7304688 L 10.232422 6.1113281 L 8.5 7.1269531 L 8.5 5.0820312 L 9.6269531 4.3046875 A 0.5 0.5 0 0 0 9.7539062 3.609375 A 0.5 0.5 0 0 0 9.0585938 3.4804688 L 8.5 3.8652344 L 8.5 3 A 0.5 0.5 0 0 0 8 2.5 z " />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;fill-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555-6-1"
+     d="M 8.000001,0.49999952 C 3.8617601,0.49999952 0.5,3.8617577 0.5,7.9999985 0.5,12.138241 3.8617601,15.5 8.000001,15.5 12.138241,15.5 15.500004,12.138241 15.5,7.9999985 15.5,3.8617577 12.138241,0.49999952 8.000001,0.49999952 Z" />
   <path
      id="path946"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#0e141f;fill-opacity:0.34999999;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
      d="m 8.0000018,3.000185 a 0.5,0.5 0 0 0 -0.5000001,0.5 V 4.3654194 L 6.9414077,3.9806538 A 0.5,0.5 0 0 0 6.2460957,4.10956 0.5,0.5 0 0 0 6.3730487,4.8048725 L 7.5000017,5.582216 V 7.627138 L 5.7675798,6.611513 5.6679705,5.2306538 A 0.5,0.5 0 0 0 5.1464861,4.76581 0.5,0.5 0 0 0 5.1328142,4.7677631 0.5,0.5 0 0 0 4.6699236,5.3009662 L 4.7207046,5.996279 3.9902359,5.568544 A 0.5,0.5 0 0 0 3.304689,5.746279 0.5,0.5 0 0 0 3.4843765,6.431826 L 4.2324234,6.871279 3.6054703,7.179873 A 0.5,0.5 0 0 0 3.3789079,7.847841 0.5,0.5 0 0 0 4.0468767,8.0763568 l 1.21875,-0.5996098 1.746094,1.0234378 -1.7500002,1.025391 -1.2441407,-0.589844 a 0.5,0.5 0 0 0 -0.6660156,0.236328 0.5,0.5 0 0 0 0.2363281,0.666016 l 0.6308594,0.2988282 -0.734375,0.431639 a 0.5,0.5 0 0 0 -0.1796875,0.685547 0.5,0.5 0 0 0 0.6855469,0.177735 l 0.7167968,-0.419922 -0.060547,0.695312 A 0.5,0.5 0 0 0 5.1035171,12.246278 0.5,0.5 0 0 0 5.6425796,11.7912 L 5.7617205,10.392762 7.5000017,9.3732318 V 11.424012 L 6.3671897,12.2287 a 0.5,0.5 0 0 0 -0.117188,0.697265 0.5,0.5 0 0 0 0.697266,0.117188 l 0.552734,-0.392578 v 0.849609 a 0.5,0.5 0 0 0 0.5000001,0.5 0.5,0.5 0 0 0 0.5,-0.5 v -0.849609 l 0.552734,0.392578 A 0.5,0.5 0 0 0 9.7500018,12.925965 0.5,0.5 0 0 0 9.6328138,12.2287 L 8.5000018,11.424012 V 9.3732318 l 1.7382812,1.0195302 0.119141,1.398438 a 0.5,0.5 0 0 0 0.539062,0.455078 0.5,0.5 0 0 0 0.457032,-0.539063 l -0.06055,-0.695312 0.716797,0.419922 a 0.5,0.5 0 0 0 0.685546,-0.177735 0.5,0.5 0 0 0 -0.179687,-0.685547 l -0.734375,-0.431639 0.630859,-0.2988282 a 0.5,0.5 0 0 0 0.236329,-0.666016 0.5,0.5 0 0 0 -0.666016,-0.236328 L 10.73828,9.5255758 8.9882798,8.5001848 10.734374,7.476747 11.953124,8.0763568 A 0.5,0.5 0 0 0 12.621093,7.847841 0.5,0.5 0 0 0 12.39453,7.179873 L 11.767577,6.871279 12.515624,6.431826 A 0.5,0.5 0 0 0 12.695311,5.746279 0.5,0.5 0 0 0 12.009765,5.568544 l -0.730469,0.427735 0.05078,-0.6953128 a 0.5,0.5 0 0 0 -0.46289,-0.5332031 0.5,0.5 0 0 0 -0.06055,-0.00195 0.5,0.5 0 0 0 -0.47461,0.4648438 L 10.232426,6.611513 8.5000038,7.627138 V 5.582216 L 9.6269548,4.8048725 A 0.5,0.5 0 0 0 9.7539078,4.10956 0.5,0.5 0 0 0 9.0585958,3.9806538 L 8.5000018,4.3654194 V 3.500185 a 0.5,0.5 0 0 0 -0.5,-0.5 z" />
   <path
      inkscape:connector-curvature="0"

--- a/elementary-xfce/actions/16/system-suspend.svg
+++ b/elementary-xfce/actions/16/system-suspend.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="16"
+   id="svg2"
    height="16"
-   id="svg4248"
+   width="16"
+   version="1.2"
    sodipodi:docname="system-suspend.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -15,56 +15,63 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview27022"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1396"
-     inkscape:window-height="859"
-     id="namedview29"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="49.562501"
-     inkscape:cx="7.6065573"
-     inkscape:cy="5.7704917"
-     inkscape:window-x="327"
-     inkscape:window-y="169"
+     inkscape:zoom="36.681164"
+     inkscape:cx="6.3111411"
+     inkscape:cy="7.1426305"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="541"
+     inkscape:window-y="18"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4248"
-     inkscape:pagecheckerboard="0" />
+     inkscape:current-layer="svg2" />
   <defs
-     id="defs4250">
+     id="defs4">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011-0-8-3">
       <stop
-         id="stop4013-8"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4013-2-3-6" />
       <stop
-         id="stop4015-5"
+         offset="0.507761"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
+         id="stop4015-7-1-68" />
       <stop
-         id="stop4017-6"
+         offset="0.83456558"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
+         id="stop4017-13-5-6" />
       <stop
-         id="stop4019-1"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop4019-92-5-3" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
+       gradientTransform="matrix(0.35135153,0,0,0.35135153,-17.203685,-0.9093047)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135138,0,0,0.35135138,-17.203669,-0.90930069)" />
+       xlink:href="#linearGradient4011-0-8-3"
+       id="linearGradient12398"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
+    <linearGradient
+       gradientTransform="matrix(0,0.36585365,-0.36585365,0,16.780487,-0.78048685)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887-3"
+       xlink:href="#linearGradient902" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient902">
@@ -77,58 +84,59 @@
          offset="1"
          id="stop900" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient902"
-       id="linearGradient1047"
-       x1="7.9701004"
-       y1="0.82754827"
-       x2="7.9701004"
-       y2="14.770559"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="M 8.000001,0.49999995 C 3.8617599,0.49999995 0.5,3.861758 0.5,7.9999994 0.5,12.138242 3.8617599,15.500002 8.000001,15.5 12.138241,15.5 15.500004,12.138242 15.5,7.9999994 15.5,3.861758 12.138241,0.49999995 8.000001,0.49999995 Z"
-     id="path2555"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1047);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate" />
+     style="opacity:1;color:#000000;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555-7-8-5-0"
+     d="M 8,0.50000007 C 3.8617571,0.50000007 0.49999994,3.8617572 0.49999994,8 c 0,4.138243 3.36175716,7.5 7.50000006,7.5 4.138243,0 7.500007,-3.361757 7.5,-7.5 C 15.5,3.8617572 12.138243,0.50000007 8,0.50000007 z" />
   <path
-     d="M 8.000001,0.49999995 C 3.8617597,0.49999995 0.5,3.8617581 0.5,8 c 0,4.138241 3.3617597,7.500002 7.500001,7.5 C 12.13824,15.5 15.500004,12.138241 15.5,8 15.5,3.8617581 12.13824,0.49999995 8.000001,0.49999995 Z"
-     id="path2555-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#007293;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     style="opacity:0.5;color:#000000;fill:none;stroke:#004f66;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;fill-opacity:1;font-variation-settings:normal;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555-7-8-5"
+     d="m 8,0.50000008 c -4.1382429,0 -7.50000006,3.36175712 -7.50000006,7.50000002 C 0.49999994,12.138243 3.8617571,15.5 8,15.5 c 4.138243,0 7.500007,-3.361757 7.5,-7.4999999 C 15.5,3.8617572 12.138243,0.50000008 8,0.50000008 z" />
   <path
-     d="m 14.500001,7.9997701 c 0,3.5899669 -2.910364,6.5002309 -6.4999178,6.5002309 C 4.4101997,14.500001 1.5,11.589704 1.5,7.9997701 1.5,4.4099688 4.4101997,1.5 8.0000832,1.5 c 3.5895538,0 6.4999178,2.9099688 6.4999178,6.4997701 z"
-     id="path8655"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     inkscape:connector-curvature="0"
+     id="path46358"
+     d="m 9.1085963,3 c 0.619703,0.7508821 0.9954827,1.7105986 0.9954827,2.7601734 0,2.3990556 -1.944829,4.3439056 -4.3439119,4.3439056 C 4.710592,10.104079 3.7508976,9.7283 3,9.108599 3.5252359,11.347465 5.533088,13 7.9321219,13 10.731056,13 13.000002,10.731056 13.000002,7.932127 13.000002,5.5330708 11.347473,3.5252441 9.1085963,3 Z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#0e141f;stroke-width:1;marker:none;enable-background:accumulate;stroke-opacity:0.15000001;stroke-dasharray:none;stroke-linejoin:round" />
+  <path
+     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient12398);stroke-width:0.99999982;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path8655-6-0-9-5"
+     d="M 14.5,7.9997643 C 14.5,11.589737 11.589633,14.5 8.0000788,14.5 4.4101952,14.5 1.4999999,11.589702 1.4999999,7.9997643 c 0,-3.5898014 2.9101953,-6.4997709 6.5000789,-6.4997709 3.5895542,0 6.4999212,2.9099695 6.4999212,6.4997709 l 0,0 z" />
   <path
      inkscape:connector-curvature="0"
      id="path3199"
-     d="m 9.608596,3.5 c 0.619703,0.7508821 0.995483,1.7105986 0.995483,2.7601734 0,2.3990556 -1.944829,4.3439056 -4.3439119,4.3439056 C 5.210592,10.604079 4.2508976,10.2283 3.5,9.608599 4.0252359,11.847465 6.033088,13.5 8.4321219,13.5 11.231056,13.5 13.500002,11.231056 13.500002,8.432127 13.500002,6.0330708 11.847473,4.0252441 9.608596,3.5 Z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#141f2b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate;opacity:0.4" />
+     d="m 10.714371,4 c 0.650689,0.7508821 1.045258,1.7105986 1.045258,2.7601734 0,2.3990556 -2.8424177,4.3439056 -5.3614541,4.3439056 C 5.2961212,11.104079 3.9884424,10.7283 3.2,10.108599 3.7514976,12.347465 5.898176,14 8.6787273,14 10.86579,14 14,11.008713 14,8.5632967 14,6.4693381 13.065193,4.5252441 10.714371,4 Z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#0e141f;fill-opacity:0.34999999;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="csscssc" />
   <path
      inkscape:connector-curvature="0"
      id="path5549"
-     d="m 9.108596,3 c 0.619703,0.7508821 0.995483,1.7105986 0.995483,2.7601734 0,2.3990556 -1.944829,4.3439056 -4.3439119,4.3439056 C 4.710592,10.104079 3.7508976,9.7283 3,9.108599 3.5252359,11.347465 5.533088,13 7.9321219,13 10.731056,13 13.000002,10.731056 13.000002,7.932127 13.000002,5.5330708 11.347473,3.5252441 9.108596,3 Z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#f1f3f5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
+     d="m 9.1085963,3 c 0.619703,0.7508821 0.9954827,1.7105986 0.9954827,2.7601734 0,2.3990556 -1.944829,4.3439056 -4.3439119,4.3439056 C 4.710592,10.104079 3.7508976,9.7283 3,9.108599 3.5252359,11.347465 5.533088,13 7.9321219,13 10.731056,13 13.000002,10.731056 13.000002,7.932127 13.000002,5.5330708 11.347473,3.5252441 9.1085963,3 Z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
   <path
      sodipodi:nodetypes="cccc"
      id="path867"
      d="m 4.5,4 h 3 l -3,4 h 3"
-     style="opacity:0.4;fill:none;stroke:#141f2b;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34999999" />
+  <path
+     sodipodi:nodetypes="cccc"
+     id="path4354"
+     d="m 4.5,4 h 3 l -3,4 h 3"
+     style="fill:none;stroke:#0e141f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.15000001" />
   <path
      sodipodi:nodetypes="cccc"
      id="path948-2-0-9-2"
      d="m 4.5,3.5 h 3 l -3,4 h 3"
-     style="fill:none;stroke:#f1f3f5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/16/system-switch-user.svg
+++ b/elementary-xfce/actions/16/system-switch-user.svg
@@ -5,7 +5,7 @@
    height="16"
    id="svg4248"
    sodipodi:docname="system-switch-user.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -27,28 +27,18 @@
      inkscape:window-height="859"
      id="namedview29"
      showgrid="false"
-     inkscape:zoom="35.04598"
-     inkscape:cx="11.784519"
-     inkscape:cy="7.6185629"
-     inkscape:window-x="522"
-     inkscape:window-y="46"
+     inkscape:zoom="12.390625"
+     inkscape:cx="19.006305"
+     inkscape:cy="21.064313"
+     inkscape:window-x="756"
+     inkscape:window-y="119"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg4248"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4250">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4447">
-      <stop
-         style="stop-color:#768299;stop-opacity:1"
-         offset="0"
-         id="stop4443" />
-      <stop
-         style="stop-color:#5b6a80;stop-opacity:1"
-         offset="1"
-         id="stop4445" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4011-4">
       <stop
@@ -69,23 +59,34 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
+       gradientTransform="matrix(0.3513514,0,0,0.35135134,-17.203671,-0.90930007)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.35135138,0,0,0.35135138,-17.203669,-0.90930069)" />
+       xlink:href="#linearGradient4011-4"
+       id="linearGradient3019"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4447"
-       id="linearGradient4449"
-       x1="6.5361342"
-       y1="1.6709471"
-       x2="6.5361342"
-       y2="14.534475"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(0,0.36585366,-0.36585366,0,16.780487,-0.78048733)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="81.658852"
+       y1="23.999998"
+       x1="-1.5996079"
+       id="linearGradient887"
+       xlink:href="#linearGradient947-5" />
+    <linearGradient
+       id="linearGradient947-5">
+      <stop
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         id="stop943-6" />
+      <stop
+         offset="1"
+         style="stop-color:#3a9104;stop-opacity:1"
+         id="stop945-2" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata4253">
@@ -99,25 +100,45 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="M 8.000001,0.49999995 C 3.8617599,0.49999995 0.5,3.861758 0.5,7.9999994 0.5,12.138242 3.8617599,15.500002 8.000001,15.5 12.138241,15.5 15.500004,12.138242 15.5,7.9999994 15.5,3.861758 12.138241,0.49999995 8.000001,0.49999995 Z"
-     id="path2555"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4449);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     id="path2555-3"
+     d="m 15.5,8.0000013 c 0,-4.1382414 -3.361758,-7.50000173 -7.4999999,-7.50000173 -4.1382408,0 -7.50000135,3.36176033 -7.50000035,7.50000173 0,4.1382387 3.36175955,7.5000027 7.50000035,7.4999987 C 12.138242,15.5 15.5,12.13824 15.5,8.0000013 Z" />
   <path
-     d="M 8.000001,0.49999995 C 3.8617597,0.49999995 0.5,3.8617581 0.5,8 c 0,4.138241 3.3617597,7.500002 7.500001,7.5 C 12.13824,15.5 15.500004,12.138241 15.5,8 15.5,3.8617581 12.13824,0.49999995 8.000001,0.49999995 Z"
-     id="path2555-6"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#223544;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6"
+     d="M 14.500001,7.9997694 C 14.500001,11.589737 11.589637,14.5 8.0000818,14.5 4.4101998,14.5 1.499999,11.589703 1.499999,7.9997694 c 0,-3.5898004 2.9102008,-6.4997693 6.5000828,-6.4997693 3.5895552,0 6.4999192,2.9099689 6.4999192,6.4997693 z" />
   <path
-     d="m 14.500001,7.9997701 c 0,3.5899669 -2.910364,6.5002309 -6.4999178,6.5002309 C 4.4101997,14.500001 1.5,11.589704 1.5,7.9997701 1.5,4.4099688 4.4101997,1.5 8.0000832,1.5 c 3.5895538,0 6.4999178,2.9099688 6.4999178,6.4997701 z"
-     id="path8655"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#206b00;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6-1"
+     d="M 8.000001,0.49999952 C 3.8617601,0.49999952 0.5,3.8617577 0.5,7.9999985 0.5,12.138241 3.8617601,15.5 8.000001,15.5 12.138241,15.5 15.500004,12.138241 15.5,7.9999985 15.5,3.8617577 12.138241,0.49999952 8.000001,0.49999952 Z" />
   <path
-     d="M 6,3 3,6.0000002 6,9 V 7 H 9 V 5 H 6 Z"
-     id="path7942"
-     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none"
-     sodipodi:nodetypes="cccccccc" />
+     id="path158364"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.5;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 10.500448,14.250196 c -0.278577,0 -0.500204,-0.223088 -0.500204,-0.500197 V 12.000196 H 7.502846 C 7.2242675,12.000196 7,11.777108 7,11.499999 V 10.500147 C 7,10.223038 7.2242675,9.9997755 7.502846,10.000049 h 2.497398 V 8.2501955 c 0,-0.277108 0.221629,-0.5001955 0.500205,-0.5001955 0.150141,0 0.284169,0.064903 0.376153,0.168034 l 2.736072,2.739156 c 0.08502,0.08958 0.137498,0.209985 0.137498,0.342907 0,0.132924 -0.05247,0.253326 -0.137498,0.342909 l -2.736072,2.739155 c -0.09198,0.103135 -0.226012,0.168035 -0.376154,0.168035 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="M 9.9999996,7 13,10 9.9999996,13 V 11 H 7 V 9 h 2.9999996 z"
-     id="path8324"
-     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none"
-     sodipodi:nodetypes="cccccccc" />
+     id="path158366"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.50196081;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 5.4999745,10.250196 c 0.278577,0 0.500205,-0.223088 0.500205,-0.5001967 V 8.0001963 H 8.497577 c 0.2785785,0 0.502846,-0.223088 0.502846,-0.500197 V 6.500147 c 0,-0.2771095 -0.2242675,-0.5003715 -0.502846,-0.5000985 H 6.000179 V 4.2501955 C 6.000179,3.9730875 5.7785505,3.75 5.4999745,3.75 5.3498325,3.75 5.215805,3.814903 5.123821,3.918034 L 2.3877487,6.6571898 c -0.085023,0.089581 -0.1374974,0.209986 -0.1374974,0.342908 0,0.1329235 0.05247,0.253326 0.1374974,0.3429085 L 5.123821,10.082161 c 0.091984,0.103135 0.2260115,0.168035 0.3761535,0.168035 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path20223"
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;stop-color:#000000"
+     d="m 5.4999745,9.2500985 c 0.278577,0 0.500205,-0.223088 0.500205,-0.500197 V 7.0000985 H 8.497577 c 0.2785785,0 0.502846,-0.223088 0.502846,-0.500197 V 5.5000492 c 0,-0.2771095 -0.2242675,-0.5003715 -0.502846,-0.5000985 H 6.000179 v -1.749853 c 0,-0.277108 -0.2216285,-0.5001955 -0.5002045,-0.5001955 -0.150142,0 -0.2841695,0.064903 -0.3761535,0.168034 L 2.3877487,5.657092 C 2.3027255,5.7466735 2.2502513,5.867078 2.2502513,6 c 0,0.1329235 0.05247,0.253326 0.1374974,0.3429085 l 2.7360723,2.739155 c 0.091984,0.103135 0.2260115,0.168035 0.3761535,0.168035 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 5.4999745,9.2500985 c 0.278577,0 0.500205,-0.223088 0.500205,-0.500197 V 7.0000985 H 8.497577 c 0.2785785,0 0.502846,-0.223088 0.502846,-0.500197 V 5.5000492 c 0,-0.2771095 -0.2242675,-0.5003715 -0.502846,-0.5000985 H 6.000179 v -1.749853 c 0,-0.277108 -0.2216285,-0.5001955 -0.5002045,-0.5001955 -0.150142,0 -0.2841695,0.064903 -0.3761535,0.168034 L 2.3877487,5.657092 C 2.3027255,5.7466735 2.2502513,5.867078 2.2502513,6 c 0,0.1329235 0.05247,0.253326 0.1374974,0.3429085 l 2.7360723,2.739155 c 0.091984,0.103135 0.2260115,0.168035 0.3761535,0.168035 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path20610"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;stroke:#206b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;stop-color:#000000"
+     d="m 10.500449,13.250197 c -0.278577,0 -0.500205,-0.223089 -0.500205,-0.500197 V 11.000197 H 7.502846 C 7.2242675,11.000197 7,10.777109 7,10.5 V 9.500148 C 7,9.223038 7.2242675,8.9997755 7.502846,9.000049 h 2.497398 V 7.2501955 c 0,-0.277108 0.221629,-0.5001955 0.500205,-0.5001955 0.150142,0 0.284169,0.064903 0.376153,0.168034 l 2.736073,2.739155 c 0.08502,0.08958 0.137497,0.209987 0.137497,0.342908 0,0.132924 -0.05247,0.253326 -0.137497,0.34291 l -2.736073,2.739155 c -0.09198,0.103135 -0.226011,0.168035 -0.376153,0.168035 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path159262"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 10.500449,13.250197 c -0.278577,0 -0.500205,-0.223089 -0.500205,-0.500197 V 11.000197 H 7.502846 C 7.2242675,11.000197 7,10.777109 7,10.5 V 9.500148 C 7,9.223038 7.2242675,8.9997755 7.502846,9.000049 h 2.497398 V 7.2501955 c 0,-0.277108 0.221629,-0.5001955 0.500205,-0.5001955 0.150142,0 0.284169,0.064903 0.376153,0.168034 l 2.736073,2.739155 c 0.08502,0.08958 0.137497,0.209987 0.137497,0.342908 0,0.132924 -0.05247,0.253326 -0.137497,0.34291 l -2.736073,2.739155 c -0.09198,0.103135 -0.226011,0.168035 -0.376153,0.168035 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/elementary-xfce/actions/24/system-lock-screen.svg
+++ b/elementary-xfce/actions/24/system-lock-screen.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg4031"
    height="24"
    width="24"
    version="1.1"
    sodipodi:docname="system-lock-screen.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,20 +23,35 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-width="1288"
+     inkscape:window-height="915"
      id="namedview31"
      showgrid="false"
-     inkscape:zoom="22.627417"
-     inkscape:cx="11.90837"
-     inkscape:cy="5.6467528"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:zoom="32"
+     inkscape:cx="12.375"
+     inkscape:cy="16.75"
+     inkscape:window-x="506"
+     inkscape:window-y="74"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg4031"
-     inkscape:document-rotation="0" />
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4033">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient930">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
+    </linearGradient>
     <linearGradient
        id="linearGradient4011-8">
       <stop
@@ -61,49 +76,10 @@
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407"
-       gradientTransform="matrix(0.51351362,0,0,0.51351351,-24.83614,-1.0212859)"
+       gradientTransform="matrix(0.51351362,0,0,0.51351351,-24.83614,-1.0212855)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3540"
        xlink:href="#linearGradient4011-8" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.2758633,-3.465473,-9.2088427e-8,41.282497,-11.162349)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient3300-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
@@ -115,55 +91,46 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient4192-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
     <linearGradient
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-22.965879,-31.073181)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.9666989"
+       x2="10.860361"
+       y2="20.846098"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3540-3"
-       xlink:href="#linearGradient4011-8" />
+       gradientTransform="matrix(1.05,0,0,1.05,-0.6,-0.59999975)" />
     <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092-5"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,6.7155205,-7.1042197,-1.8878129e-7,112.67424,-51.8281)" />
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient3300-8-2"
-       gradientUnits="userSpaceOnUse"
+       r="62.769119"
+       fy="185.29727"
+       fx="99.189415"
+       cy="185.29727"
+       cx="99.189415"
        gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient4192-6-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
+       id="radialGradient3300-8-3"
+       xlink:href="#linearGradient3820-7-2" />
+    <radialGradient
+       r="62.769119"
        fy="185.29727"
-       r="62.769119" />
+       fx="99.189415"
+       cy="185.29727"
+       cx="99.189415"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192-6-6"
+       xlink:href="#linearGradient3820-7-2" />
+    <radialGradient
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,19.694118)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
   </defs>
   <metadata
      id="metadata4036">
@@ -173,43 +140,51 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     d="m 22,21 c 0,1.656854 -4.477153,3 -10,3 -5.5228476,0 -10,-1.343146 -10,-3 0,-1.656854 4.4771524,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+     id="path8836-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
   <g
-     id="g4198-4"
-     transform="matrix(0.34552845,0,0,0.35298856,0.9430878,0.52694603)"
-     style="stroke-width:2.86337">
+     style="stroke-width:2.88033"
+     transform="matrix(0.375,0,0,0.32142723,5.8125e-7,2.4280685)"
+     id="g4198-4">
     <path
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
+       style="opacity:0.2;fill:url(#radialGradient3300-8-3);fill-opacity:1;stroke:none;stroke-width:2.88033"
        id="path3818-0-6"
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:2.86337" />
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
     <path
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.86337"
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
        id="path4190-2"
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
+       style="opacity:0.4;fill:url(#radialGradient4192-6-6);fill-opacity:1;stroke:none;stroke-width:2.88033" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555-3"
-     d="M 12.000001,2 C 6.4823463,2 2,6.4823439 2,11.999999 2,17.517656 6.4823463,22.000001 12.000001,22 17.517655,22 22.000005,17.517656 22,11.999999 22,6.4823439 17.517655,2 12.000001,2 Z" />
+     d="M 12.000001,1.5000002 C 6.2064636,1.5000002 1.5,6.2064613 1.5,11.999999 1.5,17.793539 6.2064636,22.500001 12.000001,22.5 17.793538,22.5 22.500005,17.793539 22.5,11.999999 22.5,6.2064613 17.793538,1.5000002 12.000001,1.5000002 Z" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
-     d="m 21.500003,11.999663 c 0,5.246875 -4.253609,9.500337 -9.499882,9.500337 -5.2467542,0 -9.5001236,-4.253511 -9.5001236,-9.500337 0,-5.246632 4.2533694,-9.4996635 9.5001236,-9.4996635 5.246273,0 9.499882,4.2530315 9.499882,9.4996635 z" />
+     d="m 21.500003,11.999663 c 0,5.246875 -4.253609,9.500337 -9.499882,9.500337 -5.2467544,0 -9.5001238,-4.253511 -9.5001238,-9.500337 0,-5.2466316 4.2533694,-9.4996631 9.5001238,-9.4996631 5.246273,0 9.499882,4.2530314 9.499882,9.4996631 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#223544;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
-     d="M 12.000001,2 C 6.4823463,2 2,6.4823444 2,12.000001 c 0,5.517655 4.4823463,10.000001 10.000001,10 5.517653,0 10.000004,-4.482345 9.999999,-10 C 22,6.4823444 17.517654,2 12.000001,2 Z" />
+     d="M 12.000001,1.4999997 C 6.2064636,1.4999997 1.5,6.2064613 1.5,12 1.5,17.793538 6.2064636,22.500001 12.000001,22.5 17.793537,22.5 22.500005,17.793538 22.5,12 22.5,6.2064613 17.793537,1.4999997 12.000001,1.4999997 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 11.5,6.5 c -1.662,0 -3,1.338 -3,3 V 11 H 10 V 9.332031 C 10,8.593894 10.593893,8 11.332031,8 h 1.335937 C 13.406106,8 14,8.593894 14,9.332031 V 11 h 1.5 V 9.5 c 0,-1.662 -1.338001,-3 -3,-3 z M 7,12 v 5 c 0,0.554 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446 1,-1 v -5 z"
-     id="path955"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 11.5,6 C 9.838,6 9,7.138 9,8.8 V 11 h 1.499984 V 8.8320155 c 0,-0.738137 0.593893,-1.332031 1.332031,-1.332031 h 0.335969 c 0.738138,0 1.332032,0.593894 1.332032,1.332031 V 11 H 15 V 8.8 C 15,7.138 14.161999,6 12.5,6 Z M 7,11 v 5 c 0,0.554 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446 1,-1 v -5 z"
+     id="path1754"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 11.5,7 C 9.838,7 9,8.138 9,9.8 V 12 h 1.499984 V 9.8320155 c 0,-0.738137 0.593893,-1.332031 1.332031,-1.332031 h 0.335969 c 0.738138,0 1.332032,0.593894 1.332032,1.332031 V 12 H 15 V 9.8 C 15,8.138 14.161999,7 12.5,7 Z M 7,12 v 5 c 0,0.554 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446 1,-1 v -5 z"
+     id="path995"
      sodipodi:nodetypes="ssccssssccsssccssccc" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 11.5,5.5 c -1.662,0 -3,1.338 -3,3 V 11 H 10 V 8.332031 C 10,7.593894 10.593893,7 11.332031,7 h 1.335937 C 13.406106,7 14,7.593894 14,8.332031 V 11 h 1.5 V 8.5 c 0,-1.662 -1.338001,-3 -3,-3 z M 7,11 v 5 c 0,0.554 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446 1,-1 v -5 z"
+     d="M 11.3,6 C 9.638,6 9,7.138 9,8.8 V 11 h 1.499984 V 8.8320155 c 0,-0.738137 0.393878,-1.332031 1.132016,-1.332031 h 0.735992 c 0.738138,0 1.132024,0.593894 1.132024,1.332031 V 11 H 15 V 8.8 C 15,7.138 14.362007,6 12.700008,6 Z M 7,11 v 5 c 0,0.554 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446 1,-1 v -5 z"
      id="rect4382-7"
      sodipodi:nodetypes="ssccssssccsssccssccc" />
 </svg>

--- a/elementary-xfce/actions/24/system-log-out.svg
+++ b/elementary-xfce/actions/24/system-log-out.svg
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.2"
    width="24"
    height="24"
    id="svg2"
-   sodipodi:docname="system-log-out1.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   sodipodi:docname="system-log-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,18 +22,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-width="1307"
+     inkscape:window-height="817"
      id="namedview27"
      showgrid="false"
      inkscape:zoom="16.520833"
-     inkscape:cx="11.76973"
-     inkscape:cy="6.4364772"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:cx="8.5649435"
+     inkscape:cy="10.774275"
+     inkscape:window-x="407"
+     inkscape:window-y="136"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg2"
-     inkscape:document-rotation="0" />
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4">
     <linearGradient
@@ -88,27 +90,16 @@
        id="radialGradient4192-6"
        xlink:href="#linearGradient3820-7-2" />
     <linearGradient
-       gradientTransform="matrix(0,0.4878049,-0.48780489,0,23.707317,0.29268294)"
+       gradientTransform="matrix(0,0.51219514,-0.51219513,0,24.292683,-0.29268291)"
        gradientUnits="userSpaceOnUse"
        y2="23.999998"
-       x2="44.5"
+       x2="43.625919"
        y1="23.999998"
-       x1="3.4999995"
+       x1="4.8013015"
        id="linearGradient887"
-       xlink:href="#linearGradient885" />
+       xlink:href="#linearGradient885-3" />
     <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ffa154;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#f37329;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.51351363,0,0,0.51351355,-24.836137,-1.0212861)"
+       gradientTransform="matrix(0.51351344,0,0,0.51351336,-24.836126,-1.0212818)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
        id="linearGradient3019"
@@ -116,19 +107,39 @@
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407" />
+    <linearGradient
+       id="linearGradient885-3">
+      <stop
+         id="stop881-6"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
+      <stop
+         id="stop883-7"
+         offset="1"
+         style="stop-color:#f37329;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,19.694118)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
   </defs>
   <metadata
      id="metadata7">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
+  <path
+     d="m 22,21 c 0,1.656854 -4.477153,3 -10,3 -5.522848,0 -10,-1.343146 -10,-3 0,-1.656854 4.477152,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+     id="path8836-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
   <g
      style="stroke-width:2.86337"
      transform="matrix(0.34552847,0,0,0.35298856,0.9430875,0.52694603)"
@@ -145,23 +156,25 @@
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555"
-     d="M 22,12.000002 C 22,6.4823466 17.517656,2 12,2 6.4823455,2 1.9999975,6.4823466 1.9999995,12.000002 1.9999995,17.517654 6.4823455,22.000006 12,22 c 5.517656,0 10,-4.482346 10,-9.999998 z" />
+     d="M 22.5,12.000002 C 22.5,6.2064639 17.793539,1.5 12,1.5 6.2064631,1.5 1.4999977,6.2064639 1.4999998,12.000002 1.4999998,17.793537 6.2064631,22.500006 12,22.5 c 5.793539,0 10.5,-4.706463 10.5,-10.499998 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path24690"
+     style="font-variation-settings:normal;vector-effect:none;fill:#a62100;fill-opacity:0.5;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 11.226067,18 c 0.431218,0 0.778372,-0.334646 0.778372,-0.750328 V 14 h 5.217189 C 17.652847,14 18,13.665354 18,13.249672 V 12.750328 C 18,12.334646 17.652847,11.99959 17.221628,12 H 12.004439 V 8.750326 C 12.004439,8.334646 11.657285,8 11.226067,8 c -0.23241,0 -0.439875,0.09736 -0.58226,0.252062 l -4.43097,4.223785 C 6.081227,12.610226 6,12.79084 6,12.990232 c 0,0.199392 0.08122,0.380005 0.212837,0.514385 l 4.43097,4.24332 C 10.786192,17.902647 10.993657,18 11.226067,18 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     d="m 21.500005,11.999663 c 0,5.246875 -4.253609,9.500338 -9.499883,9.500338 -5.2467525,0 -9.5001225,-4.253511 -9.5001225,-9.500338 0,-5.2466319 4.25337,-9.4996635 9.5001225,-9.4996635 5.246274,0 9.499883,4.2530316 9.499883,9.4996635 z" />
+     d="m 21.499999,11.999663 c 0,5.246873 -4.253607,9.500334 -9.49988,9.500334 -5.2467501,0 -9.5001185,-4.253509 -9.5001185,-9.500334 0,-5.2466304 4.2533684,-9.4996604 9.5001185,-9.4996604 5.246273,0 9.49988,4.2530299 9.49988,9.4996604 z" />
+  <path
+     id="path6369"
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;stop-color:#000000"
+     d="m 11.226067,17 c 0.431218,0 0.778372,-0.334646 0.778372,-0.750328 V 13 h 5.217189 C 17.652847,13 18,12.665354 18,12.249672 V 11.750328 C 18,11.334646 17.652847,10.99959 17.221628,11 H 12.004439 V 7.7503259 c 0,-0.41568 -0.347154,-0.750326 -0.778372,-0.750326 -0.23241,0 -0.439875,0.09736 -0.58226,0.252062 L 6.212837,11.475847 C 6.081227,11.610226 6,11.79084 6,11.990232 c 0,0.199392 0.08122,0.380005 0.212837,0.514385 l 4.43097,4.24332 C 10.786192,16.902647 10.993657,17 11.226067,17 Z" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     d="M 12.000001,2 C 6.4823465,2 1.9999995,6.4823444 1.9999995,11.999999 c 0,5.517656 4.482347,10.000003 10.0000015,10.000002 5.517653,0 10.000004,-4.482346 9.999999,-10.000002 C 22,6.4823444 17.517654,2 12.000001,2 Z" />
+     d="m 12.000001,1.4999995 c -5.7935369,0 -10.5000012,4.7064616 -10.5000012,10.4999985 0,5.793539 4.7064643,10.500003 10.5000012,10.500002 C 17.793537,22.5 22.500005,17.793537 22.5,11.999998 22.5,6.2064611 17.793537,1.4999995 12.000001,1.4999995 Z" />
   <path
-     d="m 10.805317,7.75 c 0.384728,0 0.612113,0.3212279 0.694455,0.7 v 2.3 h 6.805772 C 18.690273,10.75 19,11.0622 19,11.449999 v 2.85 c 0,0.3878 -0.309727,0.7 -0.694456,0.7 h -6.805772 v 2.8 c 0,0.3878 -0.309727,0.699999 -0.694455,0.699999 -0.207354,0 -0.392452,-0.09082 -0.519485,-0.235156 L 5.689663,13.604884 C 5.572242,13.479518 5.499772,13.311018 5.499772,13.125 c 0,-0.186018 0.07247,-0.354517 0.189891,-0.479883 l 4.596169,-4.65996 C 10.412864,7.840823 10.597963,7.75 10.805317,7.75 Z"
-     style="opacity:0.3;fill:#ae2109;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path890"
-     sodipodi:nodetypes="sscsssscssccsccs" />
-  <path
-     d="m 11.305545,6.7500005 c 0.384728,0 0.694455,0.312381 0.694455,0.7 V 10.25 h 6.305544 C 18.690273,10.25 19,10.5622 19,10.949999 v 2.35 c 0,0.3878 -0.309727,0.7 -0.694456,0.7 H 12 v 2.8 c 0,0.387801 -0.309727,0.7 -0.694455,0.7 -0.207354,0 -0.392452,-0.09082 -0.519485,-0.235156 L 6.189891,12.604884 C 6.07247,12.479518 6,12.311018 6,12.125001 6,11.938982 6.07247,11.770483 6.189891,11.645117 L 10.78606,6.9851575 c 0.127032,-0.144334 0.312131,-0.235157 0.519485,-0.235157 z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path873-5-3"
-     sodipodi:nodetypes="sscsssscssccsccs" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 11.226067,17 c 0.431218,0 0.778372,-0.334646 0.778372,-0.750328 V 13 h 5.217189 C 17.652847,13 18,12.665354 18,12.249672 V 11.750328 C 18,11.334646 17.652847,10.99959 17.221628,11 H 12.004439 V 7.7503259 c 0,-0.41568 -0.347154,-0.750326 -0.778372,-0.750326 -0.23241,0 -0.439875,0.09736 -0.58226,0.252062 L 6.212837,11.475847 C 6.081227,11.610226 6,11.79084 6,11.990232 c 0,0.199392 0.08122,0.380005 0.212837,0.514385 l 4.43097,4.24332 C 10.786192,16.902647 10.993657,17 11.226067,17 Z" />
 </svg>

--- a/elementary-xfce/actions/24/system-reboot.svg
+++ b/elementary-xfce/actions/24/system-reboot.svg
@@ -1,148 +1,70 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.2"
-   width="24"
-   height="24"
    id="svg2"
-   sodipodi:docname="system-restart.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   height="24"
+   width="24"
+   version="1.2"
+   sodipodi:docname="system-reboot.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview14641"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1319"
-     inkscape:window-height="980"
-     id="namedview27"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="23.363986"
-     inkscape:cx="11.539489"
-     inkscape:cy="4.8700181"
-     inkscape:window-x="516"
-     inkscape:window-y="19"
+     inkscape:zoom="8.9375"
+     inkscape:cx="20.699301"
+     inkscape:cy="13.090909"
+     inkscape:window-width="1278"
+     inkscape:window-height="801"
+     inkscape:window-x="52"
+     inkscape:window-y="112"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg2"
-     inkscape:document-rotation="0" />
+     inkscape:current-layer="svg2" />
   <defs
      id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
-         id="stop4013"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4013" />
       <stop
-         id="stop4015-3"
+         offset="0.507761"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
+         id="stop4015-3" />
       <stop
-         id="stop4017-2"
+         offset="0.83456558"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
+         id="stop4017-2" />
       <stop
-         id="stop4019"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       id="linearGradient3820-7-2">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
-    </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       gradientTransform="matrix(0,0.4878049,-0.48780489,0,23.707317,0.29268294)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999998"
-       x2="44.5"
-       y1="23.999998"
-       x1="3.4999995"
-       id="linearGradient887"
-       xlink:href="#linearGradient947-5" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ffa154;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#f37329;stop-opacity:1" />
+         id="stop4019" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.51351363,0,0,0.51351355,-24.836137,-1.0212861)"
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.83614,-1.0212801)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
-       id="linearGradient3019"
+       id="linearGradient12398-3"
        y2="44.340794"
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407" />
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2-2"
-       id="radialGradient4048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-12.142637,-15.885867)"
-       cx="99.157013"
-       cy="186.17059"
-       fx="99.157013"
-       fy="186.17059"
-       r="62.769119" />
     <linearGradient
-       id="linearGradient3820-7-2-2">
-      <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.1113759,0,0,0.83086027,-2260.66,-2697.1635)"
+       gradientTransform="matrix(0.8047894,0,0,0.60165743,-1628.8199,-1928.0804)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient947-5"
        id="linearGradient11527-6-5"
@@ -161,15 +83,27 @@
          style="stop-color:#3689e6;stop-opacity:1"
          id="stop945-2" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.72973007,0,0,0.72973007,-47.11194,-36.50875)"
+    <radialGradient
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,19.694118)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011"
-       id="linearGradient12398-3"
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407" />
+       xlink:href="#linearGradient8838"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
+    <linearGradient
+       id="linearGradient8838">
+      <stop
+         id="stop8840"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8842"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata7">
@@ -179,43 +113,46 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     style="stroke-width:2.86337"
-     transform="matrix(0.34552847,0,0,0.35298856,0.9430875,0.52694603)"
-     id="g4198-4">
-    <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:2.86337"
-       id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
-    <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
-       id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.86337" />
-  </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path2555"
-     d="M 22,12.000002 C 22,6.4823466 17.517656,2 12,2 6.4823455,2 1.9999975,6.4823466 1.9999995,12.000002 1.9999995,17.517654 6.4823455,22.000006 12,22 c 5.517656,0 10,-4.482346 10,-9.999998 z" />
+     d="m 22,21 c 0,1.656854 -4.477153,3 -10,3 -5.522848,0 -10,-1.343146 -10,-3 0,-1.656854 4.477152,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+     id="path8836-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path8655"
-     d="m 21.500005,11.999663 c 0,5.246875 -4.253609,9.500338 -9.499883,9.500338 -5.2467525,0 -9.5001225,-4.253511 -9.5001225,-9.500338 0,-5.2466319 4.25337,-9.4996635 9.5001225,-9.4996635 5.246274,0 9.499883,4.2530316 9.499883,9.4996635 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.98999999;fill:url(#linearGradient11527-6-5);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.99999982;marker:none;enable-background:accumulate"
+     id="path2555-7-8-5-0-9"
+     d="M 12,1.4999999 C 6.2064599,1.4999999 1.4999999,6.2064599 1.4999999,12 1.4999999,17.79354 6.2064599,22.5 12,22.5 17.79354,22.5 22.50001,17.79354 22.5,12 22.5,6.2064599 17.79354,1.4999999 12,1.4999999 Z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path2555-6"
-     d="M 12.000001,2 C 6.4823465,2 1.9999995,6.4823444 1.9999995,11.999999 c 0,5.517656 4.482347,10.000003 10.0000015,10.000002 5.517653,0 10.000004,-4.482346 9.999999,-10.000002 C 22,6.4823444 17.517654,2 12.000001,2 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#002e99;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
+     id="path2555-7-8-5-1"
+     d="M 12,1.4999999 C 6.2064599,1.4999999 1.4999999,6.2064599 1.4999999,12 1.4999999,17.79354 6.2064599,22.5 12,22.5 17.79354,22.5 22.50001,17.79354 22.5,12 22.5,6.2064599 17.79354,1.4999999 12,1.4999999 Z" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999997;marker:none;enable-background:accumulate"
-     d="m 12.000428,5.571 v 1.8571424 c -3.0770165,0 -5.571428,2.4944136 -5.571428,5.5714306 0,3.077017 2.4944115,5.571428 5.571428,5.571428 3.077016,0 5.571428,-2.494411 5.571428,-5.571428 h -1.857142 c 0,2.051344 -1.662941,3.714285 -3.714286,3.714285 -2.0513439,0 -3.7142856,-1.662941 -3.7142856,-3.714285 0,-2.051344 1.6629417,-3.714287 3.7142856,-3.714287 v 1.857144 l 4.642857,-2.7857145 z"
-     id="path924"
-     sodipodi:nodetypes="ccssccsscccc" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient12398-3);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6-0-9-5-0"
+     d="m 21.49999,11.99966 c 0,5.24688 -4.25361,9.50034 -9.49988,9.50034 -5.2467501,0 -9.5001101,-4.25351 -9.5001101,-9.50034 0,-5.2466301 4.25336,-9.4996601 9.5001101,-9.4996601 5.24627,0 9.49988,4.25303 9.49988,9.4996601 z" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999997;marker:none;enable-background:accumulate"
-     d="m 12.000428,4.571 v 1.8571424 c -3.0770165,0 -5.571428,2.4944138 -5.571428,5.5714306 0,3.077017 2.4944115,5.571428 5.571428,5.571428 3.077016,0 5.571428,-2.494411 5.571428,-5.571428 h -1.857142 c 0,2.051344 -1.662941,3.714285 -3.714286,3.714285 -2.0513439,0 -3.7142856,-1.662941 -3.7142856,-3.714285 0,-2.051344 1.6629417,-3.7142866 3.7142856,-3.7142866 V 10.14243 l 4.642857,-2.7857145 z"
-     id="path2984-75"
-     sodipodi:nodetypes="ccssccsscccc" />
+     id="path45206"
+     style="color:#000000;fill:#002e99;fill-opacity:0.5;fill-rule:evenodd;stroke-width:0.999867;stroke-linecap:round;-inkscape-stroke:none"
+     d="m 13.51765,6.25 c -0.287266,-1e-7 -0.517578,0.2017641 -0.517578,0.4511718 V 8.0019531 C 10.421728,7.9835054 7.0506726,10.071029 6.2598377,12.541 c -0.9228081,2.882158 0.6790691,6.006091 3.6035155,7.078023 2.9244468,1.071934 6.2088038,-0.190054 7.5390618,-2.914061 0.238742,-0.490605 0.02633,-1.087632 -0.474609,-1.333985 -0.501261,-0.247031 -1.102107,-0.04937 -1.341796,0.441406 -0.880017,1.802035 -3.098507,2.661098 -5.056641,1.943359 C 8.5712347,17.038004 7.5734779,14.571302 8.1797596,12.677734 8.9964342,10.127057 11.086524,9.994393 13.000072,9.99414 v 1.804688 c 0,0.249409 0.230311,0.451171 0.517578,0.451172 0.154826,0 0.293812,-0.05757 0.388672,-0.150391 l 2.951172,-2.546875 c 0.08768,-0.08063 0.142578,-0.188958 0.142578,-0.308594 0,-0.119634 -0.0549,-0.227967 -0.142578,-0.3085929 L 13.906322,6.4003905 C 13.811472,6.3075695 13.672476,6.2499999 13.51765,6.25 Z"
+     sodipodi:nodetypes="sscsscccsscssccsccs" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 13.518603,11 c -0.287267,0 -0.518531,-0.200788 -0.518531,-0.450197 V 5.4501956 C 13.000072,5.2007876 13.231336,5 13.518603,5 c 0.154826,0 0.293033,0.058416 0.387887,0.1512372 l 2.951795,2.5342707 c 0.08768,0.080627 0.141787,0.1889958 0.141787,0.308631 0,0.1196352 -0.05411,0.228003 -0.141787,0.308631 L 13.90649,10.848762 C 13.81163,10.941588 13.673429,11 13.518603,11 Z"
+     sodipodi:nodetypes="sccsccsccs" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path54251"
+     sodipodi:type="arc"
+     sodipodi:cx="12.000072"
+     sodipodi:cy="12.501798"
+     sodipodi:rx="5"
+     sodipodi:ry="5.0017982"
+     sodipodi:start="0.2443461"
+     sodipodi:end="5.0963614"
+     sodipodi:arc-type="arc"
+     d="M 16.85155,13.711842 A 5,5.0017982 0 0 1 12.566088,17.471444 5,5.0017982 0 0 1 7.5450389,14.772567 5,5.0017982 0 0 1 8.3136848,9.1226319 5,5.0017982 0 0 1 13.873104,7.8642112"
+     sodipodi:open="true" />
 </svg>

--- a/elementary-xfce/actions/24/system-shutdown.svg
+++ b/elementary-xfce/actions/24/system-shutdown.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="24"
    height="24"
    id="svg3041"
-   sodipodi:docname="system-shutdown1.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   sodipodi:docname="system-shutdown.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,28 +23,33 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-width="1322"
+     inkscape:window-height="799"
      id="namedview35"
      showgrid="false"
      inkscape:zoom="16.520833"
-     inkscape:cx="4.4765419"
-     inkscape:cy="6.8685849"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:cx="5.6897857"
+     inkscape:cy="22.759143"
+     inkscape:window-x="178"
+     inkscape:window-y="47"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3043">
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3406"
-       xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.836132,6.978716)" />
+       id="linearGradient26009">
+      <stop
+         id="stop26005"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop26007"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient4011">
       <stop
@@ -64,55 +69,6 @@
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="23.895569"
-       cy="3.9900031"
-       r="20.397499"
-       fx="23.895569"
-       fy="3.9900031"
-       id="radialGradient3026"
-       xlink:href="#linearGradient885"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.2316137,-1.6257082,0,18.486581,-20.720783)" />
-    <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143"
-       id="linearGradient3028"
-       xlink:href="#linearGradient885"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5160413,0,0,0.5160413,-0.384991,7.615009)" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#dd3b27;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient8838">
       <stop
@@ -124,36 +80,6 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="62.625"
-       cy="4.625"
-       r="10.625"
-       fx="62.625"
-       fy="4.625"
-       id="radialGradient3039"
-       xlink:href="#linearGradient8838"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,27.694118)" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ef6555;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#c6272e;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient885"
-       id="linearGradient877"
-       x1="12.089882"
-       y1="11.236414"
-       x2="12.089882"
-       y2="29.379152"
-       gradientUnits="userSpaceOnUse" />
     <linearGradient
        x1="71.204407"
        y1="6.2375584"
@@ -165,14 +91,44 @@
        gradientTransform="matrix(0.51351349,0,0,0.51351352,-24.836127,6.9787149)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient885"
+       xlink:href="#linearGradient26009"
        id="linearGradient905"
        gradientUnits="userSpaceOnUse"
-       x1="12.089882"
-       y1="11.236414"
-       x2="12.089882"
-       y2="29.379152"
-       gradientTransform="matrix(1.0477972,0,0,1.0477972,-0.57356613,-0.95594379)" />
+       x1="12.000114"
+       y1="10.456168"
+       x2="12.000114"
+       y2="29.543833"
+       gradientTransform="matrix(1.00017,0,0,1.00017,-0.00204033,-0.00340046)" />
+    <radialGradient
+       r="62.769119"
+       fy="185.29727"
+       fx="99.189415"
+       cy="185.29727"
+       cx="99.189415"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3300-8"
+       xlink:href="#linearGradient8838" />
+    <radialGradient
+       r="62.769119"
+       fy="185.29727"
+       fx="99.189415"
+       cy="185.29727"
+       cx="99.189415"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192-6"
+       xlink:href="#linearGradient8838" />
+    <radialGradient
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,27.694118)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8838"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
   </defs>
   <metadata
      id="metadata3046">
@@ -182,7 +138,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -190,45 +145,69 @@
      transform="translate(0,-8)"
      id="layer1">
     <path
-       d="m 24,29 c 0,1.656854 -5.372583,3 -12,3 C 5.3725827,32 -2.5e-7,30.656854 -2.5e-7,29 -2.5e-7,27.343146 5.3725827,26 12,26 c 6.627417,0 12,1.343146 12,3 l 0,0 z"
-       id="path8836"
-       style="opacity:0.3;fill:url(#radialGradient3039);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999988;marker:none;visibility:visible;display:inline;overflow:visible" />
+       d="m 22,29 c 0,1.656854 -4.477153,3 -10,3 -5.5228476,0 -10,-1.343146 -10,-3 0,-1.656854 4.4771524,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+       id="path8836-1"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
+    <g
+       style="stroke-width:2.88033"
+       transform="matrix(0.375,0,0,0.32142723,5.8125e-7,10.428069)"
+       id="g4198-4">
+      <path
+         style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:2.88033"
+         id="path3818-0-6"
+         d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+      <path
+         d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+         id="path4190-2"
+         style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.88033" />
+    </g>
     <path
-       d="M 12.000002,9 C 5.9305816,9 1,13.93058 1,19.999999 c 0,6.069422 4.9305815,11.000005 11.000002,11.000002 6.069418,0 11.000005,-4.93058 10.999999,-11.000002 C 23.000001,13.93058 18.06942,9 12.000002,9 Z"
+       d="M 12.000001,9.5 C 6.206464,9.5 1.5,14.206462 1.5,19.999999 1.5,25.793537 6.2064639,30.500003 12.000001,30.5 17.793537,30.5 22.500006,25.793537 22.5,19.999999 22.5,14.206462 17.793537,9.5 12.000001,9.5 Z"
        id="path2555"
-       style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1.00365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        d="M 12.000002,9.5 C 6.206465,9.5 1.5000013,14.206462 1.5000013,20 c 0,5.793538 4.7064637,10.500002 10.5000007,10.5 5.793535,0 10.500005,-4.706462 10.499999,-10.5 0,-5.793538 -4.706464,-10.5 -10.499999,-10.5 z"
        id="path2555-6"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#510606;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
     <path
        d="m 21.5,19.999663 c 0,5.246876 -4.253608,9.500338 -9.49988,9.500338 C 6.7533682,29.500001 2.5,25.24649 2.5,19.999663 2.5,14.753031 6.7533682,10.5 12.00012,10.5 17.246392,10.5 21.5,14.753031 21.5,19.999663 Z"
        id="path8655"
        style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   </g>
   <g
-     transform="matrix(1.1162516,0,0,1.0912086,-1.9531449,-2.2562552)"
+     transform="matrix(1.1162516,0,0,1.0912086,-1.9531449,-0.25625518)"
      id="g3011"
-     style="opacity:0.5;stroke:#5d5d5d;stroke-width:1;stroke-opacity:1">
+     style="opacity:0.5;stroke:#7a0000;stroke-width:1;stroke-opacity:1">
     <path
        d="m 9.6949685,8.2559395 c -4.6499814,2.4267145 -2.5472723,9.3806545 2.7687765,9.3806545 5.260671,0 7.61842,-6.592658 2.768775,-9.3806545"
        id="path3013"
-       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#5d5d5d;stroke-width:1.81215;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7a0000;stroke-width:1.81215;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
     <path
-       d="M 12.5,11.357548 V 6.6394015"
+       d="M 12.5,11.231817 V 6.191534"
        id="path3015"
-       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#5d5d5d;stroke-width:1.81215;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7a0000;stroke-width:1.81215;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       sodipodi:nodetypes="cc" />
   </g>
   <g
      id="g3475"
      transform="matrix(1.1162516,0,0,1.0912086,-1.9531449,-1.2562553)">
     <path
        style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.81215;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
-       id="path3339"
-       d="m 9.6949685,8.2559395 c -4.6499814,2.4267145 -2.5472723,9.3806545 2.7687765,9.3806545 5.260671,0 7.61842,-6.592658 2.768775,-9.3806545" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.81215;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
        id="path3341"
-       d="M 12.5,11.357548 V 6.6394015" />
+       d="M 12.48978,11.231817 V 6.1915341"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="opacity:1;fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:1.81215;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path27328"
+       sodipodi:type="arc"
+       sodipodi:cx="12.5"
+       sodipodi:cy="12.163285"
+       sodipodi:rx="5.364562"
+       sodipodi:ry="5.4937768"
+       sodipodi:start="5.3232542"
+       sodipodi:end="4.1015237"
+       sodipodi:arc-type="arc"
+       d="M 15.576986,7.6630467 A 5.364562,5.4937768 0 0 1 17.616274,13.815296 5.364562,5.4937768 0 0 1 12.5,17.657062 5.364562,5.4937768 0 0 1 7.3837263,13.815296 5.364562,5.4937768 0 0 1 9.4230134,7.6630469"
+       sodipodi:open="true" />
   </g>
 </svg>

--- a/elementary-xfce/actions/24/system-suspend-hibernate.svg
+++ b/elementary-xfce/actions/24/system-suspend-hibernate.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.2"
    width="24"
    height="24"
    id="svg2"
    sodipodi:docname="system-suspend-hibernate.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,18 +23,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-width="1278"
+     inkscape:window-height="1035"
      id="namedview27"
      showgrid="false"
-     inkscape:zoom="5.8409965"
-     inkscape:cx="-1.4190032"
-     inkscape:cy="0.89010322"
-     inkscape:window-x="0"
+     inkscape:zoom="33.041666"
+     inkscape:cx="8.1563684"
+     inkscape:cy="12.136192"
+     inkscape:window-x="640"
      inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg2"
-     inkscape:document-rotation="0" />
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4">
     <linearGradient
@@ -88,26 +91,6 @@
        id="radialGradient4192-6"
        xlink:href="#linearGradient3820-7-2" />
     <linearGradient
-       gradientTransform="matrix(0,0.4878049,-0.48780489,0,23.707317,0.29268294)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999998"
-       x2="44.5"
-       y1="23.999998"
-       x1="3.4999995"
-       id="linearGradient887"
-       xlink:href="#linearGradient902" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ffa154;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#f37329;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
        gradientTransform="matrix(0.51351363,0,0,0.51351355,-24.836137,-1.0212861)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
@@ -117,27 +100,17 @@
        y1="6.2375584"
        x1="71.204407" />
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,19.694118)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8-3"
-       xlink:href="#linearGradient3820-7-2" />
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6-5"
-       xlink:href="#linearGradient3820-7-2" />
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
     <linearGradient
-       gradientTransform="rotate(90,53.501255,14.667215)"
+       gradientTransform="matrix(0,0.51219512,-0.51219512,0,24.292683,-0.292682)"
        gradientUnits="userSpaceOnUse"
        y2="23.999998"
        x2="44.5"
@@ -157,15 +130,6 @@
          offset="1"
          id="stop900" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-31.442529,-41.56194)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011"
-       id="linearGradient3019-5"
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407" />
   </defs>
   <metadata
      id="metadata7">
@@ -175,10 +139,13 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     d="m 22,21 c 0,1.656854 -4.477153,3 -10,3 -5.5228476,0 -10,-1.343146 -10,-3 0,-1.656854 4.4771524,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+     id="path8836-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
   <g
      style="stroke-width:2.86337"
      transform="matrix(0.34552847,0,0,0.35298856,0.9430875,0.52694603)"
@@ -193,37 +160,55 @@
        style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.86337" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      id="path2555"
-     d="M 22,12.000002 C 22,6.4823466 17.517656,2 12,2 6.4823455,2 1.9999975,6.4823466 1.9999995,12.000002 1.9999995,17.517654 6.4823455,22.000006 12,22 c 5.517656,0 10,-4.482346 10,-9.999998 z" />
+     d="M 22.5,12.000002 C 22.5,6.2064639 17.793539,1.5 12,1.5 6.2064631,1.5 1.4999977,6.2064639 1.4999998,12.000002 1.4999998,17.793537 6.2064631,22.500006 12,22.5 c 5.793539,0 10.5,-4.706463 10.5,-10.499998 z" />
+  <path
+     inkscape:connector-curvature="0"
+     d="M 6.9199907,11.299076 8.5360239,10.500024 8.4199905,8.701 m 7.1600245,7.597944 -0.116018,-1.799053 1.616017,-0.799023 M 17.196188,15.500003 6.8038071,9.4999582"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34901962;marker:none;enable-background:accumulate"
+     id="path7056"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     inkscape:connector-curvature="0"
+     d="M 8.4199879,16.298943 8.5360048,14.499891 6.9199879,13.700867 M 17.080012,11.299076 15.463978,10.500024 15.580012,8.701 m 1.616184,0.798958 -10.3923818,6.000044"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34901962;marker:none;enable-background:accumulate"
+     id="path6691"
+     sodipodi:nodetypes="cccccccc" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
      d="m 21.500005,11.999663 c 0,5.246875 -4.253609,9.500338 -9.499883,9.500338 -5.2467525,0 -9.5001225,-4.253511 -9.5001225,-9.500338 0,-5.2466319 4.25337,-9.4996635 9.5001225,-9.4996635 5.246274,0 9.499883,4.2530316 9.499883,9.4996635 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#007293;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;fill-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      id="path2555-6"
-     d="M 12.000001,2 C 6.4823465,2 1.9999995,6.4823444 1.9999995,11.999999 c 0,5.517656 4.482347,10.000003 10.0000015,10.000002 5.517653,0 10.000004,-4.482346 9.999999,-10.000002 C 22,6.4823444 17.517654,2 12.000001,2 Z" />
+     d="m 12.000001,1.4999995 c -5.7935369,0 -10.5000012,4.7064616 -10.5000012,10.4999985 0,5.793539 4.7064643,10.500003 10.5000012,10.500002 C 17.793537,22.5 22.500005,17.793537 22.5,11.999998 22.5,6.2064611 17.793537,1.4999995 12.000001,1.4999995 Z" />
   <path
-     id="path946"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-     d="M 12,7 A 0.5,0.5 0 0 0 11.5,7.5 V 8.3652344 L 10.941406,7.9804688 A 0.5,0.5 0 0 0 10.246094,8.109375 0.5,0.5 0 0 0 10.373047,8.8046875 L 11.5,9.582031 v 2.044922 L 9.7675781,10.611328 9.6679688,9.2304688 A 0.5,0.5 0 0 0 9.1464844,8.765625 0.5,0.5 0 0 0 9.1328125,8.7675781 0.5,0.5 0 0 0 8.6699219,9.3007812 L 8.7207029,9.996094 7.9902342,9.568359 a 0.5,0.5 0 0 0 -0.6855469,0.177735 0.5,0.5 0 0 0 0.1796875,0.685547 l 0.7480469,0.439453 -0.6269531,0.308594 A 0.5,0.5 0 0 0 7.3789062,11.847656 0.5,0.5 0 0 0 8.046875,12.076172 L 9.265625,11.476562 11.011719,12.5 9.2617188,13.525391 8.0175781,12.935547 a 0.5,0.5 0 0 0 -0.6660156,0.236328 0.5,0.5 0 0 0 0.2363281,0.666016 l 0.6308594,0.298828 -0.734375,0.43164 a 0.5,0.5 0 0 0 -0.1796875,0.685547 0.5,0.5 0 0 0 0.6855469,0.177735 l 0.7167968,-0.419922 -0.060547,0.695312 a 0.5,0.5 0 0 0 0.4570312,0.539063 0.5,0.5 0 0 0 0.5390625,-0.455078 L 9.7617188,14.392578 11.5,13.373047 v 2.050781 l -1.132812,0.804688 A 0.5,0.5 0 0 0 10.25,16.925781 0.5,0.5 0 0 0 10.947266,17.042969 L 11.5,16.650391 V 17.5 A 0.5,0.5 0 0 0 12,18 0.5,0.5 0 0 0 12.5,17.5 v -0.849609 l 0.552734,0.392578 A 0.5,0.5 0 0 0 13.75,16.925781 0.5,0.5 0 0 0 13.632812,16.228516 L 12.5,15.423828 v -2.050781 l 1.738281,1.019531 0.119141,1.398438 a 0.5,0.5 0 0 0 0.539062,0.455078 0.5,0.5 0 0 0 0.457032,-0.539063 l -0.06055,-0.695312 0.716797,0.419922 a 0.5,0.5 0 0 0 0.685546,-0.177735 0.5,0.5 0 0 0 -0.179687,-0.685547 l -0.734375,-0.43164 0.630859,-0.298828 a 0.5,0.5 0 0 0 0.236329,-0.666016 0.5,0.5 0 0 0 -0.666016,-0.236328 l -1.244141,0.589844 -1.75,-1.025391 1.746094,-1.023438 1.21875,0.59961 a 0.5,0.5 0 0 0 0.667969,-0.228516 0.5,0.5 0 0 0 -0.226563,-0.667968 l -0.626953,-0.308594 0.748047,-0.439453 A 0.5,0.5 0 0 0 16.695309,9.746094 0.5,0.5 0 0 0 16.009763,9.568359 l -0.730469,0.427735 0.05078,-0.6953128 a 0.5,0.5 0 0 0 -0.46289,-0.5332031 0.5,0.5 0 0 0 -0.06055,-0.00195 0.5,0.5 0 0 0 -0.47461,0.4648438 L 14.232422,10.611328 12.5,11.626953 V 9.582031 L 13.626953,8.8046875 A 0.5,0.5 0 0 0 13.753906,8.109375 0.5,0.5 0 0 0 13.058594,7.9804688 L 12.5,8.3652344 V 7.5 A 0.5,0.5 0 0 0 12,7 Z" />
+     id="path266"
+     style="color:#000000;fill:none;stroke-linecap:round;fill-opacity:0.99000001;stroke:#0e141f;stroke-opacity:0.15000001;stroke-width:2;stroke-dasharray:none"
+     d="M 12 5.5 A 0.5 0.5 0 0 0 11.5 6 L 11.5 7.0644531 L 10.777344 6.5839844 A 0.5 0.5 0 0 0 10.083984 6.7226562 A 0.5 0.5 0 0 0 10.222656 7.4160156 L 11.5 8.2675781 L 11.5 11.132812 L 9.0175781 9.6992188 L 8.9199219 8.1679688 A 0.5 0.5 0 0 0 8.3886719 7.7011719 A 0.5 0.5 0 0 0 7.921875 8.2324219 L 7.9765625 9.0996094 L 7.0546875 8.5664062 A 0.5 0.5 0 0 0 6.3710938 8.75 A 0.5 0.5 0 0 0 6.5546875 9.4335938 L 7.4765625 9.9667969 L 6.6992188 10.351562 A 0.5 0.5 0 0 0 6.4726562 11.021484 A 0.5 0.5 0 0 0 7.1425781 11.248047 L 8.5175781 10.566406 L 11 12 L 8.5175781 13.433594 L 7.140625 12.751953 A 0.5 0.5 0 0 0 6.4726562 12.978516 A 0.5 0.5 0 0 0 6.6992188 13.648438 L 7.4765625 14.033203 L 6.5546875 14.566406 A 0.5 0.5 0 0 0 6.3710938 15.25 A 0.5 0.5 0 0 0 7.0546875 15.433594 L 7.9765625 14.900391 L 7.921875 15.767578 A 0.5 0.5 0 0 0 8.3886719 16.298828 A 0.5 0.5 0 0 0 8.9199219 15.832031 L 9.0175781 14.300781 L 11.5 12.867188 L 11.5 15.732422 L 10.222656 16.583984 A 0.5 0.5 0 0 0 10.083984 17.277344 A 0.5 0.5 0 0 0 10.777344 17.416016 L 11.5 16.935547 L 11.5 18 A 0.5 0.5 0 0 0 12 18.5 A 0.5 0.5 0 0 0 12.5 18 L 12.5 16.935547 L 13.222656 17.416016 A 0.5 0.5 0 0 0 13.916016 17.277344 A 0.5 0.5 0 0 0 13.777344 16.583984 L 12.5 15.732422 L 12.5 12.867188 L 14.982422 14.300781 L 15.080078 15.832031 A 0.5 0.5 0 0 0 15.611328 16.298828 A 0.5 0.5 0 0 0 16.078125 15.767578 L 16.023438 14.900391 L 16.945312 15.433594 A 0.5 0.5 0 0 0 17.628906 15.25 A 0.5 0.5 0 0 0 17.445312 14.566406 L 16.523438 14.033203 L 17.300781 13.648438 A 0.5 0.5 0 0 0 17.527344 12.978516 A 0.5 0.5 0 0 0 16.859375 12.751953 L 15.482422 13.433594 L 13 12 L 15.482422 10.566406 L 16.857422 11.248047 A 0.5 0.5 0 0 0 17.527344 11.021484 A 0.5 0.5 0 0 0 17.300781 10.351562 L 16.523438 9.9667969 L 17.445312 9.4335938 A 0.5 0.5 0 0 0 17.628906 8.75 A 0.5 0.5 0 0 0 16.945312 8.5664062 L 16.023438 9.0996094 L 16.078125 8.2324219 A 0.5 0.5 0 0 0 15.611328 7.7011719 A 0.5 0.5 0 0 0 15.080078 8.1679688 L 14.982422 9.6992188 L 12.5 11.132812 L 12.5 8.2675781 L 13.777344 7.4160156 A 0.5 0.5 0 0 0 13.916016 6.7226562 A 0.5 0.5 0 0 0 13.222656 6.5839844 L 12.5 7.0644531 L 12.5 6 A 0.5 0.5 0 0 0 12 5.5 z " />
   <path
      inkscape:connector-curvature="0"
-     d="m 13.342643,16.135445 -1.34266,-0.953568 -1.342652,0.953568 M 13.342643,7.89279 11.999983,8.818117 10.657331,7.89279 M 12.00001,6.999815 v 10.00037"
+     d="m 13.5,17.499823 -1.500017,-1 -1.499983,1 m 3,-9.9997342 -1.500017,1 -1.499983,-1 m 1.50001,-1 V 18.500178"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.34901962;marker:none;enable-background:accumulate"
+     id="path4524"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 13.5,16.999823 -1.500017,-1 -1.499983,1 m 3,-9.9997342 -1.500017,1 -1.499983,-1 M 12.00001,5.9999113 V 18"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path7750-9-3"
      sodipodi:nodetypes="cccccccc" />
   <path
-     sodipodi:nodetypes="cccccccc"
-     id="path7750-9-2-6"
+     inkscape:connector-curvature="0"
+     d="M 8.4199879,15.798927 8.5360048,13.999875 6.9199879,13.200851 M 17.080012,10.79906 15.463978,10.000008 15.580012,8.2009841 m 1.616184,0.798958 -10.3923818,6.0000439"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     d="M 9.1453059,15.248764 9.2870211,13.590938 7.8026533,12.886681 m 8.3705947,-1.759248 -1.460289,-0.718378 0.117636,-1.643698 m 1.432719,0.734571 -8.526628,5.000185"
-     inkscape:connector-curvature="0" />
+     id="path6687"
+     sodipodi:nodetypes="cccccccc" />
   <path
      inkscape:connector-curvature="0"
-     d="m 14.854694,15.248764 -0.141715,-1.657826 1.484368,-0.704257 M 7.8267525,11.127433 9.2870413,10.409055 9.1694051,8.765357 m -1.4327191,0.734571 8.526628,5.000185"
+     d="M 6.9199907,10.799055 8.5360239,10.000003 8.4199905,8.2009793 M 15.580015,15.798923 15.463997,13.99987 17.080014,13.200847 M 17.196188,14.999982 6.8038071,8.9999375"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path7750-9-2-9-0"
+     id="path6689"
      sodipodi:nodetypes="cccccccc" />
 </svg>

--- a/elementary-xfce/actions/24/system-suspend.svg
+++ b/elementary-xfce/actions/24/system-suspend.svg
@@ -1,71 +1,78 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.2"
-   width="24"
-   height="24"
    id="svg2"
-   sodipodi:docname="system-suspend2.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   height="24"
+   width="24"
+   version="1.2"
+   sodipodi:docname="system-suspend.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview14641"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview27"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="33.041666"
-     inkscape:cx="6.8195126"
-     inkscape:cy="10.424414"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg2"
-     inkscape:document-rotation="0" />
+     inkscape:zoom="17.875"
+     inkscape:cx="11.832168"
+     inkscape:cy="14.881119"
+     inkscape:window-width="1278"
+     inkscape:window-height="801"
+     inkscape:window-x="640"
+     inkscape:window-y="112"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
   <defs
      id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
-         id="stop4013"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4013" />
       <stop
-         id="stop4015-3"
+         offset="0.507761"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.507761" />
+         id="stop4015-3" />
       <stop
-         id="stop4017-2"
+         offset="0.83456558"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.83456558" />
+         id="stop4017-2" />
       <stop
-         id="stop4019"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop4019" />
     </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+    <linearGradient
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.83614,-1.0212801)"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
+       xlink:href="#linearGradient4011"
+       id="linearGradient12398-3"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
+    <radialGradient
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,19.694118)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
@@ -77,67 +84,8 @@
          style="stop-color:#000000;stop-opacity:0"
          id="stop3824-1-2" />
     </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
     <linearGradient
-       gradientTransform="matrix(0,0.4878049,-0.48780489,0,23.707317,0.29268294)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999998"
-       x2="44.5"
-       y1="23.999998"
-       x1="3.4999995"
-       id="linearGradient887"
-       xlink:href="#linearGradient902" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ffa154;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#f37329;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.51351363,0,0,0.51351355,-24.836137,-1.0212861)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011"
-       id="linearGradient3019"
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407" />
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8-3"
-       xlink:href="#linearGradient3820-7-2" />
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6-5"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       gradientTransform="rotate(90,53.501255,14.667215)"
+       gradientTransform="matrix(0,0.51219512,-0.51219512,0,24.292683,-0.292682)"
        gradientUnits="userSpaceOnUse"
        y2="23.999998"
        x2="44.5"
@@ -157,15 +105,6 @@
          offset="1"
          id="stop900" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-31.442529,-41.56194)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011"
-       id="linearGradient3019-5"
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407" />
   </defs>
   <metadata
      id="metadata7">
@@ -175,63 +114,53 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     style="stroke-width:2.86337"
-     transform="matrix(0.34552847,0,0,0.35298856,0.9430875,0.52694603)"
-     id="g4198-4">
-    <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:2.86337"
-       id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
-    <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
-       id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.86337" />
-  </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path2555"
-     d="M 22,12.000002 C 22,6.4823466 17.517656,2 12,2 6.4823455,2 1.9999975,6.4823466 1.9999995,12.000002 1.9999995,17.517654 6.4823455,22.000006 12,22 c 5.517656,0 10,-4.482346 10,-9.999998 z" />
+     d="m 22,21 c 0,1.656854 -4.477153,3 -10,3 -5.5228474,0 -10,-1.343146 -10,-3 0,-1.656854 4.4771526,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+     id="path8836-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path8655"
-     d="m 21.500005,11.999663 c 0,5.246875 -4.253609,9.500338 -9.499883,9.500338 -5.2467525,0 -9.5001225,-4.253511 -9.5001225,-9.500338 0,-5.2466319 4.25337,-9.4996635 9.5001225,-9.4996635 5.246274,0 9.499883,4.2530316 9.499883,9.4996635 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555-7-8-5-0-9"
+     d="M 12,1.4999999 C 6.2064599,1.4999999 1.4999999,6.2064599 1.4999999,12 1.4999999,17.79354 6.2064599,22.5 12,22.5 17.79354,22.5 22.50001,17.79354 22.5,12 22.5,6.2064599 17.79354,1.4999999 12,1.4999999 Z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#007293;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path2555-6"
-     d="M 12.000001,2 C 6.4823465,2 1.9999995,6.4823444 1.9999995,11.999999 c 0,5.517656 4.482347,10.000003 10.0000015,10.000002 5.517653,0 10.000004,-4.482346 9.999999,-10.000002 C 22,6.4823444 17.517654,2 12.000001,2 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;font-variation-settings:normal;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555-7-8-5-1"
+     d="M 12,1.4999999 C 6.2064599,1.4999999 1.4999999,6.2064599 1.4999999,12 1.4999999,17.79354 6.2064599,22.5 12,22.5 17.79354,22.5 22.50001,17.79354 22.5,12 22.5,6.2064599 17.79354,1.4999999 12,1.4999999 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient12398-3);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6-0-9-5-0"
+     d="m 21.49999,11.99966 c 0,5.24688 -4.25361,9.50034 -9.49988,9.50034 -5.2467501,0 -9.5001101,-4.25351 -9.5001101,-9.50034 0,-5.2466301 4.25336,-9.4996601 9.5001101,-9.4996601 5.24627,0 9.49988,4.25303 9.49988,9.4996601 z" />
   <path
      inkscape:connector-curvature="0"
      id="path892"
-     d="m 13.636429,7.0000435 c 0.774625,0.901007 1.244352,2.0526013 1.244352,3.3120185 0,2.878703 -2.431035,5.212391 -5.4298877,5.212391 -1.3119686,0 -2.5115863,-0.45091 -3.4502086,-1.194509 0.6565452,2.686486 3.1663602,4.669416 6.1651523,4.669416 3.498665,0 6.334848,-2.722579 6.334848,-6.081102 0,-2.878703 -2.065661,-5.2879575 -4.864256,-5.9182145 z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:#141f2b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
+     d="m 14.135744,7.2500437 c 0.774625,0.901007 1.244352,2.052601 1.244352,3.3120183 0,2.878703 -2.431035,5.212391 -5.4298874,5.212391 -1.311969,0 -2.511586,-0.45091 -3.450209,-1.194509 0.656546,2.686486 3.166361,4.669416 6.1651524,4.669416 C 16.163817,19.24936 19,16.526781 19,13.168258 19,10.289555 16.934339,7.8803007 14.135744,7.2500437 Z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#0e141f;fill-opacity:0.34902;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
   <path
      inkscape:connector-curvature="0"
      id="path5549"
-     d="m 13.455272,6.25 c 0.743641,0.9010584 1.194578,2.0527181 1.194578,3.3122075 0,2.8788665 -2.333793,5.2126865 -5.212691,5.2126865 -1.25949,0 -2.411123,-0.450935 -3.3122,-1.194576 0.630283,2.686638 3.039705,4.66968 5.918545,4.66968 3.358718,0 6.081453,-2.722732 6.081453,-6.081447 0,-2.8788665 -1.983034,-5.2882581 -4.669685,-5.918551 z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#f1f3f5;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
+     d="m 13.954587,6.4999997 c 0.743641,0.901059 1.194578,2.052718 1.194578,3.312208 0,2.8788663 -2.333793,5.2126863 -5.2126904,5.2126863 -1.25949,0 -2.411123,-0.450935 -3.3122,-1.194576 0.630283,2.686638 3.039705,4.66968 5.9185444,4.66968 3.358718,0 6.081453,-2.722732 6.081453,-6.081447 0,-2.8788673 -1.983034,-5.2882583 -4.669685,-5.9185513 z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
   <path
-     style="opacity:0.4;fill:none;stroke:#141f2b;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 5.5,10 h 2 l -2,3 h 2"
+     style="opacity:1;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34901962"
+     d="M 5.5,9.9999997 H 7.4999996 L 5.5,13 h 1.9999996"
      id="path869"
      sodipodi:nodetypes="cccc" />
   <path
-     style="fill:none;stroke:#f1f3f5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 5.5,9.5000002 h 2 L 5.5,12.5 h 2"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.5,9.5000007 H 7.4999996 L 5.5,12.5 h 1.9999996"
      id="path948-2-0-9"
      sodipodi:nodetypes="cccc" />
   <path
      sodipodi:nodetypes="cccc"
      id="path867"
-     d="m 9,6 h 3 l -3,4 h 3"
-     style="opacity:0.4;fill:none;stroke:#141f2b;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     d="M 8.9999996,6 H 12 L 8.9999996,9.9999997 H 12"
+     style="opacity:1;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34901962" />
   <path
      sodipodi:nodetypes="cccc"
      id="path948-2-0-9-2"
-     d="m 9,5.5 h 3 l -3,4 h 3"
-     style="fill:none;stroke:#f1f3f5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     d="M 8.9999996,5.5 H 12 L 8.9999996,9.4999997 H 12"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/24/system-switch-user.svg
+++ b/elementary-xfce/actions/24/system-switch-user.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    id="svg4031"
    height="24"
    width="24"
    version="1.1"
-   sodipodi:docname="xfsm-switch-user.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   sodipodi:docname="system-switch-user.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,20 +23,35 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1319"
-     inkscape:window-height="980"
+     inkscape:window-width="1288"
+     inkscape:window-height="915"
      id="namedview31"
      showgrid="false"
-     inkscape:zoom="22.627417"
-     inkscape:cx="7.0237807"
-     inkscape:cy="9.8601411"
-     inkscape:window-x="5"
-     inkscape:window-y="48"
+     inkscape:zoom="32"
+     inkscape:cx="12.375"
+     inkscape:cy="16.75"
+     inkscape:window-x="1150"
+     inkscape:window-y="187"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg4031"
-     inkscape:document-rotation="0" />
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4033">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient930">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
+    </linearGradient>
     <linearGradient
        id="linearGradient4011-8">
       <stop
@@ -61,49 +76,10 @@
        x2="71.204407"
        y1="6.2375584"
        x1="71.204407"
-       gradientTransform="matrix(0.51351362,0,0,0.51351351,-24.83614,-1.0212859)"
+       gradientTransform="matrix(0.51351362,0,0,0.51351351,-24.83614,-1.0212855)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3540"
        xlink:href="#linearGradient4011-8" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.2758633,-3.465473,-9.2088427e-8,41.282497,-11.162349)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient3300-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
@@ -115,55 +91,46 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient4192-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
     <linearGradient
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-22.965879,-31.073181)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.9666989"
+       x2="10.860361"
+       y2="20.846098"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3540-3"
-       xlink:href="#linearGradient4011-8" />
+       gradientTransform="matrix(1.05,0,0,1.05,-0.6,-0.59999975)" />
     <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092-5"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,6.7155205,-7.1042197,-1.8878129e-7,112.67424,-51.8281)" />
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient3300-8-2"
-       gradientUnits="userSpaceOnUse"
+       r="62.769119"
+       fy="185.29727"
+       fx="99.189415"
+       cy="185.29727"
+       cx="99.189415"
        gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
-       fy="185.29727"
-       r="62.769119" />
-    <radialGradient
-       xlink:href="#linearGradient3820-7-2"
-       id="radialGradient4192-6-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       cx="99.189415"
-       cy="185.29727"
-       fx="99.189415"
+       id="radialGradient3300-8-3"
+       xlink:href="#linearGradient3820-7-2" />
+    <radialGradient
+       r="62.769119"
        fy="185.29727"
-       r="62.769119" />
+       fx="99.189415"
+       cy="185.29727"
+       cx="99.189415"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4192-6-6"
+       xlink:href="#linearGradient3820-7-2" />
+    <radialGradient
+       gradientTransform="matrix(0.94117648,0,0,0.2823525,-46.941177,19.694118)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3120"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
   </defs>
   <metadata
      id="metadata4036">
@@ -173,43 +140,66 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     d="m 22,21 c 0,1.656854 -4.477153,3 -10,3 -5.5228476,0 -10,-1.343146 -10,-3 0,-1.656854 4.4771524,-3 10,-3 5.522847,0 10,1.343146 10,3 z"
+     id="path8836-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3120);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none" />
   <g
-     id="g4198-4"
-     transform="matrix(0.34552845,0,0,0.35298856,0.9430878,0.52694603)"
-     style="stroke-width:2.86337">
+     style="stroke-width:2.88033"
+     transform="matrix(0.375,0,0,0.32142723,5.8125e-7,2.4280685)"
+     id="g4198-4">
     <path
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
+       style="opacity:0.2;fill:url(#radialGradient3300-8-3);fill-opacity:1;stroke:none;stroke-width:2.88033"
        id="path3818-0-6"
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:2.86337" />
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
     <path
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:2.86337"
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
        id="path4190-2"
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
+       style="opacity:0.4;fill:url(#radialGradient4192-6-6);fill-opacity:1;stroke:none;stroke-width:2.88033" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555-3"
-     d="M 12.000001,2 C 6.4823463,2 2,6.4823439 2,11.999999 2,17.517656 6.4823463,22.000001 12.000001,22 17.517655,22 22.000005,17.517656 22,11.999999 22,6.4823439 17.517655,2 12.000001,2 Z" />
+     d="M 12.000001,1.5000002 C 6.2064636,1.5000002 1.5,6.2064613 1.5,11.999999 1.5,17.793539 6.2064636,22.500001 12.000001,22.5 17.793538,22.5 22.500005,17.793539 22.5,11.999999 22.5,6.2064613 17.793538,1.5000002 12.000001,1.5000002 Z" />
+  <path
+     id="path22840"
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;stop-color:#000000"
+     d="m 9.2265511,13.750327 c 0.4311623,0 0.7741829,-0.334646 0.7741829,-0.750328 v -1.999673 h 2.220947 c 0.431165,0 0.778272,-0.334645 0.778272,-0.750327 V 8.7503272 c 0,-0.4156822 -0.347107,-0.7507382 -0.778272,-0.7503282 H 10.000734 V 6.000326 C 10.000734,5.584646 9.6577134,5.25 9.2265511,5.25 8.9941711,5.25 8.7867328,5.34736 8.6443663,5.502062 L 4.9628095,8.9859412 C 4.8312165,9.1203202 4.75,9.3009342 4.75,9.5003262 c 0,0.199393 0.08121,0.380005 0.2128095,0.5143848 l 3.6815568,3.483553 c 0.1423665,0.154709 0.3498048,0.252063 0.5821848,0.252063 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
-     d="m 21.500003,11.999663 c 0,5.246875 -4.253609,9.500337 -9.499882,9.500337 -5.2467542,0 -9.5001236,-4.253511 -9.5001236,-9.500337 0,-5.246632 4.2533694,-9.4996635 9.5001236,-9.4996635 5.246273,0 9.499882,4.2530315 9.499882,9.4996635 z" />
+     d="m 21.500003,11.999663 c 0,5.246875 -4.253609,9.500337 -9.499882,9.500337 -5.2467544,0 -9.5001238,-4.253511 -9.5001238,-9.500337 0,-5.2466316 4.2533694,-9.4996631 9.5001238,-9.4996631 5.246273,0 9.499882,4.2530314 9.499882,9.4996631 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#223544;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="path22842"
+     style="font-variation-settings:normal;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15000001;marker:none;stop-color:#000000"
+     d="m 14.773806,18.750327 c -0.431162,0 -0.774183,-0.334646 -0.774183,-0.750328 v -1.999673 h -2.220946 c -0.431165,0 -0.778272,-0.334645 -0.778272,-0.750327 v -1.499672 c 0,-0.415682 0.347107,-0.750738 0.778272,-0.750328 h 2.220946 v -1.999673 c 0,-0.41568 0.343021,-0.750326 0.774183,-0.750326 0.23238,0 0.439819,0.09736 0.582186,0.252062 l 3.681556,3.483879 c 0.131594,0.134379 0.212809,0.314993 0.212809,0.514385 0,0.199393 -0.08121,0.380005 -0.212809,0.514385 l -3.681556,3.483553 c -0.142367,0.154709 -0.349805,0.252063 -0.582186,0.252063 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
-     d="M 12.000001,2 C 6.4823463,2 2,6.4823444 2,12.000001 c 0,5.517655 4.4823463,10.000001 10.000001,10 5.517653,0 10.000004,-4.482345 9.999999,-10 C 22,6.4823444 17.517654,2 12.000001,2 Z" />
+     d="M 12.000001,1.4999997 C 6.2064636,1.4999997 1.5,6.2064613 1.5,12 1.5,17.793538 6.2064636,22.500001 12.000001,22.5 17.793537,22.5 22.500005,17.793538 22.5,12 22.5,6.2064613 17.793537,1.4999997 12.000001,1.4999997 Z" />
   <path
-     d="M 9,6.5 V 9 h 4 v 3 H 9 v 2.5 l -4.5,-4 z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path873-5-3"
-     sodipodi:nodetypes="cccccccc" />
+     id="path7227"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.5;stroke:none;stroke-width:0.999965;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 9.2265511,14.750327 c 0.4311623,0 0.7741829,-0.334646 0.7741829,-0.750328 v -1.999673 h 2.220947 c 0.431165,0 0.778272,-0.334645 0.778272,-0.750327 V 9.7503272 c 0,-0.415682 -0.347107,-0.750738 -0.778272,-0.750328 H 10.000734 V 7.000326 C 10.000734,6.584646 9.6577134,6.25 9.2265511,6.25 8.9941711,6.25 8.7867328,6.34736 8.6443663,6.502062 L 4.9628095,9.9859412 C 4.8312165,10.12032 4.75,10.300934 4.75,10.500326 c 0,0.199393 0.08121,0.380005 0.2128095,0.514385 l 3.6815568,3.483553 c 0.1423665,0.154709 0.3498048,0.252063 0.5821848,0.252063 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="M 15,10.5 V 13 h -4 v 3 h 4 v 2.5 l 4.5,-4 z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path867"
-     sodipodi:nodetypes="cccccccc" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999965;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 9.2265511,13.750327 c 0.4311623,0 0.7741829,-0.334646 0.7741829,-0.750328 v -1.999673 h 2.220947 c 0.431165,0 0.778272,-0.334645 0.778272,-0.750327 V 8.7503272 c 0,-0.4156822 -0.347107,-0.7507382 -0.778272,-0.7503282 H 10.000734 V 6.000326 C 10.000734,5.584646 9.6577134,5.25 9.2265511,5.25 8.9941711,5.25 8.7867328,5.34736 8.6443663,5.502062 L 4.9628095,8.9859412 C 4.8312165,9.1203202 4.75,9.3009342 4.75,9.5003262 c 0,0.199393 0.08121,0.380005 0.2128095,0.5143848 l 3.6815568,3.483553 c 0.1423665,0.154709 0.3498048,0.252063 0.5821848,0.252063 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path7229"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.5;stroke:none;stroke-width:0.999965;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 14.773806,19.750327 c -0.431162,0 -0.774183,-0.334646 -0.774183,-0.750328 v -1.999673 h -2.220946 c -0.431165,0 -0.778272,-0.334645 -0.778272,-0.750327 v -1.499672 c 0,-0.415682 0.347107,-0.750738 0.778272,-0.750328 h 2.220946 v -1.999673 c 0,-0.41568 0.343021,-0.750326 0.774183,-0.750326 0.23238,0 0.439819,0.09736 0.582186,0.252062 l 3.681556,3.483879 c 0.131594,0.134379 0.212809,0.314993 0.212809,0.514385 0,0.199393 -0.08121,0.380005 -0.212809,0.514385 l -3.681556,3.483553 c -0.142367,0.154709 -0.349805,0.252063 -0.582186,0.252063 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path6499"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999965;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 14.773806,18.750327 c -0.431162,0 -0.774183,-0.334646 -0.774183,-0.750328 v -1.999673 h -2.220946 c -0.431165,0 -0.778272,-0.334645 -0.778272,-0.750327 v -1.499672 c 0,-0.415682 0.347107,-0.750738 0.778272,-0.750328 h 2.220946 v -1.999673 c 0,-0.41568 0.343021,-0.750326 0.774183,-0.750326 0.23238,0 0.439819,0.09736 0.582186,0.252062 l 3.681556,3.483879 c 0.131594,0.134379 0.212809,0.314993 0.212809,0.514385 0,0.199393 -0.08121,0.380005 -0.212809,0.514385 l -3.681556,3.483553 c -0.142367,0.154709 -0.349805,0.252063 -0.582186,0.252063 z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/elementary-xfce/actions/32/system-lock-screen.svg
+++ b/elementary-xfce/actions/32/system-lock-screen.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="32"
    height="32"
    id="svg4248"
    sodipodi:docname="system-lock-screen.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,18 +23,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-width="1474"
+     inkscape:window-height="890"
      id="namedview29"
      showgrid="false"
      inkscape:zoom="17.52299"
-     inkscape:cx="22.120215"
-     inkscape:cy="8.6527792"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:cx="8.7028527"
+     inkscape:cy="22.342077"
+     inkscape:window-x="444"
+     inkscape:window-y="120"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg4248"
-     inkscape:document-rotation="0" />
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4250">
     <linearGradient
@@ -57,25 +60,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.7500023,-5.0249359,-1.3352823e-7,58.459621,-17.585409)" />
-    <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
          id="stop3822-2-6-36"
@@ -90,64 +74,6 @@
          style="stop-color:#686868;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
-         style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092-3"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.7500018,-5.0249358,-1.3352822e-7,58.459625,-17.585406)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        y2="44.340794"
        x2="71.204407"
@@ -157,6 +83,38 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient3540"
        xlink:href="#linearGradient4011-4" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.9666989"
+       x2="10.860361"
+       y2="20.846098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.45,0,0,1.45,-1.3999995,-1.4000002)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient930">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.17524541,0,0,0.05574586,-1.376811,18.121549)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
   </defs>
   <metadata
      id="metadata4253">
@@ -166,24 +124,23 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="m 27,28.499785 a 11,3.4991173 0 1 1 -21.9999996,0 11,3.4991173 0 1 1 21.9999996,0 z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
      id="path2555-3"
-     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.9993987 1.5,15.999997 1.5,24.0006 7.999402,30.500001 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.9993987 24.0006,1.5 16.000002,1.5 Z" />
+     d="m 16.000001,1.4999999 c -8.0005983,0 -14.5000008,6.4993986 -14.5000008,14.4999981 0,8.000603 6.4994025,14.500003 14.5000008,14.500002 C 24.000599,30.5 30.500008,24.000601 30.5,15.999998 30.5,7.9993985 24.000599,1.4999999 16.000001,1.4999999 Z" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
      d="m 29.500001,15.999517 c 0,7.456083 -6.044601,13.500475 -13.499829,13.500475 -7.4559114,0 -13.500173,-6.04446 -13.500173,-13.500475 0,-7.4557374 6.0442616,-13.4995175 13.500173,-13.4995175 7.455228,0 13.499829,6.0437801 13.499829,13.4995175 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#223544;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
      d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.9993994 1.5,16.000001 c 0,8.000599 6.499402,14.500002 14.500002,14.5 8.000597,0 14.500006,-6.499401 14.499998,-14.5 C 30.5,7.9993994 24.000599,1.5 16.000002,1.5 Z" />
   <path
@@ -192,8 +149,7 @@
      id="path873"
      sodipodi:nodetypes="ssccssssccsssccssccc" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 15,8 c -1.662,0 -3,1.3676425 -3,3.016972 V 15 h 1.999985 v -3.650498 c 0,-0.738137 0.593893,-1.349003 1.332031,-1.349003 h 1.335968 c 0.738138,0 1.332032,0.610866 1.332032,1.349003 V 15 H 20 V 11.016972 C 20,9.3549716 18.661999,8 17,8 Z m -5,7 v 7 c 0,0.554 0.446,1 1,1 h 10 c 0.553999,0 1,-0.446 1,-1 v -7 z"
      id="rect4382-7"
-     sodipodi:nodetypes="ssccssssccsssccssccc" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 15 8 C 13.338002 8 12 9.3682503 12 11.017578 L 12 15 L 11 15 C 10.446001 15 10 15.446001 10 16 L 10 22 C 10 22.553999 10.446001 23 11 23 L 21 23 C 21.553999 23 22 22.553999 22 22 L 22 16 C 22 15.446001 21.553999 15 21 15 L 20 15 L 20 11.017578 C 20 9.3555794 18.661997 8 17 8 L 15 8 z M 15.332031 10 L 16.667969 10 C 17.406106 10 18 10.611473 18 11.349609 L 18 15 L 14 15 L 14 11.349609 C 14 10.611473 14.593894 10 15.332031 10 z " />
 </svg>

--- a/elementary-xfce/actions/32/system-log-out.svg
+++ b/elementary-xfce/actions/32/system-log-out.svg
@@ -1,138 +1,154 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
+   version="1.2"
    width="32"
    height="32"
-   id="svg4248">
+   id="svg2"
+   sodipodi:docname="system-log-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1273"
+     inkscape:window-height="871"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="23.363986"
+     inkscape:cx="9.1807965"
+     inkscape:cy="13.610691"
+     inkscape:window-x="377"
+     inkscape:window-y="101"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs4">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011">
       <stop
-         id="stop4013-8"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-5"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017-6"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
-         id="stop4019-1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
+       gradientTransform="matrix(0,0.70731705,-0.70731705,0,32.975609,-0.97560825)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="43.523811"
+       y1="23.999998"
+       x1="4.6204333"
+       id="linearGradient887"
+       xlink:href="#linearGradient885" />
+    <linearGradient
+       id="linearGradient885">
+      <stop
+         id="stop881"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
+      <stop
+         id="stop883"
+         offset="1"
+         style="stop-color:#f37329;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72972976,0,0,0.72972962,-36.34608,-2.5039287)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4011"
+       id="linearGradient3019"
        y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)" />
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
     <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8"
+       gradientTransform="matrix(0.17524541,0,0,0.05574929,-1.3768111,18.121125)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.7500023,-5.0249359,-1.3352823e-7,58.459621,-17.585409)" />
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
     <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
-         id="stop3822-2-6-36"
+         offset="0"
          style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
+         id="stop3822-2-6-36" />
       <stop
-         id="stop3864-8-7-6"
+         offset="0.5"
          style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
+         id="stop3864-8-7-6" />
       <stop
-         id="stop3824-1-2-4"
+         offset="1"
          style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9"
-         style="stop-color:#ffcd7d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0"
-         style="stop-color:#fc8f36;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1"
-         style="stop-color:#e23a0e;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6"
-         style="stop-color:#ac441f;stop-opacity:1"
-         offset="1" />
+         id="stop3824-1-2-4" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="M 27,28.5 A 11,3.4993327 0 1 1 5.0000004,28.5 11,3.4993327 0 1 1 27,28.5 Z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     d="M 16.000002,1.4999989 C 7.9994024,1.4999989 1.5,7.9993978 1.5,15.999998 1.5,24.0006 7.9994024,30.500002 16.000002,30.5 24.000599,30.5 30.500007,24.0006 30.5,15.999998 30.5,7.9993978 24.000599,1.4999989 16.000002,1.4999989 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate"
      id="path2555"
-     style="color:#000000;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 30.5,16.000002 C 30.5,7.9994035 24.000602,1.5000008 16,1.5000008 c -8.0005982,0 -14.5000025,6.4994027 -14.4999996,14.5000012 0,8.000596 6.4994014,14.500005 14.4999996,14.499997 8.000602,0 14.5,-6.499401 14.5,-14.499997 z" />
   <path
-     d="M 16.000002,1.4999989 C 7.999402,1.4999989 1.5,7.9993981 1.5,15.999999 1.5,24.000599 7.999402,30.500002 16.000002,30.5 24.000598,30.5 30.500008,24.000599 30.5,15.999999 30.5,7.9993981 24.000598,1.4999989 16.000002,1.4999989 z"
-     id="path2555-6"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#640000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="m 29.5,15.999521 c 0,7.456085 -6.044601,13.500478 -13.499829,13.500478 C 8.54426,29.499999 2.5,23.455537 2.5,15.999521 2.5,8.5437808 8.54426,2.5000002 16.000171,2.5000002 23.455399,2.5000002 29.5,8.5437808 29.5,15.999521 l 0,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 29.500001,15.999521 c 0,7.456084 -6.044602,13.500477 -13.499831,13.500477 -7.4559094,0 -13.5001709,-6.044462 -13.5001709,-13.500477 0,-7.4557386 6.0442615,-13.4995188 13.5001709,-13.4995188 7.455229,0 13.499831,6.0437802 13.499831,13.4995188 z" />
   <path
-     d="m 14.874652,9.03125 a 0.97549411,0.97549411 0 0 0 -0.53125,0.25 L 6.3434021,16.3125 a 0.97549411,0.97549411 0 0 0 0,1.46875 L 14.343402,24.75 a 0.97549411,0.97549411 0 0 0 1.625,-0.75 l 0,-4.03125 8.03125,0 A 0.97549411,0.97549411 0 0 0 24.968402,19 l 0,-3.9375 a 0.97549411,0.97549411 0 0 0 -0.96875,-0.96875 l -8.03125,0 0,-4.09375 a 0.97549411,0.97549411 0 0 0 -1.09375,-0.96875 z"
-     id="path4026"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#ae2109;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6"
+     d="m 16.000002,1.4999993 c -8.000599,0 -14.5000018,6.4993997 -14.5000018,14.4999967 0,8.000604 6.4994028,14.500005 14.5000018,14.500005 C 24.0006,30.500001 30.500007,24.0006 30.5,15.999996 30.5,7.999399 24.0006,1.4999993 16.000002,1.4999993 Z" />
   <path
-     d="M 14.978402,10 6.9784021,17.027124 14.978402,24 l 0,-5 9,0 0,-3.927874 -9,0 z"
-     id="path4348-5"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ae2109;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     id="path114055"
+     style="font-variation-settings:normal;fill:#7a0000;fill-opacity:0.5;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 14.962259,23.75 c 0.574957,0 1.037829,-0.451772 1.037829,-1.012942 V 19.000472 H 22.96217 C 23.537129,19.000472 24,18.548699 24,17.987528 V 16.012471 C 24,15.4513 23.537129,14.998975 22.96217,14.999529 H 16.000088 V 11.26294 c 0,-0.561168 -0.462872,-1.01294 -1.037829,-1.01294 -0.30988,0 -0.5865,0.131436 -0.776347,0.340284 L 8.2837828,16.292393 C 8.108303,16.473805 8,16.717635 8,16.986813 c 0,0.26918 0.1082929,0.513008 0.2837828,0.69442 l 5.9021292,5.728482 C 14.375759,23.618574 14.652379,23.75 14.962259,23.75 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="M 14.978402,9 6.9784021,16.027124 14.978402,23 l 0,-5 9,0 0,-3.927874 -9,0 z"
-     id="path4348"
-     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999952;marker:none" />
+     id="path873-5"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000"
+     d="m 14.962259,22.75 c 0.574957,0 1.037829,-0.451772 1.037829,-1.012942 V 18.000472 H 22.96217 C 23.537129,18.000472 24,17.548699 24,16.987528 V 15.012471 C 24,14.4513 23.537129,13.998975 22.96217,13.999529 H 16.000088 V 10.26294 c 0,-0.5611677 -0.462872,-1.01294 -1.037829,-1.01294 -0.30988,0 -0.5865,0.1314358 -0.776347,0.3402838 L 8.2837828,15.292393 C 8.108303,15.473805 8,15.717635 8,15.986813 c 0,0.26918 0.1082929,0.513008 0.2837828,0.69442 l 5.9021292,5.728482 C 14.375759,22.618574 14.652379,22.75 14.962259,22.75 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/elementary-xfce/actions/32/system-reboot.svg
+++ b/elementary-xfce/actions/32/system-reboot.svg
@@ -1,138 +1,166 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
+   version="1.2"
    width="32"
    height="32"
-   id="svg4248">
+   id="svg2"
+   sodipodi:docname="system-reboot.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview27"
+     showgrid="false"
+     inkscape:zoom="23.363986"
+     inkscape:cx="13.910298"
+     inkscape:cy="21.48606"
+     inkscape:window-x="703"
+     inkscape:window-y="16"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs4">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011">
       <stop
-         id="stop4013-8"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-5"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017-6"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
-         id="stop4019-1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
+       gradientTransform="matrix(0,0.70731705,-0.70731705,0,32.97561,-0.97560876)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887"
+       xlink:href="#linearGradient947-5" />
+    <linearGradient
+       gradientTransform="matrix(0.72972979,0,0,0.72972965,-36.346081,-2.5039294)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4011"
+       id="linearGradient3019"
        y2="44.340794"
-       id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)" />
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
+    <linearGradient
+       id="linearGradient947-5">
+      <stop
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1"
+         id="stop943-6" />
+      <stop
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop945-2" />
+    </linearGradient>
     <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8"
+       gradientTransform="matrix(0.17524541,0,0,0.05574929,-1.376811,18.121125)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02218834,3.1295839,-2.7046658,0.0191757,38.832459,-16.183171)" />
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
     <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-3-8">
-      <stop
          offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop3750-8-9" />
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
       <stop
-         offset="0.26238"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop3752-3-2" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop3754-7-2" />
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
       <stop
          offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop3756-9-3" />
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="M 27,28.5 A 11,3.4993327 0 1 1 5.0000004,28.5 11,3.4993327 0 1 1 27,28.5 Z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     d="M 16.000002,1.4999989 C 7.9994024,1.4999989 1.5,7.9993978 1.5,15.999998 1.5,24.0006 7.9994024,30.500002 16.000002,30.5 24.000599,30.5 30.500007,24.0006 30.5,15.999998 30.5,7.9993978 24.000599,1.4999989 16.000002,1.4999989 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
      id="path2555"
-     style="color:#000000;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="M 30.5,16.000003 C 30.5,7.9994029 24.000602,1.5000002 16,1.5000002 7.9994016,1.5000002 1.4999973,7.9994029 1.5000002,16.000003 1.5000002,24.000599 7.9994016,30.500007 16,30.5 c 8.000602,0 14.5,-6.499401 14.5,-14.499997 z" />
   <path
-     d="M 16.000002,1.4999989 C 7.999402,1.4999989 1.5,7.9993981 1.5,15.999999 1.5,24.000599 7.999402,30.500002 16.000002,30.5 24.000598,30.5 30.500008,24.000599 30.5,15.999999 30.5,7.9993981 24.000598,1.4999989 16.000002,1.4999989 z"
-     id="path2555-6"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#062351;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     d="m 29.5,15.999521 c 0,7.456085 -6.044601,13.500478 -13.499829,13.500478 C 8.54426,29.499999 2.5,23.455537 2.5,15.999521 2.5,8.5437808 8.54426,2.5000002 16.000171,2.5000002 23.455399,2.5000002 29.5,8.5437808 29.5,15.999521 l 0,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 29.500001,15.99952 c 0,7.456085 -6.044601,13.500478 -13.499831,13.500478 -7.4559097,0 -13.500171,-6.044462 -13.500171,-13.500478 0,-7.455738 6.0442613,-13.4995182 13.500171,-13.4995182 7.45523,0 13.499831,6.0437802 13.499831,13.4995182 z" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#105bc4;fill-opacity:1;fill-rule:nonzero;stroke:#105bc4;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-     d="m 16,8.4999993 0,2.4285707 c -4.023791,0 -7.285714,3.261926 -7.285714,7.285716 C 8.714286,22.238077 11.976209,25.5 16,25.5 c 4.02379,0 7.285714,-3.261923 7.285714,-7.285714 l -2.428571,0 c 0,2.682527 -2.174616,4.857143 -4.857143,4.857143 -2.682527,0 -4.857143,-2.174616 -4.857143,-4.857143 0,-2.682527 2.174616,-4.857143 4.857143,-4.857143 l 0,2.428572 6.071428,-3.642857 L 16,8.4999993 Z"
-     id="path4533" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6"
+     d="M 16.000002,1.5 C 7.9994036,1.5 1.5000001,7.9993989 1.5000001,15.999997 1.5000001,24.0006 7.9994036,30.5 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.9993989 24.0006,1.5 16.000002,1.5 Z" />
   <path
-     id="path4531"
-     d="M 16,7.4999993 16,9.92857 c -4.023791,0 -7.285714,3.261926 -7.285714,7.285716 C 8.714286,21.238077 11.976209,24.5 16,24.5 c 4.02379,0 7.285714,-3.261923 7.285714,-7.285714 l -2.428571,0 c 0,2.682527 -2.174616,4.857143 -4.857143,4.857143 -2.682527,0 -4.857143,-2.174616 -4.857143,-4.857143 0,-2.682527 2.174616,-4.857143 4.857143,-4.857143 l 0,2.428572 6.071428,-3.642857 L 16,7.4999993 Z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#105bc4;fill-opacity:1;fill-rule:nonzero;stroke:#105bc4;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     id="path106791"
+     style="font-variation-settings:normal;vector-effect:none;fill:#002e99;fill-opacity:0.501961;stroke:none;stroke-width:0.659997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 17.777343,7.25 c -0.430901,0 -0.777344,0.285344 -0.777344,0.638672 v 2.166016 c -0.09122,-0.01006 -0.182118,-0.02429 -0.273438,-0.03125 -2.434726,-0.185643 -4.880409,0.722864 -6.59375,2.564453 -2.2844548,2.45545 -2.785914,6.078059 -1.2480466,9.050781 1.5378676,2.972722 4.7834956,4.686179 8.1308596,4.310547 3.347364,-0.375634 6.124943,-2.76906 6.945313,-6.009766 a 1.25,1.25 0 0 0 -0.904297,-1.517578 1.25,1.25 0 0 0 -1.517579,0.904297 c -0.563023,2.224115 -2.468508,3.876731 -4.802734,4.138672 -2.334225,0.26194 -4.574604,-0.929077 -5.632812,-2.97461 -1.058208,-2.045532 -0.719431,-4.502237 0.859375,-6.199218 1.292859,-1.389634 3.195765,-2.013157 5.037109,-1.71875 v 2.539062 c 0,0.353329 0.346443,0.638672 0.777344,0.638672 0.232238,0 0.439741,-0.08334 0.582031,-0.214844 l 4.427734,-3.605468 c 0.131521,-0.114223 0.212891,-0.268018 0.212891,-0.4375 0,-0.169484 -0.08137,-0.323279 -0.212891,-0.4375 L 18.359374,7.464844 C 18.217094,7.333353 18.009581,7.25 17.777343,7.25 Z" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     d="m 16,6.4999993 0,2.4285709 c -4.023791,0 -7.285714,3.2619258 -7.285714,7.2857158 C 8.714286,20.238077 11.976209,23.5 16,23.5 c 4.02379,0 7.285714,-3.261923 7.285714,-7.285714 l -2.428571,0 c 0,2.682527 -2.174616,4.857143 -4.857143,4.857143 -2.682527,0 -4.857143,-2.174616 -4.857143,-4.857143 0,-2.682527 2.174616,-4.857143 4.857143,-4.857143 l 0,2.428572 6.071428,-3.642857 L 16,6.4999993 Z"
-     id="path2984" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.659997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 17.777796,14.75 c -0.430901,0 -0.777797,-0.284449 -0.777797,-0.637778 V 6.887777 c 0,-0.353327 0.346896,-0.637777 0.777797,-0.637777 0.232238,0 0.439549,0.08276 0.581829,0.214253 l 4.427693,3.590478 c 0.13152,0.114222 0.212681,0.267483 0.212681,0.436967 0,0.169483 -0.08116,0.323004 -0.212681,0.437227 l -4.427693,3.606822 C 18.217335,14.66725 18.010034,14.75 17.777796,14.75 Z"
+     sodipodi:nodetypes="sccsccsccs" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     id="path54251"
+     sodipodi:type="arc"
+     sodipodi:cx="16.100351"
+     sodipodi:cy="16.999893"
+     sodipodi:rx="6.8532171"
+     sodipodi:ry="6.7498751"
+     sodipodi:start="0.2443461"
+     sodipodi:end="5.0963614"
+     sodipodi:arc-type="arc"
+     d="M 22.749999,18.632836 A 6.8532171,6.7498751 0 0 1 16.876158,23.706379 6.8532171,6.7498751 0 0 1 9.9940902,20.064272 6.8532171,6.7498751 0 0 1 11.04763,12.439744 6.8532171,6.7498751 0 0 1 18.667612,10.741518"
+     sodipodi:open="true" />
 </svg>

--- a/elementary-xfce/actions/32/system-shutdown.svg
+++ b/elementary-xfce/actions/32/system-shutdown.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
    width="32"
    height="32"
-   id="svg4248"
+   id="svg3041"
    sodipodi:docname="system-shutdown.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,35 +23,49 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview53"
+     inkscape:window-width="1488"
+     inkscape:window-height="754"
+     id="namedview35"
      showgrid="false"
-     inkscape:zoom="12.390625"
-     inkscape:cx="6.9393542"
-     inkscape:cy="11.954728"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4248" />
+     inkscape:zoom="16.520833"
+     inkscape:cx="15.8285"
+     inkscape:cy="12.862548"
+     inkscape:window-x="430"
+     inkscape:window-y="75"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3041"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs3043">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient26009">
       <stop
-         id="stop4013-8"
+         id="stop26005"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop26007"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-5"
+         id="stop4015"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017-6"
+         id="stop4017"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
-         id="stop4019-1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
@@ -61,236 +75,97 @@
        x2="71.204407"
        y2="44.340794"
        id="linearGradient3089"
-       xlink:href="#linearGradient4011-4"
+       xlink:href="#linearGradient4011"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972969,0,0,0.72972969,-36.346075,-2.5039314)" />
+       gradientTransform="matrix(0.72972973,0,0,0.72972972,-36.346078,-2.5039311)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
+       gradientUnits="userSpaceOnUse"
+       x1="12.000114"
+       y1="10.420464"
+       x2="12.000114"
+       y2="51.432529"
+       gradientTransform="matrix(1.3811871,0,0,1.3811871,-0.57424614,-11.623744)" />
     <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092"
-       xlink:href="#linearGradient885"
+       gradientTransform="matrix(0.17524541,0,0,0.05575071,-1.3768112,18.1211)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02218834,3.1295839,-2.7046658,0.0191757,38.832459,-16.183171)" />
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
     <linearGradient
        id="linearGradient3820-7-2-2">
       <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="rotate(90,36.267338,26.713746)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999998"
-       x2="44.5"
-       y1="23.999998"
-       x1="3.4999995"
-       id="linearGradient887"
-       xlink:href="#linearGradient885" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
          offset="0"
-         style="stop-color:#ef6555;stop-opacity:1" />
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
       <stop
-         id="stop883"
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
+      <stop
          offset="1"
-         style="stop-color:#c6272e;stop-opacity:1" />
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient885"
-       id="linearGradient895"
-       x1="16.000002"
-       y1="1.4999989"
-       x2="16.000002"
-       y2="29.896309"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata3046">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="m 27,28.500239 a 11,3.4994221 0 1 1 -21.9999998,0 11,3.4994221 0 1 1 21.9999998,0 z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:0.999997" />
   <path
-     d="M 16.000002,1.4999989 C 7.9994024,1.4999989 1.5,7.9993978 1.5,15.999998 1.5,24.0006 7.9994024,30.500002 16.000002,30.5 24.000599,30.5 30.500007,24.0006 30.5,15.999998 30.5,7.9993978 24.000599,1.4999989 16.000002,1.4999989 z"
+     d="m 16.000001,1.4999998 c -8.000599,0 -14.5000011,6.4993994 -14.5000011,14.4999982 0,8.0006 6.4994021,14.500006 14.5000011,14.500002 C 24.000599,30.5 30.500008,24.000598 30.5,15.999998 30.5,7.9993992 24.000599,1.4999998 16.000001,1.4999998 Z"
      id="path2555"
-     style="color:#000000;fill:url(#linearGradient895);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="M 16.000002,1.4999989 C 7.999402,1.4999989 1.5,7.9993981 1.5,15.999999 1.5,24.000599 7.999402,30.500002 16.000002,30.5 24.000598,30.5 30.500008,24.000599 30.5,15.999999 30.5,7.9993981 24.000598,1.4999989 16.000002,1.4999989 z"
+     d="M 16.000001,1.4999982 C 7.9994022,1.4999982 1.4999999,7.9993988 1.4999999,16 c 0,8.000601 6.4994023,14.500004 14.5000011,14.500002 C 24.000597,30.500002 30.500008,24.000601 30.5,16 30.5,7.9993988 24.000597,1.4999982 16.000001,1.4999982 Z"
      id="path2555-6"
-     style="opacity:0.4;color:#000000;fill:none;stroke:#510606;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7a0000;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
   <path
-     d="m 29.5,15.999521 c 0,7.456085 -6.044601,13.500478 -13.499829,13.500478 C 8.54426,29.499999 2.5,23.455537 2.5,15.999521 2.5,8.5437808 8.54426,2.5000002 16.000171,2.5000002 23.455399,2.5000002 29.5,8.5437808 29.5,15.999521 l 0,0 z"
+     d="M 29.5,15.999521 C 29.5,23.455607 23.455399,29.5 16.000172,29.5 8.5442605,29.5 2.5000002,23.455537 2.5000002,15.999521 2.5000002,8.5437804 8.5442605,2.5000003 16.000172,2.5000003 23.4554,2.5000003 29.5,8.5437804 29.5,15.999521 Z"
      id="path8655"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <g
-     id="g4659"
-     transform="matrix(1.3076923,0,0,1.3076923,5.5384616,7.6923078)"
-     style="opacity:0.15;fill:#910909;fill-opacity:1">
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       label="status"
-       id="g4661" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       id="g4663" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       id="g4665" />
-    <g
-       transform="translate(-333.0004,-28)"
-       id="g4667"
-       style="fill:#910909;fill-opacity:1" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       id="g4669" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       id="g4671" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       id="g4673">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#910909;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         id="path4675"
-         d="m 341.0004,29 c -0.554,0 -1,0.446 -1,1 l 0,4 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 l 0,-4 c 0,-0.554 -0.446,-1 -1,-1 z m -3,2 c -0.23384,0 -0.45573,0.084 -0.625,0.21875 -0.16288,0.13731 -0.21487,0.18641 -0.28125,0.25 -1.27878,1.0966 -2.09375,2.71205 -2.09375,4.53125 0,3.31371 2.68629,6 6,6 3.31371,0 6,-2.68629 6,-6 0,-1.8192 -0.81497,-3.43465 -2.09375,-4.53125 -0.0664,-0.0636 -0.11837,-0.11269 -0.28125,-0.25 C 344.45613,31.08404 344.23424,31 344.0004,31 c -0.55229,0 -1,0.44772 -1,1 0,0.31104 0.14829,0.57085 0.375,0.75 0.0403,0.0378 0.0534,0.0594 0.125,0.125 0.9241,0.72905 1.5,1.85348 1.5,3.125 0,2.20914 -1.79086,4 -4,4 -2.20914,0 -4,-1.79086 -4,-4 0,-1.27152 0.5759,-2.39595 1.5,-3.125 0.0716,-0.0656 0.0847,-0.0872 0.125,-0.125 0.22671,-0.17915 0.375,-0.43896 0.375,-0.75 0,-0.55228 -0.44772,-1 -1,-1 z" />
-    </g>
-  </g>
-  <g
-     style="opacity:0.3;fill:#910909;fill-opacity:1"
-     transform="matrix(1.3076923,0,0,1.3076923,5.5384616,6.6923078)"
-     id="g4641">
-    <g
-       id="g4643"
-       label="status"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       transform="translate(-333.0004,-28)" />
-    <g
-       id="g4645"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       transform="translate(-333.0004,-28)" />
-    <g
-       id="g4647"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       transform="translate(-333.0004,-28)" />
-    <g
-       style="fill:#910909;fill-opacity:1"
-       id="g4649"
-       transform="translate(-333.0004,-28)" />
-    <g
-       id="g4651"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       transform="translate(-333.0004,-28)" />
-    <g
-       id="g4653"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       transform="translate(-333.0004,-28)" />
-    <g
-       id="g4655"
-       style="display:inline;fill:#910909;fill-opacity:1"
-       transform="translate(-333.0004,-28)">
-      <path
-         d="m 341.0004,29 c -0.554,0 -1,0.446 -1,1 l 0,4 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 l 0,-4 c 0,-0.554 -0.446,-1 -1,-1 z m -3,2 c -0.23384,0 -0.45573,0.084 -0.625,0.21875 -0.16288,0.13731 -0.21487,0.18641 -0.28125,0.25 -1.27878,1.0966 -2.09375,2.71205 -2.09375,4.53125 0,3.31371 2.68629,6 6,6 3.31371,0 6,-2.68629 6,-6 0,-1.8192 -0.81497,-3.43465 -2.09375,-4.53125 -0.0664,-0.0636 -0.11837,-0.11269 -0.28125,-0.25 C 344.45613,31.08404 344.23424,31 344.0004,31 c -0.55229,0 -1,0.44772 -1,1 0,0.31104 0.14829,0.57085 0.375,0.75 0.0403,0.0378 0.0534,0.0594 0.125,0.125 0.9241,0.72905 1.5,1.85348 1.5,3.125 0,2.20914 -1.79086,4 -4,4 -2.20914,0 -4,-1.79086 -4,-4 0,-1.27152 0.5759,-2.39595 1.5,-3.125 0.0716,-0.0656 0.0847,-0.0872 0.125,-0.125 0.22671,-0.17915 0.375,-0.43896 0.375,-0.75 0,-0.55228 -0.44772,-1 -1,-1 z"
-         id="path4657"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#910909;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-    </g>
-  </g>
-  <g
-     id="g4631"
-     transform="matrix(1.3076923,0,0,1.3076923,5.5384616,5.6923077)"
-     style="fill:#ffffff;fill-opacity:1">
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#ffffff;fill-opacity:1"
-       label="status"
-       id="layer9" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#ffffff;fill-opacity:1"
-       id="layer10" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#ffffff;fill-opacity:1"
-       id="layer13" />
-    <g
-       transform="translate(-333.0004,-28)"
-       id="layer14"
-       style="fill:#ffffff;fill-opacity:1" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#ffffff;fill-opacity:1"
-       id="layer15" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#ffffff;fill-opacity:1"
-       id="g71291" />
-    <g
-       transform="translate(-333.0004,-28)"
-       style="display:inline;fill:#ffffff;fill-opacity:1"
-       id="layer12">
-      <path
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         id="path40326"
-         d="m 341.0004,29 c -0.554,0 -1,0.446 -1,1 l 0,4 c 0,0.554 0.446,1 1,1 0.554,0 1,-0.446 1,-1 l 0,-4 c 0,-0.554 -0.446,-1 -1,-1 z m -3,2 c -0.23384,0 -0.45573,0.084 -0.625,0.21875 -0.16288,0.13731 -0.21487,0.18641 -0.28125,0.25 -1.27878,1.0966 -2.09375,2.71205 -2.09375,4.53125 0,3.31371 2.68629,6 6,6 3.31371,0 6,-2.68629 6,-6 0,-1.8192 -0.81497,-3.43465 -2.09375,-4.53125 -0.0664,-0.0636 -0.11837,-0.11269 -0.28125,-0.25 C 344.45613,31.08404 344.23424,31 344.0004,31 c -0.55229,0 -1,0.44772 -1,1 0,0.31104 0.14829,0.57085 0.375,0.75 0.0403,0.0378 0.0534,0.0594 0.125,0.125 0.9241,0.72905 1.5,1.85348 1.5,3.125 0,2.20914 -1.79086,4 -4,4 -2.20914,0 -4,-1.79086 -4,-4 0,-1.27152 0.5759,-2.39595 1.5,-3.125 0.0716,-0.0656 0.0847,-0.0872 0.125,-0.125 0.22671,-0.17915 0.375,-0.43896 0.375,-0.75 0,-0.55228 -0.44772,-1 -1,-1 z" />
-    </g>
-  </g>
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 11.68836,10.25004 c -7.1490793,3.880379 -3.9162847,14.999914 4.256836,14.999914 8.087981,0 11.712885,-10.541835 4.256829,-14.999914"
+     id="path3013"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:2.50008;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+  <path
+     d="M 16,15.500142 V 8"
+     id="path3015"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path3341"
+     d="M 16,14.500141 V 7"
+     sodipodi:nodetypes="cc" />
+  <path
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.49981;stroke-linecap:round;stroke-dasharray:none;stroke-opacity:1;stop-color:#000000"
+     id="path27328"
+     sodipodi:type="arc"
+     sodipodi:cx="16"
+     sodipodi:cy="16.279243"
+     sodipodi:rx="8.0007763"
+     sodipodi:ry="7.9708514"
+     sodipodi:start="5.3232542"
+     sodipodi:end="4.1015237"
+     sodipodi:arc-type="arc"
+     d="M 20.589057,9.7499041 A 8.0007763,7.9708514 0 0 1 23.630476,18.676125 8.0007763,7.9708514 0 0 1 16,24.250095 8.0007763,7.9708514 0 0 1 8.3695241,18.676125 8.0007763,7.9708514 0 0 1 11.410943,9.7499044"
+     sodipodi:open="true" />
 </svg>

--- a/elementary-xfce/actions/32/system-suspend-hibernate.svg
+++ b/elementary-xfce/actions/32/system-suspend-hibernate.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
+   version="1.2"
    width="32"
    height="32"
-   id="svg4248"
+   id="svg2"
    sodipodi:docname="system-suspend-hibernate.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,74 +23,85 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     id="namedview29"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview27"
      showgrid="false"
-     inkscape:zoom="8.761495"
-     inkscape:cx="4.508363"
-     inkscape:cy="28.648079"
-     inkscape:window-x="525"
-     inkscape:window-y="562"
+     inkscape:zoom="8.2604165"
+     inkscape:cx="18.27995"
+     inkscape:cy="19.369483"
+     inkscape:window-x="480"
+     inkscape:window-y="22"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4248"
+     inkscape:current-layer="svg2"
      inkscape:document-rotation="0"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs4">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011">
       <stop
-         id="stop4013-8"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-5"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017-6"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
-         id="stop4019-1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3820-7-2-2">
-      <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
+       gradientTransform="matrix(0.72972979,0,0,0.72972965,-36.346081,-2.5039294)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3019"
        y2="44.340794"
        x2="71.204407"
        y1="6.2375584"
-       x1="71.204407"
-       gradientTransform="matrix(0.7297297,0,0,0.72972954,-36.346081,-2.5039311)"
+       x1="71.204407" />
+    <radialGradient
+       gradientTransform="matrix(0.17524541,0,0,0.05574929,-1.376811,18.121125)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3540"
-       xlink:href="#linearGradient4011-4" />
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
+      <stop
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.70731706,-0.70731706,0,32.975609,-0.97560855)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887-3"
+       xlink:href="#linearGradient902" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient902">
@@ -103,18 +114,9 @@
          offset="1"
          id="stop900" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient902"
-       id="linearGradient2451"
-       x1="19.134897"
-       y1="2.5925367"
-       x2="19.134897"
-       y2="29.509588"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -125,36 +127,40 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="M 27,28.5 A 11,3.4993327 0 1 1 5.0000004,28.5 11,3.4993327 0 1 1 27,28.5 Z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2451);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path2555-3"
-     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.999399 1.5,15.999997 1.5,24.0006 7.999402,30.500001 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.999399 24.0006,1.5 16.000002,1.5 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate;stroke-dasharray:none;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555"
+     d="M 30.5,16.000003 C 30.5,7.9994029 24.000602,1.5000002 16,1.5000002 7.9994016,1.5000002 1.4999973,7.9994029 1.5000002,16.000003 1.5000002,24.000599 7.9994016,30.500007 16,30.5 c 8.000602,0 14.5,-6.499401 14.5,-14.499997 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path8655-4"
-     d="m 29.500001,15.999517 c 0,7.456083 -6.044601,13.500475 -13.499829,13.500475 -7.4559114,0 -13.500173,-6.04446 -13.500173,-13.500475 0,-7.4557374 6.0442616,-13.4995175 13.500173,-13.4995175 7.455228,0 13.499829,6.0437801 13.499829,13.4995175 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655"
+     d="m 29.500001,15.99952 c 0,7.456085 -6.044601,13.500478 -13.499831,13.500478 -7.4559097,0 -13.500171,-6.044462 -13.500171,-13.500478 0,-7.455738 6.0442613,-13.4995182 13.500171,-13.4995182 7.45523,0 13.499831,6.0437802 13.499831,13.4995182 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#007293;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path2555-6-0"
-     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.9993994 1.5,16.000001 c 0,8.000599 6.499402,14.500002 14.500002,14.5 8.000597,0 14.500006,-6.499401 14.499998,-14.5 C 30.5,7.9993994 24.000599,1.5 16.000002,1.5 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6"
+     d="M 16.000002,1.5 C 7.9994036,1.5 1.5000001,7.9993989 1.5000001,15.999997 1.5000001,24.0006 7.9994036,30.5 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.9993989 24.0006,1.5 16.000002,1.5 Z" />
+  <path
+     id="path88641"
+     style="color:#000000;fill:#0e141f;fill-opacity:0.34901962;stroke-linecap:round;-inkscape-stroke:none"
+     d="m 16.000249,5.9999988 a 0.99996501,0.99996501 0 0 0 -1,1 V 8.7871082 L 13.83814,7.941405 a 0.99996501,0.99996501 0 0 0 -1.396485,0.2207032 0.99996501,0.99996501 0 0 0 0.220703,1.3964844 l 2.337891,1.7011724 v 4.007812 l -3.472656,-2.003906 -0.302735,-2.875 A 0.99996501,0.99996501 0 0 0 10.125249,9.4980457 0.99996501,0.99996501 0 0 0 9.2365771,10.597655 l 0.1503907,1.429688 -1.546875,-0.892578 a 0.99996501,0.99996501 0 0 0 -1.3652344,0.365234 0.99996501,0.99996501 0 0 0 0.3652344,1.365234 l 1.546875,0.892578 -1.3125,0.585938 a 0.99996501,0.99996501 0 0 0 -0.5078126,1.318359 0.99996501,0.99996501 0 0 0 1.3203126,0.507813 l 2.6425782,-1.173828 3.470703,2.003906 -3.470703,2.003906 -2.6425782,-1.173828 a 0.99996501,0.99996501 0 0 0 -1.3203126,0.507813 0.99996501,0.99996501 0 0 0 0.5078126,1.318359 l 1.3125,0.585938 -1.546875,0.892578 a 0.99996501,0.99996501 0 0 0 -0.3652344,1.365234 0.99996501,0.99996501 0 0 0 1.3652344,0.365234 l 1.546875,-0.892578 -0.1503907,1.429688 a 0.99996501,0.99996501 0 0 0 0.8886719,1.099609 0.99996501,0.99996501 0 0 0 1.099609,-0.890625 l 0.302735,-2.875 3.472656,-2.003906 v 4.007812 l -2.337891,1.701172 a 0.99996501,0.99996501 0 0 0 -0.220703,1.396485 0.99996501,0.99996501 0 0 0 1.396485,0.220703 l 1.162109,-0.845703 v 1.787109 a 0.99996501,0.99996501 0 0 0 1,1 0.99996501,0.99996501 0 0 0 1,-1 V 25.21289 l 1.162109,0.845703 A 0.99996501,0.99996501 0 0 0 19.558843,25.83789 0.99996501,0.99996501 0 0 0 19.33814,24.441405 l -2.337891,-1.701172 v -4.007812 l 3.472656,2.003906 0.302735,2.875 a 0.99996501,0.99996501 0 0 0 1.099609,0.890625 0.99996501,0.99996501 0 0 0 0.888672,-1.099609 l -0.150391,-1.429688 1.546875,0.892578 a 0.99996501,0.99996501 0 0 0 1.365235,-0.365234 0.99996501,0.99996501 0 0 0 -0.365235,-1.365234 l -1.546875,-0.892578 1.3125,-0.585938 A 0.99996501,0.99996501 0 0 0 25.433843,18.33789 0.99996501,0.99996501 0 0 0 24.11353,17.830077 l -2.642578,1.173828 -3.470703,-2.003906 3.470703,-2.003906 2.642578,1.173828 a 0.99996501,0.99996501 0 0 0 1.320313,-0.507813 0.99996501,0.99996501 0 0 0 -0.507813,-1.318359 l -1.3125,-0.585938 1.546875,-0.892578 a 0.99996501,0.99996501 0 0 0 0.365235,-1.365234 0.99996501,0.99996501 0 0 0 -1.365235,-0.365234 l -1.546875,0.892578 0.150391,-1.429688 A 0.99996501,0.99996501 0 0 0 21.875249,9.4980457 0.99996501,0.99996501 0 0 0 20.77564,10.388671 l -0.302735,2.875 -3.472656,2.003906 V 11.259765 L 19.33814,9.5585926 A 0.99996501,0.99996501 0 0 0 19.558843,8.1621082 0.99996501,0.99996501 0 0 0 18.162358,7.941405 L 17.000249,8.7871082 V 6.9999988 a 0.99996501,0.99996501 0 0 0 -1,-1 z" />
   <path
      inkscape:connector-curvature="0"
-     d="m 18.75,24.25 -2.750034,-2 -2.749966,2 m 5.5,-16.5 -2.750034,2 -2.749966,-2 m 2.75002,-1.750034 v 20.000068"
+     d="m 18.750249,24.249999 -2.750034,-2 -2.749966,2 m 5.5,-16.5 -2.750034,2 -2.749966,-2 m 2.75002,-1.750034 v 20.000068"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.99993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path7750-9-3"
      sodipodi:nodetypes="cccccccc" />
   <path
      inkscape:connector-curvature="0"
-     d="m 10.230291,22.50657 0.357034,-3.3816 -3.1070345,-1.38154 M 24.51971,14.25657 21.412641,12.874971 21.769709,9.49343 M 24.660294,11 7.3397266,21.000034"
+     d="m 10.23053,22.506569 0.357034,-3.3816 -3.107035,-1.38154 m 17.03942,-3.48686 -3.107069,-1.381599 0.357068,-3.381541 m 2.890585,1.50657 -17.320568,10.000034"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.99993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2409"
      sodipodi:nodetypes="cccccccc" />
   <path
      inkscape:connector-curvature="0"
-     d="m 7.4802957,14.256562 3.1070683,-1.3816 -0.357068,-3.3815408 m 11.539419,13.0131398 -0.357035,-3.3816 3.107035,-1.38154 M 24.660279,21.000026 7.339712,10.999991"
+     d="m 7.4805495,14.25657 3.1070685,-1.3816 -0.357069,-3.3815409 m 11.539419,13.0131399 -0.357035,-3.3816 3.107035,-1.38154 M 24.660532,21.000034 7.3399655,10.999999"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.99993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2411"
      sodipodi:nodetypes="cccccccc" />

--- a/elementary-xfce/actions/32/system-suspend.svg
+++ b/elementary-xfce/actions/32/system-suspend.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
+   version="1.2"
    width="32"
    height="32"
-   id="svg4248"
+   id="svg2"
    sodipodi:docname="system-suspend.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,74 +23,85 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     id="namedview29"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview27"
      showgrid="false"
-     inkscape:zoom="12.390625"
-     inkscape:cx="5.5283732"
-     inkscape:cy="33.896595"
-     inkscape:window-x="164"
-     inkscape:window-y="522"
+     inkscape:zoom="23.363986"
+     inkscape:cx="11.21384"
+     inkscape:cy="21.48606"
+     inkscape:window-x="495"
+     inkscape:window-y="18"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4248"
+     inkscape:current-layer="svg2"
      inkscape:document-rotation="0"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4250">
+     id="defs4">
     <linearGradient
-       id="linearGradient4011-4">
+       id="linearGradient4011">
       <stop
-         id="stop4013-8"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015-5"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017-6"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
-         id="stop4019-1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3820-7-2-2">
-      <stop
-         id="stop3822-2-6-36"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-6"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-4"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
+       gradientTransform="matrix(0.72972979,0,0,0.72972965,-36.346081,-2.5039294)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3019"
        y2="44.340794"
        x2="71.204407"
        y1="6.2375584"
-       x1="71.204407"
-       gradientTransform="matrix(0.7297297,0,0,0.72972954,-36.346081,-2.5039311)"
+       x1="71.204407" />
+    <radialGradient
+       gradientTransform="matrix(0.17524541,0,0,0.05574929,-1.376811,18.121125)"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3540"
-       xlink:href="#linearGradient4011-4" />
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
+      <stop
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0,0.70731706,-0.70731706,0,32.975609,-0.97560855)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887-3"
+       xlink:href="#linearGradient902" />
     <linearGradient
        inkscape:collect="always"
        id="linearGradient902">
@@ -103,18 +114,9 @@
          offset="1"
          id="stop900" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient902"
-       id="linearGradient2451"
-       x1="19.134897"
-       y1="2.5925367"
-       x2="19.134897"
-       y2="29.509588"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata4253">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -125,49 +127,49 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="M 27,28.5 A 11,3.4993327 0 1 1 5.0000004,28.5 11,3.4993327 0 1 1 27,28.5 Z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient2451);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="path2555-3"
-     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.999399 1.5,15.999997 1.5,24.0006 7.999402,30.500001 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.999399 24.0006,1.5 16.000002,1.5 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none;enable-background:accumulate;stroke-dasharray:none;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="path2555"
+     d="M 30.5,16.000003 C 30.5,7.9994029 24.000602,1.5000002 16,1.5000002 7.9994016,1.5000002 1.4999973,7.9994029 1.5000002,16.000003 1.5000002,24.000599 7.9994016,30.500007 16,30.5 c 8.000602,0 14.5,-6.499401 14.5,-14.499997 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path8655-4"
-     d="m 29.500001,15.999517 c 0,7.456083 -6.044601,13.500475 -13.499829,13.500475 -7.4559114,0 -13.500173,-6.04446 -13.500173,-13.500475 0,-7.4557374 6.0442616,-13.4995175 13.500173,-13.4995175 7.455228,0 13.499829,6.0437801 13.499829,13.4995175 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655"
+     d="m 29.500001,15.99952 c 0,7.456085 -6.044601,13.500478 -13.499831,13.500478 -7.4559097,0 -13.500171,-6.044462 -13.500171,-13.500478 0,-7.455738 6.0442613,-13.4995182 13.500171,-13.4995182 7.45523,0 13.499831,6.0437802 13.499831,13.4995182 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#007293;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path2555-6-0"
-     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.9993994 1.5,16.000001 c 0,8.000599 6.499402,14.500002 14.500002,14.5 8.000597,0 14.500006,-6.499401 14.499998,-14.5 C 30.5,7.9993994 24.000599,1.5 16.000002,1.5 Z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-6"
+     d="M 16.000002,1.5 C 7.9994036,1.5 1.5000001,7.9993989 1.5000001,15.999997 1.5000001,24.0006 7.9994036,30.5 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.9993989 24.0006,1.5 16.000002,1.5 Z" />
   <path
      inkscape:connector-curvature="0"
-     id="path1542"
-     d="m 18.99547,8.999834 c 1.115462,1.351588 1.791868,3.079078 1.791868,4.968312 0,4.3183 -3.500691,7.81903 -7.819038,7.81903 -1.889235,0 -3.6166838,-0.676403 -4.9683,-1.791864 0.9454252,4.029959 4.559559,7.004523 8.877818,7.004523 5.038077,0 9.122181,-4.084101 9.122181,-9.122174 0,-4.318299 -2.974552,-7.9323875 -7.004529,-8.877827 z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate;opacity:0.3" />
+     id="path892"
+     d="m 19.884611,10.070057 c 1.05349,1.238955 1.692319,2.822487 1.692319,4.554284 0,3.958442 -3.306207,7.167446 -7.384646,7.167446 -1.784278,0 -3.415758,-0.620037 -4.692284,-1.642544 0.892901,3.694129 4.306249,6.420814 8.384607,6.420814 4.758183,0 8.615392,-3.74376 8.615392,-8.361992 0,-3.958442 -2.809299,-7.271356 -6.615388,-8.138008 z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#0e141f;fill-opacity:0.34901962;fill-rule:nonzero;stroke:none;stroke-width:4.8;marker:none;enable-background:accumulate" />
   <path
      inkscape:connector-curvature="0"
      id="path5549"
-     d="m 18.99547,8 c 1.115462,1.3515877 1.791868,3.079078 1.791868,4.968312 0,4.3183 -3.500691,7.81903 -7.819038,7.81903 -1.889235,0 -3.6166838,-0.676403 -4.9683,-1.791864 0.9454252,4.029959 4.559559,7.004523 8.877818,7.004523 5.038077,0 9.122181,-4.084101 9.122181,-9.122174 0,-4.318299 -2.974552,-7.9323875 -7.004529,-8.877827 z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
+     d="m 19.273752,9.5 c 0.991522,1.201411 1.592772,2.736958 1.592772,4.416279 0,3.838489 -3.111726,6.95025 -6.950256,6.95025 -1.679321,0 -3.214832,-0.601247 -4.416268,-1.592768 0.840377,3.582184 4.052942,6.226241 7.891394,6.226241 4.478293,0 8.108607,-3.63031 8.108607,-8.108599 0,-3.83849 -2.644047,-7.051012 -6.226249,-7.891403 z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.8;marker:none;enable-background:accumulate" />
   <path
-     style="fill:none;stroke:#192636;stroke-width:0.99966;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:0.3"
-     d="m 7,12.999834 h 2 l -2,4 h 2"
-     id="path1544"
+     style="opacity:1;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34901962"
+     d="m 7.5,13 h 3 l -3,5 h 3"
+     id="path869"
      sodipodi:nodetypes="cccc" />
   <path
-     style="fill:none;stroke:#ffffff;stroke-width:0.99966;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 7,12 H 9 L 7,16 H 9"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 7.5,12.5 h 3 l -3,5 h 3"
      id="path948-2-0-9"
      sodipodi:nodetypes="cccc" />
   <path
      sodipodi:nodetypes="cccc"
-     id="path1546"
-     d="m 12,7.999834 h 3 l -3,6 h 3"
-     style="fill:none;stroke:#192636;stroke-width:0.999668;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:0.3" />
+     id="path867"
+     d="m 12.5,8 h 4 l -4,5 h 4"
+     style="opacity:1;fill:none;stroke:#0e141f;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34901962" />
   <path
      sodipodi:nodetypes="cccc"
      id="path948-2-0-9-2"
-     d="m 12,7 h 3 l -3,6 h 3"
-     style="fill:none;stroke:#ffffff;stroke-width:0.999668;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     d="m 12.5,7.5 h 4 l -4,5 h 4"
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/32/system-switch-user.svg
+++ b/elementary-xfce/actions/32/system-switch-user.svg
@@ -5,7 +5,7 @@
    height="32"
    id="svg4248"
    sodipodi:docname="system-switch-user.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,19 +23,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1317"
+     inkscape:window-width="1474"
      inkscape:window-height="890"
      id="namedview29"
      showgrid="false"
      inkscape:zoom="17.52299"
-     inkscape:cx="18.803869"
-     inkscape:cy="20.202032"
-     inkscape:window-x="328"
-     inkscape:window-y="140"
+     inkscape:cx="8.7028527"
+     inkscape:cy="22.342077"
+     inkscape:window-x="678"
+     inkscape:window-y="101"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg4248"
      inkscape:document-rotation="0"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4250">
     <linearGradient
@@ -72,45 +74,6 @@
          style="stop-color:#686868;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3315"
-       xlink:href="#linearGradient3820-7-2-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17524541,0,0,0.05575992,-1.3768101,18.118568)" />
-    <radialGradient
-       cx="0.96534902"
-       cy="8.4497671"
-       r="19.99999"
-       fx="0.96534902"
-       fy="8.4497671"
-       id="radialGradient3092-3"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.7500018,-5.0249358,-1.3352822e-7,58.459625,-17.585406)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        y2="44.340794"
        x2="71.204407"
@@ -120,6 +83,38 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient3540"
        xlink:href="#linearGradient4011-4" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.9666989"
+       x2="10.860361"
+       y2="20.846098"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.45,0,0,1.45,-1.3999995,-1.4000002)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient930">
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.17524541,0,0,0.05574586,-1.376811,18.121549)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2-2"
+       id="radialGradient4277"
+       fy="186.17059"
+       fx="99.157013"
+       r="62.769119"
+       cy="186.17059"
+       cx="99.157013" />
   </defs>
   <metadata
      id="metadata4253">
@@ -133,29 +128,39 @@
     </rdf:RDF>
   </metadata>
   <path
-     d="m 27.000001,28.499422 a 11,3.4999999 0 1 1 -21.9999997,0 11,3.4999999 0 1 1 21.9999997,0 z"
+     d="m 27,28.499785 a 11,3.4991173 0 1 1 -21.9999996,0 11,3.4991173 0 1 1 21.9999996,0 z"
      id="path3818-0-2"
-     style="fill:url(#radialGradient3315);fill-opacity:1;stroke:none" />
+     style="fill:url(#radialGradient4277);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
      id="path2555-3"
-     d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.999399 1.5,15.999997 1.5,24.0006 7.999402,30.500001 16.000002,30.5 24.0006,30.5 30.500008,24.0006 30.5,15.999997 30.5,7.999399 24.0006,1.5 16.000002,1.5 Z" />
+     d="m 16.000001,1.4999999 c -8.0005983,0 -14.5000008,6.4993986 -14.5000008,14.4999981 0,8.000603 6.4994025,14.500003 14.5000008,14.500002 C 24.000599,30.5 30.500008,24.000601 30.5,15.999998 30.5,7.9993985 24.000599,1.4999999 16.000001,1.4999999 Z" />
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
      d="m 29.500001,15.999517 c 0,7.456083 -6.044601,13.500475 -13.499829,13.500475 -7.4559114,0 -13.500173,-6.04446 -13.500173,-13.500475 0,-7.4557374 6.0442616,-13.4995175 13.500173,-13.4995175 7.455228,0 13.499829,6.0437801 13.499829,13.4995175 z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#223544;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
      d="M 16.000002,1.5 C 7.999402,1.5 1.5,7.9993994 1.5,16.000001 c 0,8.000599 6.499402,14.500002 14.500002,14.5 8.000597,0 14.500006,-6.499401 14.499998,-14.5 C 30.5,7.9993994 24.000599,1.5 16.000002,1.5 Z" />
   <path
-     d="M 12,7.5 V 11 h 6 v 4 h -6 v 3.5 L 5.5,13 Z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path873-5-3"
-     sodipodi:nodetypes="cccccccc" />
+     id="path95704"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.501961;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 11.999949,18 c 0.557154,0 1.00041,-0.446176 1.00041,-1.000394 v -2.499409 h 3.993949 C 17.551465,14.500197 18,14.054021 18,13.499803 v -0.999704 c 0,-0.554219 -0.448535,-1.000743 -1.005692,-1.000197 h -3.99395 V 9.000391 C 13.000358,8.446175 12.557101,8 11.999949,8 11.699665,8 11.43161,8.129807 11.247642,8.336068 L 6.7749949,12.314184 C 6.6049483,12.493347 6.5,12.734156 6.5,13 c 0,0.265847 0.1049405,0.506652 0.2749949,0.685817 L 11.247642,17.66393 C 11.43161,17.8702 11.699665,18 11.999949,18 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="M 20,13.5 V 17 h -6 v 4 h 6 v 3.5 L 26.5,19 Z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path894"
-     sodipodi:nodetypes="cccccccc" />
+     id="path97158"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.501961;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 20.00005,26 c -0.557154,0 -1.000409,-0.446176 -1.000409,-1.000394 V 22.500197 H 15.005692 C 14.448535,22.500197 14,22.054021 14,21.499803 v -0.999704 c 0,-0.554219 0.448535,-1.000743 1.005692,-1.000197 h 3.99395 V 17.000391 C 18.999642,16.446175 19.442898,16 20.00005,16 c 0.300284,0 0.56834,0.129807 0.752307,0.336068 l 4.472647,3.978116 c 0.170047,0.179163 0.274995,0.419972 0.274995,0.685816 0,0.265847 -0.10494,0.506652 -0.274995,0.685817 L 20.752357,25.66393 C 20.568389,25.8702 20.300334,26 20.00005,26 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 11.999949,17 c 0.557154,0 1.00041,-0.446176 1.00041,-1.000394 v -2.499409 h 3.993949 C 17.551465,13.500197 18,13.054021 18,12.499803 v -0.999704 c 0,-0.554219 -0.448535,-1.000743 -1.005692,-1.000197 h -3.99395 V 8.000391 C 13.000358,7.446175 12.557101,7 11.999949,7 11.699665,7 11.43161,7.129807 11.247642,7.336068 L 6.7749949,11.314184 C 6.6049483,11.493347 6.5,11.734156 6.5,12 c 0,0.265847 0.1049405,0.506652 0.2749949,0.685817 L 11.247642,16.66393 C 11.43161,16.8702 11.699665,17 11.999949,17 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
+  <path
+     id="path94150"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.99997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 20.00005,25 c -0.557154,0 -1.000409,-0.446176 -1.000409,-1.000394 V 21.500197 H 15.005692 C 14.448535,21.500197 14,21.054021 14,20.499803 v -0.999704 c 0,-0.554219 0.448535,-1.000743 1.005692,-1.000197 h 3.99395 V 16.000391 C 18.999642,15.446175 19.442898,15 20.00005,15 c 0.300284,0 0.56834,0.129807 0.752307,0.336068 l 4.472647,3.978116 c 0.170047,0.179163 0.274995,0.419972 0.274995,0.685816 0,0.265847 -0.10494,0.506652 -0.274995,0.685817 L 20.752357,24.66393 C 20.568389,24.8702 20.300334,25 20.00005,25 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>

--- a/elementary-xfce/actions/48/system-lock-screen.svg
+++ b/elementary-xfce/actions/48/system-lock-screen.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="48"
-   height="48"
    id="svg4031"
-   sodipodi:docname="xfsm-lock.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   height="48"
+   width="48"
+   version="1.1"
+   sodipodi:docname="system-lock-screen.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,132 +23,104 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview29"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview31"
      showgrid="false"
-     inkscape:zoom="16.520833"
-     inkscape:cx="24.121059"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4031" />
+     inkscape:zoom="11.313709"
+     inkscape:cx="21.434173"
+     inkscape:cy="17.324115"
+     inkscape:window-x="105"
+     inkscape:window-y="116"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4031"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4033">
     <linearGradient
-       id="linearGradient3820-7-2-1">
+       inkscape:collect="always"
+       id="linearGradient930">
       <stop
-         id="stop3822-2-6-3"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
       <stop
-         id="stop3864-8-7-7"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-5"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
     </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3018"
-       xlink:href="#linearGradient3820-7-2-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27083381,0,0,0.08762273,-2.855072,25.187228)" />
     <linearGradient
        id="linearGradient4011-8">
       <stop
-         offset="0"
+         id="stop4013-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013-9" />
+         offset="0" />
       <stop
-         offset="0.507761"
+         id="stop4015-2"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015-2" />
+         offset="0.507761" />
       <stop
-         offset="0.83456558"
+         id="stop4017-28"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017-28" />
+         offset="0.83456558" />
       <stop
-         offset="1"
+         id="stop4019-23"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019-23" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4011-8"
-       id="linearGradient3540"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611004,-2.7279013)"
-       x1="71.204407"
-       y1="6.2375584"
+       y2="44.340794"
        x2="71.204407"
-       y2="44.340794" />
-    <radialGradient
-       gradientTransform="matrix(0,6.7155205,-7.1042197,-1.8878129e-7,84.029119,-23.48282)"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(1.0540542,0,0,1.054054,-51.611021,-2.7279011)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient3092"
-       fy="8.4497671"
-       fx="0.96534902"
-       r="19.99999"
-       cy="8.4497671"
-       cx="0.96534902" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         offset="0"
-         style="stop-color:#919caf;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#444c5c;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
-    </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
+       id="linearGradient3540"
+       xlink:href="#linearGradient4011-8" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
-         offset="0"
+         id="stop3822-2-6"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3824-1-2"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.070785"
+       x2="10.860361"
+       y2="21.97328"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientTransform="matrix(2.05,0,0,2.05,-0.6,-0.5999997)" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3300-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
      id="metadata4036">
@@ -158,45 +130,41 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587"
+     id="g4198-4"
      transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
-     id="g4198-4">
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-5);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-2);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     d="M 24.000003,3.4999982 C 12.68881,3.4999982 3.5,12.688804 3.5,23.999997 3.5,35.311193 12.68881,44.500003 24.000003,44.5 35.311192,44.5 44.50001,35.311193 44.5,23.999997 44.5,12.688804 35.311192,3.4999982 24.000003,3.4999982 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     d="M 24.000002,3.5000002 C 12.68881,3.5000002 3.5,12.688806 3.5,23.999998 3.5,35.311195 12.68881,44.500002 24.000002,44.5 35.311193,44.5 44.50001,35.311195 44.5,23.999998 44.5,12.688806 35.311193,3.5000002 24.000002,3.5000002 Z" />
   <path
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 C 13.230598,43.499998 4.5,34.769109 4.5,23.999308 4.5,13.229906 13.230598,4.4999998 24.000247,4.4999998 34.76891,4.4999998 43.5,13.229906 43.5,23.999308 l 0,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3540);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 43.500006,23.999307 c 0,10.769901 -8.731092,19.500691 -19.499757,19.500691 -10.769654,0 -19.5002541,-8.730891 -19.5002541,-19.500691 0,-10.7694 8.7306001,-19.4993068 19.5002541,-19.4993068 10.768665,0 19.499757,8.7299058 19.499757,19.4993068 z" />
   <path
-     d="M 24.000003,3.4999976 C 12.68881,3.4999976 3.5,12.688804 3.5,23.999998 3.5,35.311192 12.68881,44.500003 24.000003,44.5 35.311191,44.5 44.500011,35.311192 44.5,23.999998 44.5,12.688804 35.311191,3.4999976 24.000003,3.4999976 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
-     style="opacity:0.5;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="M 24.000001,3.4999991 C 12.68881,3.4999991 3.4999999,12.688805 3.4999999,24 c 0,11.311193 9.1888101,20.500003 20.5000011,20.500001 C 35.311191,44.500001 44.500009,35.311193 44.5,24 44.5,12.688805 35.311191,3.4999991 24.000001,3.4999991 Z" />
   <path
-     d="m 23,12.001953 c -3.859165,0 -6.998047,3.138882 -6.998047,6.998047 l 0,3 A 0.9972344,0.9972344 0 0 0 17,22.998047 l 3,0 A 0.9972344,0.9972344 0 0 0 20.998047,22 l 0,-3.335938 c 0,-0.941422 0.724593,-1.666015 1.666015,-1.666015 l 2.671876,0 c 0.941421,0 1.666015,0.724593 1.666015,1.666015 l 0,3.335938 A 0.9972344,0.9972344 0 0 0 28,22.998047 l 3,0 A 0.9972344,0.9972344 0 0 0 31.998047,22 l 0,-3 c 0,-3.859165 -3.138882,-6.998047 -6.998047,-6.998047 l -2,0 z m -7,11 A 0.9972344,0.9972344 0 0 0 15.001953,24 l 0,2 a 0.9972344,0.9972344 0 0 0 0.136719,0.5 0.9972344,0.9972344 0 0 0 -0.136719,0.5 l 0,2 a 0.9972344,0.9972344 0 0 0 0.136719,0.5 0.9972344,0.9972344 0 0 0 -0.136719,0.5 l 0,2 a 0.9972344,0.9972344 0 0 0 0.136719,0.5 0.9972344,0.9972344 0 0 0 -0.136719,0.5 l 0,1 c 0,1.643165 1.354882,2.998047 2.998047,2.998047 l 12,0 c 1.643165,0 2.998047,-1.354882 2.998047,-2.998047 l 0,-1 A 0.9972344,0.9972344 0 0 0 32.861328,32.5 0.9972344,0.9972344 0 0 0 32.998047,32 l 0,-2 A 0.9972344,0.9972344 0 0 0 32.861328,29.5 0.9972344,0.9972344 0 0 0 32.998047,29 l 0,-2 A 0.9972344,0.9972344 0 0 0 32.861328,26.5 0.9972344,0.9972344 0 0 0 32.998047,26 l 0,-2 A 0.9972344,0.9972344 0 0 0 32,23.001953 l -16,0 z"
-     id="path4741"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#206b00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 23,13 c -3.324,0 -6,2.676 -6,6 v 3 h 3 V 18.664062 C 20,17.187788 21.187786,16 22.664062,16 h 2.671874 C 26.812212,16 28,17.187788 28,18.664062 V 22 h 3 v -3 c 0,-3.324 -2.676002,-6 -6,-6 z m -9,11 v 10 c 0,1.108 0.892,2 2,2 h 16 c 1.107998,0 2,-0.892 2,-2 V 24 Z"
+     id="path955"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
   <path
-     id="rect4382-3"
-     d="m 23,13 c -3.324,0 -6,2.676 -6,6 l 0,3 3,0 0,-3.335938 C 20,17.187787 21.187787,16 22.664062,16 l 2.671876,0 C 26.812213,16 28,17.187787 28,18.664062 L 28,22 l 3,0 0,-3 c 0,-3.324 -2.676,-6 -6,-6 l -2,0 z m -7,11 0,2 3,0 0,1 -3,0 0,2 3,0 0,1 -3,0 0,2 3,0 0,1 -3,0 0,1 c 0,1.108 0.892,2 2,2 l 12,0 c 1.108,0 2,-0.892 2,-2 l 0,-1 -3,0 0,-1 3,0 0,-2 -3,0 0,-1 3,0 0,-2 -3,0 0,-1 3,0 0,-2 -16,0 z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#1c2c38;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.4137931;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;filter-blend-mode:normal;filter-gaussianBlur-deviation:0" />
-  <path
-     id="rect4382"
-     d="M 23 12 C 19.676 12 17 14.676 17 18 L 17 21 L 20 21 L 20 17.664062 C 20 16.187787 21.187787 15 22.664062 15 L 25.335938 15 C 26.812213 15 28 16.187787 28 17.664062 L 28 21 L 31 21 L 31 18 C 31 14.676 28.324 12 25 12 L 23 12 z M 16 23 L 16 25 L 19 25 L 19 26 L 16 26 L 16 28 L 19 28 L 19 29 L 16 29 L 16 31 L 19 31 L 19 32 L 16 32 L 16 33 C 16 34.108 16.892 35 18 35 L 30 35 C 31.108 35 32 34.108 32 33 L 32 32 L 29 32 L 29 31 L 32 31 L 32 29 L 29 29 L 29 28 L 32 28 L 32 26 L 29 26 L 29 25 L 32 25 L 32 23 L 16 23 z "
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 23 11 C 19.676003 11 17 13.676003 17 17 L 17 22 L 16 22 C 14.892001 22 14 22.892001 14 24 L 14 32 C 14 33.107999 14.892001 34 16 34 L 32 34 C 33.107999 34 34 33.107999 34 32 L 34 24 C 34 22.892001 33.107999 22 32 22 L 31 22 L 31 17 C 31 13.676003 28.323995 11 25 11 L 23 11 z M 22.664062 14 L 25.335938 14 C 26.812212 14 28 15.18779 28 16.664062 L 28 22 L 20 22 L 20 16.664062 C 20 15.18779 21.187788 14 22.664062 14 z " />
 </svg>

--- a/elementary-xfce/actions/48/system-log-out.svg
+++ b/elementary-xfce/actions/48/system-log-out.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg4031"
-   height="48"
+   version="1.2"
    width="48"
-   version="1.1"
+   height="48"
+   id="svg2"
    sodipodi:docname="system-log-out.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,19 +23,62 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview29"
+     inkscape:window-width="1278"
+     inkscape:window-height="957"
+     id="namedview27"
      showgrid="false"
-     inkscape:zoom="16.520833"
-     inkscape:cx="24.121059"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4031" />
+     inkscape:zoom="11.681993"
+     inkscape:cx="8.9453914"
+     inkscape:cy="15.665135"
+     inkscape:window-x="253"
+     inkscape:window-y="41"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
+     id="defs4">
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3820-7-2">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3822-2-6" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3824-1-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="rotate(90,23.999998,24)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="43.523811"
+       y1="23.999998"
+       x1="4.6204333"
+       id="linearGradient887"
+       xlink:href="#linearGradient885" />
     <linearGradient
        id="linearGradient885">
       <stop
@@ -48,26 +91,7 @@
          style="stop-color:#f37329;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4011">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013" />
-      <stop
-         offset="0.507761"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015" />
-      <stop
-         offset="0.83456558"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)"
+       gradientTransform="matrix(1.0540543,0,0,1.0540541,-51.611015,-2.7279023)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
        id="linearGradient3019"
@@ -76,93 +100,68 @@
        y1="6.2375584"
        x1="71.204407" />
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3300-8-6"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       id="linearGradient3820-7-2">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
-    </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
        cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-7"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
-    <linearGradient
-       gradientTransform="rotate(90,24,23.999999)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999999"
-       x2="44.5"
-       y1="23.999999"
-       x1="3.4999996"
-       id="linearGradient887"
-       xlink:href="#linearGradient885" />
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587306"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     id="g4198-4">
+     id="g4198-4"
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-6);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-7);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555"
-     d="m 44.500001,24.000002 c 0,-11.311193 -9.188806,-20.5000031 -20.5,-20.5000031 -11.311194,0 -20.5000051,9.1888101 -20.5000021,20.5000031 0,11.311188 9.1888081,20.500008 20.5000021,20.499997 11.311194,0 20.5,-9.188809 20.5,-20.499997 z" />
+     d="M 44.5,24.000003 C 44.5,12.688812 35.311195,3.500001 24,3.500001 c -11.311191,0 -20.5000043,9.188811 -20.5000002,20.500002 0,11.311187 9.1888092,20.500009 20.5000002,20.499996 11.311195,0 20.5,-9.188809 20.5,-20.499996 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.4993078 19.5002474,-19.4993078 C 34.76891,4.5000002 43.5,13.229906 43.5,23.999308 l 0,0 z" />
+     d="m 43.500009,23.999308 c 0,10.769901 -8.731092,19.500693 -19.499759,19.500693 -10.769649,0 -19.5002506,-8.730891 -19.5002506,-19.500693 0,-10.769402 8.7306016,-19.4993086 19.5002506,-19.4993086 10.768667,0 19.499759,8.7299066 19.499759,19.4993086 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z" />
+     d="m 24.000003,3.4999994 c -11.311192,0 -20.5000028,9.1888066 -20.5000028,20.4999956 0,11.311198 9.1888108,20.500006 20.5000028,20.500006 11.311189,0 20.500008,-9.188808 20.499997,-20.500006 C 44.5,12.688806 35.311192,3.4999994 24.000003,3.4999994 Z" />
   <path
-     d="M 21.611328,14 C 22.922425,14 24,15.092657 24,16.400391 V 21 H 34.611328 C 35.922112,21 37,22.092545 37,23.400391 v 4.199218 C 37,28.907455 35.922112,30 34.611328,30 H 24 v 4.599609 C 24,35.907457 22.92211,37 21.611328,37 20.903987,37 20.256952,36.683339 19.822266,36.189453 l 0.04687,0.05078 -9.19336,-9.070312 a -1.0001,1.0001 0 0 1 -0.02734,-0.02734 C 10.248177,26.715237 10,26.13019 10,25.5 c 0,-0.63019 0.248182,-1.215239 0.648438,-1.642578 a -1.0001,1.0001 0 0 1 0.02734,-0.02734 l 9.19336,-9.070312 -0.04687,0.05078 C 20.256952,14.316661 20.903987,14 21.611328,14 Z"
-     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#ae2109;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     id="path873-5-3-6-5" />
+     id="path24690"
+     style="font-variation-settings:normal;vector-effect:none;fill:#a62100;fill-opacity:0.5;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 22.452134,36 c 0.862436,0 1.556744,-0.669292 1.556744,-1.500656 V 28 H 34.443256 C 35.305694,28 36,27.330708 36,26.499344 V 25.500656 C 36,24.669292 35.305694,23.99918 34.443256,24 H 24.008878 V 17.500652 C 24.008878,16.669292 23.31457,16 22.452134,16 c -0.46482,0 -0.87975,0.19472 -1.16452,0.504124 l -8.86194,8.44757 C 12.162454,25.220452 12,25.58168 12,25.980464 c 0,0.398784 0.16244,0.76001 0.425674,1.02877 l 8.86194,8.48664 C 21.572384,35.805294 21.987314,36 22.452134,36 Z" />
   <path
-     id="path873-5-3-6"
-     style="font-variation-settings:normal;opacity:0.3;vector-effect:none;fill:#ae2109;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;stop-color:#000000;stop-opacity:1"
-     d="M 21.61109,15 C 22.380546,15 23,15.624762 23,16.4 v 5.599999 h 11.611089 c 0.769457,0 1.388911,0.624401 1.388911,1.4 v 4.200002 c 0,0.775599 -0.619454,1.4 -1.388911,1.4 H 23 V 34.6 c 0,0.775601 -0.619454,1.4 -1.38891,1.4 -0.414707,0 -0.784905,-0.181645 -1.038971,-0.470312 L 11.379781,26.459765 C 11.144939,26.209034 11,25.872035 11,25.499999 c 0,-0.372036 0.144939,-0.709033 0.379781,-0.959766 l 9.192338,-9.06992 C 20.826185,15.181646 21.196383,15 21.61109,15 Z" />
-  <path
-     d="M 21.61109,14 C 22.380546,14 23,14.624762 23,15.4 v 5.599999 h 11.611089 c 0.769457,0 1.388911,0.624401 1.388911,1.4 v 4.200002 c 0,0.775599 -0.619454,1.4 -1.388911,1.4 H 23 V 33.6 c 0,0.775601 -0.619454,1.4 -1.38891,1.4 -0.414707,0 -0.784905,-0.181645 -1.038971,-0.470312 L 11.379781,25.459765 C 11.144939,25.209034 11,24.872035 11,24.499999 c 0,-0.372036 0.144939,-0.709033 0.379781,-0.959766 l 9.192338,-9.06992 C 20.826185,14.181646 21.196383,14 21.61109,14 Z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path873-5-3" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 22.452134,34 c 0.862436,0 1.556744,-0.669292 1.556744,-1.500656 V 26 H 34.443256 C 35.305694,26 36,25.330708 36,24.499344 V 23.500656 C 36,22.669292 35.305694,21.99918 34.443256,22 H 24.008878 V 15.500652 C 24.008878,14.669292 23.31457,14 22.452134,14 c -0.46482,0 -0.87975,0.19472 -1.16452,0.504124 l -8.86194,8.44757 C 12.162454,23.220452 12,23.58168 12,23.980464 c 0,0.398784 0.16244,0.76001 0.425674,1.02877 l 8.86194,8.48664 C 21.572384,33.805294 21.987314,34 22.452134,34 Z" />
 </svg>

--- a/elementary-xfce/actions/48/system-reboot.svg
+++ b/elementary-xfce/actions/48/system-reboot.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
+   version="1.2"
    width="48"
    height="48"
-   id="svg4031"
-   sodipodi:docname="xfsm-reboot.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   id="svg2"
+   sodipodi:docname="system-reboot.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,19 +23,23 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
      id="namedview27"
      showgrid="false"
      inkscape:zoom="16.520833"
-     inkscape:cx="24.121059"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg4031" />
+     inkscape:cx="17.372005"
+     inkscape:cy="21.366961"
+     inkscape:window-x="359"
+     inkscape:window-y="109"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
+     id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
@@ -43,11 +47,11 @@
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4015"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         id="stop4017"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
          offset="0.83456558" />
       <stop
@@ -56,138 +60,123 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3820-7-2-1">
-      <stop
-         id="stop3822-2-6-3"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3864-8-7-7"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-5"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="rotate(90,23.999999,24)"
+       gradientUnits="userSpaceOnUse"
+       y2="23.999998"
+       x2="44.5"
+       y1="23.999998"
+       x1="3.4999995"
+       id="linearGradient887"
+       xlink:href="#linearGradient947-5" />
     <linearGradient
-       x1="71.204407"
-       y1="6.2375584"
-       x2="71.204407"
-       y2="44.340794"
-       id="linearGradient3019"
+       gradientTransform="matrix(1.0540543,0,0,1.0540541,-51.611015,-2.7279023)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)" />
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3025"
-       xlink:href="#linearGradient3820-7-2-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27083381,0,0,0.08762273,-2.855072,25.187228)" />
+       id="linearGradient3019"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407" />
     <linearGradient
-       gradientTransform="matrix(1.5712555,0,0,1.1746645,-3179.5055,-3763.7759)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient947"
-       id="linearGradient11527-6-5"
-       y2="3241.9966"
-       x2="2035.1652"
-       y1="3208.0737"
-       x1="2035.1652" />
-    <linearGradient
-       id="linearGradient947">
+       id="linearGradient947-5">
       <stop
-         id="stop943"
+         offset="0"
          style="stop-color:#64baff;stop-opacity:1"
-         offset="0" />
+         id="stop943-6" />
       <stop
-         id="stop945"
+         offset="1"
          style="stop-color:#3689e6;stop-opacity:1"
-         offset="1" />
+         id="stop945-2" />
     </linearGradient>
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
        id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
-         offset="0"
+         id="stop3822-2-6"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3824-1-2"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
        id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587"
+     id="g4198-4"
      transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
-     id="g4198-4">
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     d="m 24.000001,3.499999 c -11.311198,0 -20.5000012,9.188802 -20.5000012,20.499999 0,11.311198 9.1888032,20.500001 20.5000012,20.500001 11.311196,0 20.500018,-9.188803 20.499999,-20.500001 C 44.5,12.688801 35.311197,3.499999 24.000001,3.499999 Z"
-     id="path2555-7-8-5-0-9"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.98999999;fill:url(#linearGradient11527-6-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999988;marker:none;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     id="path2555"
+     d="M 44.5,24.000004 C 44.5,12.688811 35.311195,3.5 24,3.5 12.688809,3.5 3.4999957,12.688811 3.4999998,24.000004 3.4999998,35.311191 12.688809,44.500011 24,44.5 c 11.311195,0 20.5,-9.188809 20.5,-20.499996 z" />
   <path
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.4993078 19.5002474,-19.4993078 C 34.76891,4.5000002 43.5,13.229906 43.5,23.999308 l 0,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 43.500009,23.999308 c 0,10.769901 -8.731092,19.500693 -19.499759,19.500693 -10.769649,0 -19.5002506,-8.730891 -19.5002506,-19.500693 0,-10.769402 8.7306016,-19.4993086 19.5002506,-19.4993086 10.768667,0 19.499759,8.7299066 19.499759,19.4993086 z" />
   <path
-     d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     style="opacity:0.5;color:#000000;fill:none;stroke:#002e99;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill-opacity:1;fill-rule:nonzero;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="m 24.000003,3.4999975 c -11.311191,0 -20.5000029,9.1888055 -20.5000029,20.4999975 0,11.311199 9.1888119,20.500007 20.5000029,20.500007 11.311189,0 20.500008,-9.188808 20.499997,-20.500007 C 44.5,12.688803 35.311192,3.4999975 24.000003,3.4999975 Z" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.15;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4164"
-     d="m 24,11.570312 0,3.433594 c -5.688807,0 -10.300781,4.610022 -10.300781,10.298828 0,5.688808 4.611974,10.300782 10.300781,10.300782 5.688807,0 10.300781,-4.611974 10.300781,-10.300782 l -3.433593,0 c 0,3.792538 -3.07465,6.867188 -6.867188,6.867188 -3.792537,0 -6.867188,-3.07465 -6.867188,-6.867188 0,-3.792538 3.074651,-6.867187 6.867188,-6.867187 l 0,3.433594 8.583984,-5.148438 L 24,11.570312 Z" />
+     id="path45206"
+     style="color:#000000;fill:#002e99;fill-opacity:0.5;fill-rule:evenodd;stroke-width:1.99973;stroke-linecap:round;-inkscape-stroke:none"
+     d="m 27.033551,11 c -0.574461,0 -1.035028,0.403541 -1.035028,0.902372 v 2.601644 c -5.156051,-0.0369 -12.397798,4.138282 -13.979272,9.078379 -1.845389,5.764497 1.858439,12.512853 7.706609,14.656785 5.848172,2.143935 12.416075,-0.38012 15.076262,-5.828305 0.477425,-0.981241 0.05265,-2.175333 -0.949101,-2.668054 -1.002398,-0.494078 -2.203941,-0.09874 -2.68326,0.882839 -1.759817,3.604184 -6.196249,5.322364 -10.112034,3.88684 -3.915786,-1.435521 -5.911052,-6.669245 -4.69864,-10.4565 1.633149,-5.101515 5.812813,-5.566979 9.639436,-5.567485 v 4.109299 c 0,0.498834 0.460565,0.902371 1.035028,0.902373 0.309614,0 0.587552,-0.115144 0.777248,-0.300792 l 5.901616,-5.094189 c 0.175338,-0.161265 0.285121,-0.377928 0.285121,-0.617207 0,-0.239276 -0.109787,-0.455948 -0.285121,-0.617205 L 27.810799,11.300789 C 27.621117,11.115142 27.343165,11 27.033551,11 Z"
+     sodipodi:nodetypes="sscsscccsscssccsccs" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.05;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path4164-3"
-     d="m 23.939453,10.568359 a 1.0031133,1.0031133 0 0 0 -0.943359,1.001953 l 0,2.632813 c -5.73816,0.534074 -10.300781,5.224532 -10.300782,11.099609 0,6.23091 5.073779,11.304688 11.304688,11.304688 6.230909,0 11.304688,-5.073778 11.304688,-11.304688 a 1.0031133,1.0031133 0 0 0 -1.003907,-1.003906 l -3.433593,0 a 1.0031133,1.0031133 0 0 0 -1.003907,1.003906 c 0,3.250436 -2.612845,5.863282 -5.863281,5.863282 -3.250435,0 -5.863281,-2.612846 -5.863281,-5.863282 0,-2.893768 2.111195,-5.172637 4.859375,-5.662109 l 0,2.228516 a 1.0031133,1.0031133 0 0 0 1.519531,0.859375 l 8.583984,-5.148438 a 1.0031133,1.0031133 0 0 0 0,-1.71875 l -8.583984,-5.15039 a 1.0031133,1.0031133 0 0 0 -0.576172,-0.142579 z" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 26.166946,22.499999 c -0.646351,0 -1.166695,-0.43504 -1.166695,-0.975427 V 10.475424 C 25.000251,9.9350403 25.520595,9.5 26.166946,9.5 c 0.348358,0 0.659324,0.1265766 0.872745,0.3276803 L 33.68123,15.319 c 0.19728,0.174692 0.319021,0.409091 0.319021,0.668301 0,0.259209 -0.121748,0.494006 -0.319021,0.6687 l -6.641539,5.516316 c -0.213435,0.201123 -0.524387,0.327682 -0.872745,0.327682 z"
+     sodipodi:nodetypes="sccsccsccs" />
   <path
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     d="m 24,10.569079 0,3.433497 c -5.688807,0 -10.300491,4.611689 -10.300491,10.300495 0,5.688808 4.611684,10.300492 10.300491,10.300492 5.688807,0 10.300492,-4.611684 10.300492,-10.300492 l -3.433497,0 c 0,3.792538 -3.074457,6.866995 -6.866995,6.866995 -3.792537,0 -6.866994,-3.074457 -6.866994,-6.866995 0,-3.792538 3.074457,-6.866995 6.866994,-6.866995 l 0,3.433498 8.583743,-5.150246 L 24,10.569079 Z"
-     id="path2984" />
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path54251"
+     sodipodi:type="arc"
+     sodipodi:cx="24.152536"
+     sodipodi:cy="25.248646"
+     sodipodi:rx="10.406855"
+     sodipodi:ry="10.249931"
+     sodipodi:start="0.2443461"
+     sodipodi:end="5.0963614"
+     sodipodi:arc-type="arc"
+     d="m 34.250263,27.728329 a 10.406855,10.249931 0 0 1 -8.919637,7.70436 10.406855,10.249931 0 0 1 -10.450665,-5.530672 10.406855,10.249931 0 0 1 1.599837,-11.578124 10.406855,10.249931 0 0 1 11.571215,-2.578818"
+     sodipodi:open="true" />
 </svg>

--- a/elementary-xfce/actions/48/system-shutdown.svg
+++ b/elementary-xfce/actions/48/system-shutdown.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="48px"
-   height="48px"
-   id="svg3468"
    version="1.1"
-   sodipodi:docname="xfsm-shutdown.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   width="48"
+   height="48"
+   id="svg3041"
+   sodipodi:docname="system-shutdown.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,95 +23,50 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview31"
+     inkscape:window-width="1488"
+     inkscape:window-height="754"
+     id="namedview35"
      showgrid="false"
      inkscape:zoom="11.681993"
-     inkscape:cx="17.28569"
-     inkscape:cy="19.066568"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg3468"
-     inkscape:document-rotation="0" />
+     inkscape:cx="30.303048"
+     inkscape:cy="34.711543"
+     inkscape:window-x="417"
+     inkscape:window-y="274"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3041"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3470">
+     id="defs3043">
     <linearGradient
-       y2="44.340794"
-       x2="71.204407"
-       y1="6.2375584"
-       x1="71.204407"
-       gradientTransform="translate(-47.733515,-0.3572398)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3403"
-       xlink:href="#linearGradient4011" />
+       id="linearGradient26009">
+      <stop
+         id="stop26005"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop26007"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient4011">
       <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         id="stop4013" />
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
       <stop
          id="stop4015"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
          offset="0.507761" />
       <stop
-         offset="0.83456558"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         id="stop4017" />
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
       <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         id="stop4019" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient4340"
-       id="radialGradient3013"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,2.2874593,-3.0194057,0,36.047437,-50.630156)"
-       cx="23.895569"
-       cy="3.9900031"
-       fx="23.895569"
-       fy="3.9900031"
-       r="20.397499" />
-    <linearGradient
-       id="linearGradient3242">
-      <stop
-         id="stop3244"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3246"
-         style="stop-color:#e35d4f;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3248"
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3250"
-         style="stop-color:#690b54;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2490"
-       id="linearGradient3015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9584364,0,0,0.9584366,0.9975246,1.9975255)"
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143" />
-    <linearGradient
-       id="linearGradient2490">
-      <stop
-         id="stop2492"
-         style="stop-color:#791235;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2494"
-         style="stop-color:#dd3b27;stop-opacity:1"
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -125,153 +80,107 @@
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       r="10.625"
-       fy="4.625"
-       fx="62.625"
-       cy="4.625"
-       cx="62.625"
-       gradientTransform="matrix(2.1647059,0,0,0.7529402,-111.56471,36.517647)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3466"
-       xlink:href="#linearGradient8838" />
     <linearGradient
-       gradientTransform="rotate(90,23.75,24.250001)"
-       gradientUnits="userSpaceOnUse"
-       y2="23.999998"
-       x2="44.5"
-       y1="23.999998"
-       x1="3.4999995"
-       id="linearGradient887"
-       xlink:href="#linearGradient885" />
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#f16151;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#d62f36;stop-opacity:1" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0,4.0748498,-4.3107046,-1.1091114e-7,19.966434,-18.874068)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4340"
-       id="radialGradient3386-6"
-       fy="8.4497671"
-       fx="1.1978998"
-       r="19.99999"
-       cy="8.4497671"
-       cx="1.1978998" />
-    <linearGradient
-       id="linearGradient4340">
-      <stop
-         offset="0"
-         style="stop-color:#f8b17e;stop-opacity:1"
-         id="stop4342" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#ed5353;stop-opacity:1"
-         id="stop4344" />
-      <stop
-         offset="0.66093999"
-         style="stop-color:#c6262e;stop-opacity:1"
-         id="stop4346" />
-      <stop
-         offset="1"
-         style="stop-color:#a10705;stop-opacity:1"
-         id="stop4348" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.227899)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4011"
-       id="linearGradient3019"
-       y2="44.340794"
-       x2="71.204407"
+       x1="71.204407"
        y1="6.2375584"
-       x1="71.204407" />
-    <radialGradient
-       r="10.625"
-       fy="4.625"
-       fx="62.625"
-       cy="4.625"
-       cx="62.625"
-       gradientTransform="matrix(2.1647059,0,0,0.7529402,-111.56471,36.517647)"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient3089"
+       xlink:href="#linearGradient4011"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3466-9"
-       xlink:href="#linearGradient8838" />
+       gradientTransform="matrix(1.054054,0,0,1.0540541,-51.610998,-2.727901)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient26009"
+       id="linearGradient905"
+       gradientUnits="userSpaceOnUse"
+       x1="12.000114"
+       y1="10.420464"
+       x2="12.000114"
+       y2="29.719004"
+       gradientTransform="matrix(1.9527128,0,0,1.9527128,0.56744514,-15.054259)" />
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
+       xlink:href="#linearGradient8838"
+       id="radialGradient3300-8-9"
+       gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient8838" />
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
        cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <radialGradient
+       xlink:href="#linearGradient8838"
+       id="radialGradient4192-6-2"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient8838" />
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
-     id="metadata3473">
+     id="metadata3046">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587"
+     id="g4198-4"
      transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
-     id="g4198-4">
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8-9);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6-2);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     d="M 24.000002,3.5 C 12.68881,3.5 3.5,12.688806 3.5,23.999998 3.5,35.311192 12.68881,44.500006 24.000002,44.5 35.311192,44.5 44.500012,35.311192 44.5,23.999998 44.5,12.688806 35.311192,3.5 24.000002,3.5 Z"
+     id="path2555"
+     style="fill:url(#linearGradient905);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 24.000001,3.4999989 c -11.311191,0 -20.5000013,9.1888071 -20.5000013,20.5000001 0,11.311194 9.1888103,20.500005 20.5000013,20.500002 11.311188,0 20.500011,-9.188808 20.499999,-20.500002 C 44.5,12.688806 35.311189,3.4999989 24.000001,3.4999989 Z"
      id="path2555-6"
-     d="M 44.500001,24.500002 C 44.500001,13.188809 35.311195,4 24.000001,4 12.688807,4 3.4999961,13.188809 3.4999991,24.500002 c 0,11.311188 9.1888079,20.500008 20.5000019,20.499997 11.311194,0 20.5,-9.188809 20.5,-20.499997 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path8655-6"
-     d="M 43.5,24.49931 C 43.5,35.26921 34.76891,44 24.000247,44 13.230598,44 4.4999996,35.269111 4.4999996,24.49931 4.4999996,13.729908 13.230598,5.0000022 24.000247,5.0000022 34.76891,5.0000022 43.5,13.729908 43.5,24.49931 Z" />
+     d="m 43.5,23.999309 c 0,10.769903 -8.73109,19.500694 -19.499753,19.500694 -10.769649,0 -19.5002469,-8.730892 -19.5002469,-19.500694 0,-10.769403 8.7305979,-19.4993089 19.5002469,-19.4993089 C 34.76891,4.5000001 43.5,13.229906 43.5,23.999309 Z"
+     id="path8655"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3089);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path2555-6-2"
-     d="M 24.000003,4 C 12.68881,4 3.4999996,13.188806 3.4999996,24.5 c 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 C 35.311191,45.000002 44.500011,35.811194 44.5,24.5 44.5,13.188806 35.311191,4 24.000003,4 Z" />
+     d="M 17.724335,16.5 C 7.3186583,21.803217 12.024077,37 23.920271,37 35.692542,37 40.968686,22.592744 30.116205,16.5"
+     id="path3013"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     d="M 24.000001,8.9666664 C 25.187143,8.9666664 26,9.9181334 26,11.1 v 12.8 c 0,1.181867 -0.812857,2.133334 -1.999999,2.133334 C 22.812858,26.033334 22,25.081867 22,23.9 V 11.1 c 0,-1.1818666 0.812858,-2.1333336 2.000001,-2.1333336 z"
-     id="path887" />
+     d="M 24,24 V 13"
+     id="path3015"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     sodipodi:nodetypes="cc" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#5d5d5d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     d="m 17.397323,13.5 c -0.326114,0 -0.629764,0.132075 -0.90625,0.266667 l -0.647321,0.4 c -3.177251,2.158304 -5.41664,5.49361 -6.0848213,9.4 -7.12e-4,0.0042 -0.06402,-0.004 -0.06473,0 -0.01761,0.107584 0.01533,0.224878 0,0.333333 -0.09591,0.658844 -0.1942005,1.311085 -0.1942005,2 0,7.9529 6.4918718,14.4 14.4999988,14.4 C 32.00813,40.3 38.5,33.8529 38.5,25.9 c 0,-0.611753 -0.05361,-1.207857 -0.129464,-1.8 -0.02394,-0.184149 -0.09839,-0.351719 -0.129465,-0.533333 -0.668182,-3.90639 -2.907568,-7.241696 -6.08482,-9.4 l -0.647322,-0.4 C 31.232442,13.632075 30.928793,13.5 30.602678,13.5 c -1.179567,0 -2.136161,0.985181 -2.136161,2.199999 0,0.691376 0.357181,1.330094 0.841517,1.733334 0.153929,0.12817 0.332979,0.2528 0.517858,0.333334 2.00156,1.371686 3.484849,3.422076 4.142856,5.8 0.01243,0.04538 0.05272,0.08784 0.06473,0.133333 0.215285,0.814524 0.323661,1.649465 0.323661,2.533333 0,5.680645 -4.637049,10.266667 -10.357141,10.266667 -5.720093,0 -10.357141,-4.586022 -10.357141,-10.266667 0,-0.883868 0.108377,-1.718809 0.32366,-2.533333 0.01243,-0.04742 0.05168,-0.08618 0.06473,-0.133333 0.658009,-2.377924 2.141296,-4.428314 4.142857,-5.8 0.184875,-0.08054 0.363919,-0.205164 0.517858,-0.333334 0.484336,-0.40324 0.841517,-1.041958 0.841517,-1.733334 C 19.533484,14.485181 18.57689,13.5 17.397323,13.5 Z"
-     id="path3782-2" />
+     style="display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="path3341"
+     d="M 23.977184,22 V 11"
+     sodipodi:nodetypes="cc" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px;marker:none;enable-background:accumulate"
-     id="path3782"
-     d="m 17.625,13.875 c -0.31487,0 -0.608048,0.12382 -0.875,0.25 L 16.125,14.5 c -3.067692,2.02341 -5.22986,5.15026 -5.875,8.8125 -6.88e-4,0.004 -0.06182,-0.0038 -0.0625,0 -0.017,0.10086 0.0148,0.210824 0,0.3125 C 10.0949,24.242666 10,24.854142 10,25.5 10,32.955844 16.268014,39 24,39 31.731986,39 38,32.955844 38,25.5 38,24.926482 37.94824,24.367634 37.875,23.8125 37.85188,23.63986 37.78,23.482764 37.75,23.3125 37.10486,19.65026 34.942692,16.52341 31.875,14.5 L 31.25,14.125 c -0.266952,-0.12618 -0.56013,-0.25 -0.875,-0.25 -1.138892,0 -2.0625,0.923608 -2.0625,2.0625 0,0.648164 0.344864,1.246962 0.8125,1.625 0.14862,0.12016 0.321496,0.237 0.5,0.3125 1.932542,1.285956 3.264182,3.208196 3.8995,5.4375 0.012,0.04254 0.0509,0.08236 0.0625,0.125 0.207862,0.763616 0.3125,1.546374 0.3125,2.375 0,5.325604 -4.667024,9.2255 -9.8995,9.2255 -5.232476,0 -9.8995,-3.899896 -9.8995,-9.2255 0,-0.828626 0.10464,-1.611384 0.3125,-2.375 0.012,-0.04446 0.0499,-0.0808 0.0625,-0.125 0.635318,-2.229304 1.966958,-4.151544 3.8995,-5.4375 0.1785,-0.0755 0.35137,-0.19234 0.5,-0.3125 0.467636,-0.378038 0.8125,-0.976836 0.8125,-1.625 0,-1.138892 -0.923608,-2.0625 -2.0625,-2.0625 z M 24,9.0000002 c 1.108,0 2,0.8920001 2,1.9999998 v 12 c 0,1.108 -0.892,2 -2,2 -1.108,0 -2,-0.892 -2,-2 V 11 c 0,-1.1079997 0.892,-1.9999998 2,-1.9999998 z"
-     sodipodi:nodetypes="scccccsssccccssccccszsccccsssssssss" />
+     style="fill:none;fill-opacity:0.5;fill-rule:evenodd;stroke:#ffffff;stroke-width:4;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path27328"
+     sodipodi:type="arc"
+     sodipodi:cx="24"
+     sodipodi:cy="24.181307"
+     sodipodi:rx="12.000794"
+     sodipodi:ry="11.818693"
+     sodipodi:start="5.3232542"
+     sodipodi:end="4.1015237"
+     sodipodi:arc-type="arc"
+     d="M 30.883373,14.5 A 12.000794,11.818693 0 0 1 35.445361,27.735256 12.000794,11.818693 0 0 1 24,36 12.000794,11.818693 0 0 1 12.554639,27.735257 12.000794,11.818693 0 0 1 17.116627,14.5"
+     sodipodi:open="true" />
 </svg>

--- a/elementary-xfce/actions/48/system-suspend-hibernate.svg
+++ b/elementary-xfce/actions/48/system-suspend-hibernate.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   id="svg4031"
-   height="48"
+   version="1.2"
    width="48"
-   version="1.1"
-   sodipodi:docname="xfsm-hibernate.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   height="48"
+   id="svg2"
+   sodipodi:docname="system-suspend-hibernate.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,53 +23,44 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     id="namedview29"
+     inkscape:window-width="1277"
+     inkscape:window-height="810"
+     id="namedview27"
      showgrid="false"
-     inkscape:zoom="23.363986"
-     inkscape:cx="22.87709"
-     inkscape:cy="24.139717"
-     inkscape:window-x="251"
-     inkscape:window-y="702"
+     inkscape:zoom="2.9204983"
+     inkscape:cx="79.096092"
+     inkscape:cy="36.808787"
+     inkscape:window-x="580"
+     inkscape:window-y="122"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g4117-2"
+     inkscape:current-layer="svg2"
      inkscape:document-rotation="0"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ffa154;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#f37329;stop-opacity:1" />
-    </linearGradient>
+     id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
-         offset="0"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013" />
+         offset="0" />
       <stop
-         offset="0.507761"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015" />
+         offset="0.507761" />
       <stop
-         offset="0.83456558"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017" />
+         offset="0.83456558" />
       <stop
-         offset="1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)"
+       gradientTransform="matrix(1.0540543,0,0,1.0540541,-51.611015,-2.7279023)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
        id="linearGradient3019"
@@ -78,44 +69,44 @@
        y1="6.2375584"
        x1="71.204407" />
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
        id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
-         offset="0"
+         id="stop3822-2-6"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3824-1-2"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
        id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
     <linearGradient
-       gradientTransform="rotate(90,24,23.999999)"
+       gradientTransform="rotate(90,23.999999,24)"
        gradientUnits="userSpaceOnUse"
        y2="23.999998"
        x2="44.5"
        y1="23.999998"
        x1="3.4999995"
-       id="linearGradient887"
+       id="linearGradient887-3"
        xlink:href="#linearGradient902" />
     <linearGradient
        inkscape:collect="always"
@@ -131,7 +122,7 @@
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -142,63 +133,50 @@
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587306"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     id="g4198-4">
+     id="g4198-4"
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      id="path2555"
-     d="m 44.500001,24.000002 c 0,-11.311193 -9.188806,-20.5000031 -20.5,-20.5000031 -11.311194,0 -20.5000051,9.1888101 -20.5000021,20.5000031 0,11.311188 9.1888081,20.500008 20.5000021,20.499997 11.311194,0 20.5,-9.188809 20.5,-20.499997 z" />
+     d="M 44.5,24.000004 C 44.5,12.688811 35.311195,3.5 24,3.5 12.688809,3.5 3.4999957,12.688811 3.4999998,24.000004 3.4999998,35.311191 12.688809,44.500011 24,44.5 c 11.311195,0 20.5,-9.188809 20.5,-20.499996 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.4993078 19.5002474,-19.4993078 C 34.76891,4.5000002 43.5,13.229906 43.5,23.999308 l 0,0 z" />
+     d="m 43.500009,23.999308 c 0,10.769901 -8.731092,19.500693 -19.499759,19.500693 -10.769649,0 -19.5002506,-8.730891 -19.5002506,-19.500693 0,-10.769402 8.7306016,-19.4993086 19.5002506,-19.4993086 10.768667,0 19.499759,8.7299066 19.499759,19.4993086 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:#007293;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z" />
-  <g
-     style="display:inline;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;enable-background:new"
-     id="g4117-2"
-     transform="matrix(1.5,0,0,1.5,-309.01023,-387.55689)"
-     inkscape:label="weather-snow">
-    <rect
-       width="16"
-       height="16"
-       x="214.00682"
-       y="265.87326"
-       id="rect18110-7-1-6-6-8-6-8"
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:none;stroke:none;stroke-width:1.33333;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:new" />
-    <path
-       id="path901"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.35;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-       d="m 222.00635,267.03793 a 0.66654498,0.66654498 0 0 0 -0.66536,0.66667 v 1.41015 l -0.96094,-0.65234 a 0.66654498,0.66654498 0 0 0 -0.92578,0.17708 0.66654498,0.66654498 0 0 0 0.17708,0.92578 l 1.70964,1.16016 v 3.15885 l -2.73698,-1.58073 -0.14974,-2.05859 a 0.66654498,0.66654498 0 0 0 -0.69531,-0.61719 0.66654498,0.66654498 0 0 0 -0.0182,0.003 0.66654498,0.66654498 0 0 0 -0.61458,0.71224 l 0.0833,1.15625 -1.22005,-0.70443 a 0.66654498,0.66654498 0 0 0 -0.91016,0.24349 0.66654498,0.66654498 0 0 0 0.24349,0.91016 l 1.21875,0.70573 -1.04297,0.5039 a 0.66654498,0.66654498 0 0 0 -0.30859,0.89063 0.66654498,0.66654498 0 0 0 0.89062,0.30989 l 1.85808,-0.89974 2.73567,1.57943 -2.73958,1.58203 -1.89844,-0.88672 a 0.66654498,0.66654498 0 0 0 -0.88672,0.32292 0.66654498,0.66654498 0 0 0 0.32162,0.88672 l 1.05338,0.49219 -1.20182,0.6927 a 0.66654498,0.66654498 0 0 0 -0.24349,0.91016 0.66654498,0.66654498 0 0 0 0.91016,0.24479 l 1.20052,-0.69401 -0.099,1.15625 a 0.66654498,0.66654498 0 0 0 0.60547,0.72136 0.66654498,0.66654498 0 0 0 0.72265,-0.60547 l 0.17969,-2.08594 2.74219,-1.58333 v 3.16536 l -1.71745,1.20052 a 0.66654498,0.66654498 0 0 0 -0.16406,0.92839 0.66654498,0.66654498 0 0 0 0.92838,0.16406 l 0.95313,-0.66667 v 1.38933 a 0.66654498,0.66654498 0 0 0 0.66536,0.66536 0.66654498,0.66654498 0 0 0 0.66667,-0.66536 v -1.38933 l 0.95052,0.66667 a 0.66654498,0.66654498 0 0 0 0.92969,-0.16406 0.66654498,0.66654498 0 0 0 -0.16406,-0.92839 l -1.71615,-1.20052 v -3.16406 l 2.74219,1.58203 0.17969,2.08594 a 0.66654498,0.66654498 0 0 0 0.72265,0.60547 0.66654498,0.66654498 0 0 0 0.60547,-0.72136 l -0.10026,-1.15625 1.20182,0.69401 a 0.66654498,0.66654498 0 0 0 0.91016,-0.24479 0.66654498,0.66654498 0 0 0 -0.24479,-0.91016 l -1.20052,-0.6927 1.05208,-0.49219 a 0.66654498,0.66654498 0 0 0 0.32292,-0.88672 0.66654498,0.66654498 0 0 0 -0.88672,-0.32292 l -1.89844,0.88672 -2.73958,-1.58203 2.73567,-1.57943 1.85678,0.89974 a 0.66654498,0.66654498 0 0 0 0.89062,-0.30989 0.66654498,0.66654498 0 0 0 -0.30859,-0.89063 l -1.04297,-0.5039 1.21875,-0.70573 a 0.66654498,0.66654498 0 0 0 0.24479,-0.91016 0.66654498,0.66654498 0 0 0 -0.91016,-0.24349 l -1.22135,0.70443 0.0846,-1.15625 a 0.66654498,0.66654498 0 0 0 -0.61588,-0.71224 0.66654498,0.66654498 0 0 0 -0.0703,-0.003 0.66654498,0.66654498 0 0 0 -0.64453,0.61719 l -0.14844,2.05859 -2.73568,1.57943 v -3.15755 l 1.70833,-1.16016 a 0.66654498,0.66654498 0 0 0 0.17579,-0.92578 0.66654498,0.66654498 0 0 0 -0.92579,-0.17708 l -0.95833,0.64974 v -1.40755 a 0.66654498,0.66654498 0 0 0 -0.66667,-0.66667 z" />
-    <path
-       inkscape:connector-curvature="0"
-       d="m 224.00692,280.43646 -2.00013,-1.39854 -2.00012,1.39854 m 4.00025,-12.08899 -2.00013,1.35712 -2.00012,-1.35712 m 2.00016,-1.30967 v 14.66692"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.33309;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="path7750-9"
-       sodipodi:nodetypes="cccccccc" />
-    <path
-       sodipodi:nodetypes="cccccccc"
-       id="path7750-9-2"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.33309;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       d="m 217.75424,279.13602 0.21111,-2.43143 -2.21123,-1.03289 m 12.46949,-2.58018 -2.17536,-1.0536 0.17524,-2.41071 m 2.13429,1.07735 -12.70193,7.33346"
-       inkscape:connector-curvature="0" />
-    <path
-       inkscape:connector-curvature="0"
-       d="m 226.25939,279.13602 -0.2111,-2.43143 2.21123,-1.03289 m -12.46949,-2.58018 2.17536,-1.0536 -0.17524,-2.41071 m -2.13429,1.07735 12.70193,7.33346"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.33309;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       id="path7750-9-2-9"
-       sodipodi:nodetypes="cccccccc" />
-  </g>
+     d="m 24,3.4999975 c -11.311191,0 -20.5000025,9.1888055 -20.5000025,20.4999975 0,11.311199 9.1888115,20.500007 20.5000025,20.500007 11.311189,0 20.500008,-9.188808 20.499997,-20.500007 C 44.499997,12.688803 35.311189,3.4999975 24,3.4999975 Z" />
+  <path
+     id="path901"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#0e141f;fill-opacity:0.34901962;fill-rule:nonzero;stroke:none;stroke-width:1.99999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     d="m 23.999565,13.000009 a 0.99981747,0.99981747 0 0 0 -0.99804,1.000005 v 2.115225 l -1.44141,-0.97851 a 0.99981747,0.99981747 0 0 0 -1.38867,0.26562 0.99981747,0.99981747 0 0 0 0.26562,1.38867 l 2.56446,1.74024 v 4.738275 l -4.10547,-2.371095 -0.22461,-3.087885 a 0.99981747,0.99981747 0 0 0 -1.042965,-0.925785 0.99981747,0.99981747 0 0 0 -0.0273,0.0045 0.99981747,0.99981747 0 0 0 -0.92187,1.06836 l 0.12495,1.734375 -1.830075,-1.056645 a 0.99981747,0.99981747 0 0 0 -1.36524,0.365235 0.99981747,0.99981747 0 0 0 0.365235,1.36524 l 1.828125,1.058595 -1.564455,0.75585 a 0.99981747,0.99981747 0 0 0 -0.462885,1.335945 0.99981747,0.99981747 0 0 0 1.33593,0.464835 l 2.78712,-1.34961 4.103505,2.369145 -4.10937,2.373045 -2.84766,-1.33008 a 0.99981747,0.99981747 0 0 0 -1.33008,0.48438 0.99981747,0.99981747 0 0 0 0.48243,1.33008 l 1.58007,0.738285 -1.80273,1.03905 a 0.99981747,0.99981747 0 0 0 -0.365235,1.36524 0.99981747,0.99981747 0 0 0 1.36524,0.367185 l 1.80078,-1.041015 -0.1485,1.734375 a 0.99981747,0.99981747 0 0 0 0.908205,1.08204 0.99981747,0.99981747 0 0 0 1.083975,-0.908205 l 0.269535,-3.12891 4.113285,-2.374995 v 4.74804 l -2.576175,1.80078 a 0.99981747,0.99981747 0 0 0 -0.24609,1.392585 0.99981747,0.99981747 0 0 0 1.39257,0.24609 l 1.429695,-1.000005 v 2.083995 a 0.99981747,0.99981747 0 0 0 0.99804,0.99804 0.99981747,0.99981747 0 0 0 1.000005,-0.99804 v -2.083995 l 1.42578,1.000005 a 0.99981747,0.99981747 0 0 0 1.394535,-0.24609 0.99981747,0.99981747 0 0 0 -0.24609,-1.392585 l -2.574225,-1.80078 v -4.74609 l 4.113285,2.373045 0.269535,3.12891 a 0.99981747,0.99981747 0 0 0 1.083975,0.908205 0.99981747,0.99981747 0 0 0 0.908205,-1.08204 l -0.15039,-1.734375 1.80273,1.041015 a 0.99981747,0.99981747 0 0 0 1.36524,-0.367185 0.99981747,0.99981747 0 0 0 -0.367185,-1.36524 l -1.80078,-1.03905 1.57812,-0.738285 a 0.99981747,0.99981747 0 0 0 0.48438,-1.33008 0.99981747,0.99981747 0 0 0 -1.33008,-0.48438 l -2.84766,1.33008 -4.10937,-2.373045 4.103505,-2.369145 2.78517,1.34961 a 0.99981747,0.99981747 0 0 0 1.33593,-0.464835 0.99981747,0.99981747 0 0 0 -0.462885,-1.335945 l -1.564455,-0.75585 1.828125,-1.058595 a 0.99981747,0.99981747 0 0 0 0.367185,-1.36524 0.99981747,0.99981747 0 0 0 -1.36524,-0.365235 l -1.832025,1.056645 0.1269,-1.734375 a 0.99981747,0.99981747 0 0 0 -0.92382,-1.06836 0.99981747,0.99981747 0 0 0 -0.10545,-0.0045 0.99981747,0.99981747 0 0 0 -0.966795,0.925785 l -0.22266,3.087885 -4.10352,2.369145 v -4.736325 l 2.562495,-1.74024 a 0.99981747,0.99981747 0 0 0 0.263685,-1.38867 0.99981747,0.99981747 0 0 0 -1.388685,-0.26562 l -1.437495,0.97461 v -2.111325 a 0.99981747,0.99981747 0 0 0 -1.000005,-1.000005 z" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 27.00042,33.097805 -3.000195,-2.09781 -3.00018,2.09781 M 27.00042,14.96432 24.000225,17 21.000045,14.96432 m 3.00024,-1.964505 v 22.00038"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.99963;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path7750-9"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     sodipodi:nodetypes="cccccccc"
+     id="path7750-9-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.99963;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 17.6214,31.147144 0.316665,-3.647145 -3.316845,-1.549335 m 18.704235,-3.87027 -3.26304,-1.5804 0.26286,-3.616065 m 3.201435,1.616025 -19.052895,11.00019"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     d="m 30.379125,31.147144 -0.31665,-3.647145 3.316845,-1.549335 m -18.704235,-3.87027 3.26304,-1.5804 -0.26286,-3.616065 m -3.201435,1.616025 19.052895,11.00019"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#ffffff;stroke-width:1.99963;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path7750-9-2-9"
+     sodipodi:nodetypes="cccccccc" />
 </svg>

--- a/elementary-xfce/actions/48/system-suspend.svg
+++ b/elementary-xfce/actions/48/system-suspend.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   id="svg4031"
-   height="48"
+   version="1.2"
    width="48"
-   version="1.1"
-   sodipodi:docname="xfsm-suspend.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   height="48"
+   id="svg2"
+   sodipodi:docname="system-suspend.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -23,52 +23,44 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1319"
-     inkscape:window-height="980"
-     id="namedview29"
+     inkscape:window-width="1277"
+     inkscape:window-height="810"
+     id="namedview27"
      showgrid="false"
-     inkscape:zoom="11.681993"
-     inkscape:cx="34.818134"
-     inkscape:cy="20.94567"
-     inkscape:window-x="467"
-     inkscape:window-y="47"
+     inkscape:zoom="8.2604165"
+     inkscape:cx="15.01135"
+     inkscape:cy="21.245902"
+     inkscape:window-x="580"
+     inkscape:window-y="122"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg4031"
-     inkscape:document-rotation="0" />
+     inkscape:current-layer="svg2"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4033">
-    <linearGradient
-       id="linearGradient885">
-      <stop
-         id="stop881"
-         offset="0"
-         style="stop-color:#ffa154;stop-opacity:1" />
-      <stop
-         id="stop883"
-         offset="1"
-         style="stop-color:#f37329;stop-opacity:1" />
-    </linearGradient>
+     id="defs4">
     <linearGradient
        id="linearGradient4011">
       <stop
-         offset="0"
+         id="stop4013"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013" />
+         offset="0" />
       <stop
-         offset="0.507761"
+         id="stop4015-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015" />
+         offset="0.507761" />
       <stop
-         offset="0.83456558"
+         id="stop4017-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017" />
+         offset="0.83456558" />
       <stop
-         offset="1"
+         id="stop4019"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611001,-2.7279009)"
+       gradientTransform="matrix(1.0540543,0,0,1.0540541,-51.611015,-2.7279023)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4011"
        id="linearGradient3019"
@@ -77,44 +69,44 @@
        y1="6.2375584"
        x1="71.204407" />
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
        id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
-         offset="0"
+         id="stop3822-2-6"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3824-1-2"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
+         offset="1" />
     </linearGradient>
     <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
-       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3820-7-2"
        id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
     <linearGradient
-       gradientTransform="rotate(90,24,23.999999)"
+       gradientTransform="rotate(90,23.999999,24)"
        gradientUnits="userSpaceOnUse"
        y2="23.999998"
        x2="44.5"
        y1="23.999998"
        x1="3.4999995"
-       id="linearGradient887"
+       id="linearGradient887-3"
        xlink:href="#linearGradient902" />
     <linearGradient
        inkscape:collect="always"
@@ -130,68 +122,69 @@
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4036">
+     id="metadata7">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="stroke-width:1.40587306"
-     transform="matrix(0.70833333,0,0,0.71428273,1.33333,0.78460484)"
-     id="g4198-4">
+     id="g4198-4"
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
     <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587306"
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
        id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
+       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587" />
     <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
+       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587"
        id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587306" />
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
   </g>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient887-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
      id="path2555"
-     d="m 44.500001,24.000002 c 0,-11.311193 -9.188806,-20.5000031 -20.5,-20.5000031 -11.311194,0 -20.5000051,9.1888101 -20.5000021,20.5000031 0,11.311188 9.1888081,20.500008 20.5000021,20.499997 11.311194,0 20.5,-9.188809 20.5,-20.499997 z" />
+     d="M 44.5,24.000004 C 44.5,12.688811 35.311195,3.5 24,3.5 12.688809,3.5 3.4999957,12.688811 3.4999998,24.000004 3.4999998,35.311191 12.688809,44.500011 24,44.5 c 11.311195,0 20.5,-9.188809 20.5,-20.499996 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3019);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655"
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 -10.769649,0 -19.5002474,-8.730889 -19.5002474,-19.50069 0,-10.769402 8.7305984,-19.4993078 19.5002474,-19.4993078 C 34.76891,4.5000002 43.5,13.229906 43.5,23.999308 l 0,0 z" />
+     d="m 43.500009,23.999308 c 0,10.769901 -8.731092,19.500693 -19.499759,19.500693 -10.769649,0 -19.5002506,-8.730891 -19.5002506,-19.500693 0,-10.769402 8.7306016,-19.4993086 19.5002506,-19.4993086 10.768667,0 19.499759,8.7299066 19.499759,19.4993086 z" />
   <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:#007293;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#004f66;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path2555-6"
-     d="m 24.000003,3.499998 c -11.311193,0 -20.5000034,9.188806 -20.5000034,20.5 0,11.311194 9.1888104,20.500005 20.5000034,20.500002 11.311188,0 20.500008,-9.188808 20.499997,-20.500002 0,-11.311194 -9.188809,-20.5 -20.499997,-20.5 z" />
+     d="m 24,3.4999975 c -11.311191,0 -20.5000025,9.1888055 -20.5000025,20.4999975 0,11.311199 9.1888115,20.500007 20.5000025,20.500007 11.311189,0 20.500008,-9.188808 20.499997,-20.500007 C 44.499997,12.688803 35.311189,3.4999975 24,3.4999975 Z" />
   <path
      inkscape:connector-curvature="0"
      id="path892"
-     d="m 26.660624,13.000087 c 1.487282,1.802117 2.389157,4.105437 2.389157,6.624416 0,5.757733 -4.667588,10.425374 -10.425385,10.425374 -2.51898,0 -4.822246,-0.901871 -6.624401,-2.389153 1.260567,5.373279 6.079412,9.339364 11.837092,9.339364 6.717437,0 12.162909,-5.445468 12.162909,-12.162898 0,-5.757733 -3.96607,-10.576517 -9.339372,-11.837103 z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate;opacity:0.3" />
+     d="m 28.271488,14.500087 c 1.54925,1.802014 2.488704,4.105202 2.488704,6.624036 0,5.757408 -4.86207,10.424784 -10.859774,10.424784 -2.623938,0 -5.023174,-0.901822 -6.900418,-2.389018 1.31309,5.37297 6.33272,9.338832 12.330304,9.338832 C 32.327634,38.498721 38,33.053563 38,26.336517 38,20.579111 33.868678,15.760601 28.271488,14.500087 Z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#0e141f;fill-opacity:0.34999999;fill-rule:nonzero;stroke:none;stroke-width:4.8;marker:none;enable-background:accumulate" />
   <path
      inkscape:connector-curvature="0"
      id="path5549"
-     d="m 26.660624,12.000087 c 1.487282,1.802117 2.389157,4.105437 2.389157,6.624416 0,5.757733 -4.667588,10.425374 -10.425385,10.425374 -2.51898,0 -4.822246,-0.901871 -6.624401,-2.389153 1.260567,5.373279 6.079412,9.339364 11.837092,9.339364 6.717437,0 12.162909,-5.445468 12.162909,-12.162898 0,-5.757733 -3.96607,-10.576517 -9.339372,-11.837103 z"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.4;marker:none;enable-background:accumulate" />
+     d="m 27.909173,13 c 1.487282,1.802116 2.389156,4.105436 2.389156,6.624416 0,5.757732 -4.667586,10.425372 -10.42538,10.425372 -2.51898,0 -4.822246,-0.90187 -6.6244,-2.389152 1.260566,5.373276 6.07941,9.33936 11.837088,9.33936 6.717436,0 12.162906,-5.445464 12.162906,-12.162894 0,-5.757734 -3.966068,-10.576516 -9.33937,-11.837102 z"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.8;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-     d="M 12.5,19 A 0.4998295,0.4998295 0 0 0 12,19.5 0.4998295,0.4998295 0 0 0 12.5,20 h 2.117188 l -2.546876,4.242188 A 0.49987948,0.49987948 0 0 0 12.5,25 h 3 A 0.4998295,0.4998295 0 0 0 16,24.5 0.4998295,0.4998295 0 0 0 15.5,24 h -2.117188 l 2.546876,-4.242188 A 0.49987948,0.49987948 0 0 0 15.5,19 Z"
-     id="path894" />
+     style="opacity:1;fill:none;stroke:#0e141f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34999999"
+     d="m 11,20 h 4 l -4,6 h 4"
+     id="path869"
+     sodipodi:nodetypes="cccc" />
   <path
-     style="fill:none;stroke:#ffffff;stroke-width:0.999659;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 12.499823,18.49993 h 3.00034 l -3.00034,5.000353 h 3.00034"
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 11,19 h 4 l -4,6 h 4"
      id="path948-2-0-9"
      sodipodi:nodetypes="cccc" />
   <path
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-variant-east-asian:normal;font-feature-settings:normal;font-variation-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;shape-margin:0;inline-size:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#192636;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
-     d="M 18.5,13 A 0.49983501,0.49983501 0 0 0 18,13.5 0.49983501,0.49983501 0 0 0 18.5,14 h 3.138672 l -3.572266,6.251953 A 0.499885,0.499885 0 0 0 18.5,21 h 4 A 0.49983501,0.49983501 0 0 0 23,20.5 0.49983501,0.49983501 0 0 0 22.5,20 h -3.138672 l 3.572266,-6.251953 A 0.499885,0.499885 0 0 0 22.5,13 Z"
-     id="path896" />
+     sodipodi:nodetypes="cccc"
+     id="path867"
+     d="m 18,12 h 6 l -6,8 h 6"
+     style="opacity:1;fill:none;stroke:#0e141f;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.34999999" />
   <path
      sodipodi:nodetypes="cccc"
      id="path948-2-0-9-2"
-     d="m 18.49983,12.49993 h 4.000332 l -4.000332,7.000365 h 4.000332"
-     style="fill:none;stroke:#ffffff;stroke-width:0.99967;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+     d="m 18,11 h 6 l -6,8 h 6"
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/48/system-switch-user.svg
+++ b/elementary-xfce/actions/48/system-switch-user.svg
@@ -1,32 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   version="1.1"
-   width="48"
-   height="48"
    id="svg4031"
+   height="48"
+   width="48"
+   version="1.1"
    sodipodi:docname="system-switch-user.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
-  <g
-     style="stroke-width:1.40587"
-     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
-     id="g4198-4">
-    <path
-       style="opacity:0.2;fill:url(#radialGradient3300-8);fill-opacity:1;stroke:none;stroke-width:1.40587"
-       id="path3818-0-6"
-       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z" />
-    <path
-       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z"
-       id="path4190-2"
-       style="opacity:0.4;fill:url(#radialGradient4192-6);fill-opacity:1;stroke:none;stroke-width:1.40587" />
-  </g>
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -36,133 +23,104 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview29"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     id="namedview31"
      showgrid="false"
-     inkscape:zoom="16.520833"
-     inkscape:cx="24.242119"
-     inkscape:cy="24"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:zoom="8.0000004"
+     inkscape:cx="19.999999"
+     inkscape:cy="31.999999"
+     inkscape:window-x="723"
+     inkscape:window-y="6"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg4031"
-     inkscape:document-rotation="0" />
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs4033">
     <linearGradient
-       id="linearGradient3820-7-2-1">
+       inkscape:collect="always"
+       id="linearGradient930">
       <stop
-         id="stop3822-2-6-3"
-         style="stop-color:#3d3d3d;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0"
+         id="stop926" />
       <stop
-         id="stop3864-8-7-7"
-         style="stop-color:#686868;stop-opacity:0.49803922"
-         offset="0.5" />
-      <stop
-         id="stop3824-1-2-5"
-         style="stop-color:#686868;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1"
+         id="stop928" />
     </linearGradient>
-    <radialGradient
-       cx="99.157013"
-       cy="186.17059"
-       r="62.769119"
-       fx="99.157013"
-       fy="186.17059"
-       id="radialGradient3018"
-       xlink:href="#linearGradient3820-7-2-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.27083381,0,0,0.08762273,-2.855072,25.187228)" />
     <linearGradient
        id="linearGradient4011-8">
       <stop
-         offset="0"
+         id="stop4013-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4013-9" />
+         offset="0" />
       <stop
-         offset="0.507761"
+         id="stop4015-2"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4015-2" />
+         offset="0.507761" />
       <stop
-         offset="0.83456558"
+         id="stop4017-28"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4017-28" />
+         offset="0.83456558" />
       <stop
-         offset="1"
+         id="stop4019-23"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4019-23" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4011-8"
-       id="linearGradient3540"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.054054,0,0,1.054054,-51.611004,-2.7279013)"
-       x1="71.204407"
-       y1="6.2375584"
+       y2="44.340794"
        x2="71.204407"
-       y2="44.340794" />
-    <radialGradient
-       gradientTransform="matrix(0,6.7155205,-7.1042197,-1.8878129e-7,84.029119,-23.48282)"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(1.0540542,0,0,1.054054,-51.611021,-2.7279011)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient3092"
-       fy="8.4497671"
-       fx="0.96534902"
-       r="19.99999"
-       cy="8.4497671"
-       cx="0.96534902" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         offset="0"
-         style="stop-color:#919caf;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#444c5c;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
-    </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3300-8"
-       xlink:href="#linearGradient3820-7-2" />
+       id="linearGradient3540"
+       xlink:href="#linearGradient4011-8" />
     <linearGradient
        id="linearGradient3820-7-2">
       <stop
-         offset="0"
+         id="stop3822-2-6"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop3822-2-6" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3824-1-2"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop3824-1-2" />
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       r="62.769119"
-       fy="185.29727"
-       fx="99.189415"
-       cy="185.29727"
-       cx="99.189415"
-       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient930"
+       id="linearGradient932"
+       x1="10.860361"
+       y1="2.070785"
+       x2="10.860361"
+       y2="21.97328"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient4192-6"
-       xlink:href="#linearGradient3820-7-2" />
+       gradientTransform="matrix(2.05,0,0,2.05,-0.6,-0.5999997)" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient3300-8-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3823536,7.5555777e-8,-1.8372241e-8,0.1115198,-5.9254271,36.335849)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
+    <radialGradient
+       xlink:href="#linearGradient3820-7-2"
+       id="radialGradient4192-6-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2549024,5.3967361e-8,-1.2248161e-8,0.07965545,6.7163816,44.240666)"
+       cx="99.189415"
+       cy="185.29727"
+       fx="99.189415"
+       fy="185.29727"
+       r="62.769119" />
   </defs>
   <metadata
      id="metadata4036">
@@ -172,40 +130,52 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     id="g4198-4"
+     transform="matrix(0.70833333,0,0,0.71428273,1.3333345,0.78459684)"
+     style="stroke-width:1.40587">
+    <path
+       d="m 55.999998,57.0017 a 24,6.9985714 0 1 1 -47.9999991,0 24,6.9985714 0 1 1 47.9999991,0 z"
+       id="path3818-0-6"
+       style="opacity:0.2;fill:url(#radialGradient3300-8-5);fill-opacity:1;stroke:none;stroke-width:1.40587" />
+    <path
+       style="opacity:0.4;fill:url(#radialGradient4192-6-2);fill-opacity:1;stroke:none;stroke-width:1.40587"
+       id="path4190-2"
+       d="m 47.999998,59.0017 a 16,4.9988822 0 1 1 -31.999999,0 16,4.9988822 0 1 1 31.999999,0 z" />
+  </g>
   <path
-     d="M 24.000003,3.4999982 C 12.68881,3.4999982 3.5,12.688804 3.5,23.999997 3.5,35.311193 12.68881,44.500003 24.000003,44.5 35.311192,44.5 44.50001,35.311193 44.5,23.999997 44.5,12.688804 35.311192,3.4999982 24.000003,3.4999982 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient932);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path2555-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3092);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     d="M 24.000002,3.5000002 C 12.68881,3.5000002 3.5,12.688806 3.5,23.999998 3.5,35.311195 12.68881,44.500002 24.000002,44.5 35.311193,44.5 44.50001,35.311195 44.5,23.999998 44.5,12.688806 35.311193,3.5000002 24.000002,3.5000002 Z" />
   <path
-     d="m 43.5,23.999308 c 0,10.7699 -8.73109,19.50069 -19.499753,19.50069 C 13.230598,43.499998 4.5,34.769109 4.5,23.999308 4.5,13.229906 13.230598,4.4999998 24.000247,4.4999998 34.76891,4.4999998 43.5,13.229906 43.5,23.999308 l 0,0 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:url(#linearGradient3540);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      id="path8655-4"
-     style="opacity:0.3;color:#000000;fill:none;stroke:url(#linearGradient3540);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 43.500006,23.999307 c 0,10.769901 -8.731092,19.500691 -19.499757,19.500691 -10.769654,0 -19.5002541,-8.730891 -19.5002541,-19.500691 0,-10.7694 8.7306001,-19.4993068 19.5002541,-19.4993068 10.768665,0 19.499757,8.7299058 19.499757,19.4993068 z" />
   <path
-     d="M 24.000003,3.4999976 C 12.68881,3.4999976 3.5,12.688804 3.5,23.999998 3.5,35.311192 12.68881,44.500003 24.000003,44.5 35.311191,44.5 44.500011,35.311192 44.5,23.999998 44.5,12.688804 35.311191,3.4999976 24.000003,3.4999976 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="path2555-6-0"
-     style="opacity:0.5;color:#000000;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
+     d="M 24.000001,3.4999991 C 12.68881,3.4999991 3.4999999,12.688805 3.4999999,24 c 0,11.311193 9.1888101,20.500003 20.5000011,20.500001 C 35.311191,44.500001 44.500009,35.311193 44.5,24 44.5,12.688805 35.311191,3.4999991 24.000001,3.4999991 Z" />
   <path
-     d="m 18,13 v 5 h 8 v 6 h -8 v 5 L 9,21 Z"
-     style="opacity:0.35;fill:#1c2c38;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path866"
-     sodipodi:nodetypes="cccccccc" />
+     id="path19147"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.5;stroke:none;stroke-width:0.999966;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 19.451811,26.5 c 0.862369,0 1.548445,-0.669263 1.548445,-1.500591 V 21.000566 H 27.4432 c 0.862374,0 1.556621,-0.669261 1.556621,-1.500589 v -0.999302 c 0,-0.831328 -0.694247,-1.501411 -1.556621,-1.500591 h -6.442946 v -3.999497 c 0,-0.831324 -0.686076,-1.500587 -1.548443,-1.500587 -0.464782,0 -0.879681,0.194711 -1.164427,0.504102 L 11.62564,17.9716 C 11.36244,18.240346 11.2,18.601558 11.2,19.000325 c 0,0.398769 0.162428,0.759977 0.42564,1.028725 l 6.661744,5.966846 C 18.57213,26.3053 18.987029,26.5 19.451811,26.5 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="m 18,12 v 5 h 8 v 6 h -8 v 5 L 9,20 Z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path873-5-3"
-     sodipodi:nodetypes="cccccccc" />
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999966;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 19.451811,25.5 c 0.862369,0 1.548445,-0.669263 1.548445,-1.500591 V 20.000566 H 27.4432 c 0.862374,0 1.556621,-0.669261 1.556621,-1.500589 v -0.999302 c 0,-0.831328 -0.694247,-1.501411 -1.556621,-1.500591 h -6.442946 v -3.999497 c 0,-0.831324 -0.686076,-1.500587 -1.548443,-1.500587 -0.464782,0 -0.879681,0.194711 -1.164427,0.504102 L 11.62564,16.9716 C 11.36244,17.240346 11.2,17.601558 11.2,18.000325 c 0,0.398769 0.162428,0.759977 0.42564,1.028725 l 6.661744,5.966846 C 18.57213,25.3053 18.987029,25.5 19.451811,25.5 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="m 30,21 v 5 h -8 v 6 h 8 v 5 l 9,-8 z"
-     style="opacity:0.35;fill:#1c2c38;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path868"
-     sodipodi:nodetypes="cccccccc" />
+     id="path19149"
+     style="font-variation-settings:normal;vector-effect:none;fill:#206b00;fill-opacity:0.5;stroke:none;stroke-width:0.999966;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 28.548156,38.5 c -0.862324,0 -1.548366,-0.669263 -1.548366,-1.500591 V 33.000566 H 20.556544 C 19.694214,33.000566 19,32.331305 19,31.499977 v -0.999302 c 0,-0.831328 0.694214,-1.501411 1.556544,-1.500591 h 6.443246 v -3.999497 c 0,-0.831324 0.686042,-1.500587 1.548366,-1.500587 0.464758,0 0.879634,0.194711 1.164368,0.504102 l 6.661939,5.967498 c 0.263186,0.268746 0.425618,0.629958 0.425618,1.028725 0,0.398769 -0.16242,0.759977 -0.425618,1.028725 l -6.661939,5.966846 C 29.42779,38.3053 29.012914,38.5 28.548156,38.5 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
   <path
-     d="m 30,20 v 5 h -8 v 6 h 8 v 5 l 9,-8 z"
-     style="fill:#ffffff;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
-     id="path867"
-     sodipodi:nodetypes="cccccccc" />
+     id="path17961"
+     style="font-variation-settings:normal;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.999966;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 28.548156,37.5 c -0.862324,0 -1.548366,-0.669263 -1.548366,-1.500591 V 32.000566 H 20.556544 C 19.694214,32.000566 19,31.331305 19,30.499977 v -0.999302 c 0,-0.831328 0.694214,-1.501411 1.556544,-1.500591 h 6.443246 v -3.999497 c 0,-0.831324 0.686042,-1.500587 1.548366,-1.500587 0.464758,0 0.879634,0.194711 1.164368,0.504102 l 6.661939,5.967498 c 0.263186,0.268746 0.425618,0.629958 0.425618,1.028725 0,0.398769 -0.16242,0.759977 -0.425618,1.028725 l -6.661939,5.966846 C 29.42779,37.3053 29.012914,37.5 28.548156,37.5 Z"
+     sodipodi:nodetypes="sscsssccssccsccs" />
 </svg>


### PR DESCRIPTION
~Changes colors of Session icons based on the safety level of their action.~

Update arrow style, borders, gradients, and shadows to better match elementary style. Hopefully they're a little cleaner and clearer. Also some sizes were missing so they were added.

Current:

![session-icons-2023-current](https://github.com/shimmerproject/elementary-xfce/assets/1984060/f9c41d5e-754e-4f87-824b-fcdffc34e99d) ![session-icons-2023-plugin-current](https://github.com/shimmerproject/elementary-xfce/assets/1984060/10af6405-5fcf-4113-98f7-29d62fd137bc)

Proposed:
![session-icons-2023-prop1-w-shadow2](https://github.com/shimmerproject/elementary-xfce/assets/1984060/c3a14da3-be39-45f9-916d-68d7638fa3d4) ![session-icons-2023-plugin-prop1](https://github.com/shimmerproject/elementary-xfce/assets/1984060/5f267631-f1ec-4185-9537-5cbd64e24341)

---

Updates arrow style, borders, gradients, and shadows to better match elementary style. Should also make icons a little clearer and sharp looking.
    
Use green color for "safe" actions (Lock Screen and Switch User).
This should make them easier to see and look less like disabled icons (previously they were a greyish color).
    
Closes #351