### PR TITLE
Do not convert 'symbolic-rtl' versions.

### DIFF
--- a/svgtopng/pngtheme.sh
+++ b/svgtopng/pngtheme.sh
@@ -18,13 +18,13 @@ echo "== Processing $1"
 
 echo " * Creating png icons from svg files and symlinks"
 #ignore list customized for elementary-xfce
-find "$icondir" -iname "*.svg" -not \( -wholename "*/scalable/*" -o -wholename "*/symbolic/*" -o -wholename "*-symbolic.svg" -o -wholename "*/animations/*process-*" -o -wholename "*/animations/*gnome-spinner*" -o -wholename "*/animations*pk-action-refresh*" \) -exec $cmd {} +
+find "$icondir" -iname "*.svg" -not \( -wholename "*/scalable/*" -o -wholename "*/symbolic/*" -o -wholename "*-symbolic.svg" -o -wholename "*-symbolic-rtl.svg" -o -wholename "*/animations/*process-*" -o -wholename "*/animations/*gnome-spinner*" -o -wholename "*/animations*pk-action-refresh*" \) -exec $cmd {} +
 
 echo " * Cleanup icon directory"
 find "$icondir" -name "untitled folder" -type d -exec rm -rf {} +
 
 echo " * Deleting svg files"
-find "$icondir" -iname '*.svg' -not \( -wholename "*/scalable/*" -o -wholename "*/symbolic/*" -o -wholename "*-symbolic.svg" -o -wholename "*/animations/*process-*" -o -wholename "*/animations/*gnome-spinner*" -o -wholename "*/animations*pk-action-refresh*" \) -delete
+find "$icondir" -iname '*.svg' -not \( -wholename "*/scalable/*" -o -wholename "*/symbolic/*" -o -wholename "*-symbolic.svg" -o -wholename "*-symbolic-rtl.svg" -o -wholename "*/animations/*process-*" -o -wholename "*/animations/*gnome-spinner*" -o -wholename "*/animations*pk-action-refresh*" \) -delete
 
 #ignore the output if the theme depends on another one (e.g. elementary-xfce-dark needs to be converted before elementary-xfce)
 echo " * Checking dangling symlinks"


### PR DESCRIPTION
While updating the FreeBSD port I got failures due to cp failing to find some files, referenced by symlinks:

```
install -d /wrkdirs/usr/ports/x11-themes/xfce-icons-elementary/work/stage/usr/local/share/icons
cp -rf build/elementary-xfce /wrkdirs/usr/ports/x11-themes/xfce-icons-elementary/work/stage/usr/local/share/icons
cp: build/elementary-xfce/actions/24/go-previous-symbolic-rtl.png: No such file or directory
cp: build/elementary-xfce/actions/24/media-skip-forward-symbolic-rtl.png: No such file or directory
cp: build/elementary-xfce/actions/24/media-skip-backward-symbolic-rtl.png: No such file or directory
cp: build/elementary-xfce/actions/24/go-next-symbolic-rtl.png: No such file or directory
cp: build/elementary-xfce/actions/24/media-seek-forward-symbolic-rtl.png: No such file or directory
cp: build/elementary-xfce/actions/24/media-seek-backward-symbolic-rtl.png: No such file or directory
*** Error code 1
```

Looks like some finles with a new namiong scheme (`*-symbolic-rtl.svn`) have been added in commit 1c135add1e7a5e98e833f65002598a1d2693c38b but the expressions in the [svgtopng/pngtheme.sh](https://github.com/shimmerproject/elementary-xfce/blob/master/svgtopng/pngtheme.sh) script have not been updated to account for this.

This is the fix I'm using in the FreeBSD ports tree.