### PR TITLE
Status: Make symbolic audio icons bigger

### DIFF
--- a/elementary-xfce/status/symbolic/audio-volume-high-symbolic.svg
+++ b/elementary-xfce/status/symbolic/audio-volume-high-symbolic.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    height="16"
    width="16"
    id="svg2"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="audio-volume-high-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="39.06765"
+     inkscape:cy="8.3085047"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="426"
+     inkscape:window-y="25"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
   <metadata
      id="metadata16">
     <rdf:RDF>
@@ -22,27 +46,22 @@
   </metadata>
   <defs
      id="defs14" />
-  <g
-     color="#bebebe"
-     transform="translate(-273 291)"
-     id="g4">
-    <path
-       d="M288-283c0-3.225-1.204-5.982-2.946-7.25l-1.155 1.04c1.5 1.062 2.542 3.453 2.542 6.21s-1.042 5.148-2.542 6.21l1.155 1.04c1.742-1.268 2.946-4.025 2.946-7.25z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path6" />
-    <path
-       d="M284.939-283c0-2.18-.829-4.085-2.08-5.285l-1.068.953c.965 1.026 1.588 2.582 1.588 4.332s-.623 3.306-1.588 4.332l1.068.953c1.251-1.2 2.08-3.104 2.08-5.285z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path8" />
-    <path
-       d="M281.993-283c0-1.326-.44-2.542-1.155-3.495l-1.098.982a4.9 4.9 0 0 1 0 5.026l1.098.982a5.813 5.813 0 0 0 1.155-3.495zM273-285v4h1.652l3.348 3.37v-10.74l-3.348 3.37z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path10" />
-  </g>
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 6.5410156,1.0582968 C 6.2631888,0.94141717 5.9423864,1.0021927 5.7265625,1.2125937 L 2.8183594,4.046875 0.57226562,4.5917969 C 0.2357128,4.6739184 -8.1898201e-4,4.9758395 0,5.3222656 v 5.3554684 c -8.1912075e-4,0.346426 0.23571269,0.648348 0.57226562,0.730469 l 2.24609378,0.544922 2.9082031,2.833984 C 6.2017871,15.249996 6.9998205,14.913402 7,14.25 V 1.7497031 C 7.0000477,1.4478797 6.8191836,1.1754291 6.5410156,1.0582968 Z"
+     id="path64256"
+     sodipodi:nodetypes="cccccccccccc" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 9.25,5.25 8.5,6 v 4 l 0.75,0.75 C 9.25,10.75 10,10.088318 10,8 10,5.911682 9.25,5.25 9.25,5.25 Z"
+     id="path95579"
+     sodipodi:nodetypes="cccczc" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 11.537109,2.9746094 -1.070312,1.0507812 c 0,0 0.198996,0.1844127 0.470703,0.8125 C 11.209207,5.465978 11.5,6.4830403 11.5,8 c 0,1.5169597 -0.290793,2.534022 -0.5625,3.162109 -0.271707,0.628088 -0.470703,0.8125 -0.470703,0.8125 l 1.070312,1.050782 c 0,0 0.424749,-0.452508 0.777344,-1.267578 C 12.667048,10.942742 13,9.7104001 13,8 13,6.2895999 12.667048,5.057258 12.314453,4.2421875 11.961858,3.427117 11.537109,2.9746094 11.537109,2.9746094 Z"
+     id="path100266" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 13.791016,0.73046875 12.708984,1.7695312 c 0,0 0.398485,0.3992777 0.857422,1.4121094 C 14.025344,4.1944723 14.5,5.7708267 14.5,8 c 0,2.229173 -0.474656,3.805528 -0.933594,4.818359 -0.458937,1.012832 -0.857422,1.41211 -0.857422,1.41211 l 1.082032,1.039062 c 0,0 0.601516,-0.637959 1.142578,-1.832031 C 15.474655,12.243428 16,10.443197 16,8 16,5.556803 15.474655,3.7565724 14.933594,2.5625 14.392532,1.3684276 13.791016,0.73046875 13.791016,0.73046875 Z"
+     id="path100270" />
 </svg>

--- a/elementary-xfce/status/symbolic/audio-volume-low-symbolic.svg
+++ b/elementary-xfce/status/symbolic/audio-volume-low-symbolic.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    height="16"
    width="16"
    id="svg2"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="audio-volume-low-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="1.8672038"
+     inkscape:cy="8.0433396"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="103"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
   <metadata
      id="metadata16">
     <rdf:RDF>
@@ -22,29 +46,22 @@
   </metadata>
   <defs
      id="defs14" />
-  <g
-     color="#bebebe"
-     transform="translate(-313 291)"
-     id="g4">
-    <path
-       d="M328-283c0-3.225-1.204-5.982-2.946-7.25l-1.155 1.04c1.5 1.062 2.542 3.453 2.542 6.21s-1.042 5.148-2.542 6.21l1.155 1.04c1.742-1.268 2.946-4.025 2.946-7.25z"
-       fill="#666"
-       opacity=".35"
-       overflow="visible"
-       style="marker:none"
-       id="path6" />
-    <path
-       d="M324.939-283c0-2.18-.829-4.085-2.08-5.285l-1.068.953c.965 1.026 1.588 2.582 1.588 4.332s-.623 3.306-1.588 4.332l1.068.953c1.251-1.2 2.08-3.104 2.08-5.285z"
-       fill="#666"
-       opacity=".35"
-       overflow="visible"
-       style="marker:none"
-       id="path8" />
-    <path
-       d="M321.993-283c0-1.326-.44-2.542-1.155-3.495l-1.098.982a4.9 4.9 0 0 1 0 5.026l1.098.982a5.813 5.813 0 0 0 1.155-3.495zM313-285v4h1.652l3.348 3.37v-10.74l-3.348 3.37z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path10" />
-  </g>
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 6.5410156,1.0582968 C 6.2631888,0.94141717 5.9423864,1.0021927 5.7265625,1.2125937 L 2.8183594,4.046875 0.57226562,4.5917969 C 0.2357128,4.6739184 -8.1898201e-4,4.9758395 0,5.3222656 v 5.3554684 c -8.1912075e-4,0.346426 0.23571269,0.648348 0.57226562,0.730469 l 2.24609378,0.544922 2.9082031,2.833984 C 6.2017871,15.249996 6.9998205,14.913402 7,14.25 V 1.7497031 C 7.0000477,1.4478797 6.8191836,1.1754291 6.5410156,1.0582968 Z"
+     id="path64256"
+     sodipodi:nodetypes="cccccccccccc" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 9.25,5.25 8.5,6 v 4 l 0.75,0.75 C 9.25,10.75 10,10.088318 10,8 10,5.911682 9.25,5.25 9.25,5.25 Z"
+     id="path95579"
+     sodipodi:nodetypes="cccczc" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.5"
+     d="m 11.537109,2.9746094 -1.070312,1.0507812 c 0,0 0.198996,0.1844127 0.470703,0.8125 C 11.209207,5.465978 11.5,6.4830403 11.5,8 c 0,1.5169597 -0.290793,2.534022 -0.5625,3.162109 -0.271707,0.628088 -0.470703,0.8125 -0.470703,0.8125 l 1.070312,1.050782 c 0,0 0.424749,-0.452508 0.777344,-1.267578 C 12.667048,10.942742 13,9.7104001 13,8 13,6.2895999 12.667048,5.057258 12.314453,4.2421875 11.961858,3.427117 11.537109,2.9746094 11.537109,2.9746094 Z"
+     id="path100266" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.5"
+     d="M 13.791016,0.73046875 12.708984,1.7695312 c 0,0 0.398485,0.3992777 0.857422,1.4121094 C 14.025344,4.1944723 14.5,5.7708267 14.5,8 c 0,2.229173 -0.474656,3.805528 -0.933594,4.818359 -0.458937,1.012832 -0.857422,1.41211 -0.857422,1.41211 l 1.082032,1.039062 c 0,0 0.601516,-0.637959 1.142578,-1.832031 C 15.474655,12.243428 16,10.443197 16,8 16,5.556803 15.474655,3.7565724 14.933594,2.5625 14.392532,1.3684276 13.791016,0.73046875 13.791016,0.73046875 Z"
+     id="path100270" />
 </svg>

--- a/elementary-xfce/status/symbolic/audio-volume-medium-symbolic.svg
+++ b/elementary-xfce/status/symbolic/audio-volume-medium-symbolic.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    height="16"
    width="16"
    id="svg2"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="audio-volume-medium-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="6.8059025"
+     inkscape:cy="4.4194172"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="426"
+     inkscape:window-y="12"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
   <metadata
      id="metadata16">
     <rdf:RDF>
@@ -22,28 +46,22 @@
   </metadata>
   <defs
      id="defs14" />
-  <g
-     color="#bebebe"
-     transform="translate(-293 291)"
-     id="g4">
-    <path
-       d="M308-283c0-3.225-1.204-5.982-2.946-7.25l-1.155 1.04c1.5 1.062 2.542 3.453 2.542 6.21s-1.042 5.148-2.542 6.21l1.155 1.04c1.742-1.268 2.946-4.025 2.946-7.25z"
-       fill="#666"
-       opacity=".35"
-       overflow="visible"
-       style="marker:none"
-       id="path6" />
-    <path
-       d="M304.939-283c0-2.18-.829-4.085-2.08-5.285l-1.068.953c.965 1.026 1.588 2.582 1.588 4.332s-.623 3.306-1.588 4.332l1.068.953c1.251-1.2 2.08-3.104 2.08-5.285z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path8" />
-    <path
-       d="M301.993-283c0-1.326-.44-2.542-1.155-3.495l-1.098.982a4.9 4.9 0 0 1 0 5.026l1.098.982a5.813 5.813 0 0 0 1.155-3.495zM293-285v4h1.652l3.348 3.37v-10.74l-3.348 3.37z"
-       fill="#666"
-       overflow="visible"
-       style="marker:none"
-       id="path10" />
-  </g>
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 6.5410156,1.0582968 C 6.2631888,0.94141717 5.9423864,1.0021927 5.7265625,1.2125937 L 2.8183594,4.046875 0.57226562,4.5917969 C 0.2357128,4.6739184 -8.1898201e-4,4.9758395 0,5.3222656 v 5.3554684 c -8.1912075e-4,0.346426 0.23571269,0.648348 0.57226562,0.730469 l 2.24609378,0.544922 2.9082031,2.833984 C 6.2017871,15.249996 6.9998205,14.913402 7,14.25 V 1.7497031 C 7.0000477,1.4478797 6.8191836,1.1754291 6.5410156,1.0582968 Z"
+     id="path64256"
+     sodipodi:nodetypes="cccccccccccc" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 9.25,5.25 8.5,6 v 4 l 0.75,0.75 C 9.25,10.75 10,10.088318 10,8 10,5.911682 9.25,5.25 9.25,5.25 Z"
+     id="path95579"
+     sodipodi:nodetypes="cccczc" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 11.537109,2.9746094 -1.070312,1.0507812 c 0,0 0.198996,0.1844127 0.470703,0.8125 C 11.209207,5.465978 11.5,6.4830403 11.5,8 c 0,1.5169597 -0.290793,2.534022 -0.5625,3.162109 -0.271707,0.628088 -0.470703,0.8125 -0.470703,0.8125 l 1.070312,1.050782 c 0,0 0.424749,-0.452508 0.777344,-1.267578 C 12.667048,10.942742 13,9.7104001 13,8 13,6.2895999 12.667048,5.057258 12.314453,4.2421875 11.961858,3.427117 11.537109,2.9746094 11.537109,2.9746094 Z"
+     id="path100266" />
+  <path
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.5"
+     d="M 13.791016,0.73046875 12.708984,1.7695312 c 0,0 0.398485,0.3992777 0.857422,1.4121094 C 14.025344,4.1944723 14.5,5.7708267 14.5,8 c 0,2.229173 -0.474656,3.805528 -0.933594,4.818359 -0.458937,1.012832 -0.857422,1.41211 -0.857422,1.41211 l 1.082032,1.039062 c 0,0 0.601516,-0.637959 1.142578,-1.832031 C 15.474655,12.243428 16,10.443197 16,8 16,5.556803 15.474655,3.7565724 14.933594,2.5625 14.392532,1.3684276 13.791016,0.73046875 13.791016,0.73046875 Z"
+     id="path100270" />
 </svg>

--- a/elementary-xfce/status/symbolic/audio-volume-muted-blocking-symbolic.svg
+++ b/elementary-xfce/status/symbolic/audio-volume-muted-blocking-symbolic.svg
@@ -2,24 +2,73 @@
 <svg
    height="16"
    width="16"
+   id="svg2"
    version="1.1"
-   id="svg10"
+   sodipodi:docname="audio-volume-muted-blocking-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg">
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="8.078125"
+     inkscape:cy="8.15625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="640"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
   <defs
      id="defs14" />
   <path
-     id="path453"
-     class="warning"
-     style="font-variation-settings:normal;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000;opacity:0.8"
-     d="M 9 3 C 8.7385492 3 8.5020347 3.1005315 8.3242188 3.2636719 L 5.1621094 5.8671875 L 10 10.705078 L 10 4 C 10 3.4460012 9.5539988 3 9 3 z M 3.609375 6.078125 C 3.2502192 6.2295312 3 6.5845009 3 7 L 3 9 C 3 9.5539988 3.4460012 10 4 10 L 5 10 L 8.3457031 12.753906 C 8.3519931 12.759406 8.3568563 12.766184 8.3632812 12.771484 L 8.3867188 12.789062 C 8.5559514 12.920477 8.7681802 13 9 13 C 9.4154991 13 9.7704688 12.749781 9.921875 12.390625 L 3.609375 6.078125 z " />
+     id="path64256"
+     style="color:#000000;fill:#f9c440;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.80000001"
+     d="M 6.21875 1 C 6.0379674 1.0077625 5.8614523 1.0813901 5.7265625 1.2128906 L 2.9941406 3.8769531 L 7 7.8828125 L 7 1.75 C 7.0000477 1.4481769 6.8191833 1.1757259 6.5410156 1.0585938 C 6.4368307 1.0147639 6.3272196 0.99534248 6.21875 1 z M 1.6757812 4.3242188 L 0.57226562 4.5917969 C 0.23571314 4.6739183 -0.00081898119 4.9758399 0 5.3222656 L 0 10.677734 C -0.00081911993 11.02416 0.23571303 11.326082 0.57226562 11.408203 L 2.8183594 11.953125 L 5.7265625 14.787109 C 6.2017866 15.249996 6.9998205 14.913401 7 14.25 L 7 9.6484375 L 1.6757812 4.3242188 z " />
+  <path
+     id="path95579"
+     style="color:#000000;fill:#f9c440;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.80000001"
+     d="M 9.25 5.25 L 8.5 6 L 8.5 9.3828125 L 9.5097656 10.392578 C 9.7267756 10.004562 10 9.2651884 10 8 C 10 5.9116841 9.25 5.25 9.25 5.25 z " />
+  <path
+     id="path100266"
+     style="color:#000000;fill:#f9c440;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.80000001"
+     d="M 11.537109 2.9746094 L 10.466797 4.0253906 C 10.466797 4.0253906 10.665793 4.209804 10.9375 4.8378906 C 11.209207 5.4659774 11.5 6.4830418 11.5 8 C 11.5 9.5169582 11.209207 10.534023 10.9375 11.162109 C 10.857626 11.34675 10.784802 11.488973 10.720703 11.603516 L 11.800781 12.683594 C 11.949868 12.468857 12.14135 12.157963 12.314453 11.757812 C 12.667048 10.942742 13 9.7103984 13 8 C 13 6.2896016 12.667048 5.0572572 12.314453 4.2421875 C 11.961858 3.4271178 11.537109 2.9746094 11.537109 2.9746094 z " />
+  <path
+     id="path100270"
+     style="color:#000000;fill:#f9c440;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.80000001"
+     d="M 13.791016 0.73046875 L 12.708984 1.7695312 C 12.708984 1.7695312 13.10747 2.1688099 13.566406 3.1816406 C 14.025344 4.1944713 14.5 5.7708289 14.5 8 C 14.5 10.229171 14.025344 11.805529 13.566406 12.818359 C 13.346967 13.302641 13.143126 13.643935 12.988281 13.871094 L 14.056641 14.939453 C 14.282013 14.638051 14.616756 14.13673 14.933594 13.4375 C 15.474654 12.243429 16 10.443195 16 8 C 16 5.5568054 15.474654 3.7565712 14.933594 2.5625 C 14.392532 1.3684288 13.791016 0.73046875 13.791016 0.73046875 z " />
   <rect
      style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
      id="rect2480-1-6"
      width="1.248"
      height="19.799999"
-     x="-0.6257652"
-     y="1.416185"
+     x="-0.62400001"
+     y="1.4137089"
      rx="0.5"
      ry="0.5"
      transform="rotate(-45)" />

--- a/elementary-xfce/status/symbolic/audio-volume-muted-symbolic.svg
+++ b/elementary-xfce/status/symbolic/audio-volume-muted-symbolic.svg
@@ -1,16 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    height="16"
    width="16"
    id="svg2"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="audio-volume-muted-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="7.078125"
+     inkscape:cy="8.15625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="640"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
   <metadata
-     id="metadata14">
+     id="metadata16">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -21,24 +45,31 @@
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs12" />
-  <g
-     color="#bebebe"
-     transform="translate(-333 291)"
-     id="g4">
-    <path
-       d="M333-285v4h1.652l3.348 3.37v-10.74l-3.348 3.37z"
-       fill="#666"
-       opacity=".35"
-       overflow="visible"
-       style="marker:none"
-       id="path6" />
-    <path
-       d="M341-285v1l1 1-1 1v1h1l1-1 1 1h1v-1l-1-1 1-1v-1h-1l-1 1-1-1z"
-       fill="#666"
-       opacity=".4"
-       overflow="visible"
-       style="marker:none"
-       id="path8" />
-  </g>
+     id="defs14" />
+  <path
+     id="path64256"
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.40000001"
+     d="M 6.21875 1 C 6.0379674 1.0077625 5.8614523 1.0813901 5.7265625 1.2128906 L 2.9941406 3.8769531 L 7 7.8828125 L 7 1.75 C 7.0000477 1.4481769 6.8191833 1.1757259 6.5410156 1.0585938 C 6.4368307 1.0147639 6.3272196 0.99534248 6.21875 1 z M 1.6757812 4.3242188 L 0.57226562 4.5917969 C 0.23571314 4.6739183 -0.00081898119 4.9758399 0 5.3222656 L 0 10.677734 C -0.00081911993 11.02416 0.23571303 11.326082 0.57226562 11.408203 L 2.8183594 11.953125 L 5.7265625 14.787109 C 6.2017866 15.249996 6.9998205 14.913401 7 14.25 L 7 9.6484375 L 1.6757812 4.3242188 z " />
+  <path
+     id="path95579"
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.40000001"
+     d="M 9.25 5.25 L 8.5 6 L 8.5 9.3828125 L 9.5097656 10.392578 C 9.7267756 10.004562 10 9.2651884 10 8 C 10 5.9116841 9.25 5.25 9.25 5.25 z " />
+  <path
+     id="path100266"
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.40000001"
+     d="M 11.537109 2.9746094 L 10.466797 4.0253906 C 10.466797 4.0253906 10.665793 4.209804 10.9375 4.8378906 C 11.209207 5.4659774 11.5 6.4830418 11.5 8 C 11.5 9.5169582 11.209207 10.534023 10.9375 11.162109 C 10.857626 11.34675 10.784802 11.488973 10.720703 11.603516 L 11.800781 12.683594 C 11.949868 12.468857 12.14135 12.157963 12.314453 11.757812 C 12.667048 10.942742 13 9.7103984 13 8 C 13 6.2896016 12.667048 5.0572572 12.314453 4.2421875 C 11.961858 3.4271178 11.537109 2.9746094 11.537109 2.9746094 z " />
+  <path
+     id="path100270"
+     style="color:#000000;fill:#555761;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.40000001"
+     d="M 13.791016 0.73046875 L 12.708984 1.7695312 C 12.708984 1.7695312 13.10747 2.1688099 13.566406 3.1816406 C 14.025344 4.1944713 14.5 5.7708289 14.5 8 C 14.5 10.229171 14.025344 11.805529 13.566406 12.818359 C 13.346967 13.302641 13.143126 13.643935 12.988281 13.871094 L 14.056641 14.939453 C 14.282013 14.638051 14.616756 14.13673 14.933594 13.4375 C 15.474654 12.243429 16 10.443195 16 8 C 16 5.5568054 15.474654 3.7565712 14.933594 2.5625 C 14.392532 1.3684288 13.791016 0.73046875 13.791016 0.73046875 z " />
+  <rect
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     id="rect2480-1-6"
+     width="1.248"
+     height="19.799999"
+     x="-0.62400001"
+     y="1.4137089"
+     rx="0.5"
+     ry="0.5"
+     transform="rotate(-45)" />
 </svg>

--- a/elementary-xfce/status/symbolic/audio-volume-overamplified-symbolic.svg
+++ b/elementary-xfce/status/symbolic/audio-volume-overamplified-symbolic.svg
@@ -5,7 +5,7 @@
    id="svg2"
    version="1.1"
    sodipodi:docname="audio-volume-overamplified-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -14,23 +14,25 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview9"
+     id="namedview49079"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="30.140427"
-     inkscape:cx="20.470845"
-     inkscape:cy="7.9959054"
-     inkscape:window-width="1389"
-     inkscape:window-height="890"
-     inkscape:window-x="26"
-     inkscape:window-y="23"
+     inkscape:zoom="16"
+     inkscape:cx="15.09375"
+     inkscape:cy="7.8124999"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="426"
+     inkscape:window-y="13"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg2" />
+     inkscape:current-layer="svg2"
+     showguides="true" />
   <metadata
      id="metadata16">
     <rdf:RDF>
@@ -45,36 +47,25 @@
   <defs
      id="defs14" />
   <path
-     d="m 0,6 v 4 H 1.652 L 5,13.37 V 2.63 L 1.652,6 Z"
-     fill="#666666"
-     overflow="visible"
-     style="color:#bebebe;marker:none"
-     id="path10"
-     sodipodi:nodetypes="ccccccc" />
+     style="color:#000000;fill:#d48e15;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 6.5410156,1.0582968 C 6.2631888,0.94141717 5.9423864,1.0021927 5.7265625,1.2125937 L 2.8183594,4.046875 0.57226562,4.5917969 C 0.2357128,4.6739184 -8.1898201e-4,4.9758395 0,5.3222656 v 5.3554684 c -8.1912075e-4,0.346426 0.23571269,0.648348 0.57226562,0.730469 l 2.24609378,0.544922 2.9082031,2.833984 C 6.2017871,15.249996 6.9998205,14.913402 7,14.25 V 1.7497031 C 7.0000477,1.4478797 6.8191836,1.1754291 6.5410156,1.0582968 Z"
+     id="path64256"
+     sodipodi:nodetypes="cccccccccccc"
+     class="warning" />
   <path
-     d="m 15.031,0.016 h -2 v 4.422 l 2,-0.364 z m -3,0 h -2 v 4.966 l 2,-0.363 z M 9,0.016 7,0 V 5.535 L 9,5.17 Z m -2,10.48 v 5.52 H 9 V 10.86 Z m 3.031,0.553 v 4.967 h 2 v -4.604 z m 3,0.545 v 4.422 h 2 v -4.059 z"
-     style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#474747;marker:none"
-     color="#000000"
-     font-weight="400"
-     font-family="sans-serif"
-     overflow="visible"
-     opacity="0.35"
-     id="path6" />
+     style="color:#000000;fill:#d48e15;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 9.25,5.25 8.5,6 v 4 l 0.75,0.75 C 9.25,10.75 10,10.088318 10,8 10,5.911682 9.25,5.25 9.25,5.25 Z"
+     id="path95579"
+     sodipodi:nodetypes="cccczc"
+     class="warning" />
   <path
-     d="m 15.031,0 -2,0.737 v 14.525 l 2,0.738 z m -3,1.106 -2,0.737 v 12.313 l 2,0.738 z M 9,2.224 7,2.964 v 10.07 l 2,0.742 z"
-     style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#666666;fill-opacity:1;marker:none"
-     color="#000000"
-     font-weight="400"
-     font-family="sans-serif"
-     overflow="visible"
-     id="path4" />
+     style="color:#000000;fill:#d48e15;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 11.537109,2.9746094 -1.070312,1.0507812 c 0,0 0.198996,0.1844127 0.470703,0.8125 C 11.209207,5.465978 11.5,6.4830403 11.5,8 c 0,1.5169597 -0.290793,2.534022 -0.5625,3.162109 -0.271707,0.628088 -0.470703,0.8125 -0.470703,0.8125 l 1.070312,1.050782 c 0,0 0.424749,-0.452508 0.777344,-1.267578 C 12.667048,10.942742 13,9.7104001 13,8 13,6.2895999 12.667048,5.057258 12.314453,4.2421875 11.961858,3.427117 11.537109,2.9746094 11.537109,2.9746094 Z"
+     id="path100266"
+     class="warning" />
   <path
-     d="m 27.031,0.016 h -2 v 4.422 l 2,-0.364 z m -3,0 h -2 v 4.966 l 2,-0.363 z M 21,0.016 19,0 V 5.535 L 21,5.17 Z m -2,10.48 v 5.52 h 2 V 10.86 Z m 3.031,0.553 v 4.967 h 2 v -4.604 z m 3,0.545 v 4.422 h 2 v -4.059 z"
-     style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#474747;marker:none"
-     color="#000000"
-     font-weight="400"
-     font-family="sans-serif"
-     overflow="visible"
-     opacity="0.35"
-     id="path1179" />
+     style="color:#000000;fill:#d48e15;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="M 13.791016,0.73046875 12.708984,1.7695312 c 0,0 0.398485,0.3992777 0.857422,1.4121094 C 14.025344,4.1944723 14.5,5.7708267 14.5,8 c 0,2.229173 -0.474656,3.805528 -0.933594,4.818359 -0.458937,1.012832 -0.857422,1.41211 -0.857422,1.41211 l 1.082032,1.039062 c 0,0 0.601516,-0.637959 1.142578,-1.832031 C 15.474655,12.243428 16,10.443197 16,8 16,5.556803 15.474655,3.7565724 14.933594,2.5625 14.392532,1.3684276 13.791016,0.73046875 13.791016,0.73046875 Z"
+     id="path100270"
+     class="warning" />
 </svg>


### PR DESCRIPTION
New symbolic audio icons to make size of status / systray icons more consistent.
Also uses the new strikethrough style for muted and blocking.

Addresses part of #152

Current:
![audio-sym-current](https://github.com/shimmerproject/elementary-xfce/assets/1984060/25e316c6-9de1-472a-ac35-196852181adc)

![audio-sym-current-notify](https://github.com/shimmerproject/elementary-xfce/assets/1984060/63400246-140e-4b79-a375-29c5078b3aab)


Proposed:
![audio-sym-prop1](https://github.com/shimmerproject/elementary-xfce/assets/1984060/ddd92bea-0f54-441d-b200-19a79267fec0) 

![audio-sym-prop1-notify](https://github.com/shimmerproject/elementary-xfce/assets/1984060/79cd1c49-5350-47a6-abe1-ef3b74019950)


---

This PR uses this style for `audio-volume-muted-symbolic` and `audio-volume-muted-blocking-symbolic`:
![audio-sym-prop1-muted](https://github.com/shimmerproject/elementary-xfce/assets/1984060/e45058f0-203b-4626-8cef-be1792905fb9)

Here is an alternative, more like what upstream uses. When you go from audo low to mute, the icon "jumps" more (the speaker icon goes from left to center) and to me is a little less legible (the strikethrough sort of blocks what is behind it). But, it is cleaner looking:
![audio-sym-prop1-muted-alt](https://github.com/shimmerproject/elementary-xfce/assets/1984060/79728b5e-6157-4182-b680-9f88b8c6ab89)

Up to you on what looks better, I don't have a strong feeling either way. Here are the SVGs if you want to try them in-use.
![audio-volume-muted-symbolic](https://github.com/shimmerproject/elementary-xfce/assets/1984060/5feac466-bab5-4731-99e7-3827bbce00da)
![audio-volume-muted-blocking-symbolic](https://github.com/shimmerproject/elementary-xfce/assets/1984060/a249a5cf-e938-4578-9843-762b2c5573c3)


