### PR TITLE
Apps: Refresh software center icons

### DIFF
--- a/elementary-xfce/apps/128/org.gnome.Software.svg
+++ b/elementary-xfce/apps/128/org.gnome.Software.svg
@@ -1,71 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="org.gnome.Software.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="58.240468"
+     inkscape:cy="48.422287"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="0"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4"
-       id="linearGradient3212-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4"
-       id="linearGradient3215-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1;"
-         id="stop3788-5-5-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ac51a3;stop-opacity:1;"
-         id="stop3790-9-0-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
+     id="defs3660">
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3224"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135034,1.4865135)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -73,222 +49,177 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop3926" />
       <stop
-         offset="0.06316455"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
+         offset="0.06316455" />
       <stop
-         id="stop3930"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
+         id="stop3930" />
       <stop
-         id="stop3932"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop3932" />
     </linearGradient>
-    <linearGradient
-       y2="5.2502403"
-       x2="19.874987"
-       y1="44.520065"
-       x1="19.874987"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3353"
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4" />
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#d78ec1;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#c564be;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#9d3ea4;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#5e2c73;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933-6"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="59.536617"
+       x2="12.168998"
+       y2="-0.28057176"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6410258,0,0,2.6410258,0.6153836,0.9743586)" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient2455-1"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient2457-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient2459-7"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933-6">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop929-7" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop931-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4212">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline;opacity:0.4">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <path
-       transform="translate(-9.9997601e-8,-64)"
-       style="opacity:0.05000000000000000;color:#000000;fill:url(#linearGradient3353);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6-4"
-       d="M 50.6875,38.03125 A 2.9776489,2.9776489 0 0 0 48.03125,41 l 0,20.03125 -10.03125,0 a 2.9776489,2.9776489 0 0 0 -2.25,4.90625 l 26,30 a 2.9776489,2.9776489 0 0 0 4.5,0 l 26,-30 A 2.9776489,2.9776489 0 0 0 90,61.03125 l -10.03125,0 0,-20.03125 A 2.9776489,2.9776489 0 0 0 77,38.03125 l -26,0 a 2.9776489,2.9776489 0 0 0 -0.3125,0 z" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
-    <path
-       transform="translate(-9.9997601e-8,-64)"
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3215-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6"
-       d="M 51,38.96875 A 2.0237426,2.0237426 0 0 0 48.96875,41 l 0,20.96875 -10.96875,0 a 2.0237426,2.0237426 0 0 0 -1.53125,3.34375 l 26,30 a 2.0237426,2.0237426 0 0 0 3.0625,0 l 26,-30 A 2.0237426,2.0237426 0 0 0 90,61.96875 l -10.96875,0 0,-20.96875 A 2.0237426,2.0237426 0 0 0 77,38.96875 l -26,0 z" />
-    <path
-       transform="translate(-9.9997601e-8,-64)"
-       style="opacity:0.25000000000000000;color:#000000;fill:url(#linearGradient3212-5);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107"
-       d="M 50.90625,40 A 1.000224,1.000224 0 0 0 50,41 l 0,22 -12,0 a 1.000224,1.000224 0 0 0 -0.75,1.65625 l 26,30 a 1.000224,1.000224 0 0 0 1.5,0 l 26,-30 A 1.000224,1.000224 0 0 0 90,63 l -12,0 0,-22 a 1.000224,1.000224 0 0 0 -1,-1 l -26,0 a 1.000224,1.000224 0 0 0 -0.09375,0 z" />
-    <path
-       id="path3288-2"
-       d="m 88.5,0.499998 -24.5,29 -24.5,-29 12,0 0,-23 25,0 0,23 12,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.9854275;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.5"
+     x="12.5"
+     ry="8"
+     rx="8"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.5"
+     x="13.5"
+     ry="7"
+     rx="7"
+     height="101"
+     width="101" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42.108666,71 c -3.597168,0.004 -5.450004,4.28414 -2.98224,6.889308 l 21.891338,23.832462 c 1.619528,1.70431 4.344944,1.70431 5.964474,0 L 88.873572,77.889308 C 91.341336,75.28414 89.488502,71.003878 85.891334,71 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="m 55.441257,40.500002 c -2.032468,0 -3.670307,1.360988 -3.670307,3.051543 V 66.946709 H 41.691538 c -3.665829,0.0041 -5.556208,4.359085 -3.04134,7.009012 l 22.312445,24.241492 c 1.65044,1.733589 4.424272,1.733589 6.074715,0 L 89.349803,73.955721 c 2.514868,-2.649927 0.624491,-7.005067 -3.04134,-7.009012 H 76.229051 V 43.551545 c 0,-1.690555 -1.637839,-3.051543 -3.670307,-3.051543 z" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42,67 c -3.480434,8.8e-5 -5.300646,4.137154 -2.949218,6.703124 l 22,24 c 1.585552,1.730088 4.312884,1.730088 5.898436,0 l 22,-24 C 91.300646,71.137154 89.480434,67.000088 86,67 Z"
+     id="path6081"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="24"
+     height="30"
+     x="52"
+     y="41"
+     rx="3"
+     ry="3" />
 </svg>

--- a/elementary-xfce/apps/128/system-software-installer.svg
+++ b/elementary-xfce/apps/128/system-software-installer.svg
@@ -1,82 +1,59 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="128"
    height="128"
-   id="svg4207"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.5520834"
+     inkscape:cx="93.184749"
+     inkscape:cy="87.835775"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="359"
+     inkscape:window-y="394"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4209">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-2"
-       id="linearGradient3212-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-2">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-5-54" />
+         id="stop929" />
       <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
          offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-7" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4"
-       id="linearGradient3215-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4">
-      <stop
-         offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-5-5-3" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-0-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2144204,0,0,3.4699564,10.750311,-67.821123)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop931" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3224"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135112,-62.513486)"
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135034,1.4865135)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -84,244 +61,165 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="5.2502403"
-       x2="19.874987"
-       y1="44.520065"
-       x1="19.874987"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3353"
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4-9" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4-9">
-      <stop
          offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-5-5-3-5" />
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-0-0-0" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(5.1311087e-8,6.1720513,-6.5292943,-1.1371274e-7,119.17132,-93.225249)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.641026,0,0,2.641026,0.6153902,-60.384616)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="48.335194"
+       x2="12.168998"
+       y2="-0.20351125"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6410258,0,0,2.6410258,0.6153836,0.9743586)" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient2455-1"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient2457-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient2459-7"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
   </defs>
   <metadata
-     id="metadata4212">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,64)">
+     transform="matrix(2.6999989,0,0,0.55555607,-0.800001,94.88888)"
+     id="g2036"
+     style="display:inline;opacity:0.4">
     <g
-       transform="matrix(2.9499988,0,0,1.2222234,-6.8000012,1.555537)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-48.5"
-       x="12.5"
-       ry="6"
-       rx="6"
-       height="103"
-       width="103" />
-    <path
-       transform="translate(-9.9997601e-8,-64)"
-       style="opacity:0.05;color:#000000;fill:url(#linearGradient3353);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6-4"
-       d="M 50.6875,38.03125 A 2.9776489,2.9776489 0 0 0 48.03125,41 l 0,20.03125 -10.03125,0 a 2.9776489,2.9776489 0 0 0 -2.25,4.90625 l 26,30 a 2.9776489,2.9776489 0 0 0 4.5,0 l 26,-30 A 2.9776489,2.9776489 0 0 0 90,61.03125 l -10.03125,0 0,-20.03125 A 2.9776489,2.9776489 0 0 0 77,38.03125 l -26,0 a 2.9776489,2.9776489 0 0 0 -0.3125,0 z" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-47.5"
-       x="13.5"
-       ry="5"
-       rx="5"
-       height="101"
-       width="101" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 17.680826,-48 C 15.857736,-48 13,-45.566759 13,-43.2 L 13.03394,16 C 15.968234,15.935551 112.7728,-7.591754 115,-8.723443 L 115,-43.2 c 0,-1.809077 -2.133,-4.8 -3.71161,-4.8 z" />
-    <path
-       transform="translate(-9.9997601e-8,-64)"
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3215-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6"
-       d="M 51,38.96875 A 2.0237426,2.0237426 0 0 0 48.96875,41 l 0,20.96875 -10.96875,0 a 2.0237426,2.0237426 0 0 0 -1.53125,3.34375 l 26,30 a 2.0237426,2.0237426 0 0 0 3.0625,0 l 26,-30 A 2.0237426,2.0237426 0 0 0 90,61.96875 l -10.96875,0 0,-20.96875 A 2.0237426,2.0237426 0 0 0 77,38.96875 l -26,0 z" />
-    <path
-       transform="translate(-9.9997601e-8,-64)"
-       style="opacity:0.25;color:#000000;fill:url(#linearGradient3212-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107"
-       d="M 50.90625,40 A 1.000224,1.000224 0 0 0 50,41 l 0,22 -12,0 a 1.000224,1.000224 0 0 0 -0.75,1.65625 l 26,30 a 1.000224,1.000224 0 0 0 1.5,0 l 26,-30 A 1.000224,1.000224 0 0 0 90,63 l -12,0 0,-22 a 1.000224,1.000224 0 0 0 -1,-1 l -26,0 a 1.000224,1.000224 0 0 0 -0.09375,0 z" />
-    <path
-       id="path3288-2"
-       d="m 88.5,0.499998 -24.5,29 -24.5,-29 12,0 0,-23 25,0 0,23 12,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.9854275;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="15.5"
+     x="12.5"
+     ry="8"
+     rx="8"
+     height="103"
+     width="103" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="16.5"
+     x="13.5"
+     ry="7"
+     rx="7"
+     height="101"
+     width="101" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42.108666,71 c -3.597168,0.004 -5.450004,4.28414 -2.98224,6.889308 l 21.891338,23.832462 c 1.619528,1.70431 4.344944,1.70431 5.964474,0 L 88.873572,77.889308 C 91.341336,75.28414 89.488502,71.003878 85.891334,71 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="m 55.441257,40.500002 c -2.032468,0 -3.670307,1.360988 -3.670307,3.051543 V 66.946709 H 41.691538 c -3.665829,0.0041 -5.556208,4.359085 -3.04134,7.009012 l 22.312445,24.241492 c 1.65044,1.733589 4.424272,1.733589 6.074715,0 L 89.349803,73.955721 c 2.514868,-2.649927 0.624491,-7.005067 -3.04134,-7.009012 H 76.229051 V 43.551545 c 0,-1.690555 -1.637839,-3.051543 -3.670307,-3.051543 z" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42,67 c -3.480434,8.8e-5 -5.300646,4.137154 -2.949218,6.703124 l 22,24 c 1.585552,1.730088 4.312884,1.730088 5.898436,0 l 22,-24 C 91.300646,71.137154 89.480434,67.000088 86,67 Z"
+     id="path6081"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="24"
+     height="30"
+     x="52"
+     y="41"
+     rx="3"
+     ry="3" />
 </svg>

--- a/elementary-xfce/apps/16/org.gnome.Software.svg
+++ b/elementary-xfce/apps/16/org.gnome.Software.svg
@@ -1,165 +1,139 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="16"
+   height="16"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="org.gnome.Software.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041666"
+     inkscape:cx="18.29912"
+     inkscape:cy="25.759531"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="545"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="24px"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3175">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-6"
-       id="linearGradient3293-7"
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33333341,0,0,0.33333341,1.5e-7,-0.3333374)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3155"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2605204,0,0,0.43374453,1.7353306,-0.4776394)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486583,0.8648677)"
        x1="23.99999"
-       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.8648665,0.86486712)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
     <linearGradient
-       id="linearGradient3924-4-8">
+       id="linearGradient3924">
       <stop
-         id="stop3926-0-4"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop3926" />
       <stop
-         offset="0.06316455"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
+         offset="0.06316455" />
       <stop
-         id="stop3930-2-1"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
+         id="stop3930" />
       <stop
-         id="stop3932-9-0"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop3932" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-0">
-      <stop
-         offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1;"
-         id="stop3750-4" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1;"
-         id="stop3752-4" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#9d3ea4;stop-opacity:1;"
-         id="stop3754-4" />
-      <stop
-         offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1;"
-         id="stop3756-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-6">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1;"
-         id="stop3760-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ac51a3;stop-opacity:1;"
-         id="stop3762-1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.77899685,-0.82408577,-1.4352095e-8,14.963371,-4.1449376)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient933-6"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="63.3797"
+       x2="12.168998"
+       y2="0.98788178"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-0" />
+       gradientTransform="matrix(0.33333332,0,0,0.3333334,9.220459e-8,-0.33333512)" />
     <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.33333341,0,0,0.33333341,1.5e-7,-2.92e-6)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient3707-319-631-407-324-6" />
+       inkscape:collect="always"
+       id="linearGradient933-6">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop929-7" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop931-5" />
+    </linearGradient>
   </defs>
   <metadata
-     id="metadata3178">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="1.499997"
-       x="1.5"
-       ry="1"
-       rx="1"
-       height="13.000003"
-       width="13.000003" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="2.4999995"
-       x="2.5"
-       height="11"
-       width="11" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3155);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 2.3842909,1.9999999 C 2.1698084,1.9999999 2,2.3041548 2,2.6000007 L 2.00398,9.9999996 C 2.3491899,9.9918999 13.737978,7.0510306 14,6.9095697 l 0,-4.309569 C 14,2.3738648 13.832259,1.9999999 13.64654,1.9999999 l -11.2622633,0 z" />
-    <path
-       style="opacity:0.29999999999999999;color:#000000;fill:url(#linearGradient3293-7);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107"
-       d="M 6.34375,4 A 1.4957323,1.4957323 0 0 0 5,5.5 L 5,7 A 1.4957323,1.4957323 0 0 0 4,9.4375 l 2.84375,3.5 a 1.4957323,1.4957323 0 0 0 2.3125,0 L 12,9.4375 A 1.4957323,1.4957323 0 0 0 11,7 L 11,5.5 A 1.4957323,1.4957323 0 0 0 9.5,4 l -3,0 A 1.4957323,1.4957323 0 0 0 6.34375,4 z" />
-    <path
-       id="path3288-2"
-       d="m 10.833334,8.5072862 -2.8333339,3.4999998 -2.833334,-3.4999998 1.333334,0 0,-3.0072866 3,0 0,3.0072866 1.3333339,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542732;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="1.4999986"
+     x="1.5"
+     ry="2"
+     rx="2"
+     height="13.000003"
+     width="13" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="2.5"
+     x="2.5"
+     ry="1"
+     rx="1"
+     height="11"
+     width="11" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+     d="m 6.5788897,4.4999996 c -0.262527,0 -0.473875,0.2127855 -0.473875,0.4770976 v 3.542611 H 4.4592149 c -0.6229398,6.68e-4 -0.943805,0.750404 -0.5164493,1.206721 L 7.4840637,13.15158 c 0.2804624,0.298525 0.7524364,0.298525 1.0328984,0 L 12.057737,9.7264292 c 0.427355,-0.456317 0.10649,-1.206042 -0.51645,-1.206721 H 9.8960111 v -3.542611 c 0,-0.2643121 -0.211348,-0.4770976 -0.473874,-0.4770976 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 6.5788897,3.7499995 c -0.262527,0 -0.473875,0.2127856 -0.473875,0.4770978 V 7.7745802 H 4.750251 c -1.1035033,0 -1.6820007,0.9976447 -0.8074854,1.9314247 l 3.5412981,3.4251501 c 0.2804624,0.298525 0.7524364,0.298525 1.0328984,0 L 12.057737,9.7060049 C 12.932275,8.8314672 12.257082,7.7745802 11.250251,7.7745802 H 9.8960111 V 4.2270973 c 0,-0.2643122 -0.211348,-0.4770977 -0.473874,-0.4770977 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:0.999998;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 4.9191952,7.9995799 C 3.8798672,7.9999866 3.3593397,9.0532001 4.094,9.7865802 l 3.181251,3.1221768 c 0.4557289,0.45443 0.9942711,0.45443 1.4500001,0 L 11.906376,9.7865802 c 0.734661,-0.7333801 0.214258,-1.7865936 -0.82507,-1.7870003 z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;stroke-width:2.99999;stroke-linejoin:round"
+     id="rect902"
+     height="5"
+     x="6.0002513"
+     y="3.9995799"
+     rx="0.5"
+     ry="0.5"
+     width="4" />
 </svg>

--- a/elementary-xfce/apps/16/system-software-installer.svg
+++ b/elementary-xfce/apps/16/system-software-installer.svg
@@ -1,176 +1,139 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="16"
+   height="16"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3173"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="10.609971"
+     inkscape:cy="5.7008797"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="122"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="24px"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3175">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-0-8"
-       id="linearGradient3293-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33333341,0,0,0.33333341,1.5e-7,-0.3333374)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-0-8">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
-         id="stop3788-3-4"
-         style="stop-color:#365a7c;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
       <stop
-         id="stop3790-0-5"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         offset="1" />
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3155"
+       xlink:href="#linearGradient3924"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2605204,0,0,0.43374453,1.7353306,-0.4776394)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="43"
-       x2="23.99999"
-       y1="4.999989"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486583,0.8648677)"
        x1="23.99999"
-       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.8648665,0.86486712)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3079-9"
-       xlink:href="#linearGradient3924-4-8" />
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" />
     <linearGradient
-       id="linearGradient3924-4-8">
+       id="linearGradient3924">
       <stop
-         id="stop3926-0-4"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop3926" />
       <stop
-         offset="0.06316455"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928-6-8" />
+         offset="0.06316455" />
       <stop
-         id="stop3930-2-1"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
+         id="stop3930" />
       <stop
-         id="stop3932-9-0"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop3932" />
     </linearGradient>
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-0">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop3750-4" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop3752-4" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop3754-4" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop3756-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-6">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760-3" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762-1" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(0,0.77899685,-0.82408577,-1.4352095e-8,14.963371,-4.1449376)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="49.078144"
+       x2="12.168998"
+       y2="0.98788178"
        gradientUnits="userSpaceOnUse"
-       id="radialGradient3169"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-0" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(0.33333341,0,0,0.33333341,1.5e-7,-2.92e-6)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3171"
-       xlink:href="#linearGradient3707-319-631-407-324-6" />
+       gradientTransform="matrix(0.33333332,0,0,0.3333334,9.220459e-8,-0.33333512)" />
   </defs>
   <metadata
-     id="metadata3178">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       style="color:#000000;fill:url(#radialGradient3169);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3171);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="1.499997"
-       x="1.5"
-       ry="1"
-       rx="1"
-       height="13.000003"
-       width="13.000003" />
-    <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3079-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-0-3"
-       y="2.4999995"
-       x="2.5"
-       height="11"
-       width="11" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3155);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 2.3842909,1.9999999 C 2.1698084,1.9999999 2,2.3041548 2,2.6000007 L 2.00398,9.9999996 C 2.3491899,9.9918999 13.737978,7.0510306 14,6.9095697 l 0,-4.309569 C 14,2.3738648 13.832259,1.9999999 13.64654,1.9999999 l -11.2622633,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:url(#linearGradient3293-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107"
-       d="M 6.34375,4 A 1.4957323,1.4957323 0 0 0 5,5.5 L 5,7 A 1.4957323,1.4957323 0 0 0 4,9.4375 l 2.84375,3.5 a 1.4957323,1.4957323 0 0 0 2.3125,0 L 12,9.4375 A 1.4957323,1.4957323 0 0 0 11,7 L 11,5.5 A 1.4957323,1.4957323 0 0 0 9.5,4 l -3,0 A 1.4957323,1.4957323 0 0 0 6.34375,4 z" />
-    <path
-       id="path3288-2"
-       d="m 10.833334,8.5072862 -2.8333339,3.4999998 -2.833334,-3.4999998 1.333334,0 0,-3.0072866 3,0 0,3.0072866 1.3333339,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542732;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="1.4999986"
+     x="1.5"
+     ry="2"
+     rx="2"
+     height="13.000003"
+     width="13" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="2.5"
+     x="2.5"
+     ry="1"
+     rx="1"
+     height="11"
+     width="11" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+     d="m 6.5788897,4.5004512 c -0.262527,0 -0.473875,0.2127855 -0.473875,0.4770976 v 3.542611 H 4.4592149 c -0.6229398,6.68e-4 -0.943805,0.750404 -0.5164493,1.206721 l 3.5412981,3.4251512 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 L 12.057737,9.7268808 c 0.427355,-0.456317 0.10649,-1.206042 -0.51645,-1.206721 H 9.896011 v -3.542611 c 0,-0.2643121 -0.211348,-0.4770976 -0.473874,-0.4770976 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 6.5788897,3.7504511 c -0.262527,0 -0.473875,0.2127856 -0.473875,0.4770978 V 7.7750318 H 4.750251 c -1.1035033,0 -1.6820007,0.9976447 -0.8074854,1.9314247 l 3.5412981,3.4251505 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 L 12.057737,9.7064565 C 12.932275,8.8319188 12.257082,7.7750318 11.250251,7.7750318 H 9.896011 V 4.2275489 c 0,-0.2643122 -0.211348,-0.4770977 -0.473874,-0.4770977 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:0.999998;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 4.9191952,8.0000315 C 3.8798672,8.0004382 3.3593397,9.0536517 4.094,9.7870318 l 3.181251,3.1221772 c 0.4557289,0.45443 0.9942711,0.45443 1.45,0 l 3.181125,-3.1221772 c 0.734661,-0.7333801 0.214258,-1.7865936 -0.82507,-1.7870003 z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;stroke-width:2.99999;stroke-linejoin:round"
+     id="rect902"
+     height="5"
+     x="6.0002513"
+     y="4.0000315"
+     rx="0.5"
+     ry="0.5"
+     width="4" />
 </svg>

--- a/elementary-xfce/apps/24/org.gnome.Software.svg
+++ b/elementary-xfce/apps/24/org.gnome.Software.svg
@@ -1,60 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="org.gnome.Software.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208334"
+     inkscape:cx="9.607038"
+     inkscape:cy="16.750733"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="63"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="24px"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3428">
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3172-9-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,7.8205088)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       y2="5.2502403"
-       x2="19.874987"
-       y1="44.520065"
-       x1="19.874987"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,7.8205088)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3333"
-       xlink:href="#linearGradient3707-319-631-407-324" />
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
-      <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+     id="defs3660">
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3181"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
+       gradientTransform="matrix(0.46088194,0,0,0.46088194,0.93883524,0.93883817)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -62,74 +48,25 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
       <stop
          id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0.06316455" />
       <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1;"
-         id="stop3750" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1;"
-         id="stop3752" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#9d3ea4;stop-opacity:1;"
-         id="stop3754" />
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1;"
-         id="stop3756" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1;"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#ac51a3;stop-opacity:1;"
-         id="stop3762" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3152"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -140,17 +77,17 @@
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3154"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -161,118 +98,134 @@
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933-6"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="59.048882"
+       x2="12.168998"
+       y2="-0.0086730029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717949,0.30769232,-0.17948722)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933-6">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop929-7" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop931-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
-    <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33331)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
-    </g>
+     style="opacity:0.4;stroke-width:2"
+     id="g3712"
+     transform="matrix(0.5789476,0,0,0.2857143,-1.894742,9.071428)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="10.499998"
-       x="2.5"
-       ry="1"
-       rx="1"
-       height="19.000002"
-       width="19.000002" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
-    <path
-       transform="translate(0,7.9999999)"
-       style="opacity:0.10000000000000001;color:#000000;fill:url(#linearGradient3333);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4014-7"
-       d="M 9.5,5 A 2.4881557,2.4881557 0 0 0 7,7.5 l 0,1.5625 a 2.4881557,2.4881557 0 0 0 -1.34375,4.09375 l 4.5,5 a 2.4881557,2.4881557 0 0 0 3.6875,0 l 4.5,-5 A 2.4881557,2.4881557 0 0 0 17,9.0625 L 17,7.5 A 2.4881557,2.4881557 0 0 0 14.5,5 l -5,0 z" />
-    <path
-       transform="translate(0,7.9999999)"
-       style="opacity:0.29999999999999999;color:#000000;fill:url(#linearGradient3172-9-6);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4014"
-       d="M 9.34375,6.03125 A 1.4769903,1.4769903 0 0 0 8.03125,7.5 l 0,2.53125 -0.53125,0 A 1.4769903,1.4769903 0 0 0 6.40625,12.5 l 4.5,5 a 1.4769903,1.4769903 0 0 0 2.1875,0 l 4.5,-5 A 1.4769903,1.4769903 0 0 0 16.5,10.03125 l -0.53125,0 0,-2.53125 A 1.4769903,1.4769903 0 0 0 14.5,6.03125 l -5,0 a 1.4769903,1.4769903 0 0 0 -0.15625,0 z" />
-    <path
-       id="path3288-2"
-       d="m 16.5,19.500019 -4.500001,5 -4.499999,-5 2,0 0,-4 5,0 0,4 2,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542732;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="2.5"
+     x="2.5"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+     d="m 10.473938,8.4999995 c -0.262527,0 -0.4741217,0.2127856 -0.473875,0.4770976 V 13.270976 H 8.2089669 c -0.6229398,6.68e-4 -0.943805,0.750404 -0.5164493,1.206721 L 11.483551,18.352 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 l 3.791034,-3.874303 c 0.427355,-0.456317 0.10649,-1.206042 -0.51645,-1.206721 H 14.000937 V 8.9770971 c 0,-0.2643121 -0.211348,-0.4770976 -0.473874,-0.4770976 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.947368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="3.4736843"
+     x="3.4736843"
+     ry="1"
+     rx="1"
+     height="17.052631"
+     width="17.052631" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 10.395749,6.9999998 c -0.262527,0 -0.395443,-0.014312 -0.395498,0.2500004 V 12.020976 H 8 C 7.2534978,12.021777 6.8144196,13.171683 7.2417753,13.628 l 4.2417757,4.274 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 l 4.241776,-4.274 C 17.18558,13.171683 16.741113,12.021784 16,12.020976 H 13.999749 V 7.2500002 c 0,-0.264312 -0.132972,-0.2500004 -0.395498,-0.2500004 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:0.999998;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 8.1553626,12 c -1.0272527,4.03e-4 -1.5416082,1.242244 -0.8154835,1.968875 l 3.8446369,3.844636 c 0.450434,0.450248 1.180534,0.450248 1.630968,0 l 3.844637,-3.844636 C 17.386246,13.242244 16.87189,12.000403 15.844637,12 Z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;stroke-width:2.99999;stroke-linejoin:round"
+     id="rect902"
+     width="4"
+     height="7"
+     x="10"
+     y="7"
+     rx="0.5"
+     ry="0.5" />
 </svg>

--- a/elementary-xfce/apps/24/system-software-installer.svg
+++ b/elementary-xfce/apps/24/system-software-installer.svg
@@ -1,82 +1,56 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    height="24"
-   id="svg3426"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208334"
+     inkscape:cx="9.7126095"
+     inkscape:cy="8.1642225"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="580"
+     inkscape:window-y="295"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="24px" />
   <defs
-     id="defs3428">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-3-8"
-       id="linearGradient3172-9-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,7.8205088)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-3-8">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
-         id="stop3788-6-7-8"
-         style="stop-color:#365a7c;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
       <stop
-         id="stop3790-9-4-43"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="5.2502403"
-       x2="19.874987"
-       y1="44.520065"
-       x1="19.874987"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,7.8205088)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3333"
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-0-0-4" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-0-0-4">
-      <stop
-         id="stop3788-6-4-7-9"
-         style="stop-color:#365a7c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3790-9-8-8-2"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-8"
-       id="linearGradient3178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39077928,0,0,0.59639877,2.6029975,7.5932433)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7-8">
-      <stop
-         id="stop2687-1-9-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3181"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,8.9717328)"
+       gradientTransform="matrix(0.46088194,0,0,0.46088194,0.93883524,0.93883817)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -84,74 +58,25 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
       <stop
          id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0.06316455" />
       <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1385337,-1.2044328,-2.0976135e-8,22.177231,2.2497107)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop3750" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop3752" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop3754" />
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop3756" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48717951,0,0,0.48717951,0.30769188,8.3076897)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3152"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -162,17 +87,17 @@
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3154"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -183,118 +108,122 @@
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3156"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="48.266846"
+       x2="12.168998"
+       y2="-0.0086730029"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48717949,0,0,0.48717949,0.30769232,-0.17948722)" />
   </defs>
   <metadata
-     id="metadata3431">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-8)">
-    <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.55,0,0,0.3333336,-1.2000011,15.33331)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
-    </g>
+     style="opacity:0.4;stroke-width:2"
+     id="g3712"
+     transform="matrix(0.5789476,0,0,0.2857143,-1.894742,9.071428)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3184);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3186);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="10.499998"
-       x="2.5"
-       ry="1"
-       rx="1"
-       height="19.000002"
-       width="19.000002" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3181);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-9"
-       y="11.498756"
-       x="3.5012455"
-       height="17"
-       width="17" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 3.5764341,11 C 3.2547127,11 3,11.418213 3,11.824999 L 3.00603,22 C 3.5238425,21.988917 20.606966,17.945168 21,17.750658 l 0,-5.925659 C 21,11.514064 20.748387,11 20.46981,11 L 3.576473,11 z" />
-    <path
-       transform="translate(0,7.9999999)"
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3333);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4014-7"
-       d="M 9.5,5 A 2.4881557,2.4881557 0 0 0 7,7.5 l 0,1.5625 a 2.4881557,2.4881557 0 0 0 -1.34375,4.09375 l 4.5,5 a 2.4881557,2.4881557 0 0 0 3.6875,0 l 4.5,-5 A 2.4881557,2.4881557 0 0 0 17,9.0625 L 17,7.5 A 2.4881557,2.4881557 0 0 0 14.5,5 l -5,0 z" />
-    <path
-       transform="translate(0,7.9999999)"
-       style="opacity:0.3;color:#000000;fill:url(#linearGradient3172-9-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4014"
-       d="M 9.34375,6.03125 A 1.4769903,1.4769903 0 0 0 8.03125,7.5 l 0,2.53125 -0.53125,0 A 1.4769903,1.4769903 0 0 0 6.40625,12.5 l 4.5,5 a 1.4769903,1.4769903 0 0 0 2.1875,0 l 4.5,-5 A 1.4769903,1.4769903 0 0 0 16.5,10.03125 l -0.53125,0 0,-2.53125 A 1.4769903,1.4769903 0 0 0 14.5,6.03125 l -5,0 a 1.4769903,1.4769903 0 0 0 -0.15625,0 z" />
-    <path
-       id="path3288-2"
-       d="m 16.5,19.500019 -4.500001,5 -4.499999,-5 2,0 0,-4 5,0 0,4 2,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542732;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="2.5"
+     x="2.5"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.947368;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="3.4736843"
+     x="3.4736843"
+     ry="1"
+     rx="1"
+     height="17.052631"
+     width="17.052631" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+     d="m 10.473711,8.4997586 c -0.262527,0 -0.4741218,0.2127856 -0.4738748,0.4770976 v 4.2938788 h -1.791096 c -0.62294,6.68e-4 -0.943805,0.750404 -0.516449,1.206721 l 3.7910328,3.874303 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 l 3.791034,-3.874303 c 0.427355,-0.456317 0.10649,-1.206042 -0.51645,-1.206721 H 14.00071 V 8.9768562 c 0,-0.2643121 -0.211348,-0.4770976 -0.473874,-0.4770976 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 10.395522,6.9997589 c -0.262527,0 -0.395443,-0.014312 -0.395498,0.2500004 V 12.020735 H 7.9997732 c -0.746502,8.01e-4 -1.18558,1.150707 -0.758225,1.607024 l 4.2417758,4.274 c 0.280462,0.298525 0.752436,0.298525 1.032898,0 l 4.241776,-4.274 c 0.427355,-0.456317 -0.01711,-1.606216 -0.758225,-1.607024 H 13.999522 V 7.2497593 c 0,-0.264312 -0.132972,-0.2500004 -0.395498,-0.2500004 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-width:0.999998;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 8.1551362,11.999759 c -1.027253,4.03e-4 -1.541609,1.242244 -0.815484,1.968875 l 3.8446368,3.844636 c 0.450434,0.450248 1.180534,0.450248 1.630968,0 l 3.844637,-3.844636 c 0.726125,-0.726631 0.211769,-1.968472 -0.815484,-1.968875 z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;stroke-width:2.99999;stroke-linejoin:round"
+     id="rect902"
+     width="4"
+     height="7"
+     x="9.999774"
+     y="6.9997592"
+     rx="0.5"
+     ry="0.5" />
 </svg>

--- a/elementary-xfce/apps/32/org.gnome.Software.svg
+++ b/elementary-xfce/apps/32/org.gnome.Software.svg
@@ -1,58 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="32"
+   height="32"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="softwarecenter.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="16.750733"
+     inkscape:cy="18.228739"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="558"
+     inkscape:window-y="36"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3353">
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-0"
-       id="linearGradient3183-9"
-       gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="29"
-       x2="17"
-       y2="4" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-0"
-       id="linearGradient3186-5"
-       gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="29"
-       x2="17"
-       y2="4" />
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+     id="defs3660">
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3192"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
+       gradientTransform="matrix(0.62162163,0,0,0.62162163,1.0810836,2.0810874)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -60,216 +49,173 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop3926" />
       <stop
-         offset="0.06316455"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
+         offset="0.06316455" />
       <stop
-         id="stop3930"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
+         id="stop3930" />
       <stop
-         id="stop3932"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop3932" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8">
-      <stop
-         offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1;"
-         id="stop3750-4" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1;"
-         id="stop3752-8" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#9d3ea4;stop-opacity:1;"
-         id="stop3754-1" />
-      <stop
-         offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1;"
-         id="stop3756-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-0"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-0">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1;"
-         id="stop3760-4" />
-      <stop
-         offset="1"
-         style="stop-color:#ac51a3;stop-opacity:1;"
-         id="stop3762-4" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933-6"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="70.553894"
+       x2="12.168998"
+       y2="-0.77512693"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6410257,0,0,0.6410257,0.61538445,0.974359)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4159"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933-6">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop929-7" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop931-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3356">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
-    </g>
+     style="opacity:0.6;stroke-width:2"
+     id="g3712-8-2-4-4"
+     transform="matrix(0.7894751,0,0,0.35714285,-2.9473755,13.964286)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
+       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect2801-5-5-7-9"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
-    <path
-       style="opacity:0.10000000000000001;color:#000000;fill:url(#linearGradient3186-5);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.98542737999999996;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3877-4"
-       d="M 12.8125,9.03125 A 1.9648723,1.9648723 0 0 0 11.03125,11 l 0,3.03125 -1.125,0 A 1.9648723,1.9648723 0 0 0 8.375,17.25 l 6.09375,7.40625 a 1.9648723,1.9648723 0 0 0 3.0625,0 L 23.625,17.25 a 1.9648723,1.9648723 0 0 0 -1.53125,-3.21875 l -1.125,0 0,-3.03125 A 1.9648723,1.9648723 0 0 0 19,9.03125 l -6,0 a 1.9648723,1.9648723 0 0 0 -0.1875,0 z" />
-    <path
-       style="opacity:0.29999999999999999;color:#000000;fill:url(#linearGradient3183-9);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.98542737999999996;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3877"
-       d="M 12.8125,10 A 1.0101725,1.0101725 0 0 0 12,11 l 0,4 -2.09375,0 A 1.0101725,1.0101725 0 0 0 9.125,16.65625 l 6.09375,7.40625 a 1.0101725,1.0101725 0 0 0 1.5625,0 L 22.875,16.65625 A 1.0101725,1.0101725 0 0 0 22.09375,15 L 20,15 20,11 a 1.0101725,1.0101725 0 0 0 -1,-1 l -6,0 a 1.0101725,1.0101725 0 0 0 -0.1875,0 z" />
-    <path
-       id="path3288-2"
-       d="m 21.5,16.5 -5.5,6 -5.5,-6 3,0 0,-5 5,0 0,5 3,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542738;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4159);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3700-5-6-8-4"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="5.5"
+     x="4.5"
+     ry="1"
+     rx="1"
+     height="23"
+     width="23" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 10.12278,18.5 c -0.8992919,0.001 -1.362501,1.071035 -0.7455601,1.722327 l 5.8772211,5.958114 c 0.404882,0.426078 1.086236,0.426078 1.491118,0 L 22.62278,20.222327 C 23.239721,19.571035 22.776512,18.500969 21.87722,18.5 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="m 13.865946,10.999886 c -0.479566,0 -0.867153,0.323008 -0.866018,0.724228 v 5.276155 H 10.5 c -1.2856561,0 -1.452195,1.620818 -0.858806,2.249731 L 15.283328,25 c 0.389426,0.411436 1.043918,0.411436 1.433344,0 l 5.642134,-5.75 C 22.952195,18.621087 22.764867,17.000269 21.5,17.000269 h -2.499928 v -5.276155 c 0,-0.401222 -0.386452,-0.724228 -0.866018,-0.724228 z"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="6"
+     height="7"
+     x="13"
+     y="11"
+     rx="1"
+     ry="1" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 11,17 c -1.3359555,5.24e-4 -2.0048815,1.615555 -1.0605469,2.560547 l 4.9999999,5 c 0.585795,0.585553 1.535299,0.585553 2.121094,0 l 5,-5 C 23.004882,18.615555 22.335956,17.000524 21,17 Z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
 </svg>

--- a/elementary-xfce/apps/32/system-software-installer.svg
+++ b/elementary-xfce/apps/32/system-software-installer.svg
@@ -1,80 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="32"
+   height="32"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32px"
-   height="32px"
-   id="svg3351"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="14.621701"
+     inkscape:cy="15.800586"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="541"
+     inkscape:window-y="203"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false" />
   <defs
-     id="defs3353">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-0-3"
-       id="linearGradient3183-9"
-       gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="29"
-       x2="17"
-       y2="4" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-0-3">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760-4-7" />
+         id="stop929" />
       <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
          offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762-4-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-0-6-2"
-       id="linearGradient3186-5"
-       gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="29"
-       x2="17"
-       y2="4" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-0-6-2">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760-4-4-5" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762-4-2-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.52104027,0,0,0.81327108,3.4706604,0.354424)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         id="stop931" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3192"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62162164,0,0,0.62162164,1.0810837,2.0810873)"
+       gradientTransform="matrix(0.62162163,0,0,0.62162163,1.0810836,2.0810874)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -82,216 +59,161 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
+         id="stop3926" />
       <stop
-         offset="0.06316455"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
+         offset="0.06316455" />
       <stop
-         id="stop3930"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
+         id="stop3930" />
       <stop
-         id="stop3932"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
+         id="stop3932" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8"
-       id="radialGradient3195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2454146e-8,1.4980705,-1.58478,-2.7600178e-8,29.391093,-6.355641)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop3750-4" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop3752-8" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop3754-1" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop3756-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-0"
-       id="linearGradient3197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64102567,0,0,0.64102567,0.6153854,1.6153843)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-0">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760-4" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762-4" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3165"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3167"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="50.073002"
+       x2="12.168998"
+       y2="0.11462299"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.6410257,0,0,0.6410257,0.61538445,0.974359)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4159"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata3356">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(0.6999997,0,0,0.3333336,-0.8000003,15.33333)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
-    </g>
+     style="opacity:0.6;stroke-width:2"
+     id="g3712-8-2-4-4"
+     transform="matrix(0.7894751,0,0,0.35714285,-2.9473755,13.964286)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3195);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3197);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505"
-       y="4.5"
-       x="3.5"
-       ry="2"
-       rx="2"
-       height="25"
-       width="25" />
+       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect2801-5-5-7-9"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="5.5"
-       x="4.5"
-       ry="1"
-       rx="1"
-       height="23"
-       width="23" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3189);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 5.3578979,5 C 4.9289359,5 4,5.5702913 4,6.125 L 4.0079806,20 C 4.6984029,19.984887 27.475954,14.470682 28,14.205444 L 28,6.125 C 28,5.7009978 26.957334,5 26.585897,5 z" />
-    <path
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3186-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98542738;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3877-4"
-       d="M 12.8125,9.03125 A 1.9648723,1.9648723 0 0 0 11.03125,11 l 0,3.03125 -1.125,0 A 1.9648723,1.9648723 0 0 0 8.375,17.25 l 6.09375,7.40625 a 1.9648723,1.9648723 0 0 0 3.0625,0 L 23.625,17.25 a 1.9648723,1.9648723 0 0 0 -1.53125,-3.21875 l -1.125,0 0,-3.03125 A 1.9648723,1.9648723 0 0 0 19,9.03125 l -6,0 a 1.9648723,1.9648723 0 0 0 -0.1875,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:url(#linearGradient3183-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.98542738;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3877"
-       d="M 12.8125,10 A 1.0101725,1.0101725 0 0 0 12,11 l 0,4 -2.09375,0 A 1.0101725,1.0101725 0 0 0 9.125,16.65625 l 6.09375,7.40625 a 1.0101725,1.0101725 0 0 0 1.5625,0 L 22.875,16.65625 A 1.0101725,1.0101725 0 0 0 22.09375,15 L 20,15 20,11 a 1.0101725,1.0101725 0 0 0 -1,-1 l -6,0 a 1.0101725,1.0101725 0 0 0 -0.1875,0 z" />
-    <path
-       id="path3288-2"
-       d="m 21.5,16.5 -5.5,6 -5.5,-6 3,0 0,-5 5,0 0,5 3,0 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542738;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4159);fill-opacity:1;stroke:none;stroke-width:2"
+       id="rect3700-5-6-8-4"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="5.5"
+     x="4.5"
+     ry="1"
+     rx="1"
+     height="23"
+     width="23" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 10.122893,18.500113 c -0.899292,0.001 -1.3625011,1.071035 -0.7455602,1.722327 l 5.8772202,5.958114 c 0.404883,0.426078 1.086236,0.426078 1.491118,0 l 5.877221,-5.958114 c 0.616941,-0.651292 0.153733,-1.721358 -0.745559,-1.722327 z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:0.999999;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="m 13.866058,10.999999 c -0.479566,0 -0.867153,0.323008 -0.866018,0.724228 v 5.276155 h -2.499927 c -1.2856562,0 -1.4521951,1.620818 -0.8588061,2.249731 l 5.6421331,5.75 c 0.389426,0.411436 1.043918,0.411436 1.433344,0 l 5.642135,-5.75 c 0.593388,-0.628913 0.40606,-2.249731 -0.858807,-2.249731 h -2.499928 v -5.276155 c 0,-0.401222 -0.386451,-0.724228 -0.866018,-0.724228 z"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="6"
+     height="7"
+     x="13.000113"
+     y="11.000113"
+     rx="1"
+     ry="1" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 11.000113,17.000113 c -1.3359556,5.24e-4 -2.0048816,1.615555 -1.060547,2.560547 l 5,5 c 0.585794,0.585553 1.535298,0.585553 2.121093,0 l 5,-5 c 0.944335,-0.944992 0.275409,-2.560023 -1.060547,-2.560547 z"
+     id="path906"
+     sodipodi:nodetypes="ccccccc" />
 </svg>

--- a/elementary-xfce/apps/48/org.gnome.Software.svg
+++ b/elementary-xfce/apps/48/org.gnome.Software.svg
@@ -1,36 +1,51 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="org.gnome.Software.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="12.416878"
+     inkscape:cy="26.525835"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="478"
+     inkscape:window-y="36"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3568"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
+         style="stop-color:#7239b3;stop-opacity:1"
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
+         id="stop929" />
       <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop931" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3924"
@@ -59,55 +74,6 @@
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687;"
          id="stop3932" />
-    </linearGradient>
-    <radialGradient
-       r="19.99999"
-       fy="8.4497671"
-       fx="7.4956832"
-       cy="8.4497671"
-       cx="7.4956832"
-       gradientTransform="matrix(1.9428467e-8,2.33699,-2.4722567,-4.3056275e-8,44.890104,-11.434799)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient2874"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#d78ec1;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#c564be;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#9d3ea4;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#5e2c73;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="translate(1.2e-6,1)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient2876"
-       xlink:href="#linearGradient3707-319-631-407-324" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#650d5c;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#ac51a3;stop-opacity:1;"
-         offset="1" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
@@ -175,122 +141,80 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3374-0"
-       gradientUnits="userSpaceOnUse"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3372-1"
-       gradientUnits="userSpaceOnUse"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-9-274-7"
-       id="linearGradient3370-7"
-       gradientUnits="userSpaceOnUse"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-9-274-7">
-      <stop
-         offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3776-6" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3778-7" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="55.694267"
+       x2="12.168998"
+       y2="0.46054515"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
      id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
-      <rect
-         style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(1.1578952,0,0,0.57142859,-3.789484,19.142856)">
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="5.5"
-       x="4.5"
-       ry="2"
-       rx="2"
-       height="39"
-       width="39" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="6.5"
-       x="5.5"
-       ry="1"
-       rx="1"
-       height="37"
-       width="37" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
-    <path
-       style="opacity:0.05000000000000000;color:#000000;fill:url(#linearGradient3370-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8-3"
-       d="M 18.71875,14.09375 A 2.9091695,2.9091695 0 0 0 16.09375,17 l 0,6.09375 -1.59375,0 a 2.9091695,2.9091695 0 0 0 -2.1875,4.8125 l 9.5,11 a 2.9091695,2.9091695 0 0 0 4.375,0 l 9.5,-11 A 2.9091695,2.9091695 0 0 0 33.5,23.09375 l -1.59375,0 0,-6.09375 A 2.9091695,2.9091695 0 0 0 29,14.09375 l -10,0 a 2.9091695,2.9091695 0 0 0 -0.28125,0 z"
-       transform="translate(-2.4867694e-7,-0.99957921)" />
-    <path
-       style="opacity:0.10000000000000001;color:#000000;fill:url(#linearGradient3372-1);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8"
-       d="M 18.8125,14.96875 A 2.0262062,2.0262062 0 0 0 16.96875,17 l 0,6.96875 -2.46875,0 a 2.0262062,2.0262062 0 0 0 -1.53125,3.34375 l 9.5,11 a 2.0262062,2.0262062 0 0 0 3.0625,0 l 9.5,-11 A 2.0262062,2.0262062 0 0 0 33.5,23.96875 l -2.46875,0 0,-6.96875 A 2.0262062,2.0262062 0 0 0 29,14.96875 l -10,0 a 2.0262062,2.0262062 0 0 0 -0.1875,0 z"
-       transform="translate(-2.4867694e-7,-0.99957921)" />
-    <path
-       style="opacity:0.25000000000000000;fill:url(#linearGradient3374-0);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;color:#000000;enable-background:accumulate"
-       id="path3932"
-       d="M 18.90625,15.9375 A 1.0548436,1.0548436 0 0 0 17.9375,17 l 0,7.9375 -3.4375,0 a 1.0548436,1.0548436 0 0 0 -0.8125,1.75 l 9.5,11 a 1.0548436,1.0548436 0 0 0 1.625,0 l 9.5,-11 A 1.0548436,1.0548436 0 0 0 33.5,24.9375 l -3.4375,0 0,-7.9375 A 1.0548436,1.0548436 0 0 0 29,15.9375 l -10,0 a 1.0548436,1.0548436 0 0 0 -0.09375,0 z"
-       transform="translate(-2.4867694e-7,-0.99957921)" />
-    <path
-       id="path3288-2"
-       d="m 32.5,25.500421 -8.5,10 -8.5,-10 4,0 0,-9 9,0 0,9 4,0 z"
-       style="fill:#f7f7f7;fill-opacity:1;stroke:#ffffff;stroke-width:0.98542732;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="5.5"
+     x="4.5"
+     ry="3"
+     rx="3"
+     height="39"
+     width="39" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010001;stroke-linejoin:round;stroke-opacity:0.15;-inkscape-stroke:none"
+     d="m 21,16 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,37.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,27.572852 33.314645,26.001424 32.000078,26 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="6.5"
+     x="5.5"
+     ry="2"
+     rx="2"
+     height="37"
+     width="37" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010001;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 21,15 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,36.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,26.572852 33.314645,25.001424 32.000078,25 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;fill-opacity:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21,15 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,36.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,26.572852 33.314645,25.001424 32.000078,25 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+     id="path887"
+     sodipodi:nodetypes="ssccccccccsss" />
 </svg>

--- a/elementary-xfce/apps/48/system-software-installer.svg
+++ b/elementary-xfce/apps/48/system-software-installer.svg
@@ -1,22 +1,55 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48px"
    height="48px"
    id="svg3658"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234045"
+     inkscape:cx="-3.6827614"
+     inkscape:cy="49.966114"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="98"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs3660">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933">
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
+    </linearGradient>
     <linearGradient
        xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
        id="linearGradient3568"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.1618797,-1.4329212)"
+       gradientTransform="matrix(0.82498024,0,0,1.3012336,4.16188,-25.406682)"
        x1="16.626165"
        y1="15.298182"
        x2="20.054544"
@@ -74,19 +107,19 @@
        id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
       <stop
          id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1;"
+         style="stop-color:#d78ec1;stop-opacity:1;"
          offset="0" />
       <stop
          id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1;"
+         style="stop-color:#c564be;stop-opacity:1;"
          offset="0.26238" />
       <stop
          id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1;"
+         style="stop-color:#9d3ea4;stop-opacity:1;"
          offset="0.704952" />
       <stop
          id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1;"
+         style="stop-color:#5e2c73;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <linearGradient
@@ -102,11 +135,11 @@
        id="linearGradient3707-319-631-407-324">
       <stop
          id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1;"
+         style="stop-color:#650d5c;stop-opacity:1;"
          offset="0" />
       <stop
          id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1;"
+         style="stop-color:#ac51a3;stop-opacity:1;"
          offset="1" />
     </linearGradient>
     <radialGradient
@@ -175,7 +208,7 @@
        id="linearGradient3656"
        xlink:href="#linearGradient3702-501-757" />
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-9"
+       xlink:href="#linearGradient3707-319-631-407-324"
        id="linearGradient3374-0"
        gradientUnits="userSpaceOnUse"
        x1="19.874987"
@@ -183,18 +216,7 @@
        x2="19.874987"
        y2="5.2502403" />
     <linearGradient
-       id="linearGradient3707-319-631-407-1-846-9">
-      <stop
-         offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-1" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-7" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-4-477-1"
+       xlink:href="#linearGradient3707-319-631-407-324"
        id="linearGradient3372-1"
        gradientUnits="userSpaceOnUse"
        x1="19.874987"
@@ -202,24 +224,14 @@
        x2="19.874987"
        y2="5.2502403" />
     <linearGradient
-       id="linearGradient3707-319-631-407-1-4-477-1">
-      <stop
-         offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3782-5" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3784-9" />
-    </linearGradient>
-    <linearGradient
        xlink:href="#linearGradient3707-319-631-407-1-9-274-7"
        id="linearGradient3370-7"
        gradientUnits="userSpaceOnUse"
        x1="19.874987"
        y1="44.520065"
        x2="19.874987"
-       y2="5.2502403" />
+       y2="5.2502403"
+       gradientTransform="translate(-2e-7,-0.99957921)" />
     <linearGradient
        id="linearGradient3707-319-631-407-1-9-274-7">
       <stop
@@ -231,17 +243,105 @@
          style="stop-color:#5ea1ca;stop-opacity:1;"
          id="stop3778-7" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="48.266846"
+       x2="12.168998"
+       y2="-0.0086730029"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3011"
+       gradientUnits="userSpaceOnUse"
+       x1="12"
+       y1="16"
+       x2="12"
+       y2="8"
+       gradientTransform="matrix(1.0116033,0,0,1.0116033,24.860625,24.860761)" />
+    <linearGradient
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
+       id="linearGradient3014"
+       gradientUnits="userSpaceOnUse"
+       x1="12.47939"
+       y1="2"
+       x2="12.47939"
+       y2="22.006775"
+       gradientTransform="translate(24.999865,25)" />
+    <linearGradient
+       xlink:href="#linearGradient5128"
+       id="linearGradient3017"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.15623116,0,0,0.15623125,27.001065,27.157431)"
+       x1="86.132919"
+       y1="105.105"
+       x2="84.63858"
+       y2="20.895" />
+    <linearGradient
+       id="linearGradient5128">
+      <stop
+         id="stop5130"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5132"
+         style="stop-color:#959595;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3309-1"
+       id="linearGradient3021"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.77777782,0,0,0.77777782,12.888753,11.333331)"
+       x1="32.036148"
+       y1="19"
+       x2="32.036148"
+       y2="47.012184" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient3309-1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3311-5"
+         style="stop-color:#f6f6f6;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3313-0"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient10691"
+       id="radialGradient3026"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5217721,0,0,0.34585722,26.8,20.039474)"
+       cx="6.702713"
+       cy="73.615715"
+       fx="6.702713"
+       fy="73.615715"
+       r="7.228416" />
+    <linearGradient
+       id="linearGradient10691">
+      <stop
+         id="stop10693"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop10695"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
@@ -274,45 +374,37 @@
          width="28" />
     </g>
     <rect
-       style="color:#000000;fill:url(#radialGradient2874);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient2876);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.50196081;marker:none;enable-background:accumulate"
        id="rect5505-21"
        y="5.5"
        x="4.5"
-       ry="2"
-       rx="2"
+       ry="3"
+       rx="3"
        height="39"
        width="39" />
+    <path
+       style="color:#000000;opacity:1;fill:none;fill-opacity:1;stroke:#010000;stroke-linejoin:round;stroke-opacity:0.15000001;-inkscape-stroke:none"
+       d="m 21,16 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,37.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,27.572852 33.314645,26.001424 32.000078,26 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+       id="path13703"
+       sodipodi:nodetypes="ssccccccccsss" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
        id="rect6741"
        y="6.5"
        x="5.5"
-       ry="1"
-       rx="1"
+       ry="2"
+       rx="2"
        height="37"
        width="37" />
     <path
-       style="opacity:0.2;fill:url(#linearGradient3568);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.2169167,6 C 5.5377266,6 5,6.9124652 5,7.8 L 5.0126445,30 C 6.1058123,29.975834 42.170261,21.153092 43,20.728709 L 43,7.8 C 43,7.1215957 42.468817,6 41.88071,6 L 6.2169214,6 z" />
+       style="color:#000000;opacity:1;fill:none;fill-opacity:1;stroke:#010000;stroke-linejoin:round;stroke-opacity:0.30000001;-inkscape-stroke:none"
+       d="m 21,15 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,36.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,26.572852 33.314645,25.001424 32.000078,25 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+       id="path12165"
+       sodipodi:nodetypes="ssccccccccsss" />
     <path
-       style="opacity:0.05000000000000000;color:#000000;fill:url(#linearGradient3370-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8-3"
-       d="M 18.71875,14.09375 A 2.9091695,2.9091695 0 0 0 16.09375,17 l 0,6.09375 -1.59375,0 a 2.9091695,2.9091695 0 0 0 -2.1875,4.8125 l 9.5,11 a 2.9091695,2.9091695 0 0 0 4.375,0 l 9.5,-11 A 2.9091695,2.9091695 0 0 0 33.5,23.09375 l -1.59375,0 0,-6.09375 A 2.9091695,2.9091695 0 0 0 29,14.09375 l -10,0 a 2.9091695,2.9091695 0 0 0 -0.28125,0 z"
-       transform="translate(-2.4867694e-7,-0.99957921)" />
-    <path
-       style="opacity:0.10000000000000001;color:#000000;fill:url(#linearGradient3372-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8"
-       d="M 18.8125,14.96875 A 2.0262062,2.0262062 0 0 0 16.96875,17 l 0,6.96875 -2.46875,0 a 2.0262062,2.0262062 0 0 0 -1.53125,3.34375 l 9.5,11 a 2.0262062,2.0262062 0 0 0 3.0625,0 l 9.5,-11 A 2.0262062,2.0262062 0 0 0 33.5,23.96875 l -2.46875,0 0,-6.96875 A 2.0262062,2.0262062 0 0 0 29,14.96875 l -10,0 a 2.0262062,2.0262062 0 0 0 -0.1875,0 z"
-       transform="translate(-2.4867694e-7,-0.99957921)" />
-    <path
-       style="opacity:0.25000000000000000;fill:url(#linearGradient3374-0);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;color:#000000;enable-background:accumulate"
-       id="path3932"
-       d="M 18.90625,15.9375 A 1.0548436,1.0548436 0 0 0 17.9375,17 l 0,7.9375 -3.4375,0 a 1.0548436,1.0548436 0 0 0 -0.8125,1.75 l 9.5,11 a 1.0548436,1.0548436 0 0 0 1.625,0 l 9.5,-11 A 1.0548436,1.0548436 0 0 0 33.5,24.9375 l -3.4375,0 0,-7.9375 A 1.0548436,1.0548436 0 0 0 29,15.9375 l -10,0 a 1.0548436,1.0548436 0 0 0 -0.09375,0 z"
-       transform="translate(-2.4867694e-7,-0.99957921)" />
-    <path
-       id="path3288-2"
-       d="m 32.5,25.500421 -8.5,10 -8.5,-10 4,0 0,-9 9,0 0,9 4,0 z"
-       style="fill:#f7f7f7;fill-opacity:1;stroke:#ffffff;stroke-width:0.98542732;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+       style="color:#000000;opacity:1;fill:#ffffff;fill-opacity:1;stroke-linejoin:round;-inkscape-stroke:none"
+       d="m 21,15 c -0.554,0 -1,0.446 -1,1 v 9 h -4.000078 c -1.314567,0.0014 -1.991677,1.572852 -1.089844,2.529297 L 22.910156,36.279 c 0.591849,0.625709 1.587839,0.625709 2.179688,0 l 8.000078,-8.749703 C 33.991755,26.572852 33.314645,25.001424 32.000078,25 H 28 v -9 c 0,-0.554 -0.446,-1 -1,-1 z"
+       id="path887"
+       sodipodi:nodetypes="ssccccccccsss" />
   </g>
 </svg>

--- a/elementary-xfce/apps/64/org.gnome.Software.svg
+++ b/elementary-xfce/apps/64/org.gnome.Software.svg
@@ -1,69 +1,47 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="64"
+   height="64"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="org.gnome.Software.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
-   id="svg3398"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="42.301988"
+     inkscape:cy="15.029648"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="942"
+     inkscape:window-y="120"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3400">
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3206-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461554,-3.2564101)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3209-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461554,-3.2564101)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3212-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461554,-3.2564101)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1723404,0,0,1.8434143,3.8089875,-5.5299719)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+     id="defs3660">
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3218"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.3783747,-2.4707827)"
+       gradientTransform="matrix(1.428193,0,0,1.428193,-2.2766241,-2.2766154)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -71,223 +49,173 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
       <stop
          id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0.06316455" />
       <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7399122e-8,3.2957553,-3.4865161,-6.0720391e-8,61.460404,-19.38241)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         offset="0"
-         style="stop-color:#d78ec1;stop-opacity:1;"
-         id="stop3750" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#c564be;stop-opacity:1;"
-         id="stop3752" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#9d3ea4;stop-opacity:1;"
-         id="stop3754" />
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#5e2c73;stop-opacity:1;"
-         id="stop3756" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3223"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461544,-1.8461542)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1;"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#ac51a3;stop-opacity:1;"
-         id="stop3762" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3188"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933-6"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="55.469166"
+       x2="12.168998"
+       y2="2.2241068"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461543,-3.2564104)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4159"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933-6">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop929-7" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop931-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata3403">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(1.5000021,0,0,0.5555561,-4.0000114,35.888881)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3184);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3186);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3188);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
-    </g>
+     style="opacity:0.6"
+     id="g3712-8-2-4-4"
+     transform="matrix(1.5789502,0,0,0.7142857,-5.894751,27.928572)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3221);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3223);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="4.5"
-       x="4.5"
-       ry="3"
-       rx="3"
-       height="55"
-       width="55" />
+       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none"
+       id="rect2801-5-5-7-9"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3218);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="5.428761"
-       x="5.5"
-       ry="2"
-       rx="2"
-       height="53.142479"
-       width="53" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3215);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.7293031,5 C 5.7641384,5 5,6.2926588 5,7.5499999 L 5.0179665,39 C 6.5714146,38.965765 57.820897,26.466881 59,25.865671 L 59,7.5499999 C 59,6.5889276 58.245161,5 57.40943,5 L 6.7293072,5 z" />
-    <path
-       style="opacity:0.05000000000000000;color:#000000;fill:url(#linearGradient3212-6);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.70909089000000003;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8-3"
-       d="M 19,14.625 A 2.3624405,2.3624405 0 0 0 16.625,17 l 0,6.625 -2.125,0 a 2.3624405,2.3624405 0 0 0 -1.78125,3.90625 l 9.5,11 a 2.3624405,2.3624405 0 0 0 3.5625,0 l 9.5,-11 A 2.3624405,2.3624405 0 0 0 33.5,23.625 l -2.125,0 0,-6.625 A 2.3624405,2.3624405 0 0 0 29,14.625 l -10,0 z"
-       transform="matrix(1.4102564,0,0,1.4102564,-1.8461541,-4.6116419)" />
-    <path
-       style="opacity:0.10000000000000001;color:#000000;fill:url(#linearGradient3209-3);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.70909089000000003;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8"
-       d="M 18.84375,15.53125 A 1.4705483,1.4705483 0 0 0 17.53125,17 l 0,7.53125 -3.03125,0 a 1.4705483,1.4705483 0 0 0 -1.125,2.4375 l 9.5,11 a 1.4705483,1.4705483 0 0 0 2.25,0 l 9.5,-11 A 1.4705483,1.4705483 0 0 0 33.5,24.53125 l -3.03125,0 0,-7.53125 A 1.4705483,1.4705483 0 0 0 29,15.53125 l -10,0 a 1.4705483,1.4705483 0 0 0 -0.15625,0 z"
-       transform="matrix(1.4102564,0,0,1.4102564,-1.8461541,-4.604881)" />
-    <path
-       style="opacity:0.25000000000000000;color:#000000;fill:url(#linearGradient3206-4);fill-opacity:1.0;fill-rule:nonzero;stroke:none;stroke-width:0.70909089000000003;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932"
-       d="M 19,16.28125 A 0.70566683,0.70566683 0 0 0 18.28125,17 l 0,8.28125 -3.78125,0 a 0.70566683,0.70566683 0 0 0 -0.53125,1.1875 l 9.5,11 a 0.70566683,0.70566683 0 0 0 1.0625,0 l 9.5,-11 A 0.70566683,0.70566683 0 0 0 33.5,25.28125 l -3.78125,0 0,-8.28125 A 0.70566683,0.70566683 0 0 0 29,16.28125 l -10,0 z"
-       transform="matrix(1.4102564,0,0,1.4102564,-1.8461541,-4.6244491)" />
-    <path
-       id="path3288-2"
-       d="m 43.987124,32.499998 -11.987179,14 -11.987179,-14 5.48718,0 0,-13 13,0 0,13 5.487178,0 z"
-       style="fill:#f7f7f7;fill-opacity:1;stroke:#ffffff;stroke-width:0.98542732;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4159);fill-opacity:1;stroke:none"
+       id="rect3700-5-6-8-4"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="4"
+     rx="4"
+     height="55"
+     width="55" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="5.5784316"
+     x="5.5784316"
+     ry="3"
+     rx="3"
+     height="52.84314"
+     width="52.84314" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21.054333,34 c -1.798584,0.002 -2.725002,2.14207 -1.49112,3.444654 l 10.945669,11.916229 c 0.809764,0.852155 2.172472,0.852155 2.982237,0 L 44.436786,37.444654 C 45.670668,36.14207 44.744251,34.001939 42.945667,34 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="M 27.625,19 C 26.6278,19 26,19.669 26,20.5 V 32 h -4.945312 c -1.798584,0.002 -2.72607,2.142728 -1.492188,3.445312 l 10.947266,11.916016 c 0.809764,0.852154 2.170703,0.852154 2.980468,0 L 44.4375,35.445312 C 45.671382,34.142728 44.743897,32.001939 42.945312,32 H 38 V 20.5 C 38,19.669 37.3722,19 36.375,19 Z"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21,32 c -1.740217,4.4e-5 -2.650323,2.068577 -1.474609,3.351562 l 11,12 c 0.792776,0.865044 2.156442,0.865044 2.949218,0 l 11,-12 C 45.650323,34.068577 44.740217,32.000044 43,32 Z"
+     id="path6081"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="12"
+     height="15"
+     x="26"
+     y="19"
+     rx="1.625"
+     ry="1.625" />
 </svg>

--- a/elementary-xfce/apps/64/system-software-installer.svg
+++ b/elementary-xfce/apps/64/system-software-installer.svg
@@ -1,102 +1,59 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   width="64"
+   height="64"
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
-   id="svg3398"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234045"
+     inkscape:cx="16.124523"
+     inkscape:cy="36.230409"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="477"
+     inkscape:window-y="285"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     width="64px"
+     showguides="false"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs3400">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-7"
-       id="linearGradient3206-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461554,-3.2564101)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-7">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
-         id="stop3788-5-4"
-         style="stop-color:#365a7c;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="0"
+         id="stop929" />
       <stop
-         id="stop3790-9-4"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-0"
-       id="linearGradient3209-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461554,-3.2564101)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-0">
-      <stop
-         id="stop3788-5-5-7"
-         style="stop-color:#365a7c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3790-9-0-8"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-9-8"
-       id="linearGradient3212-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461554,-3.2564101)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-9-8">
-      <stop
-         id="stop3788-5-1-8"
-         style="stop-color:#365a7c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3790-9-8-4"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1723404,0,0,1.8434143,3.8089875,-5.5299719)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         id="stop2687-1-9"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2689-5-4"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop931" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3218"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.3783747,-2.4707827)"
+       gradientTransform="matrix(1.428193,0,0,1.428193,-2.2766241,-2.2766154)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -104,223 +61,161 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
       <stop
          id="stop3928"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
          offset="0.06316455" />
       <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7399122e-8,3.2957553,-3.4865161,-6.0720391e-8,61.460404,-19.38241)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop3750" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop3752" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop3754" />
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop3756" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3223"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461544,-1.8461542)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       cx="4.9929786"
-       cy="43.5"
-       fx="4.9929786"
-       fy="43.5"
-       r="2.5" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3188"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="47.821507"
+       x2="12.168998"
+       y2="2.2241068"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4102565,0,0,1.4102565,-1.8461543,-3.2564104)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4159"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <metadata
-     id="metadata3403">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       style="display:inline"
-       id="g2036"
-       transform="matrix(1.5000021,0,0,0.5555561,-4.0000114,35.888881)">
-      <g
-         style="opacity:0.4"
-         id="g3712"
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-        <rect
-           style="fill:url(#radialGradient3184);fill-opacity:1;stroke:none"
-           id="rect2801"
-           y="40"
-           x="38"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#radialGradient3186);fill-opacity:1;stroke:none"
-           id="rect3696"
-           transform="scale(-1,-1)"
-           y="-47"
-           x="-10"
-           height="7"
-           width="5" />
-        <rect
-           style="fill:url(#linearGradient3188);fill-opacity:1;stroke:none"
-           id="rect3700"
-           y="40"
-           x="10"
-           height="7.0000005"
-           width="28" />
-      </g>
-    </g>
+     style="opacity:0.6"
+     id="g3712-8-2-4-4"
+     transform="matrix(1.5789502,0,0,0.7142857,-5.894751,27.928572)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3221);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3223);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="4.5"
-       x="4.5"
-       ry="3"
-       rx="3"
-       height="55"
-       width="55" />
+       style="fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none"
+       id="rect2801-5-5-7-9"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3218);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="5.428761"
-       x="5.5"
-       ry="2"
-       rx="2"
-       height="53.142479"
-       width="53" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3215);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 6.7293031,5 C 5.7641384,5 5,6.2926588 5,7.5499999 L 5.0179665,39 C 6.5714146,38.965765 57.820897,26.466881 59,25.865671 L 59,7.5499999 C 59,6.5889276 58.245161,5 57.40943,5 L 6.7293072,5 z" />
-    <path
-       style="opacity:0.05;color:#000000;fill:url(#linearGradient3212-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.70909089;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8-3"
-       d="M 19,14.625 A 2.3624405,2.3624405 0 0 0 16.625,17 l 0,6.625 -2.125,0 a 2.3624405,2.3624405 0 0 0 -1.78125,3.90625 l 9.5,11 a 2.3624405,2.3624405 0 0 0 3.5625,0 l 9.5,-11 A 2.3624405,2.3624405 0 0 0 33.5,23.625 l -2.125,0 0,-6.625 A 2.3624405,2.3624405 0 0 0 29,14.625 l -10,0 z"
-       transform="matrix(1.4102564,0,0,1.4102564,-1.8461541,-4.6116419)" />
-    <path
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3209-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.70909089;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932-8"
-       d="M 18.84375,15.53125 A 1.4705483,1.4705483 0 0 0 17.53125,17 l 0,7.53125 -3.03125,0 a 1.4705483,1.4705483 0 0 0 -1.125,2.4375 l 9.5,11 a 1.4705483,1.4705483 0 0 0 2.25,0 l 9.5,-11 A 1.4705483,1.4705483 0 0 0 33.5,24.53125 l -3.03125,0 0,-7.53125 A 1.4705483,1.4705483 0 0 0 29,15.53125 l -10,0 a 1.4705483,1.4705483 0 0 0 -0.15625,0 z"
-       transform="matrix(1.4102564,0,0,1.4102564,-1.8461541,-4.604881)" />
-    <path
-       style="opacity:0.25;color:#000000;fill:url(#linearGradient3206-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.70909089;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3932"
-       d="M 19,16.28125 A 0.70566683,0.70566683 0 0 0 18.28125,17 l 0,8.28125 -3.78125,0 a 0.70566683,0.70566683 0 0 0 -0.53125,1.1875 l 9.5,11 a 0.70566683,0.70566683 0 0 0 1.0625,0 l 9.5,-11 A 0.70566683,0.70566683 0 0 0 33.5,25.28125 l -3.78125,0 0,-8.28125 A 0.70566683,0.70566683 0 0 0 29,16.28125 l -10,0 z"
-       transform="matrix(1.4102564,0,0,1.4102564,-1.8461541,-4.6244491)" />
-    <path
-       id="path3288-2"
-       d="m 43.987124,32.499998 -11.987179,14 -11.987179,-14 5.48718,0 0,-13 13,0 0,13 5.487178,0 z"
-       style="fill:#f7f7f7;fill-opacity:1;stroke:#ffffff;stroke-width:0.98542732;stroke-opacity:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+       style="fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient4159);fill-opacity:1;stroke:none"
+       id="rect3700-5-6-8-4"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="4.5"
+     x="4.5"
+     ry="4"
+     rx="4"
+     height="55"
+     width="55" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="5.5784316"
+     x="5.5784316"
+     ry="3"
+     rx="3"
+     height="52.84314"
+     width="52.84314" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.14902;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21.054333,34 c -1.798584,0.002 -2.725002,2.14207 -1.49112,3.444654 l 10.945669,11.916229 c 0.809764,0.852155 2.172472,0.852155 2.982237,0 L 44.436786,37.444654 C 45.670668,36.14207 44.744251,34.001939 42.945667,34 Z"
+     id="path3380"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path4541"
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.301961;-inkscape-stroke:none"
+     d="M 27.625,19 C 26.6278,19 26,19.669 26,20.5 V 32 h -4.945312 c -1.798584,0.002 -2.72607,2.142728 -1.492188,3.445312 l 10.947266,11.916016 c 0.809764,0.852154 2.170703,0.852154 2.980468,0 L 44.4375,35.445312 C 45.671382,34.142728 44.743897,32.001939 42.945312,32 H 38 V 20.5 C 38,19.669 37.3722,19 36.375,19 Z"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 21,32 c -1.740217,4.4e-5 -2.650323,2.068577 -1.474609,3.351562 l 11,12 c 0.792776,0.865044 2.156442,0.865044 2.949218,0 l 11,-12 C 45.650323,34.068577 44.740217,32.000044 43,32 Z"
+     id="path6081"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.75;stroke-linecap:round"
+     id="rect2264"
+     width="12"
+     height="15"
+     x="26"
+     y="19"
+     rx="1.625"
+     ry="1.625" />
 </svg>

--- a/elementary-xfce/apps/96/org.gnome.Software.svg
+++ b/elementary-xfce/apps/96/org.gnome.Software.svg
@@ -1,82 +1,45 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="96"
    height="96"
-   id="svg4207"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="org.gnome.Software.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="40.187237"
+     inkscape:cx="54.283403"
+     inkscape:cy="31.452772"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="1079"
+     inkscape:window-y="115"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4209">
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-2"
-       id="linearGradient3212-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-2">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1"
-         id="stop3788-5-54" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-7" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4"
-       id="linearGradient3215-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4">
-      <stop
-         offset="0"
-         style="stop-color:#650d5c;stop-opacity:1"
-         id="stop3788-5-5-3" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-0-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7802187,0,0,2.8193374,5.1914271,-41.104681)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
-    </linearGradient>
+     id="defs3660">
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3224"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1891937,0,0,2.1891914,-4.5405494,-36.540529)"
+       gradientTransform="matrix(2.0810811,0,0,2.0810811,-1.9459378,-1.9459246)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -84,94 +47,25 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="5.2502403"
-       x2="19.874987"
-       y1="44.520065"
-       x1="19.874987"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3353"
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4-9" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4-9">
-      <stop
          offset="0"
-         style="stop-color:#650d5c;stop-opacity:0.00784314"
-         id="stop3788-5-5-3-5" />
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-0-0-0" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(4.1347613e-8,4.9735833,-5.2614507,-9.163238e-8,92.458127,-61.540502)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#d78ec1;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#c564be;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#9d3ea4;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#5e2c73;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1281968,0,0,2.1281985,-3.076863,-35.076757)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#650d5c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#ac51a3;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -182,17 +76,17 @@
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -203,125 +97,125 @@
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933-6"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="60.74876"
+       x2="12.168998"
+       y2="1.4395114"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.025641,0,0,2.025641,-0.6153847,-2.641025)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient933-6">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop929-7" />
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="1"
+         id="stop931-5" />
     </linearGradient>
   </defs>
   <metadata
-     id="metadata4212">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,32)">
-    <g
-       transform="matrix(2.377174,0,0,0.98489605,-9.0087008,14.809914)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
-    </g>
+     style="opacity:0.4;stroke-width:0.5"
+     id="g3712"
+     transform="matrix(2.3157904,0,0,1.1428572,-7.578968,36.285712)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:0.99999964;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-25.499825"
-       x="6.5"
-       ry="4.8349433"
-       rx="4.8349285"
-       height="82.999825"
-       width="82.999847" />
-    <path
-       transform="matrix(0.83689026,0,0,0.84724483,-4.8714766,-41.178842)"
-       style="opacity:0.05;color:#000000;fill:url(#linearGradient3353);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6-4"
-       d="M 51,38.023438 A 2.9776489,2.9776489 0 0 0 48.023438,41 l 0,20.023438 -10.023438,0 a 2.9776489,2.9776489 0 0 0 -2.25,4.925781 l 26,30 a 2.9776489,2.9776489 0 0 0 4.5,0 l 26,-30 A 2.9776489,2.9776489 0 0 0 90,61.023438 l -10.023438,0 0,-20.023438 A 2.9776489,2.9776489 0 0 0 77,38.023438 l -26,0 z" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:0.5"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-24.5"
-       x="7.5"
-       ry="4.0099082"
-       rx="4.0099082"
-       height="81"
-       width="81" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 10.763023,-25 C 9.2974039,-25 7,-23.023009 7,-21.100011 L 7.027302,27 C 9.3862149,26.947636 87.20954,7.8316882 89,6.9121898 L 89,-21 c 0,-2 -2,-4 -4,-4 z" />
-    <path
-       transform="matrix(0.82901814,0,0,0.84150845,-4.4636622,-40.84341)"
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3215-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6"
-       d="M 51,38.976562 A 2.0237426,2.0237426 0 0 0 48.976562,41 l 0,20.976562 -10.976562,0 a 2.0237426,2.0237426 0 0 0 -1.529297,3.34961 l 26,30 a 2.0237426,2.0237426 0 0 0 3.058594,0 l 26,-30 A 2.0237426,2.0237426 0 0 0 90,61.976562 l -10.976562,0 0,-20.976562 A 2.0237426,2.0237426 0 0 0 77,38.976562 l -26,0 z" />
-    <path
-       transform="matrix(0.82063069,0,0,0.83698635,-3.9768653,-40.513239)"
-       style="opacity:0.25;color:#000000;fill:url(#linearGradient3212-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107"
-       d="m 51,40 a 1.000224,1.000224 0 0 0 -1,1 l 0,22 -12,0 a 1.000224,1.000224 0 0 0 -0.755859,1.654297 l 26,30 a 1.000224,1.000224 0 0 0 1.511718,0 l 26,-30 A 1.000224,1.000224 0 0 0 90,63 l -12,0 0,-22 a 1.000224,1.000224 0 0 0 -1,-1 l -26,0 z" />
-    <path
-       id="path3288-2"
-       d="M 68.442547,13.5 48.499942,37.234032 28.557367,13.499931 38.499999,13.5 l 0,-19 20,0 0,19 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542732;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:0.5"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:0.5"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#452981;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="8.5"
+     x="8.5"
+     ry="6"
+     rx="6"
+     height="79"
+     width="79" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 41.552367,29.000001 c -1.404454,0 -2.552734,1.14235 -2.552734,2.544922 v 17.455072 h -7.417602 c -1.547424,0.0017 -2.758287,0.939904 -3.283203,2.154297 -0.524916,1.214394 -0.378667,2.740232 0.683594,3.863281 l 16.412109,17.894532 c 0.002,0.002 0.0039,0.004 0.0059,0.0059 1.407411,1.483256 3.791807,1.483256 5.199218,0 0.002,-0.0019 0.004,-0.0039 0.0059,-0.0059 L 67.017578,55.017573 c 1.062261,-1.123048 1.20851,-2.648889 0.683594,-3.863281 -0.524916,-1.214392 -1.73578,-2.152626 -3.283203,-2.154297 H 57.000367 V 31.544923 c 0,-1.402572 -1.14828,-2.544922 -2.552734,-2.544922 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccsccccccsccsss" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="9.5"
+     x="9.5"
+     ry="5"
+     rx="5"
+     height="77"
+     width="77" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 41.825,27.500098 c -1.136947,0 -2.325126,1.191527 -2.325126,2.324902 V 47.6 h -7.91804 c -2.697822,0.0029 -4.087422,3.575797 -2.236634,5.532496 L 45.763368,71.03268 c 1.214623,1.280078 3.258644,1.280078 4.473267,0 L 66.654803,53.132496 C 68.505591,51.175797 67.115991,47.602913 64.41817,47.6 H 56.500126 V 29.825 c 0,-1.133375 -1.188179,-2.324902 -2.325126,-2.324902 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42,28.000001 c -1.108,0 -2,0.892 -2,2 v 18 h -8.000156 c -2.629134,0.0028 -3.983354,3.145704 -2.179688,5.058594 l 16.000156,17.499406 c 1.183698,1.251418 3.175678,1.251418 4.359376,0 L 66.179844,53.058595 c 1.803666,-1.91289 0.449446,-5.055746 -2.179688,-5.058594 H 56 v -18 c 0,-1.108 -0.892,-2 -2,-2 z"
+     id="path887"
+     sodipodi:nodetypes="ssccccccccsss" />
 </svg>

--- a/elementary-xfce/apps/96/system-software-installer.svg
+++ b/elementary-xfce/apps/96/system-software-installer.svg
@@ -1,82 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="96"
    height="96"
-   id="svg4207"
-   version="1.1">
+   id="svg3658"
+   version="1.1"
+   sodipodi:docname="system-software-installer.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview56"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.5117023"
+     inkscape:cx="-22.096568"
+     inkscape:cy="64.896227"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="46"
+     inkscape:window-y="196"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3658"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
-     id="defs4209">
+     id="defs3660">
     <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-2"
-       id="linearGradient3212-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-2">
+       inkscape:collect="always"
+       id="linearGradient933">
       <stop
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-5-54" />
+         id="stop929" />
       <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
          offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-7" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4"
-       id="linearGradient3215-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       x1="19.874987"
-       y1="44.520065"
-       x2="19.874987"
-       y2="5.2502403" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4">
-      <stop
-         offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-5-5-3" />
-      <stop
-         offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-0-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7"
-       id="linearGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.7802187,0,0,2.8193374,5.1914271,-41.104681)"
-       x1="16.626165"
-       y1="15.298182"
-       x2="20.054544"
-       y2="24.627615" />
-    <linearGradient
-       id="linearGradient8265-821-176-38-919-66-249-7-7">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop2687-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop2689-5-4" />
+         id="stop931" />
     </linearGradient>
     <linearGradient
        xlink:href="#linearGradient3924"
-       id="linearGradient3224"
+       id="linearGradient2959"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1891937,0,0,2.1891914,-4.5405494,-36.540529)"
+       gradientTransform="matrix(2.0810811,0,0,2.0810811,-1.9459378,-1.9459246)"
        x1="23.99999"
        y1="4.999989"
        x2="23.99999"
@@ -84,94 +59,25 @@
     <linearGradient
        id="linearGradient3924">
       <stop
-         id="stop3926"
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0" />
-      <stop
-         offset="0.06316455"
-         style="stop-color:#ffffff;stop-opacity:0.23529412;"
-         id="stop3928" />
-      <stop
-         id="stop3930"
-         style="stop-color:#ffffff;stop-opacity:0.15686275;"
-         offset="0.95056331" />
-      <stop
-         id="stop3932"
-         style="stop-color:#ffffff;stop-opacity:0.39215687;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="5.2502403"
-       x2="19.874987"
-       y1="44.520065"
-       x1="19.874987"
-       gradientTransform="matrix(2.6410259,0,0,2.6410259,0.6153933,-63.025638)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3353"
-       xlink:href="#linearGradient3707-319-631-407-1-846-4-8-4-9" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-1-846-4-8-4-9">
-      <stop
          offset="0"
-         style="stop-color:#365a7c;stop-opacity:1"
-         id="stop3788-5-5-3-5" />
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop3926" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.06316455" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop3930" />
       <stop
          offset="1"
-         style="stop-color:#5ea1ca;stop-opacity:1;"
-         id="stop3790-9-0-0-0" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="radialGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(4.1347613e-8,4.9735833,-5.2614507,-9.163238e-8,92.458127,-61.540502)"
-       cx="7.4956832"
-       cy="8.4497671"
-       fx="7.4956832"
-       fy="8.4497671"
-       r="19.99999" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1281968,0,0,2.1281985,-3.076863,-35.076757)"
-       x1="24"
-       y1="44"
-       x2="24"
-       y2="3.8990016" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         offset="1" />
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop3932" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-166-749"
-       id="radialGradient3190"
+       id="radialGradient3013"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        cx="4.9929786"
@@ -182,17 +88,17 @@
     <linearGradient
        id="linearGradient3688-166-749">
       <stop
-         id="stop2883"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2883" />
       <stop
-         id="stop2885"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2885" />
     </linearGradient>
     <radialGradient
        xlink:href="#linearGradient3688-464-309"
-       id="radialGradient3192"
+       id="radialGradient3015"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        cx="4.9929786"
@@ -203,125 +109,113 @@
     <linearGradient
        id="linearGradient3688-464-309">
       <stop
-         id="stop2889"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop2889" />
       <stop
-         id="stop2891"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2891" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3702-501-757"
-       id="linearGradient3194"
-       gradientUnits="userSpaceOnUse"
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443" />
     <linearGradient
        id="linearGradient3702-501-757">
       <stop
-         id="stop2895"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop2895" />
       <stop
-         id="stop2897"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop2897" />
       <stop
-         id="stop2899"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop2899" />
     </linearGradient>
+    <linearGradient
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3656"
+       xlink:href="#linearGradient3702-501-757" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient933"
+       id="linearGradient935"
+       x1="12.168998"
+       y1="47.851692"
+       x2="12.168998"
+       y2="0.32248196"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.025641,0,0,2.025641,-0.6153847,-2.641025)" />
   </defs>
   <metadata
-     id="metadata4212">
+     id="metadata3663">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,32)">
-    <g
-       transform="matrix(2.377174,0,0,0.98489605,-9.0087008,14.809914)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient3190);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient3192);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient3194);fill-opacity:1;stroke:none" />
-      </g>
-    </g>
+     style="opacity:0.4;stroke-width:0.5"
+     id="g3712"
+     transform="matrix(2.3157904,0,0,1.1428572,-7.578968,36.285712)">
     <rect
-       style="color:#000000;fill:url(#radialGradient3227);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3229);stroke-width:0.99999964;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect5505-21"
-       y="-25.499825"
-       x="6.5"
-       ry="4.8349433"
-       rx="4.8349285"
-       height="82.999825"
-       width="82.999847" />
-    <path
-       transform="matrix(0.83689026,0,0,0.84724483,-4.8714766,-41.178842)"
-       style="opacity:0.05;color:#000000;fill:url(#linearGradient3353);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6-4"
-       d="M 51,38.023438 A 2.9776489,2.9776489 0 0 0 48.023438,41 l 0,20.023438 -10.023438,0 a 2.9776489,2.9776489 0 0 0 -2.25,4.925781 l 26,30 a 2.9776489,2.9776489 0 0 0 4.5,0 l 26,-30 A 2.9776489,2.9776489 0 0 0 90,61.023438 l -10.023438,0 0,-20.023438 A 2.9776489,2.9776489 0 0 0 77,38.023438 l -26,0 z" />
+       style="fill:url(#radialGradient3013);fill-opacity:1;stroke:none;stroke-width:0.5"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
     <rect
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3224);stroke-width:0.99999958;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-7"
-       y="-24.5"
-       x="7.5"
-       ry="4.0099082"
-       rx="4.0099082"
-       height="81"
-       width="81" />
-    <path
-       style="opacity:0.2;fill:url(#linearGradient3221);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="path3333"
-       d="M 10.763023,-25 C 9.2974039,-25 7,-23.023009 7,-21.100011 L 7.027302,27 C 9.3862149,26.947636 87.20954,7.8316882 89,6.9121898 L 89,-21 c 0,-2 -2,-4 -4,-4 z" />
-    <path
-       transform="matrix(0.82901814,0,0,0.84150845,-4.4636622,-40.84341)"
-       style="opacity:0.1;color:#000000;fill:url(#linearGradient3215-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107-6"
-       d="M 51,38.976562 A 2.0237426,2.0237426 0 0 0 48.976562,41 l 0,20.976562 -10.976562,0 a 2.0237426,2.0237426 0 0 0 -1.529297,3.34961 l 26,30 a 2.0237426,2.0237426 0 0 0 3.058594,0 l 26,-30 A 2.0237426,2.0237426 0 0 0 90,61.976562 l -10.976562,0 0,-20.976562 A 2.0237426,2.0237426 0 0 0 77,38.976562 l -26,0 z" />
-    <path
-       transform="matrix(0.82063069,0,0,0.83698635,-3.9768653,-40.513239)"
-       style="opacity:0.25;color:#000000;fill:url(#linearGradient3212-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3107"
-       d="m 51,40 a 1.000224,1.000224 0 0 0 -1,1 l 0,22 -12,0 a 1.000224,1.000224 0 0 0 -0.755859,1.654297 l 26,30 a 1.000224,1.000224 0 0 0 1.511718,0 l 26,-30 A 1.000224,1.000224 0 0 0 90,63 l -12,0 0,-22 a 1.000224,1.000224 0 0 0 -1,-1 l -26,0 z" />
-    <path
-       id="path3288-2"
-       d="M 68.442547,13.5 48.499942,37.234032 28.557367,13.499931 38.499999,13.5 l 0,-19 20,0 0,19 z"
-       style="color:#000000;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542732;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="fill:url(#radialGradient3015);fill-opacity:1;stroke:none;stroke-width:0.5"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3656);fill-opacity:1;stroke:none;stroke-width:0.5"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient935);fill-opacity:1;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="8.5"
+     x="8.5"
+     ry="6"
+     rx="6"
+     height="79"
+     width="79" />
+  <path
+     style="color:#000000;fill:#010000;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 41.552367,29.000001 c -1.404454,0 -2.552734,1.14235 -2.552734,2.544922 v 17.455072 h -7.417602 c -1.547424,0.0017 -2.758287,0.939904 -3.283203,2.154297 -0.524916,1.214394 -0.378667,2.740232 0.683594,3.863281 l 16.412109,17.894532 c 0.002,0.002 0.0039,0.004 0.0059,0.0059 1.407411,1.483256 3.791807,1.483256 5.199218,0 0.002,-0.0019 0.004,-0.0039 0.0059,-0.0059 L 67.017578,55.017573 c 1.062261,-1.123048 1.20851,-2.648889 0.683594,-3.863281 -0.524916,-1.214392 -1.73578,-2.152626 -3.283203,-2.154297 H 57.000367 V 31.544923 c 0,-1.402572 -1.14828,-2.544922 -2.552734,-2.544922 z"
+     id="path13703"
+     sodipodi:nodetypes="ssccsccccccsccsss" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient2959);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741"
+     y="9.5"
+     x="9.5"
+     ry="5"
+     rx="5"
+     height="77"
+     width="77" />
+  <path
+     style="color:#000000;fill:none;fill-opacity:1;stroke:#010000;stroke-width:1;stroke-linejoin:round;stroke-opacity:0.3;-inkscape-stroke:none"
+     d="m 41.825,27.500098 c -1.136947,0 -2.325126,1.191527 -2.325126,2.324902 V 47.6 h -7.91804 c -2.697822,0.0029 -4.087422,3.575797 -2.236634,5.532496 L 45.763368,71.03268 c 1.214623,1.280078 3.258644,1.280078 4.473267,0 L 66.654803,53.132496 C 68.505591,51.175797 67.115991,47.602913 64.41817,47.6 H 56.500126 V 29.825 c 0,-1.133375 -1.188179,-2.324902 -2.325126,-2.324902 z"
+     id="path12165"
+     sodipodi:nodetypes="ssccccccccsss" />
+  <path
+     style="color:#000000;fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 42,28.000001 c -1.108,0 -2,0.892 -2,2 v 18 h -8.000156 c -2.629134,0.0028 -3.983354,3.145704 -2.179688,5.058594 l 16.000156,17.499406 c 1.183698,1.251418 3.175678,1.251418 4.359376,0 L 66.179844,53.058595 c 1.803666,-1.91289 0.449446,-5.055746 -2.179688,-5.058594 H 56 v -18 c 0,-1.108 -0.892,-2 -2,-2 z"
+     id="path887"
+     sodipodi:nodetypes="ssccccccccsss" />
 </svg>


### PR DESCRIPTION
User newer elementary gradients, borders, and arrow styles for `org.gnome.Software` and `system-software-installer`.

Split this one off from #344 as I think these are pretty uncontroversial. (any input on the discussion in #344 would be appreciated!)

Current (screenshots taken before softwarecenter changed to org.gnome.Software):
![software-installer-current1](https://github.com/shimmerproject/elementary-xfce/assets/1984060/a1d4caa1-bfb4-4c23-a17d-16b7c44d1490)

Proposed:
![software-installer-prop1](https://github.com/shimmerproject/elementary-xfce/assets/1984060/ae47869f-d64c-46f8-b85d-81cfd7c6c423)

Oh, also, many app icons are symlinked to `system-software-installer`, which means they all use the same icon. Is this okay?

![software-installer-symlinks](https://github.com/shimmerproject/elementary-xfce/assets/1984060/6247bc9e-b4bd-48ba-b8fa-a7f6b09983f6)
