### PR TITLE
Actions: Make zoom icons uniform, add contrast

### DIFF
--- a/elementary-xfce/actions/16/zoom-fit-best.svg
+++ b/elementary-xfce/actions/16/zoom-fit-best.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="16"
    height="16"
-   id="svg2">
+   id="svg2"
+   sodipodi:docname="zoom-fit-best.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="20.506097"
+     inkscape:cy="11.313708"
+     inkscape:window-width="1278"
+     inkscape:window-height="827"
+     inkscape:window-x="812"
+     inkscape:window-y="93"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <metadata
      id="metadata17">
     <rdf:RDF>
@@ -17,39 +41,126 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs4" />
+     id="defs4">
+    <linearGradient
+       y2="40.818172"
+       x2="23.99999"
+       y1="7.1818099"
+       x1="23.99999"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,1.5062179,1037.2271)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient874"
+       xlink:href="#linearGradient3924-4-8" />
+    <linearGradient
+       id="linearGradient3924-4-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-0-4" />
+      <stop
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-6-8" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-2-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-9-0" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient37446"
+       id="linearGradient14435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,-13.717096,1037.4289)"
+       x1="25"
+       y1="0"
+       x2="25"
+       y2="20.11076" />
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient37446"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop37442"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop37444"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14443"
+       id="linearGradient14437"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2991052"
+       y1="0.040277567"
+       x2="5.2991052"
+       y2="16"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,1.0666667,1037.4289)" />
+    <linearGradient
+       id="linearGradient14443"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.31999999;"
+         offset="0"
+         id="stop14439" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.38;"
+         offset="1"
+         id="stop14441" />
+    </linearGradient>
+  </defs>
   <g
      transform="translate(0,-1036.3622)"
      id="layer1">
     <rect
        width="13"
        height="13.000017"
-       rx="2"
-       ry="2"
+       rx="1"
+       ry="1"
        x="1.5"
        y="1037.8622"
        id="rect7169"
-       style="fill:#e9e9e9;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="fill:url(#linearGradient14435);fill-opacity:1;stroke:url(#linearGradient14437);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:round;stroke-dashoffset:0;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1;marker-start:none;marker-mid:none;marker-end:none" />
+    <rect
+       width="11"
+       height="11.000004"
+       x="2.4999976"
+       y="1038.8622"
+       id="rect5351"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient874);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
     <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 6.5,1039.8695 0,2 -1.0072863,0 0,0.9927 -2,0 0,-2.9927 z"
-       id="path2262" />
+       d="m 6.5,1039.8622 v 2 h -1 v 1 h -2 v -3 z"
+       id="path2262-6"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
     <path
+       d="m 9.4999998,1039.8622 v 2 H 10.5 v 1 h 2 v -3 z"
        id="path3922"
-       d="m 9.493,1039.8695 0,2 0.999714,0 0,0.9997 2,0 0,-2.9997 z"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
     <path
+       d="m 6.5,1048.8622 v -2 h -1 v -1 h -2 v 3 z"
        id="path3924"
-       d="m 6.493,1048.8695 0,-2 -1.0002863,0 0,-1.0003 -2,0 0,3.0003 z"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
     <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 9.493,1048.8695 0,-2 0.999714,0 0,-1.0003 2,0 0,3.0003 z"
-       id="path3926" />
+       d="m 9.4999998,1048.8622 v -2 H 10.5 v -1 h 2 v 3 z"
+       id="path3926"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
   </g>
 </svg>

--- a/elementary-xfce/actions/16/zoom-in.svg
+++ b/elementary-xfce/actions/16/zoom-in.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="16"
    height="16"
-   id="svg2">
+   id="svg2"
+   sodipodi:docname="zoom-in.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.532116"
+     inkscape:cx="10.863412"
+     inkscape:cy="10.019105"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="977"
+     inkscape:window-y="85"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <metadata
      id="metadata17">
     <rdf:RDF>
@@ -17,27 +41,131 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs4" />
+     id="defs4">
+    <linearGradient
+       y2="40.818172"
+       x2="23.99999"
+       y1="7.1818099"
+       x1="23.99999"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,1.5062179,1037.2271)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient874"
+       xlink:href="#linearGradient3924-4-8" />
+    <linearGradient
+       id="linearGradient3924-4-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-0-4" />
+      <stop
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-6-8" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-2-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-9-0" />
+    </linearGradient>
+    <linearGradient
+       y2="21.718079"
+       x2="7.5"
+       y1="2"
+       x1="7.5"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient864"
+       xlink:href="#linearGradient881"
+       gradientTransform="translate(0.2734724,1036.3186)" />
+    <linearGradient
+       id="linearGradient881">
+      <stop
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0"
+         id="stop877" />
+      <stop
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1"
+         id="stop879" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient37446"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop37442"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop37444"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient37446"
+       id="linearGradient14435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,-13.717096,1037.4288)"
+       x1="25"
+       y1="0"
+       x2="25"
+       y2="20.11076" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14443"
+       id="linearGradient14437"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2991052"
+       y1="0.040277567"
+       x2="5.2991052"
+       y2="16"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,1.0666667,1037.4288)" />
+    <linearGradient
+       id="linearGradient14443"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.31999999;"
+         offset="0"
+         id="stop14439" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.38;"
+         offset="1"
+         id="stop14441" />
+    </linearGradient>
+  </defs>
   <g
      transform="translate(0,-1036.3622)"
      id="layer1">
     <rect
        width="13"
        height="13.000017"
-       rx="2"
-       ry="2"
+       rx="1"
+       ry="1"
        x="1.5"
        y="1037.8622"
        id="rect7169"
-       style="fill:#e9e9e9;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient14435);fill-opacity:1;stroke:url(#linearGradient14437);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000" />
+    <rect
+       width="11"
+       height="11.000004"
+       x="2.4999976"
+       y="1038.8622"
+       id="rect5351"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient874);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
     <path
-       style="color:#000000;fill:#ffffff;stroke:#8c8c8c;stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;fill-opacity:1"
-       d="m 6.5000002,1042.8622 0,-2.0073 2.9999998,0 0,2.0073 2.007286,0 0,3 -2.007286,0 0,2.0073 -2.9999998,0 0,-2.0073 -2.0072863,0 0,-3 2.0072863,0 z"
-       id="path2262" />
+       d="m 6.5,1042.8621 v -1.9999 h 3 v 2 h 2 v 3 h -2 v 2 h -3 v -2.0001 l -2,3e-4 v -3 z"
+       id="path2262"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccccccccc" />
   </g>
 </svg>

--- a/elementary-xfce/actions/16/zoom-original.svg
+++ b/elementary-xfce/actions/16/zoom-original.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="16"
    height="16"
-   id="svg2">
+   id="svg2"
+   sodipodi:docname="zoom-original.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.532116"
+     inkscape:cx="10.61012"
+     inkscape:cy="10.019105"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="436"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <metadata
      id="metadata17">
     <rdf:RDF>
@@ -17,27 +41,111 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs4" />
+     id="defs4">
+    <linearGradient
+       y2="40.818172"
+       x2="23.99999"
+       y1="7.1818099"
+       x1="23.99999"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,1.5062179,1037.2271)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient874"
+       xlink:href="#linearGradient3924-4-8" />
+    <linearGradient
+       id="linearGradient3924-4-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-0-4" />
+      <stop
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-6-8" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-2-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-9-0" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient37446"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop37442"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop37444"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient37446"
+       id="linearGradient14435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,-13.717096,1037.4289)"
+       x1="25"
+       y1="0"
+       x2="25"
+       y2="20.11076" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14443"
+       id="linearGradient14437"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2991052"
+       y1="0.040277567"
+       x2="5.2991052"
+       y2="16"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,1.0666666,1037.4289)" />
+    <linearGradient
+       id="linearGradient14443"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.31999999;"
+         offset="0"
+         id="stop14439" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.38;"
+         offset="1"
+         id="stop14441" />
+    </linearGradient>
+  </defs>
   <g
      transform="translate(0,-1036.3622)"
      id="layer1">
     <rect
        width="13"
        height="13.000017"
-       rx="2"
-       ry="2"
+       rx="1"
+       ry="1"
        x="1.5"
        y="1037.8622"
        id="rect7169"
-       style="fill:#e9e9e9;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient14435);fill-opacity:1;stroke:url(#linearGradient14437);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000" />
+    <rect
+       width="11"
+       height="11.000004"
+       x="2.4999976"
+       y="1038.8622"
+       id="rect5351"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient874);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
     <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 6.5000002,1040.8549 2.9999998,0 0,7.0146 -2.9999998,0 0,-4.0073 -1.0000002,0 0,-2 z"
-       id="path2262" />
+       d="m 6.5,1040.8622 h 2.9999998 v 7 H 6.5 v -4 h -1 v -2 z"
+       id="path2262-9"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cccccccc" />
   </g>
 </svg>

--- a/elementary-xfce/actions/16/zoom-out.svg
+++ b/elementary-xfce/actions/16/zoom-out.svg
@@ -1,14 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    width="16"
    height="16"
-   id="svg2">
+   id="svg2"
+   sodipodi:docname="zoom-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.532116"
+     inkscape:cx="10.61012"
+     inkscape:cy="10.019105"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="400"
+     inkscape:window-y="23"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
   <metadata
      id="metadata17">
     <rdf:RDF>
@@ -17,27 +41,111 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs4" />
+     id="defs4">
+    <linearGradient
+       y2="40.818172"
+       x2="23.99999"
+       y1="7.1818099"
+       x1="23.99999"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,1.5062179,1037.2271)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient874"
+       xlink:href="#linearGradient3924-4-8" />
+    <linearGradient
+       id="linearGradient3924-4-8">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926-0-4" />
+      <stop
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928-6-8" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930-2-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932-9-0" />
+    </linearGradient>
+    <linearGradient
+       x1="63.9995"
+       y1="3.1001"
+       x2="63.9995"
+       y2="122.8994"
+       id="linearGradient37446"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop37442"
+         style="stop-color:#fafafa;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop37444"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient37446"
+       id="linearGradient14435"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,-13.717096,1037.4289)"
+       x1="25"
+       y1="0"
+       x2="25"
+       y2="20.11076" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient14443"
+       id="linearGradient14437"
+       gradientUnits="userSpaceOnUse"
+       x1="5.2991052"
+       y1="0.040277567"
+       x2="5.2991052"
+       y2="16"
+       gradientTransform="matrix(0.86666661,0,0,0.86666661,1.0666667,1037.4289)" />
+    <linearGradient
+       id="linearGradient14443"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.31999999;"
+         offset="0"
+         id="stop14439" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.38;"
+         offset="1"
+         id="stop14441" />
+    </linearGradient>
+  </defs>
   <g
      transform="translate(0,-1036.3622)"
      id="layer1">
     <rect
        width="13"
        height="13.000017"
-       rx="2"
-       ry="2"
+       rx="1"
+       ry="1"
        x="1.5"
        y="1037.8622"
        id="rect7169"
-       style="fill:#e9e9e9;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+       style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient14435);fill-opacity:1;stroke:url(#linearGradient14437);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000" />
+    <rect
+       width="11"
+       height="11.000004"
+       x="2.4999976"
+       y="1038.8622"
+       id="rect5351"
+       style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient874);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
     <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:#8c8c8c;stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 11.507286,1042.8622 0,3 -7.0145721,0 0,-3 z"
-       id="path2262" />
+       d="m 11.5,1042.8622 v 3 h -7 v -3 z"
+       id="path2262"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:#4d4d4d;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccc" />
   </g>
 </svg>

--- a/elementary-xfce/actions/24/zoom-fit-best.svg
+++ b/elementary-xfce/actions/24/zoom-fit-best.svg
@@ -1,38 +1,50 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-fit-best.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview31659"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.666667"
+     inkscape:cx="6.5046728"
+     inkscape:cy="12.981308"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="23"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
-       id="linearGradient4225">
+       id="linearGradient32924">
       <stop
-         style="stop-color:#6c6c6c;stop-opacity:0.7"
+         style="stop-color:#6c6c6c;stop-opacity:0.60000002;"
          offset="0"
-         id="stop4227" />
+         id="stop32920" />
       <stop
-         style="stop-color:#c1c1c1;stop-opacity:1;"
+         style="stop-color:#6c6c6c;stop-opacity:0.55000001;"
          offset="1"
-         id="stop4229" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
+         id="stop32922" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -132,15 +144,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.0625,0,0,1.0625,-0.75,-0.75000022)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88235294,0,0,0.88235295,1.4117647,1.4117649)" />
-    <linearGradient
        id="linearGradient3164">
       <stop
          id="stop3166"
@@ -152,12 +155,12 @@
          style="stop-color:#000000;stop-opacity:0;" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4225"
+       xlink:href="#linearGradient32924"
        id="linearGradient4261"
        x1="13"
        y1="1"
        x2="13"
-       y2="21"
+       y2="20"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        xlink:href="#linearGradient4299-652-5"
@@ -212,6 +215,34 @@
        x2="9"
        y2="15"
        gradientTransform="matrix(-1,0,0,1,24,0)" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540541,0,0,0.4054054,2.2702718,2.2702733)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233-0"
+       y2="41.167725"
+       x2="23.99999"
+       y1="6.7566175"
+       x1="23.99999" />
   </defs>
   <metadata
      id="metadata3833">
@@ -221,7 +252,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -245,69 +275,32 @@
      id="rect4133"
      y="3.4999886"
      x="3.5"
-     ry="2.6153848"
-     rx="2.6153846"
+     ry="2.5"
+     rx="2.5"
      height="17.000023"
      width="17" />
-  <rect
-     width="17"
-     height="17.000023"
-     rx="2.6153846"
-     ry="2.6153846"
-     x="3.5"
-     y="3.4999886"
-     id="rect7169"
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;opacity:0.29999999999999999" />
-  <rect
-     width="15"
-     height="15.00002"
-     rx="2.3076923"
-     ry="2.3076925"
-     x="4.5"
-     y="4.49999"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
   <g
      id="g4298">
-    <g
-       id="g4295">
-      <path
-         style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:url(#linearGradient4287);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="m 10.5,18.507286 0,-2 -2.007286,0 0,-1.985413 -2.0000003,0 0,3.985413 z"
-         id="path4269" />
-    </g>
     <path
-       style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:url(#linearGradient4293);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 10.5,7.5218728 0,2.0000001 -2.0072863,0 0,1.9854131 -2,0 0,-3.9854132 z"
-       id="path4265" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4287);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 10.5,18.5 v -2 H 8.5000002 v -2 H 6.5 v 4 z"
+       id="path4269"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4293);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 10.5,7.5 v 2 H 8.4999999 v 2 H 6.5 v -4 z"
+       id="path4265"
+       sodipodi:nodetypes="ccccccc" />
     <path
        id="path4267"
-       d="m 13.492714,7.5218728 0,2.0000001 2.007286,0 0,1.9854131 2,0 0,-3.9854132 z"
-       style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:url(#linearGradient4290);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 13.5,7.5 v 2 h 2 v 2 h 2 v -4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4290);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
     <path
-       style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:url(#linearGradient4284);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 13.492714,18.507286 0,-2 2.007286,0 0,-1.985413 2,0 0,3.985413 z"
-       id="path4271" />
-  </g>
-  <g
-     id="g3481"
-     style="stroke:url(#linearGradient4261);fill:none;fill-opacity:1">
-    <path
-       id="path2262-6"
-       d="m 10.5,6.5218725 0,2.0000001 -2.0072863,0 0,1.9854134 -2,0 0,-3.9854135 z"
-       style="color:#000000;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       style="color:#000000;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 13.492714,6.5218725 0,2.0000001 2.007286,0 0,1.9854134 2,0 0,-3.9854135 z"
-       id="path3475" />
-    <path
-       style="color:#000000;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 10.5,17.507286 0,-2 -2.007286,0 0,-1.985413 -2.0000003,0 0,3.985413 z"
-       id="path3477" />
-    <path
-       id="path3479"
-       d="m 13.492714,17.507286 0,-2 2.007286,0 0,-1.985413 2,0 0,3.985413 z"
-       style="color:#000000;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4284);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 13.5,18.5 v -2 h 2 v -2 h 2 v 4 z"
+       id="path4271"
+       sodipodi:nodetypes="ccccccc" />
   </g>
   <path
      style="fill:url(#linearGradient4313);stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
@@ -317,4 +310,66 @@
      id="path4315"
      d="m 17,14 0,3 -3,0 0,-1 2,0 0,-2 z"
      style="fill:url(#linearGradient4317);fill-opacity:1;stroke:none;opacity:0.05" />
+  <g
+     id="g3481"
+     style="stroke:url(#linearGradient4261);fill:none;fill-opacity:1">
+    <path
+       id="path2262-6"
+       d="m 10.5,6.5 v 2 H 8.4999999 v 2 H 6.5 v -4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 13.5,6.5 v 2 h 2 v 2 h 2 v -4 z"
+       id="path3475"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 10.5,17.5 v -2 H 8.5000002 v -2 H 6.5 v 4 z"
+       id="path3477"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       id="path3479"
+       d="m 13.5,17.5 v -2 h 2 v -2 h 2 v 4 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:url(#linearGradient4261);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+  <path
+     id="path2262-6-6"
+     d="M 10,7 V 8 H 8 v 2 H 7 V 7 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path32283"
+     d="m 14,7 v 1 h 2 v 2 h 1 V 7 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path32285"
+     d="m 14,17 v -1 h 2 v -2 h 1 v 3 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path32287"
+     d="M 10,17 V 16 H 8 V 14 H 7 v 3 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <rect
+     width="15"
+     height="15"
+     x="4.5"
+     y="4.5"
+     id="rect6741-9"
+     style="fill:none;stroke:url(#linearGradient3233-0);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" />
+  <rect
+     width="17"
+     height="17.000023"
+     rx="2.5"
+     ry="2.5"
+     x="3.5"
+     y="3.4999886"
+     id="rect7169"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/24/zoom-in.svg
+++ b/elementary-xfce/actions/24/zoom-in.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-in.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview31027"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.666667"
+     inkscape:cx="9.5327102"
+     inkscape:cy="12"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="385"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
@@ -19,31 +42,9 @@
          offset="0"
          id="stop4227" />
       <stop
-         style="stop-color:#c1c1c1;stop-opacity:1;"
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;"
          offset="1"
          id="stop4229" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4219" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -140,23 +141,6 @@
        y2="5"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88235294,0,0,0.88235295,1.4117647,1.4117649)" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4223"
-       x1="12"
-       y1="16"
-       x2="12"
-       y2="10"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
        xlink:href="#linearGradient4225"
        id="linearGradient4231"
        x1="15"
@@ -164,6 +148,34 @@
        x2="15"
        y2="18"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.40540541,0,0,0.4054054,2.2702718,2.2702733)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233-0"
+       y2="41.167725"
+       x2="23.99999"
+       y1="6.7566175"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -173,7 +185,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -197,38 +208,41 @@
      id="rect4133"
      y="3.4999886"
      x="3.5"
-     ry="2.6153848"
-     rx="2.6153846"
+     ry="2.5"
+     rx="2.5"
      height="17.000023"
      width="17" />
+  <path
+     id="path4173"
+     d="M 10.5,11.500295 V 8.5 h 3 v 3.000295 h 3.007 v 3 H 13.5 V 17.5 h -3 V 14.500295 H 7.493 v -3 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4181);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient4231);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 10.5,10.500009 V 7.5 h 3 v 3.000009 h 3 v 3 h -3 V 16.5 h -3 v -2.999991 h -3 v -3 z"
+     id="path2262"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 11,11 V 8 h 2 v 3 h 3 v 2 h -3 v 3 H 11 V 13 H 8 v -2 z"
+     id="path31555"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <rect
+     width="15"
+     height="15"
+     x="4.5"
+     y="4.5"
+     id="rect6741-9"
+     style="fill:none;stroke:url(#linearGradient3233-0);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" />
   <rect
      width="17"
      height="17.000023"
-     rx="2.6153846"
-     ry="2.6153846"
+     rx="2.5"
+     ry="2.5"
      x="3.5"
      y="3.4999886"
      id="rect7169"
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;opacity:0.29999999999999999" />
-  <path
-     id="path4173"
-     d="m 10.5,11.500295 0,-3.0070087 3,0 0,3.0070087 3.007,0 0,3 -3.007,0 0,3.006991 -3,0 0,-3.006991 -3.007,0 0,-3 z"
-     style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:url(#linearGradient4181);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;fill:none;fill-opacity:1;stroke:url(#linearGradient4231);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:1"
-     d="m 10.5,10.500009 0,-3.007009 3,0 0,3.007009 3.007,0 0,3 -3.007,0 0,3.006991 -3,0 0,-3.006991 -3.007,0 0,-3 z"
-     id="path2262" />
-  <rect
-     width="15"
-     height="15.00002"
-     rx="2.3076923"
-     ry="2.3076925"
-     x="4.5"
-     y="4.49999"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <path
-     style="fill:url(#linearGradient4223);stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1;opacity:0.05"
-     d="m 11,8 2,0 0,3 3,0 0,2 -3,0 0,3 -2,0 0,-3 -3,0 0,-2 3,0 z"
-     id="path4215" />
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/24/zoom-original.svg
+++ b/elementary-xfce/actions/24/zoom-original.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-original.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview30346"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="9.3691648"
+     inkscape:cy="11.844039"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="248"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
@@ -19,31 +42,9 @@
          offset="0"
          id="stop4227" />
       <stop
-         style="stop-color:#c1c1c1;stop-opacity:1;"
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;"
          offset="1"
          id="stop4229" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4219" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -132,30 +133,12 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.0625,0,0,1.0625,-0.75,-0.75000022)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88235294,0,0,0.88235295,1.4117647,1.4117649)" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4223"
-       x1="12"
-       y1="16"
-       x2="12"
-       y2="10"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.87593985,0,0.99248119)" />
-    <linearGradient
        xlink:href="#linearGradient4225"
        id="linearGradient4325"
        x1="15"
        y1="7"
        x2="15"
-       y2="16.541353"
+       y2="17.538971"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
        xlink:href="#linearGradient4299-652-5"
@@ -165,7 +148,35 @@
        y1="16"
        x2="16"
        y2="9.548872"
-       gradientTransform="translate(0,0.99998631)" />
+       gradientTransform="translate(0,0.9999863)" />
+    <linearGradient
+       gradientTransform="matrix(0.40540541,0,0,0.4054054,2.2702713,2.2702733)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233-0"
+       y2="41.167725"
+       x2="23.99999"
+       y1="6.7566175"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -175,7 +186,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -199,38 +209,41 @@
      id="rect4133"
      y="3.4999886"
      x="3.5"
-     ry="2.6153848"
-     rx="2.6153846"
+     ry="2.5"
+     rx="2.5"
      height="17.000023"
      width="17" />
   <path
      id="path4327"
-     d="m 10.492713,9.4926863 3,0 0,7.0145997 -2.999999,0 0,-4.0073 -1.0000003,0 0,-2 z"
-     style="color:#000000;fill:none;stroke:url(#linearGradient4329);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.6" />
+     d="M 10.492713,8.5 H 13.5 v 9 h -3 L 10.4927,11.499986 H 9.5 v -2 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4329);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 10.7,8 H 13 v 8 H 11 V 10 H 10 V 8.7 Z"
+     id="path30897"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:url(#linearGradient4325);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 10.492713,7.5 H 13.5 v 9 h -3 v -6 h -1 v -2 z"
+     id="path2262-9"
+     sodipodi:nodetypes="cccccccc" />
+  <rect
+     width="15"
+     height="15"
+     x="4.5"
+     y="4.5"
+     id="rect6741-9"
+     style="fill:none;stroke:url(#linearGradient3233-0);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" />
   <rect
      width="17"
      height="17.000023"
-     rx="2.6153846"
-     ry="2.6153846"
+     rx="2.5"
+     ry="2.5"
      x="3.5"
      y="3.4999886"
      id="rect7169"
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;opacity:0.29999999999999999" />
-  <rect
-     width="15"
-     height="15.00002"
-     rx="2.3076923"
-     ry="2.3076925"
-     x="4.5"
-     y="4.49999"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <path
-     style="color:#000000;fill:none;fill-opacity:1;stroke:url(#linearGradient4325);stroke-width:0.98542737999999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 10.492713,8.4927 3,0 0,7.0146 -2.999999,0 0,-4.0073 -1.0000003,0 0,-2 z"
-     id="path2262-9" />
-  <path
-     style="opacity:0.05;fill:url(#linearGradient4223);fill-opacity:1;stroke:none"
-     d="m 11,9 2,0 0,6 -2,0 0,-4 -1,0 0,-1 z"
-     id="path4215" />
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/24/zoom-out.svg
+++ b/elementary-xfce/actions/24/zoom-out.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview29546"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="25.220142"
+     inkscape:cx="6.740644"
+     inkscape:cy="16.891261"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="226"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
@@ -19,31 +42,9 @@
          offset="0"
          id="stop4227" />
       <stop
-         style="stop-color:#c1c1c1;stop-opacity:1;"
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;"
          offset="1"
          id="stop4229" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4219" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -140,23 +141,6 @@
        y2="5"
        gradientUnits="userSpaceOnUse" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.88235294,0,0,0.88235295,1.4117647,1.4117649)" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4223"
-       x1="12"
-       y1="14"
-       x2="12"
-       y2="10"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
        xlink:href="#linearGradient4225"
        id="linearGradient4231"
        x1="15"
@@ -164,6 +148,34 @@
        x2="15"
        y2="18"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.40540541,0,0,0.4054054,2.2702717,2.2702733)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233-0"
+       y2="41.167725"
+       x2="23.99999"
+       y1="6.7566175"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -173,7 +185,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -197,38 +208,38 @@
      id="rect4133"
      y="3.4999886"
      x="3.5"
-     ry="2.6153848"
-     rx="2.6153846"
+     ry="2.5"
+     rx="2.5"
      height="17.000023"
      width="17" />
-  <rect
-     width="17"
-     height="17.000023"
-     rx="2.6153846"
-     ry="2.6153846"
-     x="3.5"
-     y="3.4999886"
-     id="rect7169"
-     style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.99999994000000003;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;opacity:0.29999999999999999" />
   <path
      id="path4173"
-     d="m 16.507,11.500295 0,3 -9.014,0 0,-3 z"
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4181);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 16.5,11.500295 v 3 h -9 v -3 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4181);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient4231);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 16.507,10.500009 0,3 -9.014,0 0,-3 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 15.999999,11 v 2 H 7.9999997 v -2 z"
+     id="path30051" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4231);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 16.5,10.500009 v 3 h -9 v -3 z"
      id="path2262" />
   <rect
      width="15"
-     height="15.00002"
-     rx="2.3076923"
-     ry="2.3076925"
+     height="15"
      x="4.5"
-     y="4.49999"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <path
-     style="opacity:0.05000000000000000;fill:url(#linearGradient4223);fill-opacity:1;stroke:none"
-     d="m 16,11 0,2 -8,0 0,-2 z"
-     id="path4215" />
+     y="4.5"
+     id="rect6741-9"
+     style="fill:none;stroke:url(#linearGradient3233-0);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" />
+  <rect
+     width="17"
+     height="17.000023"
+     rx="2.5"
+     ry="2.5"
+     x="3.5"
+     y="3.4999886"
+     id="rect7169"
+     style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/32/zoom-fit-best.svg
+++ b/elementary-xfce/actions/32/zoom-fit-best.svg
@@ -1,27 +1,51 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-fit-best.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview28431"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="37.830212"
+     inkscape:cx="9.146129"
+     inkscape:cy="14.432909"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="60"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
-       id="linearGradient4186">
+       inkscape:collect="always"
+       id="linearGradient28952">
       <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
+         style="stop-color:#6c6c6c;stop-opacity:0.69999999;"
          offset="0"
-         id="stop4188" />
+         id="stop28948" />
       <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;"
          offset="1"
-         id="stop4190" />
+         id="stop28950" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -99,15 +123,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.6875,0,0,1.6875,-4.25,-4.25002)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4705883,0,0,1.4705882,-1.6470588,-1.6470778)" />
-    <linearGradient
        id="linearGradient3164">
       <stop
          style="stop-color:#000000;stop-opacity:0.05"
@@ -141,17 +156,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4225-5">
-      <stop
-         id="stop4227-9"
-         offset="0"
-         style="stop-color:#6c6c6c;stop-opacity:0.7" />
-      <stop
-         id="stop4229-2"
-         offset="1"
-         style="stop-color:#c1c1c1;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
        xlink:href="#linearGradient5060-5-6"
        id="linearGradient4335"
        gradientUnits="userSpaceOnUse"
@@ -169,42 +173,6 @@
        x2="9"
        y2="15"
        gradientTransform="translate(2,5.9999996)" />
-    <linearGradient
-       xlink:href="#linearGradient4225-5"
-       id="linearGradient4390"
-       gradientUnits="userSpaceOnUse"
-       x1="13"
-       y1="1"
-       x2="13"
-       y2="21"
-       gradientTransform="translate(5.9999994,6.0000002)" />
-    <linearGradient
-       xlink:href="#linearGradient4225-5"
-       id="linearGradient4393"
-       gradientUnits="userSpaceOnUse"
-       x1="13"
-       y1="1"
-       x2="13"
-       y2="21"
-       gradientTransform="translate(2,6.0000056)" />
-    <linearGradient
-       xlink:href="#linearGradient4225-5"
-       id="linearGradient4396"
-       gradientUnits="userSpaceOnUse"
-       x1="13"
-       y1="1"
-       x2="13"
-       y2="21"
-       gradientTransform="translate(5.9999997,2.0000002)" />
-    <linearGradient
-       xlink:href="#linearGradient4225-5"
-       id="linearGradient4399"
-       gradientUnits="userSpaceOnUse"
-       x1="13"
-       y1="1"
-       x2="13"
-       y2="21"
-       gradientTransform="translate(2,2.0000002)" />
     <linearGradient
        xlink:href="#linearGradient4299-652-5-8"
        id="linearGradient4402"
@@ -241,6 +209,43 @@
        y1="20"
        x2="10"
        y2="2.9999998" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient28952"
+       id="linearGradient28954"
+       x1="16.348051"
+       y1="5.659348"
+       x2="16.348051"
+       y2="28.200001"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.21621333,-0.21620973)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.08071423"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -250,7 +255,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -274,64 +278,34 @@
      id="rect4133"
      y="2.4999621"
      x="2.5"
-     ry="4.1538463"
-     rx="4.1538463"
+     ry="4"
+     rx="4"
      height="27.000036"
      width="27" />
-  <rect
-     width="27"
-     height="27.000036"
-     rx="4.1538463"
-     ry="4.1538463"
-     x="2.5"
-     y="2.4999638"
-     id="rect7169"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-  <rect
-     width="25"
-     height="25.000032"
-     rx="3.846154"
-     ry="3.846154"
-     x="3.5"
-     y="3.4999647"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
   <g
      id="g4295"
      transform="translate(2,6.0000003)">
     <path
        id="path4269"
-       d="m 10.5,18.507286 0,-2 -2.007286,0 0,-1.985413 -2.0000003,0 0,3.985413 z"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4412);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       d="m 11.5,19.5 v -3 h -3 v -2.999999 h -3 V 19.5 Z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4412);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
   </g>
   <path
      id="path4265"
-     d="m 12.5,9.5218726 0,2.0000004 -2.007286,0 0,1.985413 -2.0000003,0 0,-3.9854134 z"
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4408);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 13.5,8.5 v 3 h -3 v 3 h -3 v -6 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4408);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
   <path
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4405);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 19.492714,9.5218726 0,2.0000004 2.007286,0 0,1.985413 2,0 0,-3.9854134 z"
-     id="path4267" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4405);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 18.5,8.5 v 3 h 3 v 3 h 3 v -6 z"
+     id="path4267"
+     sodipodi:nodetypes="ccccccc" />
   <path
      id="path4271"
-     d="m 19.492714,24.507286 0,-2 2.007286,0 0,-1.985413 2,0 0,3.985413 z"
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4402);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient4399);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 12.5,8.5218726 0,2.0000004 -2.007286,0 0,1.985413 -2.0000003,0 0,-3.9854134 z"
-     id="path2262-6" />
-  <path
-     id="path3475"
-     d="m 19.492714,8.5218726 0,2.0000004 2.007286,0 0,1.985413 2,0 0,-3.9854134 z"
-     style="color:#000000;fill:none;stroke:url(#linearGradient4396);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     id="path3477"
-     d="m 12.5,23.507292 0,-2 -2.007286,0 0,-1.985413 -2.0000003,0 0,3.985413 z"
-     style="color:#000000;fill:none;stroke:url(#linearGradient4393);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient4390);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 19.492714,23.507286 0,-2 2.007286,0 0,-1.985413 2,0 0,3.985413 z"
-     id="path3479" />
+     d="m 18.5,25.5 v -3 h 3 v -2.999999 h 3 V 25.5 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4402);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
   <path
      style="fill:url(#linearGradient4338);fill-opacity:1;stroke:none"
      d="m 9,20 0,3 3,0 0,-1 -2,0 0,-2 z"
@@ -340,4 +314,66 @@
      id="path4315"
      d="m 23,20 0,3 -3,0 0,-1 2,0 0,-2 z"
      style="opacity:0.05;fill:url(#linearGradient4335);fill-opacity:1;stroke:none" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+     d="m 13,8 v 2 h -3 v 3 H 8 V 8 Z"
+     id="path2262-6-7"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+     d="m 19,8 v 2 h 3 v 3 h 2 V 8 Z"
+     id="path29060"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+     d="M 19,24.000001 V 22 h 3 v -2.999999 h 2 v 5 z"
+     id="path29062"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+     d="M 13,23.999998 V 22 H 10 V 19.000001 H 8 v 4.999997 z"
+     id="path29064"
+     sodipodi:nodetypes="ccccccc" />
+  <g
+     id="g28946"
+     style="stroke:url(#linearGradient28954)">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient28954);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+       d="m 13.5,7.5 v 3 h -3 v 3 h -3 v -6 z"
+       id="path2262-6"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       id="path3475"
+       d="m 18.5,7.5 v 3 h 3 v 3 h 3 v -6 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient28954);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       id="path3477"
+       d="m 13.5,24.500001 v -2.999998 h -3 v -2.999999 h -3 v 5.999997 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient28954);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient28954);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.698039;marker:none;enable-background:accumulate"
+       d="m 18.5,24.499998 v -3.000001 h 3 v -2.999999 h 3 v 6 z"
+       id="path3479"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.499999"
+     x="3.5"
+     ry="3"
+     rx="3"
+     height="25.000002"
+     width="25" />
+  <rect
+     width="27"
+     height="27.000036"
+     rx="4"
+     ry="4"
+     x="2.5"
+     y="2.4999638"
+     id="rect7169"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/32/zoom-in.svg
+++ b/elementary-xfce/actions/32/zoom-in.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-in.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview26640"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.75"
+     inkscape:cx="12.71028"
+     inkscape:cy="16"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="145"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
@@ -19,31 +42,9 @@
          offset="0"
          id="stop4227" />
       <stop
-         style="stop-color:#c1c1c1;stop-opacity:1;"
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;"
          offset="1"
          id="stop4229" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4219" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -141,24 +142,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.6656947,0,0,1.6656947,-3.9883363,-4.6545063)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4705883,0,0,1.4705882,-1.6470588,-1.6470778)" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4223"
-       x1="12"
-       y1="16"
-       x2="12"
-       y2="10"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.75,0,0,1.75,-5,-5)" />
-    <linearGradient
        xlink:href="#linearGradient4225"
        id="linearGradient4231"
        x1="15"
@@ -167,6 +150,34 @@
        y2="18"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.6656946,0,0,1.6656946,-3.9883357,-3.9883325)" />
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.21621329,-0.21620971)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.08071423"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -176,7 +187,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -200,38 +210,41 @@
      id="rect4133"
      y="2.4999621"
      x="2.5"
-     ry="4.1538463"
-     rx="4.1538463"
+     ry="4"
+     rx="4"
      height="27.000036"
      width="27" />
+  <path
+     id="path4173"
+     d="m 13.5,14.5 v -5 h 5 v 5 h 5 v 5 h -5 v 5 h -5 v -5 h -5 v -5 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4181);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 14,14 V 9 h 4 v 5 h 5 v 4 h -5 v 5 H 14 V 18 H 9 v -4 z"
+     id="path27145"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4231);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 13.5,13.5 v -5 h 5 v 5 h 5 v 5 h -5 v 5 h -5 v -5 h -5 v -5 z"
+     id="path2262"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.499999"
+     x="3.5"
+     ry="3"
+     rx="3"
+     height="25.000002"
+     width="25" />
   <rect
      width="27"
      height="27.000036"
-     rx="4.1538463"
-     ry="4.1538463"
+     rx="4"
+     ry="4"
      x="2.5"
      y="2.4999638"
      id="rect7169"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-  <path
-     id="path4173"
-     d="m 13.501458,14.501472 0,-5.0087575 4.997084,0 0,5.0087575 5.008744,0 0,4.997085 -5.008744,0 0,5.008728 -4.997084,0 0,-5.008728 -5.0087445,0 0,-4.997085 z"
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4181);stroke-width:0.98542732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient4231);stroke-width:0.98542744;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 13.501457,13.501474 0,-5.0087571 4.997085,0 0,5.0087571 5.008743,0 0,4.997083 -5.008743,0 0,5.008729 -4.997085,0 0,-5.008729 -5.0087437,0 0,-4.997083 z"
-     id="path2262" />
-  <rect
-     width="25"
-     height="25.000032"
-     rx="3.846154"
-     ry="3.846154"
-     x="3.5"
-     y="3.4999647"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <path
-     style="opacity:0.05;fill:url(#linearGradient4223);fill-opacity:1;stroke:none"
-     d="m 14,9 4,0 0,5 5,0 0,4 -5,0 0,5 -4,0 0,-5 -5,0 0,-4 5,0 z"
-     id="path4215" />
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/32/zoom-original.svg
+++ b/elementary-xfce/actions/32/zoom-original.svg
@@ -1,28 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-original.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview24401"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="10.827573"
+     inkscape:cy="16.970563"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="292"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
@@ -99,15 +111,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.6875,0,0,1.6875,-4.25,-4.25002)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4705883,0,0,1.4705882,-1.6470588,-1.6470778)" />
-    <linearGradient
        id="linearGradient4299-652-5-2">
       <stop
          id="stop3618-8-6-3"
@@ -119,17 +122,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4217">
-      <stop
-         id="stop4219"
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1;" />
-      <stop
-         id="stop4221"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient4225-7">
       <stop
          id="stop4227-8"
@@ -138,17 +130,8 @@
       <stop
          id="stop4229-4"
          offset="1"
-         style="stop-color:#c1c1c1;stop-opacity:1;" />
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient5291"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.87593985,5.0000133,4.9924872)"
-       x1="12"
-       y1="16"
-       x2="12"
-       y2="10" />
     <linearGradient
        xlink:href="#linearGradient4225-7"
        id="linearGradient5294"
@@ -167,6 +150,34 @@
        y1="16"
        x2="16"
        y2="9.548872" />
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.21621331,-0.21621005)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.08071423"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -176,7 +187,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -200,38 +210,41 @@
      id="rect4133"
      y="2.4999621"
      x="2.5"
-     ry="4.1538463"
-     rx="4.1538463"
+     ry="4"
+     rx="4"
      height="27.000036"
      width="27" />
+  <path
+     id="path4327"
+     d="m 14,10.5 h 4.5 v 13 h -3.999986 v -8 h -2 L 12.5,12.074411 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient5301);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="cccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 14.396,9.9999995 H 18 V 22.000357 H 14.99965 V 14.5 C 14.99965,14.218378 14.751619,14 14.5,14 H 12.99965 L 13,11.375 c 0,0 1.159434,-0.629863 1.396,-1.3750005 z"
+     id="path24906"
+     sodipodi:nodetypes="ccccccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient5294);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="M 13.99637,9.5 H 18.5 v 13 h -3.999986 v -8 h -2 L 12.5,11.074412 c 0,0 1.5,-0.668161 1.49637,-1.574412 z"
+     id="path2262-9"
+     sodipodi:nodetypes="cccccccc" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.499999"
+     x="3.5"
+     ry="3"
+     rx="3"
+     height="25.000002"
+     width="25" />
   <rect
      width="27"
      height="27.000036"
-     rx="4.1538463"
-     ry="4.1538463"
+     rx="4"
+     ry="4"
      x="2.5"
      y="2.4999638"
      id="rect7169"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-  <rect
-     width="25"
-     height="25.000032"
-     rx="3.846154"
-     ry="3.846154"
-     x="3.5"
-     y="3.4999647"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <path
-     id="path4327"
-     d="m 13.996369,11.492714 4.510931,0 0,11.014572 -4.007286,0 0,-6.007286 -2,0 -0.0073,-3.425589 z"
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient5301);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient5294);stroke-width:0.98542738;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 13.99637,10.492714 4.510931,0 0,11.014572 -4.007287,0 0,-6.007286 -2,0 -0.0073,-3.425588 c 0,0 1.507286,-0.675448 1.503656,-1.581698 z"
-     id="path2262-9" />
-  <path
-     style="opacity:0.05;fill:url(#linearGradient5291);fill-opacity:1;stroke:none"
-     d="m 14.000014,11 4,0 0,10 -3,0 0,-6 -2,0 0,-3 z"
-     id="path4215" />
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/32/zoom-out.svg
+++ b/elementary-xfce/actions/32/zoom-out.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="zoom-out.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview25817"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="13.567611"
+     inkscape:cy="16.771689"
+     inkscape:window-width="1419"
+     inkscape:window-height="1044"
+     inkscape:window-x="173"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
@@ -19,31 +42,9 @@
          offset="0"
          id="stop4227" />
       <stop
-         style="stop-color:#c1c1c1;stop-opacity:1;"
+         style="stop-color:#6c6c6c;stop-opacity:0.64999998;"
          offset="1"
          id="stop4229" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4219" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -141,24 +142,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.6656947,0,0,1.6656947,-3.9883363,-4.6545063)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4705883,0,0,1.4705882,-1.6470588,-1.6470778)" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4223"
-       x1="12"
-       y1="16"
-       x2="12"
-       y2="10"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.75,0,0,1.75,-5,-5)" />
-    <linearGradient
        xlink:href="#linearGradient4225"
        id="linearGradient4231"
        x1="15"
@@ -167,6 +150,34 @@
        y2="18"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(1.6656946,0,0,1.6656946,-3.9883357,-3.9883325)" />
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.21621332,-0.2162097)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.08071423"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -176,7 +187,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -200,38 +210,40 @@
      id="rect4133"
      y="2.4999621"
      x="2.5"
-     ry="4.1538463"
-     rx="4.1538463"
+     ry="4"
+     rx="4"
      height="27.000036"
      width="27" />
+  <path
+     id="path4173"
+     d="m 23.5,14.5 v 5 h -15 v -5 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:url(#linearGradient4181);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4231);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 23.5,13.5 v 5 h -15 v -5 z"
+     id="path2262"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fefefe;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 23,14 v 4 H 9 v -4 z"
+     id="path25959" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.499999"
+     x="3.5"
+     ry="3"
+     rx="3"
+     height="25.000002"
+     width="25" />
   <rect
      width="27"
      height="27.000036"
-     rx="4.1538463"
-     ry="4.1538463"
+     rx="4"
+     ry="4"
      x="2.5"
      y="2.4999638"
      id="rect7169"
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
-  <path
-     id="path4173"
-     d="m 23.507286,14.501472 0,4.997085 -15.0145725,0 0,-4.997085 z"
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4181);stroke-width:0.98542732;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  <path
-     style="color:#000000;fill:none;stroke:url(#linearGradient4231);stroke-width:0.98542744;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     d="m 23.507285,13.501474 0,4.997083 -15.0145717,0 0,-4.997083 z"
-     id="path2262" />
-  <rect
-     width="25"
-     height="25.000032"
-     rx="3.846154"
-     ry="3.846154"
-     x="3.5"
-     y="3.4999647"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <path
-     style="opacity:0.05;fill:url(#linearGradient4223);fill-opacity:1;stroke:none"
-     d="m 23,14 0,4 -14,0 0,-4 z"
-     id="path4215" />
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
 </svg>

--- a/elementary-xfce/actions/48/zoom-fit-best.svg
+++ b/elementary-xfce/actions/48/zoom-fit-best.svg
@@ -24,14 +24,14 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="39.333333"
-     inkscape:cx="15.254237"
-     inkscape:cy="36.927966"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
+     inkscape:zoom="13.906434"
+     inkscape:cx="21.069385"
+     inkscape:cy="35.091672"
+     inkscape:window-width="1419"
+     inkscape:window-height="1043"
+     inkscape:window-x="211"
+     inkscape:window-y="371"
+     inkscape:window-maximized="0"
      inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
@@ -46,17 +46,6 @@
          style="stop-color:#abacae;stop-opacity:1"
          offset="1"
          id="stop6507" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
@@ -145,15 +134,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.1875001,0,0,2.1875001,-2.25,-2.249977)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9411764,0,0,1.941174,0.7058824,0.70591423)" />
-    <linearGradient
        xlink:href="#linearGradient5060-5"
        id="linearGradient4317"
        gradientUnits="userSpaceOnUse"
@@ -171,6 +151,34 @@
        x2="23.681135"
        y2="36.661953"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="38.999996"
+       y1="6.0831103"
+       x2="38.999996"
+       y2="41.939384"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,0.89189189,2.5945846,2.5946042)" />
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -216,15 +224,6 @@
      y="6.4999776"
      id="rect7169"
      style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     width="33"
-     height="33"
-     rx="3"
-     ry="3"
-     x="7.5"
-     y="7.5"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
   <path
      id="path5307"
      d="m 22.5,13.5 v 4 h -5 v 5 h -4 v -9 z"
@@ -248,6 +247,26 @@
      id="path5315"
      d="m 25.5,36.5 v -4 h 7 v -5 h 2 v 9 z"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;stroke:#f1f3f5;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path2262-6-2"
+     d="m 21,13 v 3 h -5 v 5 h -3 v -8 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path23211"
+     d="m 27,13 v 3 h 5 v 5 h 3 v -8 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path23213"
+     d="m 27,35 v -3 h 5 v -5 h 3 v 8 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     id="path23215"
+     d="m 21,35 v -3 h -5 v -5 h -3 v 8 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      sodipodi:nodetypes="ccccccc" />
   <g
      id="g6503"
@@ -275,22 +294,31 @@
     <path
        id="path24859"
        d="m 21,13 v 3 h -5 v 5 h -3 v -8 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;opacity:0.8"
        sodipodi:nodetypes="ccccccc" />
     <path
        id="path25224"
        d="m 27,13 v 3 h 5 v 5 h 3 v -8 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        sodipodi:nodetypes="ccccccc" />
     <path
        id="path25226"
        d="m 21,35 v -3 h -5 v -5 h -3 v 8 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        sodipodi:nodetypes="ccccccc" />
     <path
        id="path25228"
        d="m 27,35 v -3 h 5 v -5 h 3 v 8 z"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
        sodipodi:nodetypes="ccccccc" />
   </g>
+  <rect
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2-8-4"
+     y="7.5"
+     x="7.5"
+     ry="3"
+     rx="3"
+     height="33"
+     width="33" />
 </svg>

--- a/elementary-xfce/actions/48/zoom-in.svg
+++ b/elementary-xfce/actions/48/zoom-in.svg
@@ -25,27 +25,16 @@
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
      inkscape:zoom="6.9532168"
-     inkscape:cx="27.181664"
+     inkscape:cx="18.0492"
      inkscape:cy="17.114381"
      inkscape:window-width="1580"
      inkscape:window-height="965"
-     inkscape:window-x="-405"
+     inkscape:window-x="0"
      inkscape:window-y="40"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
@@ -122,15 +111,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.1875001,0,0,2.1875001,-2.25,-2.249977)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9411764,0,0,1.941174,0.7058824,0.70591423)" />
-    <linearGradient
        x1="15"
        y1="-12.316096"
        x2="15"
@@ -159,6 +139,34 @@
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.2499999,0,0,2.2499999,-3.0000004,-3.0000004)" />
+    <linearGradient
+       x1="38.999996"
+       y1="6.0831103"
+       x2="38.999996"
+       y2="41.939384"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,0.89189189,2.5945846,2.5946037)" />
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -204,15 +212,6 @@
      y="6.4999776"
      id="rect7169"
      style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     width="33"
-     height="33"
-     rx="3"
-     ry="3"
-     x="7.5"
-     y="7.5"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
   <path
      d="m 21,15 h 6 v 6 h 5.999999 v 6 H 27 v 5.999999 H 21 V 27 h -6 v -6 h 6 z"
      id="path4215"
@@ -233,4 +232,13 @@
      id="path2262"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4231);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;fill-opacity:0.80000001"
      sodipodi:nodetypes="ccccccccccccc" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2-8-4"
+     y="7.5"
+     x="7.5"
+     ry="3"
+     rx="3"
+     height="33"
+     width="33" />
 </svg>

--- a/elementary-xfce/actions/48/zoom-original.svg
+++ b/elementary-xfce/actions/48/zoom-original.svg
@@ -25,27 +25,16 @@
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
      inkscape:zoom="6.9532168"
-     inkscape:cx="6.615643"
-     inkscape:cy="9.7796462"
+     inkscape:cx="-1.2224558"
+     inkscape:cy="10.28301"
      inkscape:window-width="1322"
-     inkscape:window-height="411"
+     inkscape:window-height="728"
      inkscape:window-x="303"
      inkscape:window-y="138"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
@@ -122,15 +111,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.1875001,0,0,2.1875001,-2.25,-2.249977)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9411764,0,0,1.941174,0.7058824,0.70591423)" />
-    <linearGradient
        x1="15"
        y1="-12.77952"
        x2="15"
@@ -159,6 +139,34 @@
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.508909,0,0,2.7259475,-4.8259249,-10.679661)" />
+    <linearGradient
+       x1="38.999996"
+       y1="6.0831103"
+       x2="38.999996"
+       y2="41.939384"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,0.89189189,2.5945838,2.594604)" />
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -205,15 +213,6 @@
      id="rect7169"
      style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
   <rect
-     width="33"
-     height="33"
-     rx="3"
-     ry="3"
-     x="7.5"
-     y="7.5"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
-  <rect
      style="opacity:0.5;fill:#fafafa;fill-rule:evenodd;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.5;stop-color:#000000"
      id="rect27396"
      width="7"
@@ -242,4 +241,13 @@
      id="path2262-9"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4325);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      sodipodi:nodetypes="cccccccac" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2-8-4"
+     y="7.5"
+     x="7.5"
+     ry="3"
+     rx="3"
+     height="33"
+     width="33" />
 </svg>

--- a/elementary-xfce/actions/48/zoom-out.svg
+++ b/elementary-xfce/actions/48/zoom-out.svg
@@ -24,9 +24,9 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="2.4583333"
-     inkscape:cx="-31.728814"
-     inkscape:cy="18.711865"
+     inkscape:zoom="9.8333332"
+     inkscape:cx="5.6440679"
+     inkscape:cy="24.508475"
      inkscape:window-width="1322"
      inkscape:window-height="861"
      inkscape:window-x="0"
@@ -35,17 +35,6 @@
      inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
-    <linearGradient
-       id="linearGradient4186">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0.502"
-         offset="0"
-         id="stop4188" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop4190" />
-    </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
@@ -122,15 +111,6 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.1875001,0,0,2.1875001,-2.25,-2.249977)" />
     <linearGradient
-       xlink:href="#linearGradient4186"
-       id="linearGradient4192"
-       x1="12"
-       y1="24.466665"
-       x2="12"
-       y2="2.9333332"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9411764,0,0,1.941174,0.7058824,0.70591423)" />
-    <linearGradient
        x1="15"
        y1="-0.67051095"
        x2="15"
@@ -159,6 +139,34 @@
        xlink:href="#linearGradient5060"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(2.25,0,0,2.9999998,-3.000003,-11.999997)" />
+    <linearGradient
+       x1="38.999996"
+       y1="6.0831103"
+       x2="38.999996"
+       y2="41.939384"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189189,0,0,0.89189189,2.5945845,2.5946039)" />
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
   </defs>
   <metadata
      id="metadata3833">
@@ -204,15 +212,6 @@
      y="6.4999776"
      id="rect7169"
      style="opacity:0.3;fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
-  <rect
-     width="33"
-     height="33"
-     rx="3"
-     ry="3"
-     x="7.5"
-     y="7.5"
-     id="rect4183"
-     style="fill:none;stroke:url(#linearGradient4192);stroke-width:1" />
   <path
      d="m 33,21 v 6 H 15 v -6 z"
      id="path4215"
@@ -229,4 +228,13 @@
      d="m 33.5,20.5 v 7 h -19 v -7 z"
      id="path2262"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient4231-6);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2-8-4"
+     y="7.5"
+     x="7.5"
+     ry="3"
+     rx="3"
+     height="33"
+     width="33" />
 </svg>


### PR DESCRIPTION
Adjust icon gradients and borders at 16px.
Fill symbols with lighter color to improve contrast at all sizes.

Should make the zoom icons more legible and uniform at all sizes, and 16px borders should look better in dark themes.

---

It's kind of subtle, but looks a lot better in use I think.

Current (left), Proposed (right):

Menus:

![zoom-menu-current](https://github.com/shimmerproject/elementary-xfce/assets/1984060/0998ebbe-dfed-452b-ae41-6a951b950bb2) ![zoom-menu-proposed](https://github.com/shimmerproject/elementary-xfce/assets/1984060/3ca07c0c-2a53-476e-8b6b-dd845208e143)

Toolbar: 

![zoom-toolbar-current](https://github.com/shimmerproject/elementary-xfce/assets/1984060/46f61e22-b5ea-4fed-b618-50643485d602) ![zoom-toolbar-proposed2](https://github.com/shimmerproject/elementary-xfce/assets/1984060/1780f912-b339-4818-af59-3c4d366f6ddd)

