### PR TITLE
Animations: Add VPN "connecting" icons at 16px

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,3 +52,7 @@ https://creativecommons.org/licenses/by-nc-sa/3.0
 Perl sillhoutte licensed under CC-BY-SA 4.0 International by Yaru/Jupi007
 https://github.com/ubuntu/yaru
 https://github.com/Jupi007
+
+VPN/Loading animation icons from Paper (CC-BY-SA-4.0) and Papirus (GPL3) icon themes
+https://github.com/snwh/paper-icon-theme
+https://github.com/PapirusDevelopmentTeam/papirus-icon-theme

--- a/elementary-xfce-dark/panel/16/nm-vpn-connecting.svg
+++ b/elementary-xfce-dark/panel/16/nm-vpn-connecting.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce-dark/panel/16/nm-vpn-connecting12.svg
+++ b/elementary-xfce-dark/panel/16/nm-vpn-connecting12.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce-dark/panel/16/nm-vpn-connecting13.svg
+++ b/elementary-xfce-dark/panel/16/nm-vpn-connecting13.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce-dark/panel/16/nm-vpn-connecting14.svg
+++ b/elementary-xfce-dark/panel/16/nm-vpn-connecting14.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce/animations/16/nm-vpn-connecting01-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting01-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4688"
+   sodipodi:docname="nm-vpn-connecting01-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview4690"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9216417"
+     inkscape:cy="11"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="521"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4688" />
+  <defs
+     id="defs4680">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0,-1,-1,0,20,20)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop4670" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop4672" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0,1,1,0,-4,-3.99995)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop4675" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop4677" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="M 8,1 C 4.134,1 1,4.134 1,8 c 0,3.866 3.134,7 7,7 V 13 C 5.2386,13 3,10.761 3,8 3,5.2386 5.2386,3 8,3 9.3,3 9.3,1 8,1 Z"
+     id="path4682" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 8,1 v 2 c 2.761,0 5,2.2386 5,5 0.75,0 1.424,0.294 1.947,0.758 C 14.979,8.509 15,8.257 15,8 15,4.134 11.866,1 8,1 Z M 9,12.885 C 8.676,12.952 8.345,13 8,13 v 2 c 0.342,0 0.673,-0.041 1,-0.094 z"
+     id="path4684" />
+  <path
+     fill="#555761"
+     d="m 13,9 c -1.108,0 -2,0.91085 -2,2.0312 v 0.969 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path4686" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting01.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting01.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg4688"
+   sodipodi:docname="nm-vpn-connecting01.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview4690"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9216417"
+     inkscape:cy="11"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="521"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4688" />
+  <defs
+     id="defs4680">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0,-1,-1,0,20,20)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop4670"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop4672"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0,1,1,0,-4,-3.99995)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop4675"
+         style="stop-color:#3689e6;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop4677"
+         style="stop-color:#3689e6;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 8,1 v 2 c 2.761,0 5,2.2386 5,5 0.75,0 1.424,0.294 1.947,0.758 C 14.979,8.509 15,8.257 15,8 15,4.134 11.866,1 8,1 Z M 9,12.885 C 8.676,12.952 8.345,13 8,13 v 2 c 0.342,0 0.673,-0.041 1,-0.094 z"
+     id="path4684" />
+  <path
+     fill="#444444"
+     d="m 13,9 c -1.108,0 -2,0.91085 -2,2.0312 v 0.969 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path4686"
+     style="fill:#f9c440" />
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="M 8,1 C 4.134,1 1,4.134 1,8 c 0,3.866 3.134,7 7,7 V 13 C 5.2386,13 3,10.761 3,8 3,5.2386 5.2386,3 8,3 9.3,3 9.3,1 8,1 Z"
+     id="path4682" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting02-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting02-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg56030"
+   sodipodi:docname="nm-vpn-connecting02-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview56032"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="10.986318"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg56030" />
+  <defs
+     id="defs56022">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.43366,-0.90108,-0.90108,-0.43366,13.608771,24.018249)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop56012" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop56014" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.43366,0.90108,0.90108,0.43366,2.3903713,-8.0155512)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop56017" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop56019" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.3417713,1.0071488 c -2.7253,-0.13199998 -5.3913,1.3462 -6.6486,3.9589 -1.67650004,3.4832 -0.2122,7.6672002 3.2714,9.3442002 l 0.8672,-1.803 c -2.4882,-1.198 -3.5352,-4.1860002 -2.3379,-6.6740002 1.1975,-2.4882 4.1859,-3.5354 6.6738997,-2.3379 1.171,0.5638 2.039,-1.2369 0.867,-1.8007 -0.871,-0.4192 -1.7849997,-0.6435 -2.6929997,-0.6875 z"
+     id="path56024" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 11.034771,1.6946488 -0.867,1.8007 c 1.789,0.8613 2.805,2.6485 2.803,4.5099 0.01,0 0.019,-0.004 0.029,-0.004 0.742,0 1.409,0.287 1.93,0.742 0.306,-2.8601 -1.154,-5.7297 -3.895,-7.0486 z m -5.2029997,10.8130002 -0.8672,1.803 c 1.305,0.627 2.7022,0.787 4.0352,0.591 v -2.035 c -1.036,0.217 -2.1409,0.135 -3.168,-0.359 z"
+     id="path56026" />
+  <path
+     fill="#555761"
+     d="m 12.999771,9 c -1.108,0 -2,0.91085 -2,2.0312 v 0.96875 H 9.9997713 v 4 h 5.9999997 v -4 h -1 V 11.0312 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path56028" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting02.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting02.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg56030"
+   sodipodi:docname="nm-vpn-connecting02.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview56032"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="10.986318"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg56030" />
+  <defs
+     id="defs56022">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.43366,-0.90108,-0.90108,-0.43366,13.608771,24.018249)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop56012"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop56014"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.43366,0.90108,0.90108,0.43366,2.3903713,-8.0155512)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop56017"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop56019"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.3417713,1.0071488 c -2.7253,-0.13199998 -5.3913,1.3462 -6.6486,3.9589 -1.67650004,3.4832 -0.2122,7.6672002 3.2714,9.3442002 l 0.8672,-1.803 c -2.4882,-1.198 -3.5352,-4.1860002 -2.3379,-6.6740002 1.1975,-2.4882 4.1859,-3.5354 6.6738997,-2.3379 1.171,0.5638 2.039,-1.2369 0.867,-1.8007 -0.871,-0.4192 -1.7849997,-0.6435 -2.6929997,-0.6875 z"
+     id="path56024" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 11.034771,1.6946488 -0.867,1.8007 c 1.789,0.8613 2.805,2.6485 2.803,4.5099 0.01,0 0.019,-0.004 0.029,-0.004 0.742,0 1.409,0.287 1.93,0.742 0.306,-2.8601 -1.154,-5.7297 -3.895,-7.0486 z m -5.2029997,10.8130002 -0.8672,1.803 c 1.305,0.627 2.7022,0.787 4.0352,0.591 v -2.035 c -1.036,0.217 -2.1409,0.135 -3.168,-0.359 z"
+     id="path56026" />
+  <path
+     fill="#444444"
+     d="m 12.999771,9 c -1.108,0 -2,0.91085 -2,2.0312 v 0.96875 H 9.9997713 v 4 h 5.9999997 v -4 h -1 V 11.0312 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path56028"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting03-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting03-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg56591"
+   sodipodi:docname="nm-vpn-connecting03-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview56593"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg56591" />
+  <defs
+     id="defs56583">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.78152,-0.62388,-0.62388,-0.78152,6.1092224,24.864928)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop56573" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop56575" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.78152,0.62388,0.62388,0.78152,9.8923224,-8.8648715)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop56578" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop56580" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.1113224,0.99992849 c -1.568,-0.0255 -3.1562,0.47400001 -4.4782,1.52930001 -3.02139996,2.4119 -3.51539996,6.8167 -1.1035,9.8376995 l 1.5625,-1.248 c -1.7228,-2.1579995 -1.3687,-5.3046995 0.7891,-7.0271995 2.1581,-1.7228 5.3040996,-1.369 7.0270996,0.7891 0.811,1.016 2.374,-0.2321 1.563,-1.2481 -1.357,-1.6995 -3.343,-2.6 -5.3599996,-2.63280001 z"
+     id="path56585" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 13.471322,3.6327285 -1.563,1.2481 c 0.737,0.9229 1.067,2.0253 1.065,3.1211 0.009,0 0.018,-0.002 0.027,-0.002 0.751,0 1.426,0.294 1.949,0.76 0.195,-1.7743 -0.277,-3.6218 -1.478,-5.1272 z m -9.3771996,7.4861995 -1.5645,1.248 c 1.6064,2.013 4.094,2.88 6.4707,2.537 v -2.029 c -1.781,0.365 -3.694,-0.237 -4.9062,-1.756 z"
+     id="path56587" />
+  <path
+     fill="#555761"
+     d="m 13.000322,8.9999285 c -1.108,0 -2,0.91085 -2,2.0311995 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199995 -0.892,-2.0309995 -2,-2.0309995 z m 0,1 c 0.554,0 1,0.4423995 1,0.9999995 v 1 h -2 v -1 c 0,-0.5576 0.446,-0.9999995 1,-0.9999995 z"
+     id="path56589" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting03.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting03.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg56591"
+   sodipodi:docname="nm-vpn-connecting03.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview56593"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg56591" />
+  <defs
+     id="defs56583">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.78152,-0.62388,-0.62388,-0.78152,6.1092224,24.864928)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop56573"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop56575"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.78152,0.62388,0.62388,0.78152,9.8923224,-8.8648715)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop56578"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop56580"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.1113224,0.99992849 c -1.568,-0.0255 -3.1562,0.47400001 -4.4782,1.52930001 -3.02139996,2.4119 -3.51539996,6.8167 -1.1035,9.8376995 l 1.5625,-1.248 c -1.7228,-2.1579995 -1.3687,-5.3046995 0.7891,-7.0271995 2.1581,-1.7228 5.3040996,-1.369 7.0270996,0.7891 0.811,1.016 2.374,-0.2321 1.563,-1.2481 -1.357,-1.6995 -3.343,-2.6 -5.3599996,-2.63280001 z"
+     id="path56585" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 13.471322,3.6327285 -1.563,1.2481 c 0.737,0.9229 1.067,2.0253 1.065,3.1211 0.009,0 0.018,-0.002 0.027,-0.002 0.751,0 1.426,0.294 1.949,0.76 0.195,-1.7743 -0.277,-3.6218 -1.478,-5.1272 z m -9.3771996,7.4861995 -1.5645,1.248 c 1.6064,2.013 4.094,2.88 6.4707,2.537 v -2.029 c -1.781,0.365 -3.694,-0.237 -4.9062,-1.756 z"
+     id="path56587" />
+  <path
+     fill="#444444"
+     d="m 13.000322,8.9999285 c -1.108,0 -2,0.91085 -2,2.0311995 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199995 -0.892,-2.0309995 -2,-2.0309995 z m 0,1 c 0.554,0 1,0.4423995 1,0.9999995 v 1 h -2 v -1 c 0,-0.5576 0.446,-0.9999995 1,-0.9999995 z"
+     id="path56589"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting04-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting04-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg56742"
+   sodipodi:docname="nm-vpn-connecting04-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview56744"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg56742" />
+  <defs
+     id="defs56734">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.97476,-0.22325,-0.22325,-0.97476,-1.0182477,22.375891)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop56724" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop56726" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.97476,0.22325,0.22325,0.97476,17.018352,-6.3761095)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop56729" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop56731" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 7.8443523,0.99989053 c -0.465,0.0108 -0.9354,0.0679 -1.4065,0.17579997 -3.7683,0.8631 -6.12479997,4.6185 -5.2617,8.3862 l 1.9512,-0.445 c -0.6165,-2.6913 1.0644,-5.3737 3.7558,-5.99 2.6922,-0.6165 5.3741997,1.066 5.9901997,3.7578 0.29,1.2672 2.239,0.8202 1.949,-0.4473 -0.755,-3.2972 -3.723,-5.51339997 -6.9779997,-5.43749997 z"
+     id="path56736" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 14.822352,6.4373905 -1.949,0.4453 c 0.086,0.3772 0.104,0.7502 0.098,1.1212 0.01,0 0.019,-0.004 0.029,-0.004 0.752,0 1.428,0.294 1.951,0.76 0.085,-0.756 0.051,-1.538 -0.129,-2.3225 z m -11.6969997,2.6775 -1.9492,0.447 c 0.82,3.5810005 4.2518,5.8760005 7.8242,5.3560005 v -2.023 c -2.6523,0.543 -5.2674,-1.126 -5.875,-3.7800005 z"
+     id="path56738" />
+  <path
+     fill="#555761"
+     d="m 13.000352,8.9998905 c -1.108,0 -2,0.91085 -2,2.0312005 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200005 -0.892,-2.0310005 -2,-2.0310005 z m 0,1 c 0.554,0 1,0.4424005 1,1.0000005 v 1 h -2 v -1 c 0,-0.5576 0.446,-1.0000005 1,-1.0000005 z"
+     id="path56740" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting04.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting04.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg56742"
+   sodipodi:docname="nm-vpn-connecting04.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview56744"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg56742" />
+  <defs
+     id="defs56734">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.97476,-0.22325,-0.22325,-0.97476,-1.0182477,22.375891)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop56724"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop56726"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.97476,0.22325,0.22325,0.97476,17.018352,-6.3761095)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop56729"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop56731"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 7.8443523,0.99989053 c -0.465,0.0108 -0.9354,0.0679 -1.4065,0.17579997 -3.7683,0.8631 -6.12479997,4.6185 -5.2617,8.3862 l 1.9512,-0.445 c -0.6165,-2.6913 1.0644,-5.3737 3.7558,-5.99 2.6922,-0.6165 5.3741997,1.066 5.9901997,3.7578 0.29,1.2672 2.239,0.8202 1.949,-0.4473 -0.755,-3.2972 -3.723,-5.51339997 -6.9779997,-5.43749997 z"
+     id="path56736" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 14.822352,6.4373905 -1.949,0.4453 c 0.086,0.3772 0.104,0.7502 0.098,1.1212 0.01,0 0.019,-0.004 0.029,-0.004 0.752,0 1.428,0.294 1.951,0.76 0.085,-0.756 0.051,-1.538 -0.129,-2.3225 z m -11.6969997,2.6775 -1.9492,0.447 c 0.82,3.5810005 4.2518,5.8760005 7.8242,5.3560005 v -2.023 c -2.6523,0.543 -5.2674,-1.126 -5.875,-3.7800005 z"
+     id="path56738" />
+  <path
+     fill="#444444"
+     d="m 13.000352,8.9998905 c -1.108,0 -2,0.91085 -2,2.0312005 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200005 -0.892,-2.0310005 -2,-2.0310005 z m 0,1 c 0.554,0 1,0.4424005 1,1.0000005 v 1 h -2 v -1 c 0,-0.5576 0.446,-1.0000005 1,-1.0000005 z"
+     id="path56740"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting05-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting05-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg57256"
+   sodipodi:docname="nm-vpn-connecting05-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57258"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg57256" />
+  <defs
+     id="defs57248">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.97515,0.22155,0.22155,-0.97515,-6.3604237,17.042622)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop57238" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop57240" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.97515,-0.22155,-0.22155,0.97515,22.360776,-1.0435779)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop57243" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop57245" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.1447763,0.99962215 c -3.2558,-0.0703 -6.2217,2.15059995 -6.9712,5.44919995 l 1.9512,0.4434 c 0.6118,-2.6928 3.2924,-4.3793 5.984,-3.7676 2.3209997,0.5274 3.8719997,2.5928 3.8699997,4.877 0.007,0 0.014,-0.002 0.021,-0.002 0.75,0 1.424,0.294 1.947,0.758 0.385,-3.4893 -1.891,-6.7878 -5.3959997,-7.5842 -0.471,-0.107 -0.941,-0.1638 -1.406,-0.17379995 z"
+     id="path57250" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 1.1755763,6.4488221 c -0.85649999,3.7697999 1.5035,7.5207999 5.2734,8.3767999 0.8638,0.196 1.7238,0.208 2.5508,0.086 v -2.037 c -0.676,0.145 -1.388,0.163 -2.1074,0 -2.6928,-0.612 -4.3794,-3.2899999 -3.7676,-5.9823999 z"
+     id="path57252" />
+  <path
+     fill="#555761"
+     d="m 12.999776,8.9996221 c -1.108,0 -2,0.91085 -2,2.0311999 v 0.96875 H 9.9997763 v 4 h 5.9999997 v -4 h -1 v -0.96875 c 0,-1.1199999 -0.892,-2.0309999 -2,-2.0309999 z m 0,1 c 0.554,0 1,0.4423999 1,0.9999999 v 1 h -2 v -1 c 0,-0.5576 0.446,-0.9999999 1,-0.9999999 z"
+     id="path57254" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting05.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting05.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg57256"
+   sodipodi:docname="nm-vpn-connecting05.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57258"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg57256" />
+  <defs
+     id="defs57248">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.97515,0.22155,0.22155,-0.97515,-6.3604237,17.042622)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop57238"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop57240"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.97515,-0.22155,-0.22155,0.97515,22.360776,-1.0435779)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop57243"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop57245"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.1447763,0.99962215 c -3.2558,-0.0703 -6.2217,2.15059995 -6.9712,5.44919995 l 1.9512,0.4434 c 0.6118,-2.6928 3.2924,-4.3793 5.984,-3.7676 2.3209997,0.5274 3.8719997,2.5928 3.8699997,4.877 0.007,0 0.014,-0.002 0.021,-0.002 0.75,0 1.424,0.294 1.947,0.758 0.385,-3.4893 -1.891,-6.7878 -5.3959997,-7.5842 -0.471,-0.107 -0.941,-0.1638 -1.406,-0.17379995 z"
+     id="path57250" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 1.1755763,6.4488221 c -0.85649999,3.7697999 1.5035,7.5207999 5.2734,8.3767999 0.8638,0.196 1.7238,0.208 2.5508,0.086 v -2.037 c -0.676,0.145 -1.388,0.163 -2.1074,0 -2.6928,-0.612 -4.3794,-3.2899999 -3.7676,-5.9823999 z"
+     id="path57252" />
+  <path
+     fill="#444444"
+     d="m 12.999776,8.9996221 c -1.108,0 -2,0.91085 -2,2.0311999 v 0.96875 H 9.9997763 v 4 h 5.9999997 v -4 h -1 v -0.96875 c 0,-1.1199999 -0.892,-2.0309999 -2,-2.0309999 z m 0,1 c 0.554,0 1,0.4423999 1,0.9999999 v 1 h -2 v -1 c 0,-0.5576 0.446,-0.9999999 1,-0.9999999 z"
+     id="path57254"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting06-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting06-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg57770"
+   sodipodi:docname="nm-vpn-connecting06-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57772"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg57770" />
+  <defs
+     id="defs57762">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.78261,0.62251,0.62251,-0.78261,-8.8606628,9.9211474)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop57752" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop57754" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.78261,-0.62251,-0.62251,0.78261,24.862337,6.0791474)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop57757" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop57759" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 7.8793372,1.0021474 c -2.017,0.0363 -4.0038,0.9387 -5.3575,2.6406 l 1.5664,1.2441 c 1.719,-2.1611 4.8641,-2.5176 7.0250998,-0.7988 1.242,0.987 1.874,2.4432 1.873,3.9141 0.005,0 0.009,-0.002 0.014,-0.002 0.747,0 1.419,0.291 1.941,0.752 0.249,-2.3045 -0.635,-4.6808 -2.584,-6.2305 -1.323,-1.0529 -2.9089998,-1.54780002 -4.4779998,-1.5195 z"
+     id="path57764" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 2.5218372,3.6427474 c -2.40659999,3.0256 -1.90449999,7.4293996 1.1211,9.8363996 1.5723,1.25 3.5144,1.706 5.3574,1.439 v -2.022 c -1.398,0.285 -2.9073,-0.024 -4.1113,-0.982 -2.1615,-1.72 -2.5198,-4.8659996 -0.8008,-7.0272996 z"
+     id="path57766" />
+  <path
+     fill="#555761"
+     d="m 13.000337,9.0001474 c -1.108,0 -2,0.91085 -2,2.0311996 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199996 -0.892,-2.0309996 -2,-2.0309996 z m 0,0.9999996 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path57768" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting06.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting06.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg57770"
+   sodipodi:docname="nm-vpn-connecting06.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57772"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg57770" />
+  <defs
+     id="defs57762">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.78261,0.62251,0.62251,-0.78261,-8.8606628,9.9211474)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop57752"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop57754"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.78261,-0.62251,-0.62251,0.78261,24.862337,6.0791474)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop57757"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop57759"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 7.8793372,1.0021474 c -2.017,0.0363 -4.0038,0.9387 -5.3575,2.6406 l 1.5664,1.2441 c 1.719,-2.1611 4.8641,-2.5176 7.0250998,-0.7988 1.242,0.987 1.874,2.4432 1.873,3.9141 0.005,0 0.009,-0.002 0.014,-0.002 0.747,0 1.419,0.291 1.941,0.752 0.249,-2.3045 -0.635,-4.6808 -2.584,-6.2305 -1.323,-1.0529 -2.9089998,-1.54780002 -4.4779998,-1.5195 z"
+     id="path57764" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 2.5218372,3.6427474 c -2.40659999,3.0256 -1.90449999,7.4293996 1.1211,9.8363996 1.5723,1.25 3.5144,1.706 5.3574,1.439 v -2.022 c -1.398,0.285 -2.9073,-0.024 -4.1113,-0.982 -2.1615,-1.72 -2.5198,-4.8659996 -0.8008,-7.0272996 z"
+     id="path57766" />
+  <path
+     fill="#444444"
+     d="m 13.000337,9.0001474 c -1.108,0 -2,0.91085 -2,2.0311996 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199996 -0.892,-2.0309996 -2,-2.0309996 z m 0,0.9999996 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path57768"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting07-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting07-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg57921"
+   sodipodi:docname="nm-vpn-connecting07-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57923"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.3880596"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg57921" />
+  <defs
+     id="defs57913">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.43523,0.90032,0.90032,-0.43523,-8.0259688,2.4187429)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop57903" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop57905" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.43523,-0.90032,-0.90032,0.43523,24.027031,13.580943)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop57908" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop57910" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.3260312,1.0058429 c -1.127,-0.0535 -2.2853,0.1656 -3.3729,0.6914 l 0.8711,1.8007 c 2.4868,-1.202 5.4767998,-0.1596 6.6777998,2.3262 0.34,0.704 0.482,1.4458 0.477,2.1778 0.007,0 0.014,-0.002 0.021,-0.002 0.743,0 1.411,0.288 1.932,0.744 0.138,-1.259 -0.038,-2.5664 -0.629,-3.7909 -1.157,-2.3929 -3.496,-3.8297 -5.9769998,-3.9472 z"
+     id="path57915" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 4.9531312,1.6972429 c -3.4806,1.6826 -4.93840005,5.8687 -3.2558,9.3497001 1.3617,2.817 4.3626,4.298 7.3027,3.871 v -2.045 c -2.1895,0.45 -4.4847,-0.593 -5.502,-2.697 -1.2018,-2.4860001 -0.1599,-5.4761001 2.3262,-6.6780001 z"
+     id="path57917" />
+  <path
+     fill="#555761"
+     d="m 13.000031,8.9999429 c -1.108,0 -2,0.91085 -2,2.0312001 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200001 -0.892,-2.0310001 -2,-2.0310001 z m 0,1 c 0.554,0 1,0.4424001 1,1.0000001 v 1 h -2 v -1 c 0,-0.5576 0.446,-1.0000001 1,-1.0000001 z"
+     id="path57919" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting07.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting07.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg57921"
+   sodipodi:docname="nm-vpn-connecting07.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview57923"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg57921" />
+  <defs
+     id="defs57913">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.43523,0.90032,0.90032,-0.43523,-8.0259688,2.4187429)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop57903"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop57905"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.43523,-0.90032,-0.90032,0.43523,24.027031,13.580943)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop57908"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop57910"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 8.3260312,1.0058429 c -1.127,-0.0535 -2.2853,0.1656 -3.3729,0.6914 l 0.8711,1.8007 c 2.4868,-1.202 5.4767998,-0.1596 6.6777998,2.3262 0.34,0.704 0.482,1.4458 0.477,2.1778 0.007,0 0.014,-0.002 0.021,-0.002 0.743,0 1.411,0.288 1.932,0.744 0.138,-1.259 -0.038,-2.5664 -0.629,-3.7909 -1.157,-2.3929 -3.496,-3.8297 -5.9769998,-3.9472 z"
+     id="path57915" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 4.9531312,1.6972429 c -3.4806,1.6826 -4.93840005,5.8687 -3.2558,9.3497001 1.3617,2.817 4.3626,4.298 7.3027,3.871 v -2.045 c -2.1895,0.45 -4.4847,-0.593 -5.502,-2.697 -1.2018,-2.4860001 -0.1599,-5.4761001 2.3262,-6.6780001 z"
+     id="path57917" />
+  <path
+     fill="#444444"
+     d="m 13.000031,8.9999429 c -1.108,0 -2,0.91085 -2,2.0312001 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200001 -0.892,-2.0310001 -2,-2.0310001 z m 0,1 c 0.554,0 1,0.4424001 1,1.0000001 v 1 h -2 v -1 c 0,-0.5576 0.446,-1.0000001 1,-1.0000001 z"
+     id="path57919"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting08-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting08-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58072"
+   sodipodi:docname="nm-vpn-connecting08-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58074"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="11.068408"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58072" />
+  <defs
+     id="defs58064">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.0017459,1,1,-0.0017459,-4.0210893,-3.9790389)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58054" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop58056" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.0017459,-1,-1,0.0017459,20.021011,19.979011)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop58059" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58061" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 7.9880107,1.0000111 0.004,2 c 2.7620003,-0.0048 5.0030003,2.2294 5.0080003,4.99 v 0.01 c 0.754,0 1.431,0.296 1.955,0.764 0.028,-0.255 0.046,-0.513 0.045,-0.776 -0.007,-3.8657 -3.146,-6.99480004 -7.0120003,-6.988 z m 1.012,11.8729999 c -0.321,0.073 -0.649,0.126 -0.992,0.127 -1.3004,0.002 -1.2966,2.002 0.004,2 0.336,-0.001 0.664,-0.035 0.988,-0.082 z"
+     id="path58066" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 7.9880107,1.0000111 c -3.8654,0.0068 -6.99469996,3.1454 -6.988,7.012 0.0068,3.8659999 3.1454,6.9949999 7.012,6.9879999 l -0.004,-2 c -2.761,0.005 -5.0031,-2.229 -5.008,-4.9899999 -0.0048,-2.7621 2.2313,-5.0052 4.992,-5.01 z"
+     id="path58068" />
+  <path
+     fill="#555761"
+     d="m 13.000011,9.0000111 c -1.108,0 -2,0.91085 -2,2.0311999 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199999 -0.892,-2.0309999 -2,-2.0309999 z m 0,0.9999999 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path58070" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting08.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting08.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58072"
+   sodipodi:docname="nm-vpn-connecting08.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58074"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58072" />
+  <defs
+     id="defs58064">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(0.0017459,1,1,-0.0017459,-4.0210893,-3.9790389)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58054"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop58056"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(-0.0017459,-1,-1,0.0017459,20.021011,19.979011)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop58059"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58061"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 7.9880107,1.0000111 0.004,2 c 2.7620003,-0.0048 5.0030003,2.2294 5.0080003,4.99 v 0.01 c 0.754,0 1.431,0.296 1.955,0.764 0.028,-0.255 0.046,-0.513 0.045,-0.776 -0.007,-3.8657 -3.146,-6.99480004 -7.0120003,-6.988 z m 1.012,11.8729999 c -0.321,0.073 -0.649,0.126 -0.992,0.127 -1.3004,0.002 -1.2966,2.002 0.004,2 0.336,-0.001 0.664,-0.035 0.988,-0.082 z"
+     id="path58066" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 7.9880107,1.0000111 c -3.8654,0.0068 -6.99469996,3.1454 -6.988,7.012 0.0068,3.8659999 3.1454,6.9949999 7.012,6.9879999 l -0.004,-2 c -2.761,0.005 -5.0031,-2.229 -5.008,-4.9899999 -0.0048,-2.7621 2.2313,-5.0052 4.992,-5.01 z"
+     id="path58068" />
+  <path
+     fill="#444444"
+     d="m 13.000011,9.0000111 c -1.108,0 -2,0.91085 -2,2.0311999 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199999 -0.892,-2.0309999 -2,-2.0309999 z m 0,0.9999999 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path58070"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting09-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting09-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58586"
+   sodipodi:docname="nm-vpn-connecting09-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58588"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="11.068408"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58586" />
+  <defs
+     id="defs58578">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.43209,0.90183,0.90183,0.43209,2.3638123,-8.0073142)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58568" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop58570" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.43209,-0.90183,-0.90183,-0.43209,13.637112,24.006686)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop58573" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58575" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 11.025112,1.6871858 -0.865,1.8027 c 1.794,0.8592 2.813,2.6498 2.811,4.5138 0.01,0 0.019,-0.004 0.029,-0.004 0.743,0 1.411,0.288 1.932,0.744 0.307,-2.8653 -1.158,-5.7402 -3.907,-7.0565 z M 5.4181123,12.401186 c -0.9348,-0.023 -1.4673,1.418 -0.4414,1.909 1.3023,0.624 2.6944,0.783 4.0234,0.587 v -2.031 c -1.033,0.216 -2.135,0.133 -3.1602,-0.357 -0.1465,-0.07 -0.2883,-0.104 -0.4218,-0.108 z"
+     id="path58580" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 8.3301123,1.0055858 c -2.7249,-0.12730002 -5.3896,1.3539 -6.6425,3.9687 -1.67039995,3.4864 -0.1974,7.6674002 3.2891,9.3374002 l 0.8632,-1.802 c -2.4903,-1.193 -3.5408,-4.1800002 -2.3476,-6.6702002 1.1931,-2.4903 4.1788,-3.5428 6.6697997,-2.3496 l 0.863,-1.8027 c -0.871,-0.4176 -1.7869997,-0.6392 -2.6949997,-0.6816 z"
+     id="path58582" />
+  <path
+     fill="#555761"
+     d="m 13.000112,8.9996858 c -1.108,0 -2,0.91085 -2,2.0312002 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200002 -0.892,-2.0310002 -2,-2.0310002 z m 0,1 c 0.554,0 1,0.4424002 1,1.0000002 v 1 h -2 v -1 c 0,-0.5576 0.446,-1.0000002 1,-1.0000002 z"
+     id="path58584" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting09.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting09.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58586"
+   sodipodi:docname="nm-vpn-connecting09.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58588"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58586" />
+  <defs
+     id="defs58578">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.43209,0.90183,0.90183,0.43209,2.3638123,-8.0073142)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58568"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop58570"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.43209,-0.90183,-0.90183,-0.43209,13.637112,24.006686)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop58573"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58575"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 11.025112,1.6871858 -0.865,1.8027 c 1.794,0.8592 2.813,2.6498 2.811,4.5138 0.01,0 0.019,-0.004 0.029,-0.004 0.743,0 1.411,0.288 1.932,0.744 0.307,-2.8653 -1.158,-5.7402 -3.907,-7.0565 z M 5.4181123,12.401186 c -0.9348,-0.023 -1.4673,1.418 -0.4414,1.909 1.3023,0.624 2.6944,0.783 4.0234,0.587 v -2.031 c -1.033,0.216 -2.135,0.133 -3.1602,-0.357 -0.1465,-0.07 -0.2883,-0.104 -0.4218,-0.108 z"
+     id="path58580" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 8.3301123,1.0055858 c -2.7249,-0.12730002 -5.3896,1.3539 -6.6425,3.9687 -1.67039995,3.4864 -0.1974,7.6674002 3.2891,9.3374002 l 0.8632,-1.802 c -2.4903,-1.193 -3.5408,-4.1800002 -2.3476,-6.6702002 1.1931,-2.4903 4.1788,-3.5428 6.6697997,-2.3496 l 0.863,-1.8027 c -0.871,-0.4176 -1.7869997,-0.6392 -2.6949997,-0.6816 z"
+     id="path58582" />
+  <path
+     fill="#444444"
+     d="m 13.000112,8.9996858 c -1.108,0 -2,0.91085 -2,2.0312002 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200002 -0.892,-2.0310002 -2,-2.0310002 z m 0,1 c 0.554,0 1,0.4424002 1,1.0000002 v 1 h -2 v -1 c 0,-0.5576 0.446,-1.0000002 1,-1.0000002 z"
+     id="path58584"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting10-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting10-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58737"
+   sodipodi:docname="nm-vpn-connecting10-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58739"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="11.068408"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58737" />
+  <defs
+     id="defs58729">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.78043,0.62524,0.62524,0.78043,9.8632991,-8.868258)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58719" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop58721" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.78043,-0.62524,-0.62524,-0.78043,6.1381991,24.867742)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop58724" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58726" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 13.463299,3.622742 -1.561,1.252 c 0.74,0.9238 1.074,2.029 1.073,3.127 0.008,0 0.016,-0.002 0.025,-0.002 0.751,0 1.426,0.293 1.949,0.758 0.195,-1.7781 -0.279,-3.6287 -1.486,-5.135 z m -10.0659999,7.129 c -0.7438,-0.029 -1.469,0.864 -0.8594,1.625 1.6072,2.006 4.0905,2.871 6.4629,2.529 v -2.031 c -1.778,0.364 -3.6893,-0.234 -4.9023,-1.748 -0.2032,-0.254 -0.4533,-0.365 -0.7012,-0.375 z"
+     id="path58731" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 8.0982991,0.99974204 c -1.5693,-0.0228 -3.1548,0.47959996 -4.475,1.53709996 -3.01709999,2.4171 -3.50309999,6.8219 -1.0859,9.8399 l 1.5606,-1.25 c -1.7265,-2.155 -1.3798,-5.3028 0.7753,-7.0293 2.155,-1.7265 5.3029999,-1.3798 7.0289999,0.7753 l 1.561,-1.25 c -1.36,-1.6971 -3.349,-2.5937 -5.3649999,-2.62299996 z"
+     id="path58733" />
+  <path
+     fill="#555761"
+     d="m 13.000299,8.999742 c -1.108,0 -2,0.91085 -2,2.0312 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path58735" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting10.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting10.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58737"
+   sodipodi:docname="nm-vpn-connecting10.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58739"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58737" />
+  <defs
+     id="defs58729">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.78043,0.62524,0.62524,0.78043,9.8632991,-8.868258)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58719"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop58721"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.78043,-0.62524,-0.62524,-0.78043,6.1381991,24.867742)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop58724"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58726"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 13.463299,3.622742 -1.561,1.252 c 0.74,0.9238 1.074,2.029 1.073,3.127 0.008,0 0.016,-0.002 0.025,-0.002 0.751,0 1.426,0.293 1.949,0.758 0.195,-1.7781 -0.279,-3.6287 -1.486,-5.135 z m -10.0659999,7.129 c -0.7438,-0.029 -1.469,0.864 -0.8594,1.625 1.6072,2.006 4.0905,2.871 6.4629,2.529 v -2.031 c -1.778,0.364 -3.6893,-0.234 -4.9023,-1.748 -0.2032,-0.254 -0.4533,-0.365 -0.7012,-0.375 z"
+     id="path58731" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 8.0982991,0.99974204 c -1.5693,-0.0228 -3.1548,0.47959996 -4.475,1.53709996 -3.01709999,2.4171 -3.50309999,6.8219 -1.0859,9.8399 l 1.5606,-1.25 c -1.7265,-2.155 -1.3798,-5.3028 0.7753,-7.0293 2.155,-1.7265 5.3029999,-1.3798 7.0289999,0.7753 l 1.561,-1.25 c -1.36,-1.6971 -3.349,-2.5937 -5.3649999,-2.62299996 z"
+     id="path58733" />
+  <path
+     fill="#444444"
+     d="m 13.000299,8.999742 c -1.108,0 -2,0.91085 -2,2.0312 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path58735"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting11-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting11-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58888"
+   sodipodi:docname="nm-vpn-connecting11-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58890"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="11.068408"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58888" />
+  <defs
+     id="defs58880">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.97437,0.22495,0.22495,0.97437,16.99328,-6.3914148)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58870" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop58872" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.97437,-0.22495,-0.22495,-0.97437,-0.99211991,22.392185)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop58875" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop58877" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 14.82028,6.4259852 -1.947,0.4492 c 0.088,0.38 0.105,0.756 0.098,1.129 0.01,0 0.019,-0.004 0.029,-0.004 0.752,0 1.428,0.295 1.951,0.762 0.085,-0.761 0.052,-1.547 -0.131,-2.3362 z m -12.5129999,1.9512 c -0.6166,-0.066 -1.30970001,0.406 -1.1269,1.197 0.8252,3.5749998 4.2538,5.8619998 7.8203,5.3439998 v -2.023 c -2.6483,0.541 -5.2595,-1.121 -5.8711,-3.7699998 -0.1097,-0.475 -0.4523,-0.708 -0.8223,-0.748 z"
+     id="path58882" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 7.8322801,1.0001852 c -0.465,0.0117 -0.9353,0.071 -1.4062,0.1797 -3.7672,0.8696 -6.11580001,4.6276 -5.2461,8.3943 l 1.9492,-0.449 c -0.6212,-2.6906 1.0555,-5.3749 3.7461,-5.9961 2.691,-0.6212 5.3769999,1.0555 5.9979999,3.7461 l 1.947,-0.4492 c -0.761,-3.2965 -3.733,-5.50739998 -6.9879999,-5.4258 z"
+     id="path58884" />
+  <path
+     fill="#555761"
+     d="m 13.00028,9.0001852 c -1.108,0 -2,0.91085 -2,2.0311998 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199998 -0.892,-2.0309998 -2,-2.0309998 z m 0,0.9999998 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path58886" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting11.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting11.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg58888"
+   sodipodi:docname="nm-vpn-connecting11.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview58890"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg58888" />
+  <defs
+     id="defs58880">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.97437,0.22495,0.22495,0.97437,16.99328,-6.3914148)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58870"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop58872"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.97437,-0.22495,-0.22495,-0.97437,-0.99211991,22.392185)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop58875"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop58877"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 14.82028,6.4259852 -1.947,0.4492 c 0.088,0.38 0.105,0.756 0.098,1.129 0.01,0 0.019,-0.004 0.029,-0.004 0.752,0 1.428,0.295 1.951,0.762 0.085,-0.761 0.052,-1.547 -0.131,-2.3362 z m -12.5129999,1.9512 c -0.6166,-0.066 -1.30970001,0.406 -1.1269,1.197 0.8252,3.5749998 4.2538,5.8619998 7.8203,5.3439998 v -2.023 c -2.6483,0.541 -5.2595,-1.121 -5.8711,-3.7699998 -0.1097,-0.475 -0.4523,-0.708 -0.8223,-0.748 z"
+     id="path58882" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 7.8322801,1.0001852 c -0.465,0.0117 -0.9353,0.071 -1.4062,0.1797 -3.7672,0.8696 -6.11580001,4.6276 -5.2461,8.3943 l 1.9492,-0.449 c -0.6212,-2.6906 1.0555,-5.3749 3.7461,-5.9961 2.691,-0.6212 5.3769999,1.0555 5.9979999,3.7461 l 1.947,-0.4492 c -0.761,-3.2965 -3.733,-5.50739998 -6.9879999,-5.4258 z"
+     id="path58884" />
+  <path
+     fill="#444444"
+     d="m 13.00028,9.0001852 c -1.108,0 -2,0.91085 -2,2.0311998 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199998 -0.892,-2.0309998 -2,-2.0309998 z m 0,0.9999998 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path58886"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting12-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting12-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg59039"
+   sodipodi:docname="nm-vpn-connecting12-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview59041"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="10.986318"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg59039" />
+  <defs
+     id="defs59031">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.97553,-0.21985,-0.21985,0.97553,22.344942,-1.0678381)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop59021" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop59023" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.97553,0.21985,0.21985,-0.97553,-6.344058,17.068362)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop59026" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop59028" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 1.988242,5.7093619 c -0.3698,0.0416 -0.7092,0.2763 -0.8164,0.7519 -0.85,3.7711001 1.5176,7.5171001 5.289,8.3671001 0.8601,0.194 1.7161,0.207 2.5391,0.086 v -2.039 c -0.674,0.145 -1.383,0.164 -2.0996,0.002 -2.6947,-0.607 -4.3864,-3.2820001 -3.7793,-5.9747001 0.1786,-0.7928 -0.5166,-1.2626 -1.1328,-1.1933 z"
+     id="path59033" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 8.132942,0.99836188 c -3.2554,-0.0644 -6.2174,2.16090002 -6.9611,5.46100002 v 0.0019 l 1.9511,0.4395 c 0.6071,-2.6938 3.2824,-4.3845 5.977,-3.7774 2.324,0.524 3.878,2.5918 3.877,4.879 0.008,0 0.015,-0.002 0.023,-0.002 0.751,0 1.426,0.293 1.949,0.758 0.387,-3.4956 -1.899,-6.7968 -5.41,-7.5881 -0.471,-0.1062 -0.941,-0.1626 -1.406,-0.17190002 z"
+     id="path59035" />
+  <path
+     fill="#555761"
+     d="m 12.999942,9.0003619 c -1.108,0 -2,0.91085 -2,2.0312001 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200001 -0.892,-2.0310001 -2,-2.0310001 z m 0,1.0000001 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path59037" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting12.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting12.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg59039"
+   sodipodi:docname="nm-vpn-connecting12.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview59041"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="10.986318"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg59039" />
+  <defs
+     id="defs59031">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.97553,-0.21985,-0.21985,0.97553,22.344942,-1.0678381)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop59021"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop59023"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.97553,0.21985,0.21985,-0.97553,-6.344058,17.068362)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop59026"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop59028"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 1.988242,5.7093619 c -0.3698,0.0416 -0.7092,0.2763 -0.8164,0.7519 -0.85,3.7711001 1.5176,7.5171001 5.289,8.3671001 0.8601,0.194 1.7161,0.207 2.5391,0.086 v -2.039 c -0.674,0.145 -1.383,0.164 -2.0996,0.002 -2.6947,-0.607 -4.3864,-3.2820001 -3.7793,-5.9747001 0.1786,-0.7928 -0.5166,-1.2626 -1.1328,-1.1933 z"
+     id="path59033" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 8.132942,0.99836188 c -3.2554,-0.0644 -6.2174,2.16090002 -6.9611,5.46100002 v 0.0019 l 1.9511,0.4395 c 0.6071,-2.6938 3.2824,-4.3845 5.977,-3.7774 2.324,0.524 3.878,2.5918 3.877,4.879 0.008,0 0.015,-0.002 0.023,-0.002 0.751,0 1.426,0.293 1.949,0.758 0.387,-3.4956 -1.899,-6.7968 -5.41,-7.5881 -0.471,-0.1062 -0.941,-0.1626 -1.406,-0.17190002 z"
+     id="path59035" />
+  <path
+     fill="#444444"
+     d="m 12.999942,9.0003619 c -1.108,0 -2,0.91085 -2,2.0312001 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1200001 -0.892,-2.0310001 -2,-2.0310001 z m 0,1.0000001 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path59037"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting13-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting13-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg59190"
+   sodipodi:docname="nm-vpn-connecting13-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview59192"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="6.7176616"
+     inkscape:cy="11.068408"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg59190" />
+  <defs
+     id="defs59182">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.78369,-0.62115,-0.62115,0.78369,24.858456,6.050372)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop59172" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop59174" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.78369,0.62115,0.62115,-0.78369,-8.8572442,9.951372)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop59177" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop59179" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 3.2133558,3.273772 c -0.2479,0.0109 -0.4974,0.1242 -0.6992,0.3789 -2.4014,3.0297 -1.8912,7.4327 1.1386,9.8337 1.571,1.246 3.5087,1.7 5.3477,1.434 v -2.025 c -1.395,0.284 -2.9023,-0.021 -4.1055,-0.975 -2.1644,-1.716 -2.5277,-4.861 -0.8125,-7.0255 0.6057,-0.7641 -0.1255,-1.6537 -0.8691,-1.6211 z"
+     id="path59184" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 7.8674558,1.002372 c -2.0163,0.0398 -4.0025,0.9461 -5.3533,2.6503 l 1.5683,1.2422 c 1.7152,-2.1641 4.859,-2.5277 7.0230002,-0.8125 1.246,0.9869 1.88,2.4459 1.879,3.92 0.006,0 0.011,-0.002 0.016,-0.002 0.747,0 1.417,0.292 1.939,0.752 0.249,-2.3079 -0.638,-4.6875 -2.591,-6.2364 -1.326,-1.0506 -2.9120002,-1.54459995 -4.4810002,-1.5136 z"
+     id="path59186" />
+  <path
+     fill="#555761"
+     d="m 13.000456,9.000372 c -1.108,0 -2,0.91085 -2,2.0312 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path59188" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting13.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting13.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg59190"
+   sodipodi:docname="nm-vpn-connecting13.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview59192"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="8.8519899"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg59190" />
+  <defs
+     id="defs59182">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.78369,-0.62115,-0.62115,0.78369,24.858456,6.050372)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop59172"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop59174"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.78369,0.62115,0.62115,-0.78369,-8.8572442,9.951372)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop59177"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop59179"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 3.2133558,3.273772 c -0.2479,0.0109 -0.4974,0.1242 -0.6992,0.3789 -2.4014,3.0297 -1.8912,7.4327 1.1386,9.8337 1.571,1.246 3.5087,1.7 5.3477,1.434 v -2.025 c -1.395,0.284 -2.9023,-0.021 -4.1055,-0.975 -2.1644,-1.716 -2.5277,-4.861 -0.8125,-7.0255 0.6057,-0.7641 -0.1255,-1.6537 -0.8691,-1.6211 z"
+     id="path59184" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 7.8674558,1.002372 c -2.0163,0.0398 -4.0025,0.9461 -5.3533,2.6503 l 1.5683,1.2422 c 1.7152,-2.1641 4.859,-2.5277 7.0230002,-0.8125 1.246,0.9869 1.88,2.4459 1.879,3.92 0.006,0 0.011,-0.002 0.016,-0.002 0.747,0 1.417,0.292 1.939,0.752 0.249,-2.3079 -0.638,-4.6875 -2.591,-6.2364 -1.326,-1.0506 -2.9120002,-1.54459995 -4.4810002,-1.5136 z"
+     id="path59186" />
+  <path
+     fill="#444444"
+     d="m 13.000456,9.000372 c -1.108,0 -2,0.91085 -2,2.0312 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.12 -0.892,-2.031 -2,-2.031 z m 0,1 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path59188"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting14-symbolic.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting14-symbolic.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg59341"
+   sodipodi:docname="nm-vpn-connecting14-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview59343"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="11.041045"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg59341" />
+  <defs
+     id="defs59333">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.4368,-0.89956,-0.89956,0.4368,24.037408,13.553371)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop59323" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity="0"
+         id="stop59325" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.4368,0.89956,0.89956,-0.4368,-8.035292,2.4473712)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#555761"
+         id="stop59328" />
+      <stop
+         offset="1"
+         stop-color="#555761"
+         stop-opacity=".5"
+         id="stop59330" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 5.365608,1.5941712 c -0.1335,0.004 -0.2757,0.0384 -0.4218,0.1093 -3.4777,1.6887 -4.92900002,5.8779 -3.2403,9.3558998 1.3648,2.81 4.3615,4.265 7.2969,3.839 v -2.025 c -2.1855,0.449 -4.4768,-0.591 -5.4961,-2.689 -1.2062,-2.4839998 -0.1715,-5.4757998 2.3125,-6.6819998 1.0235,-0.4969 0.4835,-1.9366 -0.4512,-1.9082 z"
+     id="path59335" />
+  <path
+     style="fill:url(#linearGradient3605);opacity:0.5"
+     d="m 8.312408,1.0062712 c -1.126,-0.0515 -2.282,0.1695 -3.3686,0.6972 l 0.873,1.7989 c 2.4836,-1.2062 5.4756,-0.1696 6.6816,2.3144 0.343,0.7063 0.487,1.4506 0.482,2.1856 0.007,0 0.013,-0.002 0.02,-0.002 0.743,0 1.411,0.288 1.932,0.744 0.139,-1.262 -0.039,-2.573 -0.635,-3.8006 -1.161,-2.391 -3.503,-3.8244 -5.985,-3.9375 z"
+     id="path59337" />
+  <path
+     fill="#555761"
+     d="m 13.000408,9.0003712 c -1.108,0 -2,0.91085 -2,2.0311998 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199998 -0.892,-2.0309998 -2,-2.0309998 z m 0,0.9999998 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path59339" />
+</svg>

--- a/elementary-xfce/animations/16/nm-vpn-connecting14.svg
+++ b/elementary-xfce/animations/16/nm-vpn-connecting14.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   version="1.1"
+   id="svg59341"
+   sodipodi:docname="nm-vpn-connecting14.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview59343"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.545455"
+     inkscape:cx="7.9490049"
+     inkscape:cy="6.6629352"
+     inkscape:window-width="1920"
+     inkscape:window-height="1020"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg59341" />
+  <defs
+     id="defs59333">
+    <linearGradient
+       id="linearGradient3605"
+       x1="7"
+       x2="19"
+       y1="12"
+       y2="5"
+       gradientTransform="matrix(-0.4368,-0.89956,-0.89956,0.4368,24.037408,13.553371)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop59323"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity="0"
+         id="stop59325"
+         style="stop-color:#64baff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3611"
+       x1="7"
+       x2="17"
+       y1="12"
+       y2="12"
+       gradientTransform="matrix(0.4368,0.89956,0.89956,-0.4368,-8.035292,2.4473712)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#444444"
+         id="stop59328"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#444444"
+         stop-opacity=".5"
+         id="stop59330"
+         style="stop-color:#64baff;stop-opacity:0.5;" />
+    </linearGradient>
+  </defs>
+  <path
+     style="fill:url(#linearGradient3611)"
+     d="m 5.365608,1.5941712 c -0.1335,0.004 -0.2757,0.0384 -0.4218,0.1093 -3.4777,1.6887 -4.92900002,5.8779 -3.2403,9.3558998 1.3648,2.81 4.3615,4.265 7.2969,3.839 v -2.025 c -2.1855,0.449 -4.4768,-0.591 -5.4961,-2.689 -1.2062,-2.4839998 -0.1715,-5.4757998 2.3125,-6.6819998 1.0235,-0.4969 0.4835,-1.9366 -0.4512,-1.9082 z"
+     id="path59335" />
+  <path
+     style="fill:url(#linearGradient3605)"
+     d="m 8.312408,1.0062712 c -1.126,-0.0515 -2.282,0.1695 -3.3686,0.6972 l 0.873,1.7989 c 2.4836,-1.2062 5.4756,-0.1696 6.6816,2.3144 0.343,0.7063 0.487,1.4506 0.482,2.1856 0.007,0 0.013,-0.002 0.02,-0.002 0.743,0 1.411,0.288 1.932,0.744 0.139,-1.262 -0.039,-2.573 -0.635,-3.8006 -1.161,-2.391 -3.503,-3.8244 -5.985,-3.9375 z"
+     id="path59337" />
+  <path
+     fill="#444444"
+     d="m 13.000408,9.0003712 c -1.108,0 -2,0.91085 -2,2.0311998 v 0.96875 h -1 v 4 h 6 v -4 h -1 v -0.96875 c 0,-1.1199998 -0.892,-2.0309998 -2,-2.0309998 z m 0,0.9999998 c 0.554,0 1,0.4424 1,1 v 1 h -2 v -1 c 0,-0.5576 0.446,-1 1,-1 z"
+     id="path59339"
+     style="fill:#f9c440" />
+</svg>

--- a/elementary-xfce/panel/16/nm-vpn-connecting.svg
+++ b/elementary-xfce/panel/16/nm-vpn-connecting.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce/panel/16/nm-vpn-connecting12.svg
+++ b/elementary-xfce/panel/16/nm-vpn-connecting12.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce/panel/16/nm-vpn-connecting13.svg
+++ b/elementary-xfce/panel/16/nm-vpn-connecting13.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg

--- a/elementary-xfce/panel/16/nm-vpn-connecting14.svg
+++ b/elementary-xfce/panel/16/nm-vpn-connecting14.svg
@@ -1,1 +1,0 @@
-network-vpn-acquiring.svg


### PR DESCRIPTION
If this style is okay, I'd like to update other sizes to match (in a future PR).

Add symbolic "connecting" icons seen when trying to connect to a VPN.

Add/Update non-symbolic icons to match, use blue color to avoid needing monochrome icons for light and dark themes.

Icons from Papirus/Paper icon themes, updated AUTHORS with licensing and links.