### PR TITLE
Mimes: Some new, update others to match upstream

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,7 @@ https://creativecommons.org/licenses/by/4.0/
 Sass logo licensed under CC-BY-NC-SA-3.0 Unported License by Sass team
 https://sass-lang.com/styleguide/brand
 https://creativecommons.org/licenses/by-nc-sa/3.0
+
+Perl sillhoutte licensed under CC-BY-SA 4.0 International by Yaru/Jupi007
+https://github.com/ubuntu/yaru
+https://github.com/Jupi007

--- a/elementary-xfce/mimes/128/application-ovf.svg
+++ b/elementary-xfce/mimes/128/application-ovf.svg
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-x-qemu-disk.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.6640625"
+     inkscape:cx="94.592375"
+     inkscape:cy="19.894428"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="527"
+     inkscape:window-y="67"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172"
+     inkscape:snap-center="true" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="68"
+     height="68"
+     x="30"
+     y="26"
+     rx="6"
+     ry="6" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="64"
+     cy="60"
+     r="24" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="64"
+     cy="60.000004"
+     r="9" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="64"
+     cy="60.000004"
+     r="6.9999995" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="64"
+     cy="60.000004"
+     r="5" />
+</svg>

--- a/elementary-xfce/mimes/128/application-sql.svg
+++ b/elementary-xfce/mimes/128/application-sql.svg
@@ -1,1 +1,235 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.6640625"
+     inkscape:cx="80.703812"
+     inkscape:cy="55.929619"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="124"
+     inkscape:window-y="198"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 35,51 1,30 c 0,5.956265 14.588145,11.5 28,11.5 13.411855,0 29,-5.493557 29,-11.5 L 91.964286,51 C 91.964286,51 79.21974,61.5 64,61.5 48.78026,61.5 35,51 35,51 Z"
+     id="path3996"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 35.5,48 V 61 C 35.5,66.666627 49.712114,72.526414 64,72.499908 78.211911,72.473548 92.5,66.666627 92.5,61 V 48"
+     id="path4358"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247"
+     d="m 92.5,48.5 c 0.0042,-7.181051 -12.756936,-13 -28.5,-13 -15.743064,0 -28.50417,5.818949 -28.5,13 -0.0042,7.181051 12.756936,13 28.5,13 15.743064,0 28.50417,-5.818949 28.5,-13 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 35.5,57 c 0,1.840112 0,12.480844 0,14.166656 0,5.666627 14.212114,11.359758 28.5,11.333252 14.211911,-0.02636 28.5,-5.666625 28.5,-11.333252 0,-1.995601 0,-12.398018 0,-14.166656"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992" />
+  <path
+     id="path3994"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="M 35.5,67 V 81 C 35.5,86.666624 49.712114,92.52641 64,92.49991 78.211911,92.47351 92.5,86.666624 92.5,81 V 67"
+     sodipodi:nodetypes="cscsc" />
+</svg>

--- a/elementary-xfce/mimes/128/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/128/application-vnd.flatpak.ref.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="128"
    height="128"
-   id="svg3172">
+   id="svg3172"
+   sodipodi:docname="application-vnd.flatpak.ref.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview37"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.328125"
+     inkscape:cx="63.906158"
+     inkscape:cy="63.906158"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3172" />
   <defs
      id="defs3174">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -188,7 +209,7 @@
      id="path4160-6-1"
      style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26771665;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 63.867188,28.000102 -27.757812,16.023438 -0.10938,31.953124 28,16.023438 28,-15.996094 -0.1211,-31.980468 z m 0,2.539062 v 23.13672 l 3.261718,1.949218 -3.261718,1.878906 L 40.371094,43.92979 Z M 90,45.664164 V 74.92979 L 64,89.816508 v -29.26953 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 64.132804,28.000102 27.757812,16.023438 0.10938,31.953124 -28,16.023438 -28,-15.996094 0.1211,-31.980468 z m 0,2.539062 v 23.13672 l -3.261718,1.949218 3.261718,1.878906 23.496094,-13.574218 z m -26.132812,15.125 V 74.92979 l 26,14.886718 v -29.26953 z"
      id="path7680" />
 </svg>

--- a/elementary-xfce/mimes/128/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/128/application-vnd.flatpak.svg
@@ -4,12 +4,34 @@
    width="128"
    height="128"
    id="svg3049"
+   sodipodi:docname="application-vnd.flatpak.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview55"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.328125"
+     inkscape:cx="63.906158"
+     inkscape:cy="63.906158"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3049" />
   <defs
      id="defs3051">
     <linearGradient
@@ -302,6 +324,6 @@
      d="M 112.68494,37.405659 106.81213,24.81031 c -1.2911,-2.7908 -2.49377,-4.93544 -3.89286,-6.270543 -1.3991,-1.335104 -3.642888,-2.039772 -6.40658,-2.039772 l -65.213205,0 c -2.767335,0 -4.81217,0.703721 -6.216072,2.032395 -1.403902,1.328674 -2.597679,3.457821 -3.844745,6.252106 v 0.0037 l -6.090267,12.765866" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.99;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="m 63.867188,46.000102 -27.757812,16.023438 -0.10938,31.953124 28,16.023436 28,-15.996092 -0.1211,-31.980468 z m 0,2.539062 v 23.13672 l 3.261718,1.949218 -3.261718,1.878906 L 40.371094,61.92979 Z M 90,63.664164 V 92.92979 L 64,107.81651 V 78.546978 Z"
+     d="m 64.132804,46.000102 27.757812,16.023438 0.10938,31.953124 -28,16.023436 -28,-15.996092 0.1211,-31.980468 z m 0,2.539062 v 23.13672 l -3.261718,1.949218 3.261718,1.878906 23.496094,-13.574218 z m -26.132812,15.125 V 92.92979 l 26,14.88672 V 78.546978 Z"
      id="path7680" />
 </svg>

--- a/elementary-xfce/mimes/128/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/128/application-x-bittorrent.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="128"
    height="128"
-   id="svg3172">
+   id="svg3172"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview39"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.328125"
+     inkscape:cx="9.8533724"
+     inkscape:cy="64"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="218"
+     inkscape:window-y="397"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172" />
   <defs
      id="defs3174">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -188,15 +209,23 @@
      id="path4160-6-1"
      style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 35.99996,70.99654 28,34.00001 28,-34.00001 -16,0.003 V 58.99613 c 0,4 -4,4 -4,4 0,0 -4,0 -4,-4 0,-4 -4,-4 -4,-4 0,0 -4,0 -4,4 0,4 -4,4 -4,4 0,0 -4,0 -4,-4.00341 v 12.00341 z"
-     id="path11053"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-  <path
-     d="m 63.99996,20.99653 c 0,0 -4,0 -4,4 0,4 -4,4 -4,4 0,0 -4,0.003 -4,-4 v 56 h 24 v -56 c 0,4 -4,4 -4,4 0,0 -4,0 -4,-4 0,-4 -4,-4 -4,-4 z"
+     d="m 63.99996,20.99653 c 0,0 -4,0 -4,4 0,4 -4,4 -4,4 0,0 -4,0.003 -4,-4 V 81 h 24 V 24.99653 c 0,4 -4,4 -4,4 0,0 -4,0 -4,-4 0,-4 -4,-4 -4,-4 z"
      id="path11077"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="csccccccsc" />
   <path
-     d="m 55.99996,38.99653 c 0,0 -4,-0.003 -4,4 v 24 h 24 v -24 c 0,-4 -4,-4 -4,-4 0,0 -4,0 -4,4 0,4 -4,4 -4,4 0,0 -4,0 -4,-4 0,-4 -4,-4 -4,-4 z"
+     d="m 55.99996,38.99653 c 0,0 -4,-0.003 -4,4 V 67 h 24 V 42.99653 c 0,-4 -4,-4 -4,-4 0,0 -4,0 -4,4 0,4 -4,4 -4,4 0,0 -4,0 -4,-4 0,-4 -4,-4 -4,-4 z"
      id="path11071"
-     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="csccscscsc" />
+  <path
+     d="M 75.99996,70.99954 V 58.99613 c 0,4 -4,4 -4,4 0,0 -4,0 -4,-4 0,-4 -4,-4 -4,-4 0,0 -4,0 -4,4 0,4 -4,4 -4,4 0,0 -4,0 -4,-4.00341 V 71 Z"
+     id="path11053"
+     style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="cccscscccc" />
+  <path
+     id="path873-5-3-3-7-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 42,68 c -1.846696,0 -3,1.485336 -3,3.332032 0,0.995294 0.433778,1.886332 1.121094,2.496092 l 21.59375,23.261716 c 0.596992,0.56362 1.399342,0.91017 2.285156,0.91017 0.885811,0 1.688164,-0.34655 2.285157,-0.91017 L 87.878907,73.828124 C 88.566219,73.218366 89,72.327326 89,71.332032 89,69.485336 88.291558,68.447876 86.5,68 Z"
+     sodipodi:nodetypes="csccsccscc" />
 </svg>

--- a/elementary-xfce/mimes/128/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/128/application-x-partial-download.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3172"
    height="128"
    width="128"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="application-x-partial-download.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.328125"
+     inkscape:cx="63.906158"
+     inkscape:cy="63.906158"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g848" />
   <defs
      id="defs3174">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -192,8 +213,9 @@
      id="g848">
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       d="m 60,55 v 8 h 8 v -8 z m 8,8 v 8 h -8 v -8 h -8 v 7.996094 H 36 L 64,104.99609 92,70.996094 76,71 v -8 z"
-       id="path11053" />
+       d="m 60,55 v 8 h 8 v -8 z m 8,8 v 8 h -8 v -8 h -8 v 7.996094 L 76,71 v -8 z"
+       id="path11053"
+       sodipodi:nodetypes="cccccccccccccc" />
     <path
        style="opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none"
        d="m 52,39 v 8 h 8 v -8 z m 8,8 v 8 h 8 8 v -8 -8 h -8 v 8 z m 0,8 h -8 v 8 h 8 z"
@@ -202,5 +224,10 @@
        style="opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none"
        d="m 60,23 v 8 h 8 v -8 z m 8,8 v 8 h 8 v -8 z m 0,8 h -8 v 8 h 8 z m -8,0 v -8 h -8 v 8 z"
        id="rect868" />
+    <path
+       id="path873-5-3-3-7"
+       style="font-variation-settings:normal;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 42,71.00009 c -1.846692,0 -3,1.487293 -3,3.333984 0,0.995292 0.431827,1.884383 1.119141,2.494141 l 21.595703,23.259765 c 0.596991,0.56361 1.399344,0.91211 2.285156,0.91211 0.885808,0 1.688165,-0.3485 2.285156,-0.91211 L 87.880859,76.828215 C 88.568169,76.218457 89,75.329366 89,74.334074 89,72.487383 88.291554,71.447965 86.5,71.00009 Z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/128/application-x-perl.svg
+++ b/elementary-xfce/mimes/128/application-x-perl.svg
@@ -1,1 +1,264 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.328125"
+     inkscape:cx="73.571848"
+     inkscape:cy="70.944282"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="598"
+     inkscape:window-y="122"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 36.812244,30.352602 c -2.119792,0.02376 -3.554688,0.453125 -3.554688,0.453125 0,0 3.934403,12.538372 11.3125,11.296875 l 0.710938,-2.589844 c -0.06941,6.003855 2.045264,13.369182 2.75,15.65039 -2.356995,5.996397 -5.63782,15.668217 -4.640625,20.970704 0.779214,4.143389 2.358756,7.322383 5.253906,9.544922 H 48.25951 c -1.967492,7.945584 3.935278,9.931775 15.740234,5.958984 11.804956,3.972791 17.707727,1.986601 15.740234,-5.958984 h -0.384765 c 2.89515,-2.222539 4.474692,-5.401533 5.253906,-9.544922 0.997194,-5.302487 -2.283629,-14.974307 -4.640625,-20.970704 0.704736,-2.281208 2.819406,-9.646535 2.75,-15.65039 l 0.710938,2.589844 c 7.378096,1.241497 11.3125,-11.296875 11.3125,-11.296875 0,0 -7.226564,-2.149522 -13.191407,2.9375 -1.132983,-1.998987 -3.868388,-3.390625 -5.746093,-3.390625 -3.989263,0 -5.90221,1.693359 -11.804688,1.693359 -5.902479,0 -7.815424,-1.693359 -11.804688,-1.693359 -1.877707,0 -4.613111,1.391638 -5.746093,3.390625 -3.306266,-2.819696 -7.000499,-3.420178 -9.636719,-3.390625 z"
+     sodipodi:nodetypes="sccccscccccscccccssscs" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 50.227386,49.925018 c 0,0 -8.349623,18.164165 -6.836391,26.210629 1.05239,5.595969 3.557491,9.436731 8.803908,11.531346 3.109807,1.241582 11.805099,-1.98642 11.805099,-1.98642 v -13.904938 0 0 c 0,0 -7.870066,-2.607177 -9.468673,-12.663427 0,0 0.845869,8.593978 2.444477,8.84228"
+     id="path925"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 46.784233,34.033659 c -6.025519,-5.462655 -13.526677,-3.227932 -13.526677,-3.227932 0,0 3.935034,12.539274 11.313221,11.297762"
+     id="path927"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 48.25987,85.680573 c -1.967516,7.94568 3.935033,9.932099 15.740132,5.95926 11.805098,3.972839 17.707647,1.98642 15.740131,-5.95926"
+     id="path932"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 52.614776,40.62014 c 3.728449,-1.748824 7.690874,0.395189 7.557103,0.61449 0,0 -1.287464,5.390482 -4.330494,4.925451 -2.850548,-0.435617 -3.224218,-4.317562 -3.226609,-5.539941 z"
+     id="path938-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsc" />
+  <path
+     sodipodi:nodetypes="ccsscsscc"
+     inkscape:connector-curvature="0"
+     id="path947"
+     d="m 79.740133,55.884276 v 0 c 0,0 5.092719,-15.25267 1.967516,-21.850617 C 80.687487,31.879884 77.772616,30.354 75.8051,30.354 c -3.989311,0 -5.902549,1.693239 -11.805098,1.693239 -5.90255,0 -7.815787,-1.693239 -11.805099,-1.693239 -1.967517,0 -4.882387,1.525884 -5.902549,3.679659 -3.125203,6.597947 1.967516,21.850617 1.967516,21.850617 v 0"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path949"
+     d="m 77.772616,49.925018 c 0,0 8.349624,18.164165 6.836392,26.210629 -1.052389,5.595969 -3.557491,9.436731 -8.803908,11.531346 -3.109806,1.241582 -11.805098,-1.98642 -11.805098,-1.98642 v -13.904938 0 0 c 0,0 7.870065,-2.607177 9.468673,-12.663427 0,0 -0.932824,8.769552 -2.531432,9.017855"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path951"
+     d="m 81.215771,34.033659 c 6.025518,-5.462655 13.526674,-3.227932 13.526674,-3.227932 0,0 -3.935033,12.539274 -11.313219,11.297762"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path955"
+     d="m 75.385227,40.62014 c -3.728448,-1.748824 -7.690874,0.395189 -7.557102,0.61449 0,0 1.287464,5.390482 4.330494,4.925451 2.850548,-0.435617 3.224218,-4.317562 3.226608,-5.539941 z"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+</svg>

--- a/elementary-xfce/mimes/128/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/128/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/128/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/128/application-x-sharedlib.svg
@@ -1,1 +1,292 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3172"
+   height="128"
+   width="128"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3100" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3102" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3104" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop3094" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop3096" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3019-2"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-3"
+       id="linearGradient3016-9"
+       y2="42.194839"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-6" />
+      <stop
+         offset="0.00648027"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-0" />
+      <stop
+         offset="0.99423188"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-2" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4097"
+       xlink:href="#linearGradient3702-501-757-486"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient4095"
+       xlink:href="#linearGradient3688-464-309-255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient4093"
+       xlink:href="#linearGradient3688-464-309-255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)" />
+    <linearGradient
+       gradientTransform="matrix(1.3334595,0,0,1.3334595,-58.855548,-7.8786126)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(1.2380161,0,0,1.2380161,12.149879,11.625586)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(1.2379195,0,0,1.2379195,42.849556,64.829792)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)"
+     style="opacity:0.2;stroke-width:1.03923047"
+     id="g978">
+    <rect
+       width="14.210526"
+       height="4.9999995"
+       x="103.78947"
+       y="116.00149"
+       id="rect2801"
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+    <rect
+       width="14.210526"
+       height="4.9999995"
+       x="-24.210518"
+       y="-121.00149"
+       transform="scale(-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+    <rect
+       width="79.578949"
+       height="5"
+       x="24.210518"
+       y="116.00149"
+       id="rect3700"
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+  </g>
+  <path
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none"
+     id="path4160"
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1"
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z" />
+  <rect
+     transform="matrix(0.87157445,-0.49026317,0.87157445,0.49026317,0,0)"
+     ry="11.182091"
+     rx="11.182091"
+     y="89.539589"
+     x="-59.359879"
+     height="43.250622"
+     width="43.250622"
+     id="rect48-5-5"
+     style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.08172;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-7-9-6-8"
+     style="opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal"
+     d="M 64 55 C 60.476816 55 56.953552 55.758785 54.253906 57.277344 L 36.083984 67.5 L 54.253906 77.722656 C 59.653187 80.759769 68.346814 80.759769 73.746094 77.722656 L 91.916016 67.5 L 73.746094 57.277344 C 71.046448 55.758785 67.523184 55 64 55 z " />
+  <rect
+     transform="matrix(0.87157435,-0.49026335,0.87157435,0.49026335,0,0)"
+     ry="11.182471"
+     rx="11.182471"
+     y="77.301208"
+     x="-47.122196"
+     height="43.251324"
+     width="43.251324"
+     id="rect48-5-1-7"
+     style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-8-2-7"
+     style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.08171934;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M -7.1388122 80.569151 C -9.1600419 78.547922 -11.954928 77.300637 -15.05247 77.300637 L -33.864534 77.300211 L -33.864107 96.112275 C -33.864107 102.30736 -28.877018 107.29445 -22.681936 107.29445 L -3.8698716 107.29487 L -3.8702984 88.482809 C -3.8702984 85.385267 -5.1175826 82.590381 -7.1388122 80.569151 z "
+     transform="matrix(0.87157435,-0.49026335,0.87157435,0.49026335,0,0)" />
+  <path
+     id="rect48-5-1-8-2-7-6"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;-inkscape-stroke:none;marker:none;paint-order:normal;stop-color:#000000"
+     d="m 64,43 c -3.523304,0 -7.046356,0.758732 -9.746094,2.277344 L 37.857422,54.5 54.253907,63.722656 c 5.399477,3.037224 14.092715,3.037224 19.49219,2e-6 L 90.142576,54.499999 73.746094,45.277344 C 71.046356,43.758732 67.523304,43 64,43 Z" />
+  <rect
+     transform="matrix(0.87157435,-0.49026335,0.87157435,0.49026335,0,0)"
+     ry="11.182471"
+     rx="11.182471"
+     y="63.023254"
+     x="-32.844242"
+     height="43.251324"
+     width="43.251324"
+     id="rect48-5-1-8-2"
+     style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+</svg>

--- a/elementary-xfce/mimes/128/application-x-shellscript.svg
+++ b/elementary-xfce/mimes/128/application-x-shellscript.svg
@@ -24,12 +24,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="1.8837767"
-     inkscape:cx="62.64012"
-     inkscape:cy="45.12212"
+     inkscape:cx="62.109272"
+     inkscape:cy="44.591272"
      inkscape:window-width="1317"
      inkscape:window-height="893"
      inkscape:window-x="226"
-     inkscape:window-y="581"
+     inkscape:window-y="135"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3172" />
   <defs
@@ -236,7 +236,7 @@
      x="30"
      y="30"
      rx="6"
-     ry="5.8125" />
+     ry="6" />
   <path
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.3117px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3018-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      d="m 48.000156,43 v 2.0625 c -1.641402,0.15682 -3.225094,0.566462 -4.5,1.625 -1.829824,1.414218 -1.969426,4.239688 -0.625,6 1.299938,1.57724 3.238356,2.287452 5.125,3 v 4.25 c -2.103634,-0.17184 -4.088504,-0.70003 -6,-1.5625 v 3.5625 c 1.91326,0.811852 3.920142,1.14682 6,1.1875 v 2.75 h 2 v -2.8125 c 1.273118,-0.11442 2.622728,-0.336322 3.75,-0.9375 1.566002,-0.768834 2.63214,-2.4231 2.5625,-4.125 0.0064,-0.822848 -0.261252,-1.630762 -0.75,-2.3125 -1.307402,-1.744608 -3.589982,-2.454746 -5.5625,-3.25 V 48.375 c 1.56394,0.1272 3.174056,0.487214 4.625,1.0625 l 1.3125,-3.1875 C 54.084892,45.45627 52.02009,45.083 50.000156,45 v -2 z m 0,5.4375 v 3.25 c -0.796286,-0.350212 -1.72372,-0.812216 -1.6875,-1.8125 -0.03726,-0.944216 0.88139,-1.3467 1.6875,-1.4375 z m 2,8 c 0.789734,0.385398 1.9822,0.745666 2,1.75 0.04538,1.02485 -1.105968,1.50586 -2,1.625 z m 12,8.5625 v 4 H 78 v -4 z"

--- a/elementary-xfce/mimes/128/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/128/application-x-vdi-disk.svg
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview48"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="2.6640625"
+     inkscape:cx="74.322581"
+     inkscape:cy="85.958944"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="607"
+     inkscape:window-y="119"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172" />
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="68"
+     height="68"
+     x="30"
+     y="26"
+     rx="6"
+     ry="6" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="M 30,51.5 H 42 L 50,78 60,42 69,64.999998 78,42 86,69.5 h 12"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/128/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/128/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/128/text-markdown.svg
+++ b/elementary-xfce/mimes/128/text-markdown.svg
@@ -1,15 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="128"
    height="128"
-   id="svg3172">
+   id="svg3172"
+   sodipodi:docname="text-markdown.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:snap-global="false"
+     showguides="false"
+     inkscape:zoom="7.5351065"
+     inkscape:cx="60.981222"
+     inkscape:cy="48.70535"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="-49"
+     inkscape:window-y="143"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3172" />
   <defs
      id="defs3174">
     <linearGradient
@@ -155,6 +179,34 @@
          offset="1"
          style="stop-color:#505f6f;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4613"
+       id="linearGradient910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5833335,0,0,1.5999825,-41.333343,-44.998754)"
+       x1="64"
+       y1="95.511299"
+       x2="64"
+       y2="30.674192" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4613"
+       id="linearGradient2053"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2954547,0,0,1.369903,-19.636371,-30.030228)"
+       x1="64"
+       y1="99.945259"
+       x2="64"
+       y2="24.15126" />
+    <linearGradient
+       xlink:href="#linearGradient4613"
+       id="linearGradient910-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0833335,0,0,1.0999761,-3.333562,-11.49825)"
+       x1="64"
+       y1="109.25758"
+       x2="64"
+       y2="13.1972" />
   </defs>
   <metadata
      id="metadata3177">
@@ -164,7 +216,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -209,6 +260,22 @@
      style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
      id="rect4550"
-     d="m 33,39 c -2.735406,0 -5,2.264594 -5,5 v 32 c 0,2.735406 2.264594,5 5,5 h 62 c 2.735406,0 5,-2.264594 5,-5 V 44 c 0,-2.735406 -2.264594,-5 -5,-5 z m 0,4 h 62 c 0.588594,0 1,0.411406 1,1 v 32 c 0,0.588594 -0.411406,1 -1,1 H 33 c -0.588594,0 -1,-0.411406 -1,-1 V 44 c 0,-0.588594 0.411406,-1 1,-1 z m 6,6 v 22 h 6 V 58 l 6,6.5 6,-6.5 v 13 h 6 V 49 H 57 L 51,55.625 45,49 Z m 38,0 V 60 H 70 L 80,72 90,60 H 83 V 49 Z"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 33,39 c -2.735406,0 -5,2.264594 -5,5 v 32 c 0,2.735406 2.264594,5 5,5 h 62 c 2.735406,0 5,-2.264594 5,-5 V 44 c 0,-2.735406 -2.264594,-5 -5,-5 z m 0,4 h 62 c 0.588594,0 1,0.411406 1,1 v 32 c 0,0.588594 -0.411406,1 -1,1 H 33 c -0.588594,0 -1,-0.411406 -1,-1 V 44 c 0,-0.588594 0.411406,-1 1,-1 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="ssssssssssssssssss" />
+  <path
+     id="path906-2"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient910-3);fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 43.167557,49.000237 C 41.967236,49.000237 41,49.980915 41,51.199676 V 68.80056 c 0,1.218761 0.967236,2.199439 2.167557,2.199439 h 1.667778 c 1.200322,0 2.164885,-0.980678 2.164885,-2.199439 V 58.712321 l 4.866334,5.798033 c 0.26431,0.262838 0.609563,0.429814 0.994244,0.459224 0.05258,0.0055 0.106368,0.0081 0.160361,0.0081 0.03956,-0.0011 0.07882,-0.0041 0.117603,-0.0081 0.384682,-0.02941 0.729931,-0.196383 0.994244,-0.459224 l 4.866332,-5.798033 v 10.088238 c -4e-6,1.218761 0.964557,2.199439 2.164881,2.199439 h 1.66778 c 1.200324,0 2.167558,-0.980677 2.167558,-2.199438 V 51.199676 c 0,-1.218761 -0.967236,-2.199439 -2.167558,-2.199439 h -3.161793 c -0.563521,-0.0084 -1.129074,0.206113 -1.560856,0.644523 L 52.999778,56.197424 47.876205,49.64476 C 47.444423,49.206357 46.878868,48.991849 46.31535,49.000237 Z"
+     sodipodi:nodetypes="ssssssccccccccssssscccccs" />
+  <path
+     id="path906"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient2053);fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 70.84091,59 C 69.820606,59 69,59.95236 69,61.133807 c 0,0.636738 0.240316,1.201887 0.620028,1.591995 l 7.095172,7.692251 c 0.329838,0.360603 0.769818,0.581948 1.259232,0.581948 0.489406,0 0.929397,-0.221345 1.259232,-0.581948 l 7.146308,-7.692251 C 86.759716,62.335698 87,61.770545 87,61.133807 87,59.95236 86.179402,59 85.159091,59 Z"
+     sodipodi:nodetypes="csccsccscc" />
+  <path
+     id="path1737"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient910);fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 77.25,48.999906 c -1.247044,0 -2.251232,1.112304 -2.25,2.492188 V 60 h 6 v -8.507906 c 0,-1.379884 -1.002962,-2.492188 -2.25,-2.492188 z"
+     sodipodi:nodetypes="scccsss" />
 </svg>

--- a/elementary-xfce/mimes/128/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/128/text-x-bibtex.svg
@@ -1,0 +1,205 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="128"
+   height="128"
+   id="svg3172">
+  <defs
+     id="defs3174">
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-486">
+      <stop
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309-255">
+      <stop
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3019-2"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="42.194839"
+       id="linearGradient3016-9"
+       xlink:href="#linearGradient3977-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+    <linearGradient
+       id="linearGradient3977-3">
+      <stop
+         id="stop3979-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00648027" />
+      <stop
+         id="stop3983-6"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99423188" />
+      <stop
+         id="stop3985-2"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3148"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-486"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-255"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+  </defs>
+  <metadata
+     id="metadata3177">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g978"
+     style="opacity:0.2;stroke-width:1.03923047"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+    <rect
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect2801"
+       y="116.00149"
+       x="103.78947"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-121.00149"
+       x="-24.210518"
+       height="4.9999995"
+       width="14.210526" />
+    <rect
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
+       id="rect3700"
+       y="116.00149"
+       x="24.210518"
+       height="5"
+       width="79.578949" />
+  </g>
+  <path
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+  <path
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     id="g4137">
+    <path
+       id="path3475"
+       d="m 61,22.5 h 13.119141 z m 13.949219,0 h 10.048828 z m 10.878906,0 H 96 Z M 61,28.5 h 6.890625 z m 7.804688,0 h 8.96875 z m 9.798828,0 h 5.978515 z m 6.808593,0 H 96 Z m -24.410156,6.005859 h 6.146485 z m 6.976563,0 h 5.230468 z m 6.060546,0 8.220704,0.08203 z m 8.96875,0.08203 H 96 Z M 61.011719,40.5 h 11.541015 z m 12.289062,0 h 7.888672 z m 8.800781,0 h 3.15625 z m 3.986329,0 h 1.74414 z m 2.658203,0 H 96 Z M 31,50.500258 h 10.962891 z m 11.792969,0 h 11.208984 z m 12.041015,0 L 65.6,50.521742 Z m 28.31836,0 h 5.232422 z m 6.0625,0 H 96 Z m -22.642578,0.0078 H 82.265625 Z M 31,56.5 h 6.728516 z m 7.640625,0 h 5.730469 z m 6.726563,0 h 5.148437 z m 5.978515,0 h 2.242188 z M 54.5,56.5 h 4.982422 z m 5.978516,0 h 13.037109 z m 13.951172,0 h 9.964843 z m 10.794921,0 h 3.154297 z m 3.984375,0 H 96 Z M 31,62.5 h 10.962891 z m 11.792969,0 h 11.208984 z m 12.041015,0 h 4.316407 z m 5.146485,0 h 10.546875 z m 11.376953,0 h 13.285156 z m 14.199219,0 H 96 Z M 31,68.5 h 11.875 z m 12.789062,0 h 12.289063 z m 13.119141,0 h 4.900391 z m 5.730469,0 h 11.541016 z m 12.289062,0 h 7.888672 z m 8.800782,0 h 3.15625 z m 3.986328,0 h 1.74414 z m 2.658203,0 H 96 Z M 31,74.5 h 10.214844 z m 11.294922,0 h 4.65039 z m 5.480469,0 h 2.324218 z m 3.238281,0 h 4.234375 z m 5.148437,0 h 4.316407 z m 5.148438,0 h 6.890625 z m 7.804687,0 h 8.966797 z m 9.798828,0 h 5.978516 z m 6.808594,0 H 96 Z M 31,84.458984 h 8.720703 z m 9.550781,0 h 13.451172 z m 14.283203,0 h 6.558594 z m 7.388672,0 h 3.798828 z M 31,90.5 h 10.214844 z m 11.294922,0 h 4.65039 z m 5.480469,0 h 2.324218 z m 3.238281,0 h 4.234375 z m 5.148437,0 h 4.316407 z m 5.148438,0 h 4.6875 z M 31,96.5 h 10.796875 z m 11.708984,0 h 3.238282 z m 4.070313,0 h 7.388672 z M 55,96.5 h 10.978516 z m -24,6 h 10.796875 z m 11.708984,0 h 4.650391 z m 5.480469,0 h 7.308594 z m 8.138672,0 H 66 Z"
+       style="fill:none;stroke:#7e8087;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 69.926727,100.61486 c 3.53772,-1.64492 7.238798,-3.373229 7.238798,-7.074298 0,-1.15145 -0.493478,-1.15145 -2.631875,-1.315942 -2.385136,-0.164493 -3.373227,-1.727165 -3.373227,-3.865562 0,-2.96086 1.891657,-4.359049 4.194547,-4.359049 3.454339,0 6.005112,3.043107 6.005112,7.237663 0,3.208735 -1.562682,6.497437 -4.359049,8.883718 -1.891658,1.56267 -3.454339,2.13839 -6.087349,2.87861 z m 14.640945,0 c 3.536585,-1.64492 7.237664,-3.373229 7.237664,-7.074298 0,-1.15145 -0.493479,-1.15145 -2.631875,-1.315942 -2.385146,-0.164493 -3.372093,-1.727165 -3.372093,-3.865562 0,-2.96086 1.891658,-4.359049 4.194547,-4.359049 3.454339,0 6.003968,3.043107 6.003968,7.237663 0,3.208735 -1.562672,6.497437 -4.35904,8.883718 -1.891667,1.56267 -3.454339,2.13839 -6.086214,2.87861 z"
+       id="path3253" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 42.437273,24.38528 c -3.537934,1.645018 -7.239236,3.372297 -7.239236,7.07359 0,1.151519 0.493508,1.151519 2.632034,1.316021 2.385281,0.164503 3.373441,1.72727 3.373441,3.865805 0,2.961031 -1.891772,4.359304 -4.19481,4.359304 -3.454539,0 -6.005466,-3.044436 -6.005466,-7.239236 0,-3.207794 1.562767,-6.49784 4.359304,-8.88312 C 37.254321,23.316022 38.818232,22.740262 41.450266,22 Z m 14.641841,0 c -3.536799,1.645018 -7.238101,3.372297 -7.238101,7.07359 0,1.151519 0.493508,1.151519 2.632034,1.316021 2.38529,0.164503 3.372297,1.72727 3.372297,3.865805 0,2.961031 -1.891772,4.359304 -4.194801,4.359304 -3.454548,0 -6.004331,-3.044436 -6.004331,-7.239236 0,-3.207794 1.562766,-6.49784 4.359303,-8.88312 C 51.897297,23.316022 53.460063,22.740262 56.092098,22 Z"
+       id="path3255" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/128/text-x-install.svg
+++ b/elementary-xfce/mimes/128/text-x-install.svg
@@ -1,140 +1,140 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="128"
+   id="svg3172"
    height="128"
-   id="svg3172">
+   width="128"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3174">
     <linearGradient
        id="linearGradient3600">
       <stop
-         id="stop3602"
+         offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         id="stop3602" />
       <stop
-         id="stop3604"
+         offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         id="stop3604" />
     </linearGradient>
     <linearGradient
        id="linearGradient3702-501-757-486">
       <stop
-         id="stop3100"
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
+         id="stop3100" />
       <stop
-         id="stop3102"
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
+         id="stop3102" />
       <stop
-         id="stop3104"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3104" />
     </linearGradient>
     <linearGradient
        id="linearGradient3688-464-309-255">
       <stop
-         id="stop3094"
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
+         id="stop3094" />
       <stop
-         id="stop3096"
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
+         id="stop3096" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3019-2"
+       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6285655,0,0,2.5204893,0.914429,-4.3579715)" />
+       id="linearGradient3019-2"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
     <linearGradient
-       x1="23.99999"
-       y1="5.5641499"
-       x2="23.99999"
-       y2="42.194839"
-       id="linearGradient3016-9"
-       xlink:href="#linearGradient3977-3"
+       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4594595,0,0,3.1081081,4.9729852,-14.594554)" />
+       xlink:href="#linearGradient3977-3"
+       id="linearGradient3016-9"
+       y2="42.194839"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999" />
     <linearGradient
        id="linearGradient3977-3">
       <stop
-         id="stop3979-6"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3979-6" />
       <stop
-         id="stop3981-0"
+         offset="0.00648027"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.00648027" />
+         id="stop3981-0" />
       <stop
-         id="stop3983-6"
+         offset="0.99423188"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99423188" />
+         id="stop3983-6" />
       <stop
-         id="stop3985-2"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3985-2" />
     </linearGradient>
     <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3148"
-       xlink:href="#linearGradient3104-6"
+       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1456297,0,0,2.3791292,158.08983,-7.746462)" />
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-6">
       <stop
-         id="stop3106-3"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
+         id="stop3106-3" />
       <stop
-         id="stop3108-9"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-486"
-       id="linearGradient4097"
-       y2="39.999443"
-       x2="25.058096"
-       y1="47.027729"
+       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)"
        x1="25.058096"
-       gradientTransform="matrix(2.8421052,0,0,0.71428566,-4.2105336,87.430066)" />
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4097"
+       xlink:href="#linearGradient3702-501-757-486"
+       gradientUnits="userSpaceOnUse" />
     <radialGradient
-       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-255"
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
        id="radialGradient4095"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <radialGradient
-       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)"
-       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309-255"
-       id="radialGradient4093"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,-52.665305,-162.00149)" />
+    <radialGradient
+       cx="4.9929786"
        cy="43.5"
-       cx="4.9929786" />
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient4093"
+       xlink:href="#linearGradient3688-464-309-255"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(5.6949649,0,0,0.99999992,75.334676,75.001496)" />
   </defs>
   <metadata
      id="metadata3177">
@@ -144,51 +144,50 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="g978"
+     transform="matrix(0.92592591,0,0,1,4.7407489,0)"
      style="opacity:0.2;stroke-width:1.03923047"
-     transform="matrix(0.92592591,0,0,1,4.7407489,0)">
+     id="g978">
     <rect
-       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288"
-       id="rect2801"
-       y="116.00149"
+       width="14.210526"
+       height="4.9999995"
        x="103.78947"
-       height="4.9999995"
-       width="14.210526" />
-    <rect
-       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288"
-       id="rect3696"
-       transform="scale(-1)"
-       y="-121.00149"
-       x="-24.210518"
-       height="4.9999995"
-       width="14.210526" />
-    <rect
-       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288"
-       id="rect3700"
        y="116.00149"
-       x="24.210518"
+       id="rect2801"
+       style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+    <rect
+       width="14.210526"
+       height="4.9999995"
+       x="-24.210518"
+       y="-121.00149"
+       transform="scale(-1)"
+       id="rect3696"
+       style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
+    <rect
+       width="79.578949"
        height="5"
-       width="79.578949" />
+       x="24.210518"
+       y="116.00149"
+       id="rect3700"
+       style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none;stroke-width:1.48070288" />
   </g>
   <path
-     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z"
+     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none"
      id="path4160"
-     style="display:inline;fill:url(#linearGradient3019-2);fill-opacity:1;stroke:none" />
+     d="m 18,2.0004521 c 21.081878,0 91.99989,0.00694 91.99989,0.00694 L 110,118 c 0,0 -61.333339,0 -91.999999,0 0,-38.666664 0,-77.33333 0,-115.999995 z" />
   <path
-     d="m 109.5,117.5 h -91 V 2.500002 h 91 z"
+     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3016-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 109.5,117.5 h -91 V 2.500002 h 91 z" />
   <path
-     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z"
+     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      id="path4160-6-1"
-     style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 17.500001,1.49999 c 21.311001,0 92.999899,0.008 92.999899,0.008 l 1e-4,116.99202 c 0,0 -61.999997,0 -92.999999,0 0,-39.000096 0,-77.999807 0,-116.999456 z" />
   <path
-     d="M 87,63 64,89.5 41,63 H 57 V 38 h 14 v 25 z"
-     id="path3288-2-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e8087;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+     id="path873-5-3-3-7-4"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 89,67.334205 c 0,-1.846667 -0.708822,-2.885465 -2.500353,-3.333333 h -14.49977 v -26.66659 c 0,-1.846666 -1.153201,-3.333333 -2.999873,-3.333333 h -10 c -1.846671,0 -2.976793,1.486811 -2.999873,3.333333 v 26.66659 H 42.000353 c -1.84667,0 -3.000352,1.486666 -3.000352,3.333333 0,0.995278 0.432493,1.883738 1.119802,2.493488 L 61.714841,93.088545 C 62.311831,93.652152 63.114199,94 64.000005,94 c 0.885786,0 1.688173,-0.34785 2.285143,-0.911455 L 87.880206,69.827693 C 88.567507,69.217943 89,68.329483 89,67.334205 Z" />
 </svg>

--- a/elementary-xfce/mimes/16/application-ovf.svg
+++ b/elementary-xfce/mimes/16/application-ovf.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg3810"
+   sodipodi:docname="application-x-qemu-disk.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="42.625"
+     inkscape:cx="6.8387097"
+     inkscape:cy="8"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="551"
+     inkscape:window-y="46"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z"
+       id="path4160"
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z"
+       id="rect6741-1"
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    <path
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+       id="path4160-8"
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  </g>
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="8"
+     height="8"
+     x="4"
+     y="4"
+     rx="0.70588231"
+     ry="0.70588231" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="8"
+     cy="8"
+     r="3" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="8"
+     cy="8"
+     r="1.25" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="8"
+     cy="8"
+     r="1" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="8"
+     cy="8"
+     r="0.75" />
+</svg>

--- a/elementary-xfce/mimes/16/application-sql.svg
+++ b/elementary-xfce/mimes/16/application-sql.svg
@@ -1,1 +1,156 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview24"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="32.000001"
+     inkscape:cx="12.734374"
+     inkscape:cy="10.375"
+     inkscape:window-width="1396"
+     inkscape:window-height="955"
+     inkscape:window-x="667"
+     inkscape:window-y="204"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline"
+       id="path4160"
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect6741-1"
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="path4160-8"
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  </g>
+  <g
+     style="fill:#999999;stroke-width:2.66666"
+     id="g12"
+     transform="matrix(0.075,0,0,0.075,0,3)" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none"
+     d="m 4.0000001,5.5 v 6 c 0,0.770247 1.99878,1.5 3.999885,1.5 C 10.00099,13 12,12.165468 12,11.5 v -6 C 12,5.5 10.270734,7.267234 7.9998851,7.267234 5.7290351,7.267234 4.0000001,5.5 4.0000001,5.5 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 4.2500001,5 v 3.25 c 0,0.843079 1.618072,1.753944 3.749885,1.75 C 10.120362,9.9961 11.749999,9.093079 11.749999,8.25 V 5"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="M 11.749999,5 C 11.750634,3.931605 10.348816,3 7.9998851,3 5.6509541,3 4.2493781,3.931605 4.2500001,5 4.2493721,6.068394 5.6509541,7 7.9998851,7 10.348816,7 11.750622,6.068394 11.749999,5 Z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 4.2500001,8.5 v 2.75 c 0,0.843079 1.618072,1.753943 3.749885,1.75 2.1204769,-0.0039 3.7501139,-0.906921 3.7501139,-1.75 V 8.5"
+     style="fill:none;stroke:#7239b3;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+</svg>

--- a/elementary-xfce/mimes/16/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/16/application-vnd.flatpak.ref.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3810"
    height="16"
    width="16"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="application-vnd.flatpak.ref.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview24"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="42.625"
+     inkscape:cx="8.0117302"
+     inkscape:cy="8"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="-3"
+     inkscape:window-y="92"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
   <defs
      id="defs3812">
     <linearGradient
@@ -80,6 +102,16 @@
        x2="-51.786404"
        y1="50.786446"
        x1="-51.786404" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600"
+       id="linearGradient928"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.28571361,0,0,0.30419701,14.857127,0.2326048)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
   </defs>
   <metadata
      id="metadata3815">
@@ -89,7 +121,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -106,11 +137,11 @@
      id="path4160-8"
      style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26771665;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="M 7.9810272,3.4285713 4,5.7142855 v 4.5680815 l 4,2.289062 4,-2.284598 V 5.7142855 Z m 0.018968,1.1619579 V 8.0083704 L 5.0102504,6.2918747 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 8.0189728,3.4285713 12,5.7142855 V 10.282367 L 8,12.571429 4,10.286831 V 5.7142855 Z M 8.0000048,4.5905292 V 8.0083704 L 10.98975,6.2918747 Z"
      id="path925" />
   <path
      id="rect905"
-     d="M 11,7.4472656 8,9.1621094 V 11.425781 L 11,9.71875 Z"
-     style="opacity:1;vector-effect:none;fill:url(#linearGradient3806);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;font-variant-east_asian:normal" />
+     d="M 5,7.4472656 8,9.1621094 V 11.425781 L 5,9.71875 Z"
+     style="opacity:1;vector-effect:none;fill:url(#linearGradient928);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
 </svg>

--- a/elementary-xfce/mimes/16/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/16/application-vnd.flatpak.svg
@@ -5,12 +5,34 @@
    viewBox="0 0 16 16"
    width="16"
    id="svg97"
+   sodipodi:docname="application-vnd.flatpak.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview50"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="42.625"
+     inkscape:cx="7.9882698"
+     inkscape:cy="7.9882698"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg97" />
   <metadata
      id="metadata101">
     <rdf:RDF>
@@ -268,5 +290,5 @@
   <path
      id="path925"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="M 7.9804688 4.4296875 L 4 6.7148438 L 4 11.283203 L 8 13.572266 L 12 11.287109 L 12 6.7148438 L 7.9804688 4.4296875 z M 8 5.5917969 L 8 9.0097656 L 5.0097656 7.2929688 L 8 5.5917969 z M 11 8 L 11 10.271484 L 8 11.978516 L 8 9.7148438 L 11 8 z " />
+     d="M 8.0195312,4.4296875 12,6.7148438 V 11.283203 L 8,13.572266 4,11.287109 V 6.7148438 Z M 8,5.5917969 V 9.0097656 L 10.990234,7.2929688 Z M 5,8 v 2.271484 l 3,1.707032 V 9.7148438 Z" />
 </svg>

--- a/elementary-xfce/mimes/16/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/16/application-x-bittorrent.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="16"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 16 16"
-   width="16">
+   width="16"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="42.625"
+     inkscape:cx="5.3841642"
+     inkscape:cy="6.7800587"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="139"
+     inkscape:window-y="230"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -113,16 +135,24 @@
        id="path4160-8"
        style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
-       d="m 12,201 4,5 4,-5.00043 L 18,201 v -1.50043 c 0,0.5 -0.704505,0.50043 -0.704505,0.50043 0,0 -0.720971,0 -0.720971,-0.5 0,-0.5 -0.588388,-0.5 -0.588388,-0.5 0,0 -0.588389,0 -0.588389,0.5 0,0.5 -0.588388,0.5 -0.588388,0.5 0,0 -0.809359,0 -0.809359,-0.50043 V 201 Z"
-       id="path26667-3"
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
-    <path
-       d="m 15.986136,194 c 0,0 -0.588389,0 -0.588389,0.5 0,0.5 -0.588388,0.5 -0.588388,0.5 0,0 -0.809359,4.2e-4 -0.809359,-0.5 v 7 l 4,-4.3e-4 v -7 c 0,0.5 -0.704505,0.50043 -0.704505,0.50043 0,0 -0.720971,0 -0.720971,-0.5 0,-0.5 -0.588388,-0.5 -0.588388,-0.5 z"
+       d="m 15.986136,194 c 0,0 -0.588389,0 -0.588389,0.5 0,0.5 -0.588388,0.5 -0.588388,0.5 0,0 -0.809359,4.2e-4 -0.809359,-0.5 v 6.5002 l 4,-4.3e-4 v -6.5002 c 0,0.5 -0.704505,0.50043 -0.704505,0.50043 0,0 -0.720971,0 -0.720971,-0.5 0,-0.5 -0.588388,-0.5 -0.588388,-0.5 z"
        id="path10362-6"
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="csccccccsc" />
     <path
-       d="m 14.809359,197 c 0,0 -0.809359,-4.3e-4 -0.809359,0.5 v 3 l 4,-4.3e-4 v -3 C 18,196.99957 17.295495,197 17.295495,197 c 0,0 -0.720971,0 -0.720971,0.5 0,0.5 -0.588388,0.5 -0.588388,0.5 0,0 -0.588389,0 -0.588389,-0.5 0,-0.5 -0.588388,-0.5 -0.588388,-0.5 z"
+       d="m 14.809359,197 c 0,0 -0.809359,-4.3e-4 -0.809359,0.5 v 3.5002 l 4,-4.3e-4 v -3.5002 C 18,196.99957 17.295495,197 17.295495,197 c 0,0 -0.720971,0 -0.720971,0.5 0,0.5 -0.588388,0.5 -0.588388,0.5 0,0 -0.588389,0 -0.588389,-0.5 0,-0.5 -0.588388,-0.5 -0.588388,-0.5 z"
        id="path10323-1"
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="csccscscsc" />
+    <path
+       d="m 18,201 v -1.50043 c 0,0.5 -0.704505,0.50043 -0.704505,0.50043 0,0 -0.720971,0 -0.720971,-0.5 0,-0.5 -0.588388,-0.5 -0.588388,-0.5 0,0 -0.588389,0 -0.588389,0.5 0,0.5 -0.588388,0.5 -0.588388,0.5 0,0 -0.809359,0 -0.809359,-0.50043 V 201 Z"
+       id="path26667-3"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cccscscccc" />
+    <path
+       id="path873-5"
+       style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 12.599609,200.99999 c -0.332543,0 -0.599609,0.27417 -0.599609,0.61914 0,0.18593 0.07741,0.35094 0.201172,0.46484 l 3.378906,3.54493 c 0.107504,0.10528 0.252596,0.17187 0.41211,0.17187 0.159513,0 0.304605,-0.0666 0.412109,-0.17187 l 3.394531,-3.54493 C 19.922596,201.97007 20,201.80506 20,201.61913 c 0,-0.34497 -0.267065,-0.61914 -0.599609,-0.61914 z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/16/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/16/application-x-partial-download.svg
@@ -1,26 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg3810">
+   id="svg3810"
+   sodipodi:docname="application-x-partial-download.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview35"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="30.140427"
+     inkscape:cx="4.9601156"
+     inkscape:cy="5.9388675"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="13"
+     inkscape:window-y="213"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <defs
      id="defs3812">
-    <linearGradient
-       x1="23.99999"
-       y1="6.9230647"
-       x2="23.99999"
-       y2="41.076912"
-       id="linearGradient3988"
-       xlink:href="#linearGradient3977"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
     <linearGradient
        id="linearGradient3977">
       <stop
@@ -52,15 +65,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3806"
-       xlink:href="#linearGradient3600"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
-    <linearGradient
        id="linearGradient3104-9">
       <stop
          id="stop3106-5"
@@ -71,44 +75,6 @@
          style="stop-color:#000000;stop-opacity:0.24691358"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3019"
-       xlink:href="#linearGradient3104-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
-    <linearGradient
-       id="linearGradient4330">
-      <stop
-         id="stop4332"
-         style="stop-color:#e4c6fa;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4334"
-         style="stop-color:#cd9ef7;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop4336"
-         style="stop-color:#7239b3;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop4338"
-         style="stop-color:#452981;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       r="12.671875"
-       fy="16.231987"
-       fx="17.347919"
-       cy="16.231987"
-       cx="17.347919"
-       gradientTransform="matrix(0,3.7401365,-4.9547482,0,88.430656,-81.326572)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient885"
-       xlink:href="#linearGradient4330" />
     <linearGradient
        y2="47.013336"
        y1="0.98520643"
@@ -145,7 +111,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -167,9 +132,15 @@
        d="m 10.499962,192.49997 c 2.520676,0 11.000063,9.6e-4 11.000063,9.6e-4 l 1.3e-5,14.9991 H 10.499962 Z" />
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       d="M 7,7 V 8 H 9 V 7 Z M 9,8 V 9 H 7 V 8 H 6 V 9 H 4 l 4,5 4,-5 H 10 V 8 Z"
+       d="M 7,7 V 8 H 9 V 7 Z M 9,8 V 9 H 7 V 8 H 6 v 1 h 4 V 8 Z"
        transform="translate(8,192.00001)"
-       id="path26667-3" />
+       id="path26667-3"
+       sodipodi:nodetypes="cccccccccccccc" />
+    <path
+       id="path873-5"
+       style="display:inline;fill:#68b723;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;enable-background:new;stop-color:#000000"
+       d="m 12.599609,200.99999 c -0.332544,0 -0.599609,0.27417 -0.599609,0.61914 0,0.18593 0.07741,0.35094 0.201172,0.46484 l 3.378906,3.54493 c 0.107504,0.10528 0.252595,0.17187 0.412109,0.17187 0.159514,0 0.304606,-0.0666 0.41211,-0.17187 l 3.394531,-3.54493 C 19.922596,201.97007 20,201.80506 20,201.61913 c 0,-0.34497 -0.267065,-0.61914 -0.599609,-0.61914 z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
   <path
      style="display:inline;opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none;enable-background:new"

--- a/elementary-xfce/mimes/16/application-x-perl.svg
+++ b/elementary-xfce/mimes/16/application-x-perl.svg
@@ -1,1 +1,189 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview24"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="8.296875"
+     inkscape:cy="6.78125"
+     inkscape:window-width="1396"
+     inkscape:window-height="955"
+     inkscape:window-x="552"
+     inkscape:window-y="61"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.076912"
+       x2="23.99999"
+       y1="6.9230647"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline"
+       id="path4160"
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect6741-1"
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="path4160-8"
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  </g>
+  <g
+     style="fill:#999999;stroke-width:2.66666"
+     id="g12"
+     transform="matrix(0.075,0,0,0.075,0,3)" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="M 3.7206308,3.3049 C 3.3869637,3.30873 3.1611029,3.378137 3.1611029,3.378137 c 0,0 0.6192976,2.0265289 1.7806509,1.8258693 L 5.0536595,4.7854214 C 5.0427325,5.7558009 5.3755956,6.9462298 5.4865252,7.3149322 5.1155211,8.2841081 4.5991003,9.8473257 4.756065,10.704348 c 0.1226522,0.669679 0.3712815,1.183487 0.8269938,1.542708 h -0.060564 c 0,0.801233 0.6873817,0.963129 2.4776019,0.963129 1.8811454,0 2.4776013,-0.03803 2.4776013,-0.963129 h -0.06056 c 0.455708,-0.359221 0.704337,-0.873029 0.826992,-1.542708 0.156961,-0.8570223 -0.359461,-2.4202399 -0.730465,-3.3894158 0.110929,-0.3687024 0.44379,-1.5591313 0.432865,-2.5295108 l 0.111906,0.418585 c 1.161353,0.2006596 1.780652,-1.8258694 1.780652,-1.8258694 0,0 -1.137502,-0.3474189 -2.076402,0.4747767 C 10.584348,3.5298252 10.15378,3.3049 9.8582209,3.3049 H 6.1419713 C 5.8464098,3.3049 5.4158419,3.5298252 5.2375042,3.8529137 4.7170797,3.397177 4.1355867,3.3001238 3.7206308,3.3049 Z"
+     sodipodi:nodetypes="sccccscccccsccccccccs" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path1039"
+     d="m 5.9509123,6.3314888 c 0,0 -1.4995046,2.9761722 -1.2646864,4.2237912 0.1633083,0.86766 0.6879263,1.303379 1.5020549,1.628156 0.4825712,0.192505 1.8998539,-0.308005 1.8998539,-0.308005 L 7.9069663,9.7194564 h 0.1811535 v 0 c 0,0 -0.9119802,-0.4042479 -1.160052,-1.9634845 0,0 0.1717436,1.4822391 0.4198084,1.5207332"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path1041"
+     d="M 5.5410311,3.9681739 C 4.6059991,3.121182 3.3175675,3.4676807 3.3175675,3.4676807 c 0,0 0.6106306,1.9442303 1.7555631,1.7517336"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csc"
+     inkscape:connector-curvature="0"
+     id="path1043"
+     d="m 5.5776501,11.875431 c -0.3053154,1.231994 0.5772548,1.245183 2.5104697,1.245183 1.9332152,0 2.8157842,-0.01321 2.5104692,-1.245183"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path1045"
+     d="m 6.2444812,4.6564151 c 0.856777,-0.4014823 1.7673306,0.090723 1.7365872,0.1410749 0,0 -0.295848,1.0963001 -0.9951302,0.9895355 C 6.3309059,5.6869723 6.2450331,4.9370469 6.2444812,4.6564151 Z"
+     style="display:inline;fill:#3689e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 10.356455,7.2554778 v 0 c 0,0 0.790277,-2.3649473 0.305315,-3.3879675 C 10.503463,3.5335622 10.051139,3.25151 9.745824,3.25151 9.1267734,3.25151 9.0040658,3.25 8.0881198,3.25 c -0.9159459,0 -1.0884202,0.00151 -1.7074715,0.00151 -0.3053153,0 -0.7576394,0.2820522 -0.915946,0.6160003 -0.4849614,1.0230202 0.1808946,3.3879675 0.1808946,3.3879675 v 0"
+     id="path1049"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsscsscc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 10.051139,6.3314888 c 0,0 1.651043,2.9305177 1.416226,4.1781292 -0.163308,0.867666 -0.665278,1.349041 -1.4794062,1.673818 -0.482571,0.192505 -1.8998241,-0.308005 -1.8998241,-0.308005 L 8.2693114,9.7194564 H 8.0881198 v 0 c 0,0 0.8881889,-0.4042479 1.1362537,-1.9634845 0,0 -0.1717365,1.4822391 -0.4198091,1.5207332"
+     id="path1051"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 10.585441,3.9681663 c 0.935025,-0.8469919 2.099043,-0.5005008 2.099043,-0.5005008 0,0 -0.61063,1.944238 -1.755563,1.7517336"
+     id="path1053"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path1359"
+     d="M 9.724475,4.6564151 C 8.867698,4.2549328 7.9571444,4.7471381 7.9878878,4.79749 c 0,0 0.295848,1.0963001 0.9951302,0.9895355 C 9.6380503,5.6869723 9.7239231,4.9370469 9.724475,4.6564151 Z"
+     style="display:inline;fill:#3689e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+</svg>

--- a/elementary-xfce/mimes/16/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/16/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/16/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/16/application-x-sharedlib.svg
@@ -1,1 +1,209 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg3810"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3812">
+    <linearGradient
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+    <linearGradient
+       gradientTransform="matrix(0.17131718,0,0,0.17131718,-7.4304176,-1.1433003)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(0.1590544,0,0,0.1590544,2.0064376,1.0481229)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(0.159042,0,0,0.159042,6.0030184,7.8311136)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z"
+       id="path4160"
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z"
+       id="rect6741-1"
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    <path
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+       id="path4160-8"
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  </g>
+  <rect
+     transform="matrix(0.84799521,-0.53000389,0.84799521,0.53000389,0,0)"
+     ry="1.4366273"
+     rx="1.4366273"
+     y="11.372575"
+     x="-7.4952116"
+     height="5.5566549"
+     width="5.5566549"
+     id="rect48-5-5"
+     style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.05474;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-8-2-8-4"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.999989;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;-inkscape-stroke:none;marker:none;paint-order:normal;stop-color:#000000"
+     d="M 8,7.5 C 7.559587,7.5 7.1187172,7.6054892 6.78125,7.8164062 L 4.5058594,9.238281 C 4.3793092,9.317375 4.2763599,9.406203 4.1972659,9.5 4.2763599,9.5938 4.3793092,9.682625 4.5058594,9.761719 l 2.2753901,1.421875 c 0.6749346,0.421834 1.7625663,0.421834 2.4375008,0 L 11.494141,9.761719 c 0.12655,-0.07909 0.229498,-0.167923 0.308594,-0.261718 -0.07909,-0.0938 -0.182043,-0.182625 -0.308594,-0.261719 L 9.2187505,7.8164068 C 8.8812836,7.60549 8.4404136,7.5000006 8.0000009,7.5000008 Z" />
+  <rect
+     transform="matrix(0.8479983,-0.52999895,0.8479983,0.52999895,0,0)"
+     ry="1.4366708"
+     rx="1.4366708"
+     y="9.4858131"
+     x="-5.6085567"
+     height="5.5567245"
+     width="5.5567245"
+     id="rect48-5-1-7"
+     style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.05477;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-8-2-8"
+     style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.05473744;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M -0.47169894 9.9056801 C -0.73137692 9.6460021 -1.0908426 9.4855731 -1.4888 9.4855731 L -4.1718187 9.4853428 C -4.3210527 9.4853428 -4.4655545 9.5084414 -4.6006779 9.5502935 C -4.64253 9.6854169 -4.6656287 9.8299187 -4.6656287 9.9791527 L -4.6653983 12.662171 C -4.6653983 13.458086 -4.0241051 14.09938 -3.2281902 14.09938 L -0.54517154 14.09961 C -0.39593752 14.09961 -0.25143573 14.076511 -0.11631235 14.034659 C -0.074460231 13.899536 -0.051361602 13.755034 -0.051361602 13.6058 L -0.051591955 10.922781 C -0.051591955 10.524824 -0.21202095 10.165358 -0.47169894 9.9056801 z "
+     transform="matrix(0.8479983,-0.52999895,0.8479983,0.52999895,0,0)" />
+  <rect
+     transform="matrix(0.8479983,-0.52999895,0.8479983,0.52999895,0,0)"
+     ry="1.4366708"
+     rx="1.4366708"
+     y="7.5990171"
+     x="-3.72176"
+     height="5.5567245"
+     width="5.5567245"
+     id="rect48-5-1-8-2"
+     style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.05477;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+</svg>

--- a/elementary-xfce/mimes/16/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/16/application-x-vdi-disk.svg
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg3810"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="42.625"
+     inkscape:cx="8.0117302"
+     inkscape:cy="8"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="731"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3810" />
+  <defs
+     id="defs3812">
+    <linearGradient
+       x1="23.99999"
+       y1="6.9230647"
+       x2="23.99999"
+       y2="41.076912"
+       id="linearGradient3988"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         id="stop3602"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3806"
+       xlink:href="#linearGradient3600"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         id="stop3106-5"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0" />
+      <stop
+         id="stop3108-5"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3019"
+       xlink:href="#linearGradient3104-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)" />
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z"
+       id="path4160"
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z"
+       id="rect6741-1"
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    <path
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
+       id="path4160-8"
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  </g>
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="8"
+     height="8"
+     x="4"
+     y="4"
+     rx="0.70588231"
+     ry="0.70588231" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 4.0000002,7.5 h 1 L 6.25,10.25 7.75,6.25 8.825,8.5 9.9999999,6.25 11,9.5 h 1"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/16/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/16/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/16/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/16/text-x-bibtex.svg
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3810"
+   height="16"
+   width="16"
+   version="1.1">
+  <defs
+     id="defs3812">
+    <linearGradient
+       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3988"
+       y2="41.589603"
+       x2="23.99999"
+       y1="6.2052388"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0.02929282"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="0.97230476"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3806"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3104-9">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.33950618"
+         id="stop3106-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop3108-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-9"
+       id="linearGradient3019"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+  </defs>
+  <metadata
+     id="metadata3815">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       style="fill:url(#linearGradient3806);fill-opacity:1;stroke:none;display:inline"
+       id="path4160"
+       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+       id="rect6741-1"
+       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3019);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+       id="path4160-8"
+       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
+  </g>
+  <g
+     id="g4141">
+    <path
+       style="fill:none;stroke:#7e8087;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3475"
+       d="m 9,3.499995 1.412041,0 z m 1.512564,0 1.487436,0 z M 9,5.494812 10.291458,5.505188 Z m 1.38191,0.010376 1.61809,0 z m -6.3819099,1.9896074 0.9949753,0 z m 1.0954773,0 1.6281406,0 z m 1.7286437,0 0.7939702,0 z m 0.8944722,0 0.7437182,0 z m 0.8442213,0 0.6331654,0 z m 0.7336684,0 0.994975,0.010376 z m 1.085427,0.010376 1.61809,0 z M 4.0000001,9.5 l 0.7537691,0 z m 0.8643219,0 0.6934672,0 z m 0.8140698,0 0.6231156,0 z m 0.7236186,0 0.2713566,0 z m 0.3819095,0 0.603015,0 z m 0.7236186,0 1.5778887,0 z m 1.6884415,0 1.206031,0 z m 1.306533,0 0.381909,0 z m 0.482412,0 0.904523,0 z m -6.9849249,1.994804 0.9949753,0 z m 1.0954773,0 1.9045226,0 z M 4.0000001,13.5 l 1.2462313,0 z m 1.3567841,0 0.5628138,0 z M 6.020101,13.5 7,13.5 Z" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 7.8812594,13.6234 c 0.558587,-0.259727 1.1429681,-0.532617 1.1429681,-1.116997 0,-0.181808 -0.07792,-0.181808 -0.415559,-0.20778 -0.3766,-0.02597 -0.532615,-0.272711 -0.532615,-0.610352 0,-0.467504 0.298683,-0.688271 0.662297,-0.688271 0.545422,0 0.948175,0.48049 0.948175,1.142789 0,0.506642 -0.246739,1.025911 -0.68827,1.402693 C 8.6995725,13.79222 8.4528335,13.883124 8.0370955,14 l -0.155836,-0.3766 z m 2.3117286,0 c 0.558408,-0.259727 1.142789,-0.532617 1.142789,-1.116997 0,-0.181808 -0.07792,-0.181808 -0.415559,-0.20778 -0.376602,-0.02597 -0.532436,-0.272711 -0.532436,-0.610352 0,-0.467504 0.298683,-0.688271 0.662297,-0.688271 0.545422,0 0.947995,0.48049 0.947995,1.142789 0,0.506642 -0.246738,1.025911 -0.688269,1.402693 C 11.011121,13.79222 10.764383,13.883124 10.348823,14 l -0.155835,-0.3766 z"
+       id="path3253" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="M 5.8053736,3.3766233 C 5.2467526,3.6363627 4.662337,3.9090912 4.662337,4.4935056 c 0,0.1818189 0.077922,0.1818189 0.415584,0.2077932 C 5.454544,4.7272728 5.6105692,4.9740255 5.6105692,5.311689 5.6105692,5.7792198 5.3118688,6 4.9482316,6 4.4027776,6 4,5.5192998 4,4.8569628 4,4.3504689 4.2467524,3.830988 4.688311,3.4543647 4.9870132,3.2077929 5.2339462,3.1168836 5.6495308,3 l 0.1558428,0.3766233 z m 2.3118696,0 C 7.5588016,3.6363627 6.9743854,3.9090912 6.9743854,4.4935056 c 0,0.1818189 0.077922,0.1818189 0.4155846,0.2077932 C 7.7665942,4.7272728 7.9224376,4.9740255 7.9224376,5.311689 7.9224376,5.7792198 7.6237366,6 7.2601006,6 6.7146454,6 6.3120484,5.5192998 6.3120484,4.8569628 c 0,-0.5064939 0.2467524,-1.0259748 0.688311,-1.4025981 C 7.2990616,3.2077929 7.5458146,3.1168836 7.9613986,3 l 0.1558446,0.3766233 z"
+       id="path3255" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/16/text-x-install.svg
+++ b/elementary-xfce/mimes/16/text-x-install.svg
@@ -1,18 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3942"
    height="16"
    width="16"
-   version="1.1">
-  <defs
-     id="defs3944">
-    <linearGradient
+   version="1.1"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs3944"><linearGradient
        gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3104-9"
@@ -20,19 +19,14 @@
        y2="2.9062471"
        x2="-51.786404"
        y1="50.786446"
-       x1="-51.786404" />
-    <linearGradient
-       id="linearGradient3104-9">
-      <stop
+       x1="-51.786404" /><linearGradient
+       id="linearGradient3104-9"><stop
          offset="0"
          style="stop-color:#000000;stop-opacity:0.33950618"
-         id="stop3106-5" />
-      <stop
+         id="stop3106-5" /><stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0.24691358"
-         id="stop3108-5" />
-    </linearGradient>
-    <linearGradient
+         id="stop3108-5" /></linearGradient><linearGradient
        gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3977"
@@ -40,38 +34,27 @@
        y2="41.076912"
        x2="23.99999"
        y1="6.9230647"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient3977">
-      <stop
+       x1="23.99999" /><linearGradient
+       id="linearGradient3977"><stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979" />
-      <stop
+         id="stop3979" /><stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981" />
-      <stop
+         id="stop3981" /><stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983" />
-      <stop
+         id="stop3983" /><stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600">
-      <stop
+         id="stop3985" /></linearGradient><linearGradient
+       id="linearGradient3600"><stop
          offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602" />
-      <stop
+         id="stop3602" /><stop
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604" />
-    </linearGradient>
-    <linearGradient
+         id="stop3604" /></linearGradient><linearGradient
        gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600"
@@ -79,34 +62,19 @@
        y2="47.013336"
        x2="25.132275"
        y1="0.98520643"
-       x1="25.132275" />
-  </defs>
-  <metadata
-     id="metadata3947">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <path
+       x1="25.132275" /></defs><metadata
+     id="metadata3947"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><path
      d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 Z"
      id="path4160"
-     style="display:inline;fill:url(#linearGradient3940);fill-opacity:1;stroke:none" />
-  <path
+     style="display:inline;fill:url(#linearGradient3940);fill-opacity:1;stroke:none" /><path
      d="M 12.5,14.5 H 3.4999999 V 1.5 H 12.5 Z"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3095);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
+     style="fill:none;stroke:url(#linearGradient3095);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><path
      d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 10e-8,-15.00005204 z"
      id="path4160-8"
-     style="display:inline;fill:none;stroke:url(#linearGradient3092);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-  <path
-     id="path843"
-     d="m 7,5 h 2 v 3 h 2.5 L 8,12.5 4.5,8 H 7 Z"
-     style="fill:#7e8087;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-</svg>
+     style="display:inline;fill:none;stroke:url(#linearGradient3092);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><path
+     id="path873-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 12,8.6191468 C 12,8.2741721 11.732283,8 11.399738,8 H 9 V 3.6223384 C 9,3.2773632 8.7480665,2.9996408 8.4155215,2.9996408 H 7.5828668 C 7.2503218,2.9996408 6.999673,3.2773632 7,3.6223384 V 8 H 4.600261 C 4.267717,8 4,8.2741721 4,8.6191468 4,8.8050744 4.07789,8.9710466 4.20165,9.0849543 L 7.580678,12.62973 C 7.688182,12.735018 7.832672,12.8 7.992186,12.8 8.1517,12.8 8.29619,12.73502 8.403694,12.62973 L 11.79835,9.0849543 C 11.922118,8.9710466 12,8.8050744 12,8.6191468 Z" /></svg>

--- a/elementary-xfce/mimes/24/application-ovf.svg
+++ b/elementary-xfce/mimes/24/application-ovf.svg
@@ -1,0 +1,214 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg3828"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview37"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="40.187236"
+     inkscape:cx="12.615946"
+     inkscape:cy="14.706162"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="600"
+     inkscape:window-y="373"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.4736748"
+       x2="23.99999"
+       y2="41.526306"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="16.999998"
+     height="2"
+     x="3.5000007"
+     y="22"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z"
+     id="path4160-3"
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none" />
+  <path
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+     id="path4160-3-1"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="12"
+     height="12"
+     x="6"
+     y="6"
+     rx="1.0588235"
+     ry="1.0588235" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="12"
+     cy="12"
+     r="4.5" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="12"
+     cy="11.999995"
+     r="1.75" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="12"
+     cy="11.999995"
+     r="1.5" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="12"
+     cy="11.999995"
+     r="1.25" />
+</svg>

--- a/elementary-xfce/mimes/24/application-sql.svg
+++ b/elementary-xfce/mimes/24/application-sql.svg
@@ -1,1 +1,204 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg3828"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview37"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="11.964809"
+     inkscape:cy="12"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.4736748"
+       x2="23.99999"
+       y2="41.526306"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="16.999998"
+     height="2"
+     x="3.5000007"
+     y="22"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z"
+     id="path4160-3"
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none" />
+  <path
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+     id="path4160-3-1"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none"
+     d="M 7.0000003,9.0000001 V 16 c 0,1.073678 2.498475,2.236356 4.9998567,2.236356 C 14.501237,18.236356 17,16.927623 17,16 V 9.0000001 C 17,9.0000001 14.838417,11 11.999857,11 9.1612944,11 7.0000002,9.0000001 7.0000003,9.0000001 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 7.2500003,8.8529205 v 2.6556885 c 0,1.175201 2.08509,1.996888 4.7498567,1.991391 C 14.650452,13.4945 16.75,12.68381 16.75,11.508609 V 8.8529205"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:0.499999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="m 16.75,8.8529205 c 7.94e-4,-1.4892773 -1.81398,-2.102921 -4.750143,-2.102921 -2.9361651,0 -4.7506344,0.6136437 -4.7498567,2.102921 C 7.2492143,10.342197 9.0636919,11 11.999857,11 14.93602,11 16.750779,10.342197 16.75,8.8529205 Z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 7.2500003,10.895758 v 2.859974 c 0,1.175199 2.08509,1.999764 4.7498567,1.994268 C 14.650452,15.7445 16.75,14.930931 16.75,13.755732 v -2.859974"
+     style="fill:none;stroke:#7239b3;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:0.499999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 7.2500003,12.938596 v 3.26854 c 0,1.1752 2.08509,2.048333 4.7498567,2.042838 C 14.650452,18.244474 16.75,17.382336 16.75,16.207136 v -3.26854"
+     sodipodi:nodetypes="cscsc" />
+</svg>

--- a/elementary-xfce/mimes/24/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/24/application-vnd.flatpak.ref.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="24"
    height="24"
-   id="svg3828">
+   id="svg3828"
+   sodipodi:docname="application-vnd.flatpak.ref.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview32"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="11.982405"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3828" />
   <defs
      id="defs3830">
     <linearGradient
@@ -124,7 +146,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -157,6 +178,6 @@
      style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   <path
      id="path904"
-     d="M 11.976562 6 L 7.0195312 8.7539062 L 7 14.246094 L 12 17 L 17 14.25 L 17 8.7539062 L 11.976562 6 z M 12 7.1582031 L 12 10.353516 L 10.990234 10.921875 L 8.0742188 9.3007812 L 12 7.1582031 z M 16 9.3007812 L 16 13.666016 L 12 15.884766 L 12 11.519531 L 16 9.3007812 z "
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26771665;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 12.023438,6 16.980469,8.7539062 17,14.246094 12,17 7,14.25 V 8.7539062 Z M 12,7.1582031 v 3.1953129 l 1.009766,0.568359 2.916015,-1.6210938 z M 8,9.3007812 v 4.3652348 l 4,2.21875 v -4.365235 z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/24/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/24/application-vnd.flatpak.svg
@@ -4,12 +4,34 @@
    width="24"
    height="24"
    id="svg7107"
+   sodipodi:docname="application-vnd.flatpak.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="11.982405"
+     inkscape:cy="11.982405"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7107" />
   <defs
      id="defs7109">
     <linearGradient
@@ -292,6 +314,6 @@
      id="path87-0-9-7-6-4" />
   <path
      id="path904"
-     d="M 11.976562,8 7.0195312,10.753906 7,16.246094 12,19 17,16.25 V 10.753906 Z M 12,9.1582031 v 3.1953129 l -1.009766,0.568359 -2.9160152,-1.621094 z m 4,2.1425779 v 4.365235 l -4,2.21875 v -4.365235 z"
+     d="M 12.023438,8 16.980469,10.753906 17,16.246094 12,19 7,16.25 V 10.753906 Z M 12,9.1582031 v 3.1953129 l 1.009766,0.568359 2.916015,-1.621094 z M 8,11.300781 v 4.365235 l 4,2.21875 v -4.365235 z"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/24/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/24/application-x-bittorrent.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="24"
    viewBox="0 0 24 24.000027"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="24.000027">
+   height="24.000027"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="40.187191"
+     inkscape:cx="8.8709859"
+     inkscape:cy="13.014097"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="9"
+     inkscape:window-y="235"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -157,15 +179,22 @@
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10832"
-       d="m 52,191.45556 c 0,0 -0.666655,0 -0.666655,0.63707 0,0.63703 -0.666685,0.63703 -0.666685,0.63703 0,0 -0.66666,4.5e-4 -0.66666,-0.63703 v 8.9186 h 4 v -8.9186 c 0,0.63703 -0.666655,0.63703 -0.666655,0.63703 0,0 -0.66669,0 -0.66669,-0.63703 C 52.666655,191.45556 52,191.45556 52,191.45556 Z" />
+       d="m 52,191.45556 c 0,0 -0.666655,0 -0.666655,0.63707 0,0.63703 -0.666685,0.63703 -0.666685,0.63703 0,0 -0.66666,4.5e-4 -0.66666,-0.63703 V 201 h 4 v -8.90737 c 0,0.63703 -0.666655,0.63703 -0.666655,0.63703 0,0 -0.66669,0 -0.66669,-0.63703 C 52.666655,191.45556 52,191.45556 52,191.45556 Z"
+       sodipodi:nodetypes="csccccccsc" />
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10846"
-       d="m 50.666668,194.33707 c 0,0 -0.666666,-5.4e-4 -0.666666,0.63704 v 4.36296 h 3.999997 v -4.36296 c 0,-0.63704 -0.666666,-0.63704 -0.666666,-0.63704 0,0 -0.666667,0 -0.666667,0.63704 0,0.63705 -0.666666,0.63705 -0.666666,0.63705 0,0 -0.666666,0 -0.666666,-0.63705 0,-0.63704 -0.666666,-0.63704 -0.666666,-0.63704 z" />
+       d="m 50.666668,194.33707 c 0,0 -0.666666,-5.4e-4 -0.666666,0.63704 V 199 h 3.999997 v -4.02589 c 0,-0.63704 -0.666666,-0.63704 -0.666666,-0.63704 0,0 -0.666667,0 -0.666667,0.63704 0,0.63705 -0.666666,0.63705 -0.666666,0.63705 0,0 -0.666666,0 -0.666666,-0.63705 0,-0.63704 -0.666666,-0.63704 -0.666666,-0.63704 z"
+       sodipodi:nodetypes="csccscscsc" />
     <path
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+       id="path873-5"
+       style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 56.999999,199.7778 c 0,-0.4309 -0.334639,-0.7778 -0.750328,-0.7778 h -8.49934 C 47.33465,199 47,199.3469 47,199.7778 c 0,0.23224 0.0974,0.43955 0.25206,0.58183 l 4.22379,4.42769 C 51.610229,204.91883 51.79084,205 51.990229,205 c 0.199401,0 0.380009,-0.0812 0.514391,-0.21268 l 4.243319,-4.42769 c 0.15471,-0.14228 0.25206,-0.34959 0.25206,-0.58183 z" />
+    <path
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10852"
-       d="m 52,196.95508 c 0,0 -0.66699,5e-4 -0.66699,0.63769 0,0.63704 -0.66602,0.63672 -0.66602,0.63672 0,0 -0.66699,0.001 -0.66699,-0.63672 V 200 H 49.85742 47 l 5,6.45996 L 57,200 h -1.14258 l -1.713865,0.001 V 200 H 54 v -2.40722 c 0,0.63703 -0.66699,0.63671 -0.66699,0.63671 0,0 -0.66602,3.2e-4 -0.66602,-0.63671 0,-0.63707 -0.66699,-0.6377 -0.66699,-0.6377 z" />
+       d="m 52,196.95508 c 0,0 -0.66699,5e-4 -0.66699,0.63769 0,0.63704 -0.66602,0.63672 -0.66602,0.63672 0,0 -0.66699,0.001 -0.66699,-0.63672 V 200 h 4 v -2.40722 c 0,0.63703 -0.66699,0.63671 -0.66699,0.63671 0,0 -0.66602,3.2e-4 -0.66602,-0.63671 0,-0.63707 -0.66699,-0.6377 -0.66699,-0.6377 z"
+       sodipodi:nodetypes="csccccccsc" />
     <path
        style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient7078);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
        id="path7076"

--- a/elementary-xfce/mimes/24/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/24/application-x-partial-download.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="24.000027"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 24 24.000027"
-   width="24">
+   width="24"
+   sodipodi:docname="application-x-partial-download.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416635"
+     inkscape:cx="10.152504"
+     inkscape:cy="12.633445"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="140"
+     inkscape:window-y="465"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -156,9 +178,14 @@
        style="display:inline;opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        id="path10852"
-       transform="translate(40,186)"
-       d="M 11 11 L 11 12 L 10 12 L 10 14 L 9.8574219 14 L 9 14 L 7 14 L 12 20.458984 L 17 14 L 15.857422 14 L 15 14 L 14.144531 14.001953 L 14.144531 14 L 14 14 L 14 12 L 13 12 L 13 11 L 11 11 z M 11 13 L 13 13 L 13 14 L 11 14 L 11 13 z "
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+       d="m 51,196 v 1 h -1 v 2 h 4 v -2 h -1 v -1 z m 0,2 h 2 v 1 h -2 z"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cccccccccccccc" />
+    <path
+       id="path873-5-5"
+       style="font-variation-settings:normal;display:inline;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:new;stop-color:#000000"
+       d="m 47.75,199 c -0.41568,0 -0.75,0.34591 -0.75,0.77684 0,0.23226 0.09725,0.43936 0.251953,0.58166 l 4.224609,4.42875 c 0.13438,0.13152 0.314281,0.21275 0.513672,0.21275 0.199392,0 0.379292,-0.0813 0.513672,-0.21275 l 4.244141,-4.42875 C 56.902757,200.2162 57,200.0091 57,199.77684 57,199.34591 56.665682,199 56.25,199 Z"
+       sodipodi:nodetypes="csccsccscc" />
     <path
        d="m 43.5,207.99999 v 1.99998 c -0.64533,0.004 -1.56008,-0.44811 -1.56008,-1.00013 0,-0.55203 0.72013,-0.99985 1.56008,-0.99985 z"
        id="path7076"
@@ -170,10 +197,12 @@
   </g>
   <path
      id="rect851"
-     d="M 11 5 L 11 7 L 13 7 L 13 5 L 11 5 z M 13 7 L 13 8 L 14 8 L 14 7 L 13 7 z M 13 8 L 11 8 L 11 9 L 13 9 L 13 8 z M 11 8 L 11 7 L 10 7 L 10 8 L 11 8 z "
-     style="opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none" />
+     d="m 11,5 v 1 h 2 V 5 Z m 2,1 v 1 h 1 V 6 Z m 0,1 h -2 v 1 h 2 z M 11,7 V 6 h -1 v 1 z"
+     style="opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none"
+     sodipodi:nodetypes="cccccccccccccccccccc" />
   <path
      id="rect859"
-     d="M 10 8 L 10 9 L 11 9 L 11 8 L 10 8 z M 11 9 L 11 10 L 10 10 L 10 12 L 11 12 L 11 11 L 13 11 L 14 11 L 14 8 L 13 8 L 13 9 L 11 9 z "
-     style="opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none" />
+     d="m 10,7 v 1 h 1 V 7 Z m 1,1 v 1 h -1 v 2 h 1 v -1 h 2 1 V 7 h -1 v 1 z"
+     style="opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none"
+     sodipodi:nodetypes="ccccccccccccccccc" />
 </svg>

--- a/elementary-xfce/mimes/24/application-x-perl.svg
+++ b/elementary-xfce/mimes/24/application-x-perl.svg
@@ -1,1 +1,232 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg3828"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview37"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="20.093618"
+     inkscape:cx="10.650148"
+     inkscape:cy="13.735705"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="601"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.4736748"
+       x2="23.99999"
+       y2="41.526306"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="16.999998"
+     height="2"
+     x="3.5000007"
+     y="22"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z"
+     id="path4160-3"
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none" />
+  <path
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+     id="path4160-3-1"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 5.9494344,5.3778907 c -0.4717518,0.00543 -0.7910829,0.1038964 -0.7910829,0.1038964 0,0 0.8755876,2.8748989 2.5175554,2.5902368 l 0.1582168,-0.593818 c -0.015449,1.3766113 0.4551661,3.0653921 0.6120029,3.5884451 -0.5245405,1.374904 -1.2546768,3.592534 -1.032754,4.808333 0.1734108,0.950028 0.5249327,1.678933 1.1692369,2.188535 h -0.085629 c 0,1.136654 0.9718477,1.366325 3.5029325,1.366325 2.659639,0 3.502932,-0.05395 3.502932,-1.366325 h -0.08563 c 0.644305,-0.509602 0.995826,-1.238507 1.169239,-2.188535 0.221921,-1.215799 -0.508216,-3.433429 -1.032756,-4.808333 0.156836,-0.523053 0.627448,-2.2118338 0.612003,-3.5884451 l 0.158216,0.5938181 c 1.641968,0.2846621 2.517556,-2.5902368 2.517556,-2.5902368 0,0 -1.608245,-0.4928596 -2.9357,0.6735333 C 15.653632,5.6969769 15.044879,5.3778907 14.627004,5.3778907 H 9.3728224 c -0.4178768,0 -1.0266307,0.3190862 -1.2787717,0.7774298 C 7.3582537,5.5087978 6.5361156,5.3711151 5.9494344,5.3778907 Z"
+     sodipodi:nodetypes="sccccscccccsccccccccs" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path1039"
+     d="m 9.1026955,9.6715067 c 0,0 -2.1200595,4.2220933 -1.7880642,5.9920053 0.2308919,1.230889 0.9726178,1.849016 2.1236653,2.309754 0.6822784,0.273093 2.6860894,-0.436945 2.6860894,-0.436945 l -0.256143,-3.058535 h 0.256122 v 0 c 0,0 -1.289394,-0.573479 -1.640128,-2.785462 0,0 0.242818,2.102752 0.593542,2.157361"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path1041"
+     d="M 8.5231891,6.3188323 C 7.2012035,5.1172624 5.3795674,5.6088167 5.3795674,5.6088167 c 0,0 0.863334,2.7581475 2.4820854,2.4850654"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csc"
+     inkscape:connector-curvature="0"
+     id="path1043"
+     d="m 8.5749625,17.536321 c -0.431667,1.747745 0.8161461,1.766455 3.5494025,1.766455 2.733256,0 3.981069,-0.01874 3.549402,-1.766455"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path1045"
+     d="m 9.708,7.0562757 c 0.824154,-0.3875228 1.700037,0.087568 1.670464,0.1361696 0,0 -0.284583,1.0581816 -0.957239,0.9551293 C 9.791134,8.0510006 9.708531,7.3271499 9.708,7.0562757 Z"
+     style="display:inline;fill:#3689e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 15.331428,10.982307 v 0 c 0,0 1.117325,-3.35499 0.431666,-4.8062792 C 15.539275,5.7022783 14.899761,5.30215 14.468094,5.30215 13.592855,5.30215 13.419366,5.3 12.124365,5.3 c -1.295001,0 -1.538852,0.00215 -2.4140914,0.00215 -0.4316671,0 -1.071181,0.4001283 -1.2950012,0.8738778 -0.6856578,1.4512892 0.255756,4.8062792 0.255756,4.8062792 v 0"
+     id="path1049"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsscsscc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.6;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 14.899761,9.6715067 c 0,0 2.33431,4.1573263 2.002316,5.9272273 -0.230892,1.230899 -0.940596,1.913794 -2.091644,2.374532 -0.682278,0.273093 -2.686047,-0.436945 -2.686047,-0.436945 l 0.256155,-3.058535 h -0.256176 v 0 c 0,0 1.255757,-0.573479 1.606481,-2.785462 0,0 -0.242808,2.102752 -0.593543,2.157361"
+     id="path1051"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.6;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 15.655178,6.3188215 c 1.321975,-1.2015699 2.967711,-0.7100264 2.967711,-0.7100264 0,0 -0.863334,2.7581583 -2.482085,2.4850654"
+     id="path1053"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:#3689e6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 14.641739,7.0562757 c -0.824154,-0.3875228 -1.700037,0.087568 -1.670463,0.1361696 0,0 0.284583,1.0581816 0.957238,0.9551293 0.630091,-0.096574 0.712694,-0.8204247 0.713225,-1.0912989 z"
+     id="path1055"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsc" />
+</svg>

--- a/elementary-xfce/mimes/24/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/24/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/24/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/24/application-x-sharedlib.svg
@@ -1,1 +1,257 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       gradientTransform="matrix(0.25228092,0,0,0.25228092,-12.430461,-0.19515718)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(0.2342229,0,0,0.2342229,2.1608186,2.3373157)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(0.23420463,0,0,0.23420463,8.7407904,11.631299)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
+  <path
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-3-1"
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+  <rect
+     transform="matrix(0.86377605,-0.50387591,0.86377605,0.50387591,0,0)"
+     ry="2.115571"
+     rx="2.115571"
+     y="18.235664"
+     x="-12.525877"
+     height="8.1827059"
+     width="8.1827059"
+     id="rect48-5-5"
+     style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.07181;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-7-5"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.07181;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;-inkscape-stroke:none;marker:none;paint-order:normal;stop-color:#000000;stop-opacity:1"
+     d="M -4.9615867 18.854031 C -5.3439745 18.471643 -5.873739 18.235767 -6.4597534 18.235771 L -10.045598 18.235447 L -10.045275 21.821292 C -10.045275 22.993353 -9.1009093 23.937719 -7.9288482 23.937719 L -4.3430033 23.938043 L -4.3433264 20.352198 C -4.3433226 19.766183 -4.5791989 19.236419 -4.9615867 18.854031 z "
+     transform="matrix(0.86377889,-0.50387104,0.86377889,0.50387104,0,0)" />
+  <rect
+     transform="matrix(0.86377889,-0.50387104,0.86377889,0.50387104,0,0)"
+     ry="2.1156359"
+     rx="2.1156359"
+     y="14.762626"
+     x="-9.0529919"
+     height="8.1828108"
+     width="8.1828108"
+     id="rect48-5-1-7"
+     style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.07184;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-8-2-1"
+     style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.07181459;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M -1.4884758 15.38092 C -1.8708766 14.998519 -2.400612 14.76266 -2.9866425 14.76266 L -6.5724875 14.762337 L -6.5721644 18.348181 C -6.5721644 19.520243 -5.6277985 20.464609 -4.4557374 20.464609 L -0.86989242 20.464932 L -0.87021551 16.879087 C -0.87021551 16.293056 -1.106075 15.763321 -1.4884758 15.38092 z "
+     transform="matrix(0.86377889,-0.50387104,0.86377889,0.50387104,0,0)" />
+  <rect
+     transform="matrix(0.86377889,-0.50387104,0.86377889,0.50387104,0,0)"
+     ry="2.1156359"
+     rx="2.1156359"
+     y="11.289515"
+     x="-5.5798807"
+     height="8.1828108"
+     width="8.1828108"
+     id="rect48-5-1-8-2"
+     style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.07184;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+</svg>

--- a/elementary-xfce/mimes/24/application-x-shellscript.svg
+++ b/elementary-xfce/mimes/24/application-x-shellscript.svg
@@ -24,12 +24,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="10.046809"
-     inkscape:cx="10.351545"
-     inkscape:cy="29.263023"
+     inkscape:cx="10.152477"
+     inkscape:cy="29.163489"
      inkscape:window-width="1317"
      inkscape:window-height="893"
      inkscape:window-x="567"
-     inkscape:window-y="301"
+     inkscape:window-y="135"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3828" />
   <defs
@@ -203,8 +203,8 @@
      height="12"
      x="5"
      y="6"
-     rx="1.3125"
-     ry="1.2857143" />
+     rx="2"
+     ry="2" />
   <path
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.3117px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3018-5);fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      d="m 8.4992491,8.252 v 0.5136416 c -0.408771,0.039054 -0.803172,0.1410708 -1.120672,0.4046878 -0.455696,0.352194 -0.490463,1.0558446 -0.155649,1.4942296 0.323735,0.392793 0.806474,0.569663 1.276321,0.747115 v 1.058413 c -0.523885,-0.04279 -1.018194,-0.174334 -1.49423,-0.389123 v 0.8872 c 0.476476,0.202182 0.976267,0.285602 1.49423,0.295733 v 0.684855 h 0.498077 v -0.70042 c 0.3170549,-0.02849 0.6531599,-0.08376 0.9338949,-0.233474 0.389993,-0.191469 0.655503,-0.603445 0.638159,-1.027283 0.0016,-0.204921 -0.06506,-0.406122 -0.186778,-0.575901 C 10.057009,10.9772 9.488558,10.800348 8.9973261,10.602299 V 9.5905814 c 0.3894809,0.03168 0.7904619,0.121335 1.1518019,0.264603 l 0.326864,-0.79381 C 10.014583,8.8637055 9.500368,8.7707469 8.9973261,8.7500767 V 8.252 Z m 0,1.3541464 V 10.41552 c -0.198305,-0.08722 -0.429271,-0.202272 -0.420251,-0.4513816 -0.0093,-0.235146 0.2195,-0.33538 0.420251,-0.357992 z m 0.498078,1.9923066 C 9.194,11.694433 9.490971,11.784152 9.495404,12.03427 c 0.0113,0.255227 -0.275429,0.375017 -0.4980769,0.404687 z M 12,14.000376 v 1 h 4 v -1 z"

--- a/elementary-xfce/mimes/24/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/24/application-x-vdi-disk.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg3828"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview37"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="9.9534091"
+     inkscape:cy="29.163489"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="744"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3828" />
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.4736748"
+       x2="23.99999"
+       y2="41.526306"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="16.999998"
+     height="2"
+     x="3.5000007"
+     y="22"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z"
+     id="path4160-3"
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none" />
+  <path
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z"
+     id="path4160-3-1"
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="12"
+     height="12"
+     x="6"
+     y="6"
+     rx="1.0588235"
+     ry="1.0588235" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 6,10.5 h 1.5 l 2,5 2,-6.5 1.75,4.25 L 15,9 16.5,14.5 H 18"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/24/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/24/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/24/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/24/text-x-bibtex.svg
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3828"
+   height="24"
+   width="24"
+   version="1.1">
+  <defs
+     id="defs3830">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-7" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977"
+       id="linearGradient3013"
+       y2="41.526306"
+       x2="23.99999"
+       y1="6.4736748"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-4"
+       id="linearGradient3016"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3021"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3024"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3027"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+  </defs>
+  <metadata
+     id="metadata3833">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="22"
+     x="3.5000007"
+     height="2"
+     width="16.999998" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
+  <path
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
+     id="path4160-3"
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
+  <path
+     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-3-1"
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
+  <g
+     id="g4137">
+    <path
+       id="path3475"
+       d="m 14,4.5 1.683594,0 z m 1.835938,0 L 18,4.5 Z M 14,6.4921875 l 1.501953,0.015625 z m 1.638672,0.015625 2.361328,0 z M 14,8.5 l 1.380859,0 z m 1.546875,0 0.578125,0 z m 0.728516,0 0.318359,0 z m 0.486328,0 L 18,8.5 Z M 12,10.484375 l 2.152344,0 z m 2.304688,0 1.199218,0 z m 1.351562,0 1.123047,0 z m 1.275391,0 1.068359,0 z M 6,10.5 l 1.8828125,0 z m 2.0488281,0 0.8496094,0 z m 1.0019531,0 1.3359378,0 z m 1.4882808,0 1.261719,0 z M 6,12.5 l 1.9121094,0 z m 2.0644531,0 2.0488279,0 z m 2.2011719,0 0.789063,0 z m 0.941406,0 1.927735,0 z m 2.078125,0 2.429688,0 z m 2.595703,0 L 18,12.5 Z M 6,14.5 l 1.7753906,0 z m 1.9726562,0 0.8496094,0 z m 1.0019532,0 0.4257812,0 z m 0.5917968,0 0.7753908,0 z m 0.9414058,0 0.789063,0 z m 0.941407,0 1.259765,0 z m 1.425781,0 1.640625,0 z m 1.791016,0 1.09375,0 z m 1.246093,0 L 18,14.5 Z M 6,16.492188 l 1.5019531,0 z m 1.6542969,0 2.3457031,0 z M 6,18.5 l 1.8828125,0 z m 2.0488281,0 0.5917969,0 z m 0.7441407,0 L 10,18.5 Z M 6,20.5 l 1.8828125,0 z m 2.0488281,0 0.8496094,0 z m 1.0019531,0 L 10,20.5 Z"
+       style="fill:none;stroke:#7e8087;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 11.135115,20.372332 c 0.930979,-0.432877 1.904948,-0.887695 1.904948,-1.86166 0,-0.303013 -0.129864,-0.303013 -0.6926,-0.346301 -0.627667,-0.04327 -0.887691,-0.454517 -0.887691,-1.017254 C 11.459773,16.367945 11.957578,16 12.5636,16 c 0.909036,0 1.580293,0.800818 1.580293,1.904649 0,0.844403 -0.411233,1.709851 -1.147118,2.337821 C 12.49897,20.6537 12.087738,20.805206 11.394841,21 l -0.259726,-0.627668 z m 3.85288,0 c 0.93068,-0.432877 1.904647,-0.887695 1.904647,-1.86166 0,-0.303013 -0.129861,-0.303013 -0.692597,-0.346301 -0.62767,-0.04327 -0.887393,-0.454517 -0.887393,-1.017254 C 15.312652,16.367945 15.810458,16 16.41648,16 c 0.909038,0 1.579993,0.800818 1.579993,1.904649 0,0.844403 -0.41123,1.709851 -1.147117,2.337821 C 16.35155,20.6537 15.94032,20.805206 15.24772,21 l -0.259725,-0.627668 z"
+       id="path3253" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="M 9.0089563,4.6277055 C 8.0779212,5.0606045 7.103895,5.515152 7.103895,6.489176 c 0,0.3030315 0.12987,0.3030315 0.69264,0.3463215 C 8.42424,6.8787845 8.6842825,7.2900425 8.6842825,7.852815 8.6842825,8.6320325 8.1864475,9 7.5803862,9 6.6712962,9 6,8.1988325 6,7.0949375 6,6.2507815 6.4112537,5.38498 7.147185,4.7572745 7.6450225,4.3463215 8.0565775,4.194806 8.7492175,4 l 0.2597388,0.6277055 z m 3.8531167,0 c -0.930737,0.432899 -1.904764,0.8874465 -1.904764,1.8614705 0,0.3030315 0.12987,0.3030315 0.692641,0.3463215 0.627708,0.043287 0.887446,0.454545 0.887446,1.0173175 C 12.537396,8.6320325 12.039561,9 11.433501,9 10.524409,9 9.8534138,8.1988325 9.8534138,7.0949375 c 0,-0.844156 0.4112542,-1.7099575 1.1471852,-2.337663 C 11.498436,4.3463215 11.909691,4.194806 12.602331,4 l 0.259742,0.6277055 z"
+       id="path3255" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/24/text-x-install.svg
+++ b/elementary-xfce/mimes/24/text-x-install.svg
@@ -1,85 +1,61 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3828"
    height="24"
    width="24"
-   version="1.1">
-  <defs
-     id="defs3830">
-    <linearGradient
-       id="linearGradient4417">
-      <stop
+   version="1.1"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs3830"><linearGradient
+       id="linearGradient4417"><stop
          id="stop4419"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
+         offset="0" /><stop
          id="stop4421"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.01246384" />
-      <stop
+         offset="0.01246384" /><stop
          id="stop4423"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98888642" />
-      <stop
+         offset="0.98888642" /><stop
          id="stop4425"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4409">
-      <stop
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient4409"><stop
          id="stop4411"
          offset="0"
-         style="stop-color:#000000;stop-opacity:0.239" />
-      <stop
+         style="stop-color:#000000;stop-opacity:0.239" /><stop
          id="stop4413"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0.318" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
+         style="stop-color:#000000;stop-opacity:0.318" /></linearGradient><linearGradient
+       id="linearGradient3600-4"><stop
          offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
-      <stop
+         id="stop3602-7" /><stop
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
+         id="stop3604-6" /></linearGradient><linearGradient
+       id="linearGradient5060"><stop
          offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
+         id="stop5062" /><stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
+         id="stop5064" /></linearGradient><linearGradient
+       id="linearGradient5048"><stop
          offset="0"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
+         id="stop5050" /><stop
          offset="0.5"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
+         id="stop5056" /><stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
+         id="stop5052" /></linearGradient><linearGradient
        gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4417"
@@ -87,8 +63,7 @@
        y2="41.507179"
        x2="23.99999"
        y1="6.5833335"
-       x1="23.99999" />
-    <linearGradient
+       x1="23.99999" /><linearGradient
        gradientTransform="matrix(0.45714178,0,0,0.43456667,1.0285964,0.90372283)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3600-4"
@@ -96,8 +71,7 @@
        y2="47.013336"
        x2="25.132275"
        y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
+       x1="25.132275" /><radialGradient
        gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5060"
@@ -106,8 +80,7 @@
        fx="605.71429"
        r="117.14286"
        cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
+       cx="605.71429" /><radialGradient
        gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5060"
@@ -116,8 +89,7 @@
        fx="605.71429"
        r="117.14286"
        cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
+       cx="605.71429" /><linearGradient
        gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient5048"
@@ -125,57 +97,38 @@
        y2="609.50507"
        x2="302.85715"
        y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
+       x1="302.85715" /><linearGradient
        gradientUnits="userSpaceOnUse"
        y2="22.542051"
        x2="16.570093"
        y1="1.6074718"
        x1="16.570093"
        id="linearGradient4415"
-       xlink:href="#linearGradient4409" />
-  </defs>
-  <metadata
-     id="metadata3833">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <rect
+       xlink:href="#linearGradient4409" /></defs><metadata
+     id="metadata3833"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
      style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="rect2879"
      y="22"
      x="3.5000007"
      height="2"
-     width="16.999998" />
-  <path
+     width="16.999998" /><path
      style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2881"
-     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
-  <path
+     d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" /><path
      style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
      id="path2883"
-     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
-  <path
+     d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" /><path
      style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none"
      id="path4160-3"
-     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" />
-  <path
+     d="m 4,2 c 3.6664118,0 15.99998,0.0013 15.99998,0.0013 L 20,22 C 20,22 9.3333337,22 4,22 4,15.33334 4,8.6666817 4,2.0000212 Z" /><path
      style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
      id="rect6741-1"
-     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
-  <path
+     d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" /><path
      style="opacity:1;fill:none;stroke:url(#linearGradient4415);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
      id="path4160-3-1"
-     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e8087;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.12315285;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path3288-2-2-3"
-     d="M 17,12 11.999999,18 7,12 h 3 V 7 h 4 v 5 z" />
-</svg>
+     d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" /><path
+     id="path873-5-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 17,13.773933 C 17,13.342715 16.665354,12.99556 16.249672,12.99556 H 14 V 7.778372 C 14,7.347153 13.657882,7 13.242201,7 H 10.75819 C 10.342508,7 9.99959,7.347153 10,7.778372 V 12.99556 H 7.750326 C 7.334646,12.99556 7,13.342715 7,13.773933 c 0,0.232409 0.09736,0.439875 0.252062,0.582259 l 4.223784,4.430971 C 11.610226,18.918773 11.79084,19 11.990232,19 c 0.199392,0 0.380005,-0.08123 0.514385,-0.212837 l 4.24332,-4.430971 C 16.902647,14.213808 17,14.006342 17,13.773933 Z" /></svg>

--- a/elementary-xfce/mimes/32/application-ovf.svg
+++ b/elementary-xfce/mimes/32/application-ovf.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   sodipodi:docname="application-x-qemu-disk.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="30.140427"
+     inkscape:cx="16.638782"
+     inkscape:cy="15.892277"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="708"
+     inkscape:window-y="46"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3182"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="16"
+     height="16"
+     x="8"
+     y="7"
+     rx="1.4117647"
+     ry="1.4117647" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="16"
+     cy="15"
+     r="6" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="16"
+     cy="15"
+     r="2" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="16"
+     cy="15"
+     r="1.75" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="16"
+     cy="15"
+     r="1.5" />
+</svg>

--- a/elementary-xfce/mimes/32/application-sql.svg
+++ b/elementary-xfce/mimes/32/application-sql.svg
@@ -1,1 +1,224 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.3125"
+     inkscape:cx="16"
+     inkscape:cy="16"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="571"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3182" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 10,12.5 v 8.25 c 0,1.313954 2.531218,2.233333 5.9998,2.233333 C 19.468384,22.983333 22,21.885213 22,20.75 V 12.5 c 0,0 -2.06406,2 -6.0002,2 C 12.063661,14.5 10,12.5 10,12.5 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 9.5,11.5 v 3.25 c 0,1.438196 2.804658,2.506728 6.4998,2.5 C 19.675295,17.2433 22.5,16.188196 22.5,14.75 V 11.5"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="m 22.5,11.5 c 0.0011,-1.822559 -2.428717,-3 -6.5002,-3 -4.071481,0 -6.5008785,1.177441 -6.4998,3 -0.00109,1.822559 2.428319,2.5 6.4998,2.5 4.071483,0 6.501279,-0.677441 6.5002,-2.5 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 9.5,14 v 3.5 c 0,1.438196 2.804658,2.756727 6.4998,2.75 C 19.675295,20.2433 22.5,18.938196 22.5,17.5 V 14"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 9.5,16.5 v 4 c 0,1.438195 2.804658,2.506726 6.4998,2.5 C 19.675295,22.9933 22.5,21.938195 22.5,20.5 v -4"
+     sodipodi:nodetypes="cscsc" />
+</svg>

--- a/elementary-xfce/mimes/32/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/32/application-vnd.flatpak.ref.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3182"
    height="32"
    width="32"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="application-vnd.flatpak.ref.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.3125"
+     inkscape:cx="15.97654"
+     inkscape:cy="15.97654"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3182" />
   <defs
      id="defs3184">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -177,6 +198,6 @@
      style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   <path
      id="path925"
-     d="M 15.966797,7 9,11 v 7.994141 L 16,23 23,19.001953 V 11 Z M 16,8.1720982 v 6.7946988 l -5.997679,-3.393516 z m 6,4.5698778 v 5.678448 l -6,3.419631 V 16.13875 Z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26771665;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 16.033203,7 23,11 v 7.994141 L 16,23 9,19.001953 V 11 Z M 16,8.1720982 v 6.7946988 l 5.997679,-3.393516 z m -6,4.5698778 v 5.678448 l 6,3.419631 V 16.13875 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/32/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/32/application-vnd.flatpak.svg
@@ -4,12 +4,34 @@
    width="32"
    height="32"
    id="svg6860"
+   sodipodi:docname="application-vnd.flatpak.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview73"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.3125"
+     inkscape:cx="15.97654"
+     inkscape:cy="15.97654"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6860" />
   <defs
      id="defs6862">
     <linearGradient
@@ -99,19 +121,6 @@
        y1="19.239614"
        x2="-5.8870335"
        y2="43.792946" />
-    <linearGradient
-       id="linearGradient106305">
-      <stop
-         offset="0"
-         stop-color="#dac197"
-         id="stop106301"
-         style="stop-color:#e7c591;stop-opacity:1" />
-      <stop
-         offset="1"
-         stop-color="#b19974"
-         id="stop106303"
-         style="stop-color:#cfa25e;stop-opacity:1" />
-    </linearGradient>
     <linearGradient
        xlink:href="#linearGradient855"
        id="linearGradient1703"
@@ -205,15 +214,6 @@
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient855"
-       id="linearGradient1703-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.72,0,0,1.8485205,90.789217,-31.080714)"
-       x1="-5.8870335"
-       y1="11.482978"
-       x2="-5.8870335"
-       y2="22.148865" />
-    <linearGradient
        id="linearGradient855">
       <stop
          id="stop851"
@@ -223,91 +223,6 @@
          id="stop853"
          offset="1"
          style="stop-color:#d4d4d4;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient855"
-       id="linearGradient121756-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.72,0,0,1.8485205,90.789217,-31.080714)"
-       x1="-5.8870335"
-       y1="19.72085"
-       x2="-5.8870335"
-       y2="43.375748" />
-    <linearGradient
-       xlink:href="#d"
-       id="linearGradient121758-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.70964,0,0,1.56625,26.904267,-16.521443)"
-       x1="23.452"
-       y1="30.555"
-       x2="43.007"
-       y2="45.933998" />
-    <linearGradient
-       xlink:href="#linearGradient3924-2-2-5-8-6"
-       id="linearGradient121760-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.1891893,32.738397,-1.6469854)"
-       x1="23.99999"
-       y1="5.9204559"
-       x2="23.99999"
-       y2="42.079544" />
-    <linearGradient
-       id="linearGradient3924-2-2-5-8-6">
-      <stop
-         id="stop3926-9-4-9-6-2"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928-9-8-6-5-9"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.09302325" />
-      <stop
-         id="stop3930-3-5-1-7-1"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.9069767" />
-      <stop
-         id="stop3932-8-0-4-8-2"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient121303"
-       id="linearGradient121764-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.2162165,32.738397,-1.826894)"
-       x1="25.086039"
-       y1="-1.3623691"
-       x2="25.086039"
-       y2="18.299334" />
-    <linearGradient
-       xlink:href="#c"
-       id="linearGradient121762"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5,0,0,1.35714,31.153777,-18.973443)"
-       x1="24.537001"
-       y1="21.915001"
-       x2="24.537001"
-       y2="7.9130001" />
-    <linearGradient
-       id="c">
-      <stop
-         offset="0"
-         stop-color="#fff"
-         id="stop36" />
-      <stop
-         offset="0.28147671"
-         stop-color="#fff"
-         id="stop38" />
-      <stop
-         offset="0.33052009"
-         stop-color="#fff"
-         stop-opacity=".643"
-         id="stop40" />
-      <stop
-         offset="1"
-         stop-color="#fff"
-         stop-opacity=".391"
-         id="stop42" />
     </linearGradient>
   </defs>
   <metadata
@@ -397,6 +312,6 @@
      d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
   <path
      id="path925"
-     d="M 15.966797,11 9,15 v 7.994141 L 16,27 23,23.001953 V 15 Z M 16,12.172098 v 6.794699 l -5.997679,-3.393516 z m 6,4.569878 v 5.678448 l -6,3.419631 V 20.13875 Z"
+     d="M 16.033203,11 23,15 v 7.994141 L 16,27 9,23.001953 V 15 Z M 16,12.172098 v 6.794699 l 5.997679,-3.393516 z m -6,4.569878 v 5.678448 l 6,3.419631 V 20.13875 Z"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/32/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/32/application-x-bittorrent.svg
@@ -1,17 +1,40 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="32"
    viewBox="0 0 32 32.001812"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="32.001812">
+   height="32.001812"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     units="mm"
+     inkscape:zoom="15.06936"
+     inkscape:cx="4.744727"
+     inkscape:cy="21.102422"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="81"
+     inkscape:window-y="326"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -177,15 +200,18 @@
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path26667"
-       d="m 89,195 7,9.00001 7,-9.00001 -4,8.6e-4 V 192 c 0,1 -1,1 -1,1 0,0 -1,0 -1,-1 0,-1 -1,-1 -1,-1 0,0 -1,0 -1,1 0,1 -1,1 -1,1 0,0 -1,0 -1,-1.00085 V 195 Z" />
+       d="M 99,194.99862 V 192 c 0,1 -1,1 -1,1 0,0 -1,0 -1,-1 0,-1 -1,-1 -1,-1 0,0 -1,0 -1,1 0,1 -1,1 -1,1 0,0 -1,0 -1,-1.00085 v 2.99861 z"
+       sodipodi:nodetypes="cccscscccc" />
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10362"
-       d="m 96,183 c 0,0 -1,0 -1,1 0,1 -1,1 -1,1 0,0 -1,8.5e-4 -1,-1 v 14 h 6 v -14 c 0,1 -1,1 -1,1 0,0 -1,0 -1,-1 0,-1 -1,-1 -1,-1 z" />
+       d="m 96,184.00019 c 0,0 -1,0 -1,1 0,1 -1,1 -1,1 0,0 -1,8.5e-4 -1,-1 v 13.99819 h 6 v -13.99819 c 0,1 -1,1 -1,1 0,0 -1,0 -1,-1 0,-1 -1,-1 -1,-1 z"
+       sodipodi:nodetypes="csccccccsc" />
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10323"
-       d="m 94,187 c 0,0 -1,-8.5e-4 -1,1 v 6 h 6 v -6 c 0,-1 -1,-1 -1,-1 0,0 -1,0 -1,1 0,1 -1,1 -1,1 0,0 -1,0 -1,-1 0,-1 -1,-1 -1,-1 z" />
+       d="m 94,188.00019 c 0,0 -1,-8.5e-4 -1,1 v 5.99819 h 6 v -5.99819 c 0,-1 -1,-1 -1,-1 0,0 -1,0 -1,1 0,1 -1,1 -1,1 0,0 -1,0 -1,-1 0,-1 -1,-1 -1,-1 z"
+       sodipodi:nodetypes="csccscscsc" />
     <path
        style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient7070);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
        id="path7068"
@@ -194,5 +220,10 @@
        style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient7074);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
        id="path7072"
        d="M 107,207.00002 V 209 c 0.64533,0.004 1.56008,-0.44811 1.56008,-1.00013 0,-0.55203 -0.72013,-0.99985 -1.56008,-0.99985 z" />
+    <path
+       id="path873-5-3-3-7-4"
+       style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 90.132828,193.99819 c -0.492469,0 -0.798828,0.3962 -0.798828,0.88867 0,0.26542 0.115536,0.50341 0.298828,0.66602 l 5.757813,6.20312 c 0.159206,0.15031 0.373148,0.24219 0.609375,0.24219 0.236221,0 0.450174,-0.0919 0.609375,-0.24219 l 5.759769,-6.20312 c 0.18329,-0.16261 0.29883,-0.4006 0.29883,-0.66602 0,-0.49247 -0.19021,-0.76923 -0.66797,-0.88867 z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/32/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/32/application-x-partial-download.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="32.001812"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 32 32.001812"
-   width="32">
+   width="32"
+   sodipodi:docname="application-x-partial-download.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.311293"
+     inkscape:cx="9.361234"
+     inkscape:cy="14.358584"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="286"
+     inkscape:window-y="466"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11300" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -176,9 +198,13 @@
        style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
     <path
        id="path26667"
-       transform="translate(80,177.99819)"
-       d="M 15 13.001953 L 15 15.001953 L 17 15.001953 L 17 13.001953 L 15 13.001953 z M 17 15.001953 L 17 17.001953 L 15 17.001953 L 15 15.001953 L 13 15.001953 L 13 17.001953 L 9 17.001953 L 16 26.001953 L 23 17.001953 L 19 17.001953 L 19 15.001953 L 17 15.001953 z "
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+       d="m 95,190.00019 v 2 h 2 v -2 z m 2,2 v 2 h -2 v -2 h -2 v 2 h 6 v -2 z"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cccccccccccccc" />
+    <path
+       id="path873-5-3-3-7-4"
+       style="font-variation-settings:normal;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 90.131838,193.99819 c -0.492469,0 -0.798828,0.3962 -0.798828,0.88867 0,0.26542 0.115536,0.50341 0.298829,0.66602 l 5.757812,6.20312 c 0.159206,0.15031 0.373148,0.24219 0.609375,0.24219 0.236221,0 0.450174,-0.0919 0.609375,-0.24219 l 5.759769,-6.20312 c 0.18328,-0.16261 0.29882,-0.4006 0.29882,-0.66602 0,-0.49247 -0.1902,-0.76923 -0.66797,-0.88867 z" />
     <path
        d="m 85,207 v 1.99998 c -0.64533,0.004 -1.56008,-0.44811 -1.56008,-1.00013 C 83.43992,207.44782 84.16005,207 85,207 Z"
        id="path7068"
@@ -190,10 +216,10 @@
   </g>
   <path
      id="rect859"
-     d="M 13 9.0019531 L 13 11.001953 L 15 11.001953 L 15 9.0019531 L 13 9.0019531 z M 15 11.001953 L 15 13.001953 L 17 13.001953 L 19 13.001953 L 19 11.001953 L 19 9.0019531 L 17 9.0019531 L 17 11.001953 L 15 11.001953 z M 15 13.001953 L 13 13.001953 L 13 15.001953 L 15 15.001953 L 15 13.001953 z "
+     d="m 13,8.002 v 2 h 2 v -2 z m 2,2 v 2 h 2 2 v -2 -2 h -2 v 2 z m 0,2 h -2 v 2 h 2 z"
      style="opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none" />
   <path
      id="rect869"
-     d="M 15 5.0019531 L 15 7.0019531 L 17 7.0019531 L 17 5.0019531 L 15 5.0019531 z M 17 7.0019531 L 17 9.0019531 L 19 9.0019531 L 19 7.0019531 L 17 7.0019531 z M 17 9.0019531 L 15 9.0019531 L 15 11.001953 L 17 11.001953 L 17 9.0019531 z M 15 9.0019531 L 15 7.0019531 L 13 7.0019531 L 13 9.0019531 L 15 9.0019531 z "
+     d="m 15,4.002 v 2 h 2 v -2 z m 2,2 v 2 h 2 v -2 z m 0,2 h -2 v 2 h 2 z m -2,0 v -2 h -2 v 2 z"
      style="opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none" />
 </svg>

--- a/elementary-xfce/mimes/32/application-x-perl.svg
+++ b/elementary-xfce/mimes/32/application-x-perl.svg
@@ -1,1 +1,252 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.65625"
+     inkscape:cx="7.3196482"
+     inkscape:cy="9.0087978"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="491"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3182" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="M 8.7039392,6.6570674 C 8.13507,6.6635774 7.7499999,6.7817803 7.7499999,6.7817803 c 0,0 1.0558404,3.4509047 3.0358321,3.1092085 L 10.97662,9.1781952 c -0.01863,1.6524248 0.548869,3.6795648 0.737993,4.3074148 -0.632525,1.650375 -1.512971,4.312324 -1.245362,5.771715 0.20911,1.140374 0.632998,2.01532 1.409942,2.627024 h -0.103257 c -0.527998,2.186844 1.056076,2.733497 4.224064,1.640077 3.167988,1.09342 4.75206,0.546767 4.224063,-1.640077 h -0.103257 c 0.776946,-0.611704 1.200833,-1.48665 1.409944,-2.627024 0.267608,-1.459391 -0.612837,-4.12134 -1.245363,-5.771715 0.189123,-0.62785 0.756618,-2.65499 0.737993,-4.3074148 l 0.190787,0.7127936 C 23.19416,10.232685 24.25,6.7817803 24.25,6.7817803 c 0,0 -1.939327,-0.5916074 -3.540057,0.8084803 -0.30405,-0.5501758 -1.038125,-0.9331932 -1.542026,-0.9331932 -1.070563,0 -1.583923,0.4660591 -3.167917,0.4660591 -1.583995,0 -2.097355,-0.4660591 -3.167917,-0.4660591 -0.503903,0 -1.237978,0.3830174 -1.542026,0.9331932 C 10.402785,6.8142027 9.4113975,6.6489342 8.7039392,6.6570674 Z"
+     sodipodi:nodetypes="sccccscccccscccccssscs" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 12.191813,11.942965 c 0,0 -2.3087067,5.144511 -1.890291,7.423456 0.290989,1.584908 0.983661,2.672701 2.434318,3.265944 C 13.595714,22.98401 16,22.069765 16,22.069765 v -3.938201 0 0 c 0,0 -2.176107,-0.738412 -2.618129,-3.586575 0,0 0.233887,2.434014 0.675908,2.504338"
+     id="path925"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="M 11.239766,7.4421641 C 9.5736833,5.8950142 7.4995808,6.5279394 7.4995808,6.5279394 c 0,0 1.0880542,3.5514116 3.1281552,3.1997874"
+     id="path927"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="M 11.647786,22.069765 C 11.103759,24.320166 12.73584,24.882766 16,23.757564 c 3.264161,1.125202 4.896242,0.562602 4.352215,-1.687799"
+     id="path932"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 12.851937,9.307608 c 1.030931,-0.495307 2.126559,0.1119268 2.089571,0.1740368 0,0 -0.35599,1.5267102 -1.1974,1.3950022 -0.788189,-0.123376 -0.89151,-1.2228342 -0.892171,-1.569039 z"
+     id="path938-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsc" />
+  <path
+     sodipodi:nodetypes="ccsscsscc"
+     inkscape:connector-curvature="0"
+     id="path947"
+     d="m 20.352215,13.630764 v 0 c 0,0 1.408158,-4.319908 0.544027,-6.1885999 C 20.614162,6.8321654 19.808188,6.4 19.264161,6.4 18.161099,6.4 17.632081,6.8795643 16,6.8795643 14.36792,6.8795643 13.838901,6.4 12.73584,6.4 c -0.544027,0 -1.350001,0.4321654 -1.632081,1.0421641 -0.864131,1.8686919 0.544027,6.1885999 0.544027,6.1885999 v 0"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path949"
+     d="m 19.808188,11.942965 c 0,0 2.308707,5.144511 1.890291,7.423456 -0.290989,1.584908 -0.983661,2.672701 -2.434318,3.265944 C 18.404286,22.98401 16,22.069765 16,22.069765 v -3.938201 0 0 c 0,0 2.176107,-0.738412 2.618129,-3.586575 0,0 -0.25793,2.48374 -0.699951,2.554065"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path951"
+     d="m 20.760235,7.4421641 c 1.666082,-1.5471499 3.740184,-0.9142247 3.740184,-0.9142247 0,0 -1.088054,3.5514116 -3.128154,3.1997874"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path955"
+     d="m 19.148064,9.307608 c -1.030931,-0.495307 -2.12656,0.1119268 -2.089571,0.1740368 0,0 0.35599,1.5267102 1.1974,1.3950022 0.788189,-0.123376 0.891511,-1.2228342 0.892171,-1.569039 z"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:0.8;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+</svg>

--- a/elementary-xfce/mimes/32/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/32/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/32/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/32/application-x-sharedlib.svg
@@ -1,1 +1,280 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       gradientTransform="matrix(0.33336487,0,0,0.33336487,-15.988694,-0.69484278)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(0.30950401,0,0,0.30950401,2.7825386,3.1613306)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(0.30947986,0,0,0.30947986,10.96741,15.952429)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <g
+     id="g4472">
+    <rect
+       transform="matrix(0.87157445,-0.49026318,0.87157445,0.49026318,0,0)"
+       ry="2.7955227"
+       rx="2.7955227"
+       y="23.659708"
+       x="-16.114777"
+       height="10.812655"
+       width="10.812655"
+       id="rect48-5-5"
+       style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.08172;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+    <path
+       id="rect48-5-1-7-1"
+       style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.08172149;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+       d="M -6.1191078 24.476693 C -6.6243981 23.971402 -7.323599 23.661121 -8.0979579 23.66112 L -13.056593 23.658367 L -13.054961 28.615882 C -13.054961 30.164653 -11.807068 31.412546 -10.258297 31.412546 L -5.3007825 31.414178 L -5.3035355 26.455543 C -5.3035357 25.681184 -5.6138175 24.981983 -6.1191078 24.476693 z "
+       transform="matrix(0.87157434,-0.49026336,0.87157434,0.49026336,0,0)" />
+    <rect
+       transform="matrix(0.87157434,-0.49026336,0.87157434,0.49026336,0,0)"
+       ry="2.7956178"
+       rx="2.7956178"
+       y="19.580233"
+       x="-12.03548"
+       height="10.812831"
+       width="10.812831"
+       id="rect48-5-1-7"
+       style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+    <path
+       id="rect48-5-1-8-2-7"
+       style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.08172149;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+       d="M -2.0396677 20.397253 C -2.5449751 19.891945 -3.2452529 19.58056 -4.0196383 19.58056 L -8.9771531 19.578927 L -8.9755206 24.536442 C -8.9755206 26.085213 -7.727628 27.333105 -6.1788572 27.333105 L -1.2213424 27.334738 L -1.222975 22.377223 C -1.222975 21.602838 -1.5343603 20.90256 -2.0396677 20.397253 z "
+       transform="matrix(0.87157434,-0.49026336,0.87157434,0.49026336,0,0)" />
+    <rect
+       transform="matrix(0.87157434,-0.49026336,0.87157434,0.49026336,0,0)"
+       ry="2.7956178"
+       rx="2.7956178"
+       y="15.500793"
+       x="-7.956039"
+       height="10.812831"
+       width="10.812831"
+       id="rect48-5-1-8-2"
+       style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/32/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/32/application-x-vdi-disk.svg
@@ -1,0 +1,213 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="21.3125"
+     inkscape:cx="13.677419"
+     inkscape:cy="16"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="471"
+     inkscape:window-y="506"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3182" />
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="16"
+     height="16"
+     x="8"
+     y="7"
+     rx="1.4117647"
+     ry="1.4117647" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 8,12.5 h 2.5 l 2.25,6.25 2.75,-7.74989 1.875,5.24989 2,-5.24989 L 21.5,17.5 H 24"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/32/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/32/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/32/text-markdown.svg
+++ b/elementary-xfce/mimes/32/text-markdown.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="32"
    height="32"
-   id="svg3182">
+   id="svg3182"
+   sodipodi:docname="text-markdown.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="60.280853"
+     inkscape:cx="16.995446"
+     inkscape:cy="15.875688"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="86"
+     inkscape:window-y="295"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3182" />
   <defs
      id="defs3184">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -177,6 +198,12 @@
      d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
   <path
      id="rect4959"
-     d="M 9.0000001,10 C 8.4546501,10 8,10.4546 8,11 v 8 c 0,0.5453 0.4546501,1 1.0000001,1 H 23 c 0.54536,0 1,-0.4547 1,-1 v -8 c 0,-0.5454 -0.45464,-1 -1,-1 z m 0,1 H 23 v 8 H 9.0000001 Z M 10,12 v 6 h 1 v -4.1875 l 2,2.5625 2,-2.5625 V 18 h 1 V 12 H 15 L 13,14.5625 11,12 Z m 9,0 v 3 h -1.5 l 2,3 2,-3 H 20 v -3 z"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4a525a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 9.0000001,10 C 8.4546501,10 8,10.4546 8,11 v 8 c 0,0.5453 0.4546501,1 1.0000001,1 H 23 c 0.54536,0 1,-0.4547 1,-1 v -8 c 0,-0.5454 -0.45464,-1 -1,-1 z m 0,1 H 23 v 8 H 9.0000001 Z M 10,12 v 6 h 1 v -4.1875 l 2,2.5625 2,-2.5625 V 18 h 1 V 12 H 15 L 13,14.5625 11,12 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4a525a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:16;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="ssssssssscccccccccccccccccc" />
+  <path
+     id="path873-5-3-3-7-4"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:3.99999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 22,15.333334 C 22,15.148667 21.92911,15.044787 21.749965,15 h -1.749971 v -2.666658 c 0,-0.184668 -0.115325,-0.333334 -0.299988,-0.333334 h -0.400013 c -0.184667,0 -0.297679,0.148681 -0.299987,0.333334 V 15 h -1.69997 C 17.115369,15 17,15.148667 17,15.333334 c 0,0.09952 0.04325,0.188374 0.111975,0.249349 l 2.159502,2.326085 c 0.0597,0.05636 0.139937,0.09115 0.228518,0.09115 0.08857,0 0.168816,-0.03479 0.228514,-0.09115 l 2.159506,-2.326085 c 0.06873,-0.06097 0.111975,-0.149821 0.111975,-0.249349 z"
+     sodipodi:nodetypes="cccsssccssccscccc" />
 </svg>

--- a/elementary-xfce/mimes/32/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/32/text-x-bibtex.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg3182">
+  <defs
+     id="defs3184">
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         id="stop3979"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99999994" />
+      <stop
+         id="stop3985"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-4">
+      <stop
+         id="stop3602-7"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-6"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3148"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+  </defs>
+  <metadata
+     id="metadata3187">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="22.100021"
+     height="2"
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
+     id="path2881"
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
+     id="path2883"
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
+     id="path4160-3"
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
+  <g
+     id="g4141">
+    <path
+       id="path3475"
+       d="m 16,5.5 2.59375,0 z m 2.802734,0 2.527344,0 z m 2.736328,0 L 24,5.5 Z M 16,7.4902344 l 1.277344,0 z m 1.486328,0 1.316406,0 z m 1.523438,0 2.070312,0.019531 z m 2.257812,0.019531 2.732422,0 z M 16,9.5 l 2.738281,0 z m 2.927734,0 1.984375,0 z m 2.214844,0 0.792969,0 z m 1.001953,0 0.439453,0 z M 22.8125,9.5 24,9.5 Z M 8,12.5 l 1.0664062,0 z m 1.4003906,0 3.9492184,0 z m 4.1992184,0 3.146485,0 z m 3.355469,0 3.384766,0 z m 3.59375,0 1.650391,0 z m 1.859375,0 1.546875,0 z M 8,14.5 l 2.632812,0 z m 2.841797,0 2.820312,0 z m 3.029297,0 1.085937,0 z m 1.294922,0 2.654296,0 z m 2.863281,0 3.341797,0 z m 3.572265,0 L 24,14.5 Z M 8,16.5 l 2.863281,0 z m 3.091797,0 3.091797,0 z m 3.300781,0 1.234375,0 z m 1.44336,0 2.902343,0 z m 3.091796,0 1.984375,0 z m 2.214844,0 0.792969,0 z m 1.001953,0 0.439453,0 z m 0.667969,0 1.1875,0 z M 8,18.5 l 2.445312,0 z m 2.716797,0 1.169922,0 z m 1.378906,0 0.583985,0 z m 0.814453,0 1.064453,0 z m 1.294922,0 1.085938,0 z m 1.294922,0 1.734375,0 z m 1.964844,0 2.255859,0 z m 2.464844,0 1.503906,0 z m 1.71289,0 L 24,18.5 Z M 8,21.490234 l 2.068359,0 z m 2.277344,0 3.384765,0 z m 3.59375,0 2.128906,0 z M 8,23.5 l 2.589844,0 z m 2.820312,0 0.814454,0 z m 1.023438,0 1.859375,0 z m 2.068359,0 L 16,23.5 Z M 8,25.5 l 2.589844,0 z m 2.820312,0 1.169922,0 z m 1.378907,0 1.839843,0 z m 2.048828,0 L 16,25.5 Z"
+       style="fill:none;stroke:#7e8087;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 17.140476,25.372333 c 0.930979,-0.432878 1.904947,-0.887695 1.904947,-1.861661 0,-0.303013 -0.129863,-0.303013 -0.692599,-0.346301 -0.627667,-0.04328 -0.887691,-0.454517 -0.887691,-1.017253 0,-0.779173 0.497805,-1.147118 1.103828,-1.147118 0.909036,0 1.580292,0.800817 1.580292,1.904649 0,0.844403 -0.411232,1.709851 -1.147117,2.337821 C 18.504331,25.6537 18.093099,25.805206 17.400202,26 l -0.259726,-0.627667 z m 3.85288,0 c 0.93068,-0.432878 1.904648,-0.887695 1.904648,-1.861661 0,-0.303013 -0.129862,-0.303013 -0.692598,-0.346301 -0.62767,-0.04328 -0.887393,-0.454517 -0.887393,-1.017253 0,-0.779173 0.497805,-1.147118 1.103828,-1.147118 0.909037,0 1.579992,0.800817 1.579992,1.904649 0,0.844403 -0.41123,1.709851 -1.147116,2.337821 C 22.356911,25.6537 21.945681,25.805206 21.253081,26 l -0.259725,-0.627667 z"
+       id="path3253" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="M 11.008956,5.6277055 C 10.077921,6.0606045 9.103895,6.515152 9.103895,7.489176 c 0,0.3030315 0.12987,0.3030315 0.69264,0.346322 0.627705,0.04329 0.887747,0.4545445 0.887747,1.017317 C 10.684282,9.632033 10.186448,10 9.580386,10 8.671296,10 8,9.198833 8,8.094938 8,7.2507815 8.411254,6.38498 9.147185,5.7572745 9.645022,5.3463215 10.056577,5.194806 10.749218,5 l 0.259738,0.6277055 z m 3.853116,0 c -0.930736,0.432899 -1.904763,0.8874465 -1.904763,1.8614705 0,0.3030315 0.12987,0.3030315 0.692641,0.346322 0.627707,0.04329 0.887446,0.4545445 0.887446,1.017317 C 14.537396,9.632033 14.039561,10 13.433501,10 12.524409,10 11.853414,9.198833 11.853414,8.094938 c 0,-0.8441565 0.411254,-1.709958 1.147185,-2.3376635 C 13.498436,5.3463215 13.909691,5.194806 14.602331,5 l 0.259741,0.6277055 z"
+       id="path3255" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/32/text-x-install.svg
+++ b/elementary-xfce/mimes/32/text-x-install.svg
@@ -1,140 +1,140 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg3182"
-   height="32"
+   version="1.1"
    width="32"
-   version="1.1">
+   height="32"
+   id="svg3182"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3184">
     <linearGradient
        id="linearGradient3977">
       <stop
-         offset="0"
+         id="stop3979"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979" />
+         offset="0" />
       <stop
-         offset="0"
+         id="stop3981"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981" />
+         offset="0" />
       <stop
-         offset="0.99999994"
+         id="stop3983"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983" />
+         offset="0.99999994" />
       <stop
-         offset="1"
+         id="stop3985"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient3600-4">
       <stop
-         offset="0"
+         id="stop3602-7"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop3604-6"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5060">
       <stop
-         offset="0"
+         id="stop5062"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop5064"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
+         offset="1" />
     </linearGradient>
     <linearGradient
        id="linearGradient5048">
       <stop
-         offset="0"
+         id="stop5050"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977"
-       id="linearGradient3013"
-       y2="41.814808"
-       x2="23.99999"
-       y1="6.1851754"
-       x1="23.99999" />
-    <linearGradient
-       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3016"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
-       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3021"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
-       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3024"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3027"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
-       id="linearGradient3104-6">
-      <stop
-         id="stop3106-3"
-         style="stop-color:#000000;stop-opacity:0.31782946"
          offset="0" />
       <stop
-         id="stop3108-9"
-         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="23.99999"
+       y1="6.1851754"
+       x2="23.99999"
+       y2="41.814808"
+       id="linearGradient3013"
+       xlink:href="#linearGradient3977"
        gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3016"
+       xlink:href="#linearGradient3600-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3021"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3024"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)" />
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3027"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
        id="linearGradient3148"
-       xlink:href="#linearGradient3104-6" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
   </defs>
   <metadata
      id="metadata3187">
@@ -144,39 +144,38 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <rect
-     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="29"
-     x="4.9499893"
+     width="22.100021"
      height="2"
-     width="22.100021" />
+     x="4.9499893"
+     y="29"
+     id="rect2879"
+     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
   <path
-     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
      id="path2881"
-     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z" />
+     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
   <path
-     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
      id="path2883"
-     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z" />
+     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
   <path
-     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline"
+     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z"
      id="path4160-3"
-     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z" />
+     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline" />
   <path
-     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     d="m 26.5,28.5 -21,0 0,-27 21,0 z"
      id="rect6741-1"
-     d="m 26.5,28.5 -21,0 0,-27 21,0 z" />
+     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
   <path
-     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z"
+     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
      id="path4160-6-1"
-     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e8087;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path3288-2-2-3"
-     d="M 22,15 15.999999,22 10,15 h 4 V 9 h 4 v 6 z" />
+     id="path873-5-3-3-7-4"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 22.666772,16.888903 C 22.666772,16.396451 22.477749,16.119433 22,16 H 18 V 8.8887973 C 18,8.3963451 17.692475,7.9998945 17.200022,7.9998945 h -2.400044 c -0.492453,0 -0.793824,0.396489 -0.799978,0.8889028 V 16 h -3.866665 c -0.4924529,0 -0.8001071,0.396451 -0.8001071,0.888903 0,0.265412 0.1153332,0.502339 0.2986192,0.664941 l 5.7587669,6.202991 c 0.1592,0.150298 0.373168,0.243059 0.609387,0.243059 0.236213,0 0.450186,-0.09276 0.609381,-0.243059 l 5.758773,-6.202991 c 0.183283,-0.162602 0.298617,-0.399529 0.298617,-0.664941 z" />
 </svg>

--- a/elementary-xfce/mimes/48/application-ovf.svg
+++ b/elementary-xfce/mimes/48/application-ovf.svg
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   sodipodi:docname="application-x-qemu-disk.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="29.331378"
+     inkscape:cy="24.316715"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="689"
+     inkscape:window-y="102"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901"
+     inkscape:snap-bbox="true"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3029">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3031" />
+      <stop
+         offset="0.01487851"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3033" />
+      <stop
+         offset="0.98463625"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3035" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3029"
+       id="linearGradient3106"
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3109"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3112"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3115"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3118"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="42.429947"
+     x="7.7378473"
+     height="3.5700529"
+     width="32.508301" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none"
+     id="path4160"
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 H 7 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="24"
+     height="24.000002"
+     x="12"
+     y="10"
+     rx="3"
+     ry="3" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="24"
+     cy="22"
+     r="8" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="24"
+     cy="22"
+     r="3" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="24"
+     cy="22"
+     r="2" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="24"
+     cy="22"
+     r="1.5" />
+</svg>

--- a/elementary-xfce/mimes/48/application-sql.svg
+++ b/elementary-xfce/mimes/48/application-sql.svg
@@ -1,1 +1,224 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="34.438795"
+     inkscape:cy="28.566284"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="239"
+     inkscape:window-y="166"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     id="path4160"
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 13,20 v 12 c 0,2.016344 5.6812,3.5 10.999694,3.5 C 29.318187,35.5 35,33.742053 35,32 V 20 c 0,0 -4.964892,3.626316 -11.000306,3.626316 C 17.96428,23.626316 13,20 13,20 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 12.500001,18.368421 v 5.063158 c 0,2.207002 5.833807,4.078745 11.499693,4.068421 5.635757,-0.01027 11.500305,-1.861419 11.500305,-4.068421 v -5.063158"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="M 35.499999,18.563158 C 35.501699,15.766328 30.242633,13.5 23.999694,13.5 c -6.242939,0 -11.501347,2.266328 -11.499693,5.063158 -0.0017,2.79683 5.256754,4.936842 11.499693,4.936842 6.242939,0 11.501959,-2.140012 11.500305,-4.936842 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 12.500001,21.873684 v 5.51754 c 0,2.207002 5.833807,4.1191 11.499693,4.108776 5.635757,-0.01027 11.500305,-1.901774 11.500305,-4.108776 v -5.51754"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 12.500001,25.768421 v 5.452631 c 0,2.207001 5.833807,4.289268 11.499693,4.278948 5.635757,-0.01028 11.500305,-2.071947 11.500305,-4.278948 v -5.452631"
+     sodipodi:nodetypes="cscsc" />
+</svg>

--- a/elementary-xfce/mimes/48/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/48/application-vnd.flatpak.ref.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg3901">
+   id="svg3901"
+   sodipodi:docname="application-vnd.flatpak.ref.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208333"
+     inkscape:cx="23.964809"
+     inkscape:cy="23.964809"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -177,6 +198,6 @@
      d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
   <path
      id="path7680"
-     d="M 23.953125,11 14.039062,16.757812 14,28.242188 24,34 34,28.251953 33.957031,16.757812 Z m 0,1.13308 v 8.093482 L 24.972289,20.840454 24,21.400967 16,16.75 Z M 33,17.362553 v 10.309322 l -9,5.177734 V 22.540287 Z"
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26771641;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 24.046875,11 33.960938,16.757812 34,28.242188 24,34 14,28.251953 14.042969,16.757812 Z m 0,1.13308 v 8.093482 L 23.027711,20.840454 24,21.400967 32,16.75 Z M 15,17.362553 v 10.309322 l 9,5.177734 V 22.540287 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/48/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/48/application-vnd.flatpak.svg
@@ -4,12 +4,34 @@
    width="48"
    height="48"
    id="svg6649"
+   sodipodi:docname="application-vnd.flatpak.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview68"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="14.208333"
+     inkscape:cx="23.964809"
+     inkscape:cy="23.964809"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6649" />
   <defs
      id="defs6651">
     <linearGradient
@@ -99,19 +121,6 @@
        y1="19.341915"
        x2="-5.8870335"
        y2="43.375748" />
-    <linearGradient
-       id="linearGradient106305">
-      <stop
-         offset="0"
-         stop-color="#dac197"
-         id="stop106301"
-         style="stop-color:#e7c591;stop-opacity:1" />
-      <stop
-         offset="1"
-         stop-color="#b19974"
-         id="stop106303"
-         style="stop-color:#cfa25e;stop-opacity:1" />
-    </linearGradient>
     <linearGradient
        xlink:href="#linearGradient855"
        id="linearGradient1703"
@@ -205,15 +214,6 @@
          id="stop42-3" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient855"
-       id="linearGradient1703-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.72,0,0,1.8485205,102.47434,-21.474271)"
-       x1="-5.8870335"
-       y1="11.482978"
-       x2="-5.8870335"
-       y2="22.148865" />
-    <linearGradient
        id="linearGradient855">
       <stop
          id="stop851"
@@ -223,72 +223,6 @@
          id="stop853"
          offset="1"
          style="stop-color:#d4d4d4;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient855"
-       id="linearGradient121756-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.72,0,0,1.8485205,102.47434,-21.474271)"
-       x1="-5.8870335"
-       y1="19.72085"
-       x2="-5.8870335"
-       y2="43.375748" />
-    <linearGradient
-       xlink:href="#d"
-       id="linearGradient121758-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.70964,0,0,1.56625,38.589389,-6.915)"
-       x1="23.452"
-       y1="30.555"
-       x2="43.007"
-       y2="45.933998" />
-    <linearGradient
-       xlink:href="#linearGradient3924-2-2-5-8"
-       id="linearGradient121760-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.1891893,44.423519,7.9594574)"
-       x1="23.99999"
-       y1="5.9204559"
-       x2="23.99999"
-       y2="42.079544" />
-    <linearGradient
-       xlink:href="#linearGradient121303"
-       id="linearGradient121764-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.2162165,44.423519,7.7795488)"
-       x1="25.086039"
-       y1="-1.3623691"
-       x2="25.086039"
-       y2="18.299334" />
-    <linearGradient
-       xlink:href="#c"
-       id="linearGradient121762"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5,0,0,1.35714,42.838899,-9.367)"
-       x1="24.537001"
-       y1="21.915001"
-       x2="24.537001"
-       y2="7.9130001" />
-    <linearGradient
-       id="c">
-      <stop
-         offset="0"
-         stop-color="#fff"
-         id="stop36" />
-      <stop
-         offset="0.28147671"
-         stop-color="#fff"
-         id="stop38" />
-      <stop
-         offset="0.33052009"
-         stop-color="#fff"
-         stop-opacity=".643"
-         id="stop40" />
-      <stop
-         offset="1"
-         stop-color="#fff"
-         stop-opacity=".391"
-         id="stop42" />
     </linearGradient>
   </defs>
   <metadata
@@ -380,6 +314,6 @@
      id="path87" />
   <path
      id="path7680"
-     d="M 23.953125,17 14.039062,22.757812 14,34.242188 24,40 34,34.251953 33.957031,22.757812 Z m 0,1.13308 v 8.093482 L 24.972289,26.840454 24,27.400967 16,22.75 Z M 33,23.362553 v 10.309322 l -9,5.177734 V 28.540287 Z"
+     d="M 24.046875,17 33.960938,22.757812 34,34.242188 24,40 14,34.251953 14.042969,22.757812 Z m 0,1.13308 v 8.093482 L 23.027711,26.840454 24,27.400967 32,22.75 Z M 15,23.362553 v 10.309322 l 9,5.177734 V 28.540287 Z"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/48/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/48/application-x-bittorrent.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="48"
    viewBox="0 0 48 48"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="48">
+   height="48"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041667"
+     inkscape:cx="0.21114369"
+     inkscape:cy="13.372434"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="15"
+     inkscape:window-y="312"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -185,14 +207,22 @@
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10693"
-       d="m 152,171.91113 c 0,0 -1.33331,0 -1.33331,1.27413 0,1.27407 -1.33337,1.27407 -1.33337,1.27407 0,0 -1.33332,8.9e-4 -1.33332,-1.27407 v 17.83719 h 8 v -17.83719 c 0,1.27407 -1.33331,1.27407 -1.33331,1.27407 0,0 -1.33338,0 -1.33338,-1.27407 0,-1.27413 -1.33331,-1.27413 -1.33331,-1.27413 z" />
+       d="m 152,171.91113 c 0,0 -1.33331,0 -1.33331,1.27413 0,1.27407 -1.33337,1.27407 -1.33337,1.27407 0,0 -1.33332,8.9e-4 -1.33332,-1.27407 V 191 h 8 v -17.81474 c 0,1.27407 -1.33331,1.27407 -1.33331,1.27407 0,0 -1.33338,0 -1.33338,-1.27407 0,-1.27413 -1.33331,-1.27413 -1.33331,-1.27413 z"
+       sodipodi:nodetypes="csccccccsc" />
     <path
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10707"
-       d="m 149.33334,177.67415 c 0,0 -1.33334,-0.001 -1.33334,1.27408 v 8.72592 h 8 v -8.72592 c 0,-1.27408 -1.33333,-1.27408 -1.33333,-1.27408 0,0 -1.33334,0 -1.33334,1.27408 0,1.27409 -1.33333,1.27409 -1.33333,1.27409 0,0 -1.33333,0 -1.33333,-1.27409 0,-1.27408 -1.33333,-1.27408 -1.33333,-1.27408 z" />
+       d="m 149.33334,177.67415 c 0,0 -1.33334,-0.001 -1.33334,1.27408 V 188 h 8 v -9.05177 c 0,-1.27408 -1.33333,-1.27408 -1.33333,-1.27408 0,0 -1.33334,0 -1.33334,1.27408 0,1.27409 -1.33333,1.27409 -1.33333,1.27409 0,0 -1.33333,0 -1.33333,-1.27409 0,-1.27408 -1.33333,-1.27408 -1.33333,-1.27408 z"
+       sodipodi:nodetypes="csccscscsc" />
     <path
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10725"
-       d="m 152,182.91016 c 0,0 -1.33398,0.001 -1.33398,1.27539 0,1.27407 -1.33204,1.27343 -1.33204,1.27343 0,0 -1.33398,0.002 -1.33398,-1.27343 V 189 H 147.71484 142 L 152,201.91992 162,189 h -2.28516 l -3.42773,0.002 V 189 H 156 v -4.81445 c 0,1.27407 -1.33398,1.27343 -1.33398,1.27343 0,0 -1.33204,6.4e-4 -1.33204,-1.27343 0,-1.27413 -1.33398,-1.27539 -1.33398,-1.27539 z" />
+       d="m 152,182.91016 c 0,0 -1.33398,0.001 -1.33398,1.27539 0,1.27407 -1.33204,1.27343 -1.33204,1.27343 0,0 -1.33398,0.002 -1.33398,-1.27343 V 189 h 8 v -4.81445 c 0,1.27407 -1.33398,1.27343 -1.33398,1.27343 0,0 -1.33204,6.4e-4 -1.33204,-1.27343 0,-1.27413 -1.33398,-1.27539 -1.33398,-1.27539 z"
+       sodipodi:nodetypes="csccccccsc" />
+    <path
+       id="path873-5"
+       style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 144.91795,187 c -0.6928,0 -1.25195,0.57773 -1.25195,1.29586 0,0.38705 0.16215,0.73283 0.41992,0.96995 l 7.04101,7.379 c 0.22397,0.21918 0.52511,0.35519 0.85743,0.35519 0.33233,0 0.63345,-0.13601 0.85742,-0.35519 l 7.07226,-7.379 c 0.25785,-0.23712 0.41992,-0.5829 0.41992,-0.96995 0,-0.71813 -0.55913,-1.29586 -1.25195,-1.29586 z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/48/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/48/application-x-partial-download.svg
@@ -5,7 +5,7 @@
    width="48"
    version="1.1"
    sodipodi:docname="application-x-partial-download.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,28 +23,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="22.056921"
-     inkscape:cx="24.00607"
-     inkscape:cy="19.812375"
+     inkscape:zoom="22.056922"
+     inkscape:cx="26.884984"
+     inkscape:cy="13.759853"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="890"
-     inkscape:window-y="50"
+     inkscape:window-x="687"
+     inkscape:window-y="256"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
-    <linearGradient
-       id="linearGradient855">
-      <stop
-         id="stop851"
-         offset="0"
-         style="stop-color:#a56de2;stop-opacity:1" />
-      <stop
-         id="stop853"
-         offset="1"
-         style="stop-color:#7239b3;stop-opacity:1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient3403">
       <stop
@@ -168,14 +157,6 @@
        gradientUnits="userSpaceOnUse"
        id="linearGradient3170"
        xlink:href="#linearGradient3104-6" />
-    <linearGradient
-       gradientUnits="userSpaceOnUse"
-       y2="54.350002"
-       x2="36.868137"
-       y1="6.2374997"
-       x1="36.868137"
-       id="linearGradient857"
-       xlink:href="#linearGradient855" />
   </defs>
   <metadata
      id="metadata3906">
@@ -217,17 +198,27 @@
      style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   <path
      id="path10725"
-     d="m 23,19.999996 v 3 h 2 v -3 z m 2,3 v 3 h -2 v -3 h -3 v 3 H 14 L 24,39 34,25.999996 h -6 v -3 z"
+     d="m 23,17.999996 v 3 h 2 v -3 z m 2,3 v 3 h -2 v -3 h -3 v 3 h 8 v -3 z"
      style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccccccccccccc" />
+     sodipodi:nodetypes="cccccccccccccc" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="m 16.917969,24 c -0.692801,0 -1.251953,0.578179 -1.251953,1.296874 0,0.387348 0.162155,0.733398 0.419922,0.970704 l 7.041015,7.384765 c 0.223968,0.219349 0.525106,0.355469 0.857422,0.355469 0.332332,0 0.633454,-0.136124 0.857422,-0.355469 l 7.072265,-7.384765 c 0.257849,-0.237306 0.419922,-0.583356 0.419922,-0.970704 0,-0.718695 -0.559137,-1.296875 -1.251953,-1.296874 z"
+     sodipodi:nodetypes="csccsccscc" />
   <path
      id="rect867"
-     d="m 22.999997,8 v 3 h 2 V 8 Z m 2,3 v 3 h 3 v -3 z m 0,3 h -2 v 3 h 2 z m -2,0 v -3 h -3 v 3 z"
+     d="m 24.999997,12 h -2 v 3 h 2 z"
      style="display:inline;opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none;enable-background:new"
-     sodipodi:nodetypes="cccccccccccccccccccc" />
+     sodipodi:nodetypes="ccccc" />
   <path
      id="rect875"
-     d="m 19.999997,14 v 3 h 3 v -3 z m 3,3 v 3 h 2 3 v -3 -3 h -3 v 3 z m 0,3 h -3 v 3 h 3 z"
+     d="m 19.999997,12 v 3 h 3 v -3 z m 3,3 v 3 h 2 3 v -3 -3 h -3 v 3 z m 0,3 h -3 v 3 h 3 z"
      style="display:inline;opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:2;stroke-opacity:1;marker:none;enable-background:new"
      sodipodi:nodetypes="ccccccccccccccccccc" />
+  <path
+     id="path1144"
+     d="m 26,9 h -4 v 3 h 4 z"
+     style="display:inline;opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1.99999;stroke-opacity:1;marker:none;enable-background:new"
+     sodipodi:nodetypes="ccccc" />
 </svg>

--- a/elementary-xfce/mimes/48/application-x-perl.svg
+++ b/elementary-xfce/mimes/48/application-x-perl.svg
@@ -1,1 +1,273 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041668"
+     inkscape:cx="21.536657"
+     inkscape:cy="30.967741"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="458"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       id="SVGID_1_"
+       gradientUnits="userSpaceOnUse"
+       x1="500.00351"
+       y1="579.10577"
+       x2="-0.09653803"
+       y2="1079.2058"
+       gradientTransform="matrix(0.9998,0,0,0.9998,0.09651873,-578.99)">
+      <stop
+         offset="3.435144e-03"
+         style="stop-color:#E44857"
+         id="stop4" />
+      <stop
+         offset="0.4689"
+         style="stop-color:#C711E1"
+         id="stop6" />
+      <stop
+         offset="1"
+         style="stop-color:#7F52FF"
+         id="stop8" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     id="path4160"
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 12.660781,10.499417 c -0.884103,0.0099 -1.482556,0.188985 -1.482556,0.188985 0,0 1.640924,5.229389 4.718113,4.711597 l 0.296511,-1.080148 c -0.02895,2.504032 0.85302,5.575895 1.146945,6.52732 -0.983034,2.500922 -2.35137,6.534756 -1.935469,8.746268 0.324987,1.728086 0.983768,3.053952 2.191251,3.980908 h -0.160475 c -0.820583,3.313871 1.64129,4.142253 6.564792,2.485318 4.923502,1.656935 7.385375,0.828553 6.564791,-2.485318 H 30.40421 c 1.207483,-0.926956 1.866263,-2.252822 2.191251,-3.980908 0.4159,-2.211512 -0.952435,-6.245346 -1.935469,-8.746268 0.293924,-0.951425 1.175892,-4.023288 1.146944,-6.52732 l 0.296512,1.080148 c 3.077188,0.517792 4.718113,-4.711597 4.718113,-4.711597 0,0 -3.013989,-0.896503 -5.50175,1.225146 -0.472535,-0.833719 -1.613392,-1.414131 -2.396528,-1.414131 -1.663805,0 -2.461639,0.706251 -4.92339,0.706251 -2.461752,0 -3.259585,-0.706251 -4.92339,-0.706251 -0.783137,0 -1.923994,0.580412 -2.396528,1.414131 -1.378947,-1.176013 -2.919703,-1.426457 -4.019194,-1.414131 z"
+     sodipodi:nodetypes="sccccscccccscccccssscs" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 18.255845,18.6625 c 0,0 -3.482384,7.575743 -2.851259,10.931687 0.438921,2.333916 1.483726,3.935785 3.671853,4.809388 C 20.373448,34.921402 24,33.575097 24,33.575097 v -5.799343 0 0 c 0,0 -3.282374,-1.087377 -3.949106,-5.281545 0,0 0.352787,3.584297 1.01952,3.687856"
+     id="path925"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 16.819806,12.034679 c -2.513067,-2.278315 -5.641581,-1.346277 -5.641581,-1.346277 0,0 1.641187,5.229766 4.718414,4.711967"
+     id="path927"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="M 17.435251,33.575097 C 16.614658,36.889008 19.076439,37.717485 24,36.06053 c 4.923562,1.656955 7.385342,0.828478 6.564749,-2.485433"
+     id="path932"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 19.251555,14.781708 c 1.555028,-0.729384 3.207639,0.164821 3.151847,0.256285 0,0 -0.536963,2.248213 -1.806122,2.054262 -1.18888,-0.181683 -1.344727,-1.800729 -1.345725,-2.310547 z"
+     id="path938-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsc" />
+  <path
+     sodipodi:nodetypes="ccsscsscc"
+     inkscape:connector-curvature="0"
+     id="path947"
+     d="m 30.564749,21.147933 v 0 c 0,0 2.124024,-6.361443 0.820593,-9.113254 C 30.959863,11.136402 29.744155,10.5 28.923562,10.5 27.259737,10.5 26.461781,11.206201 24,11.206201 21.538219,11.206201 20.740264,10.5 19.076439,10.5 c -0.820594,0 -2.036301,0.636402 -2.461781,1.534679 -1.303431,2.751811 0.820593,9.113254 0.820593,9.113254 v 0"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path949"
+     d="m 29.744155,18.6625 c 0,0 3.482384,7.575743 2.851259,10.931687 -0.43892,2.333916 -1.483725,3.935785 -3.671852,4.809388 C 27.626553,34.921402 24,33.575097 24,33.575097 v -5.799343 0 0 c 0,0 3.282375,-1.087377 3.949107,-5.281545 0,0 -0.389053,3.657523 -1.055786,3.761083"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path951"
+     d="m 31.180194,12.034679 c 2.513068,-2.278315 5.641581,-1.346277 5.641581,-1.346277 0,0 -1.641187,5.229766 -4.718413,4.711967"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path955"
+     d="m 28.748445,14.781708 c -1.555027,-0.729384 -3.207639,0.164821 -3.151846,0.256285 0,0 0.536963,2.248213 1.806122,2.054262 1.18888,-0.181683 1.344727,-1.800729 1.345724,-2.310547 z"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+</svg>

--- a/elementary-xfce/mimes/48/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/48/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/48/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/48/application-x-sharedlib.svg
@@ -1,1 +1,277 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.50456181,0,0,0.50456181,-21.883999,-3.3672416)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(0.4684458,0,0,0.4684458,5.3139576,3.6823098)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(0.46840924,0,0,0.46840924,17.481582,23.262595)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     id="path4160"
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <rect
+     transform="matrix(0.86377602,-0.50387596,0.86377602,0.50387596,0,0)"
+     ry="4.2311416"
+     rx="4.2311416"
+     y="33.4944"
+     x="-22.074833"
+     height="16.36541"
+     width="16.36541"
+     id="rect48-5-5"
+     style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.07181;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-7-0"
+     style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.07181999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M -6.9462187 34.731108 C -7.7109942 33.966332 -8.7693928 33.49571 -9.9414215 33.495718 L -17.842652 33.494263 C -17.926819 33.494264 -18.010231 33.502545 -18.093154 33.507346 C -18.097954 33.59027 -18.106236 33.673678 -18.106236 33.757848 L -18.104782 41.659078 C -18.104782 44.0032 -16.218311 45.889671 -13.874189 45.889671 L -5.9729585 45.891125 C -5.8887891 45.891125 -5.8053813 45.882843 -5.7224565 45.878043 C -5.7176562 45.79512 -5.7093747 45.711708 -5.7093742 45.627541 L -5.7108285 37.726311 C -5.7108209 36.554282 -6.1814431 35.495883 -6.9462187 34.731108 z "
+     transform="matrix(0.86377886,-0.50387109,0.86377886,0.50387109,0,0)" />
+  <rect
+     transform="matrix(0.86377886,-0.50387109,0.86377886,0.50387109,0,0)"
+     ry="4.2312713"
+     rx="4.2312713"
+     y="28.532934"
+     x="-17.113661"
+     height="16.36562"
+     width="16.36562"
+     id="rect48-5-1-7"
+     style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.07184;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-8-2-6"
+     style="vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:1.0718167;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal;font-variation-settings:normal;opacity:0.15;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="M -1.9846322 29.769521 C -2.7494337 29.00472 -3.8077741 28.534131 -4.9798351 28.534131 L -12.152655 28.532354 L -12.150878 35.705174 C -12.150878 38.049296 -10.264407 39.935767 -7.920285 39.935767 L -0.74746474 39.937545 L -0.74924198 32.764724 C -0.74924198 31.592663 -1.2198306 30.534323 -1.9846322 29.769521 z "
+     transform="matrix(0.86377886,-0.50387109,0.86377886,0.50387109,0,0)" />
+  <rect
+     transform="matrix(0.86377886,-0.50387109,0.86377886,0.50387109,0,0)"
+     ry="4.2312713"
+     rx="4.2312713"
+     y="22.579027"
+     x="-11.15976"
+     height="16.36562"
+     width="16.36562"
+     id="rect48-5-1-8-2"
+     style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.07184;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+</svg>

--- a/elementary-xfce/mimes/48/application-x-shellscript.svg
+++ b/elementary-xfce/mimes/48/application-x-shellscript.svg
@@ -24,12 +24,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="14.208333"
-     inkscape:cx="29.10264"
-     inkscape:cy="24.000001"
+     inkscape:cx="29.067449"
+     inkscape:cy="23.929619"
      inkscape:window-width="1317"
      inkscape:window-height="893"
      inkscape:window-x="600"
-     inkscape:window-y="332"
+     inkscape:window-y="135"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3901" />
   <defs
@@ -224,7 +224,7 @@
      x="12"
      y="12"
      rx="2"
-     ry="2.2" />
+     ry="2" />
   <path
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.3117px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;marker:none;enable-background:accumulate"
      id="path3987-0"

--- a/elementary-xfce/mimes/48/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/48/application-x-vdi-disk.svg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.046809"
+     inkscape:cx="37.175983"
+     inkscape:cy="14.631511"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="868"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3029">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3031" />
+      <stop
+         offset="0.01487851"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3033" />
+      <stop
+         offset="0.98463625"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3035" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3037" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3029"
+       id="linearGradient3106"
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600"
+       id="linearGradient3109"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <radialGradient
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3112"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3115"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3118"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="rect2879"
+     y="42.429947"
+     x="7.7378473"
+     height="3.5700529"
+     width="32.508301" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2881"
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z" />
+  <path
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
+     id="path2883"
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none"
+     id="path4160"
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 H 7 Z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
+     id="rect6741-1"
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
+     id="path4160-6-1"
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="24"
+     height="24.000002"
+     x="12"
+     y="10"
+     rx="2"
+     ry="2" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 12,19 h 4 l 3,9 4,-11 3,7 3,-7 3,9 h 4"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/48/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/48/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/48/text-markdown.svg
+++ b/elementary-xfce/mimes/48/text-markdown.svg
@@ -1,15 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3901"
    height="48"
    width="48"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-markdown.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="28.416667"
+     inkscape:cx="24.228739"
+     inkscape:cy="24.316716"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="378"
+     inkscape:window-y="456"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
     <linearGradient
@@ -155,17 +176,21 @@
          offset="1"
          style="stop-color:#505f6f;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="-6.4428625"
+       x2="64"
+       y1="126.85467"
+       x1="64"
+       id="linearGradient4615-2"
+       xlink:href="#linearGradient4613"
+       gradientTransform="matrix(0.38235294,0,0,0.38235294,-0.4705882,-2.2057852)" />
   </defs>
   <metadata
      id="metadata3906">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <rect
@@ -197,6 +222,12 @@
      d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
   <path
      id="rect4550"
-     d="m 13,15 c -1.090703,0 -2,0.909297 -2,2 v 12 c 0,1.090703 0.909297,2 2,2 h 22 c 1.090703,0 2,-0.909297 2,-2 V 17 c 0,-1.090703 -0.909297,-2 -2,-2 z m 0,2 H 35 V 29 H 13 Z m 2,2 v 8 h 2 v -5.154297 l 2.5,2.71875 2.5,-2.71875 V 27 h 2 V 19 H 22 L 19.5,21.78125 17,19 Z m 14,0 v 4 h -2.5 l 3.5,4 3.5,-4 H 31 v -4 z"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 13,15 c -1.090703,0 -2,0.909297 -2,2 v 12 c 0,1.090703 0.909297,2 2,2 h 22 c 1.090703,0 2,-0.909297 2,-2 V 17 c 0,-1.090703 -0.909297,-2 -2,-2 z m 0,2 H 35 V 29 H 13 Z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="sssssssssccccc" />
+  <path
+     id="path574"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient4615-2);fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 16.75,19.000089 c -0.415499,0 -0.75,0.357593 -0.75,0.800781 v 6.398438 c 0,0.44319 0.334501,0.800781 0.75,0.800781 h 0.5 c 0.415495,0 0.750004,-0.357591 0.75,-0.800781 v -3.59375 l 2.107422,2.107422 c 0.09149,0.09558 0.210592,0.155415 0.34375,0.166015 0.01821,0.0021 0.03794,0.0039 0.05664,0.0039 0.01369,-3.99e-4 0.0276,-0.0024 0.04102,-0.0039 0.133158,-0.01069 0.25226,-0.07044 0.34375,-0.166015 l 2.10742,-2.107422 v 3.59375 c -5e-6,0.44319 0.334499,0.800781 0.749996,0.800781 H 24.25 c 0.415498,0 0.75,-0.357591 0.75,-0.800781 V 19.80087 c 0,-0.443188 -0.334502,-0.800781 -0.75,-0.800781 h -0.734375 c -0.195064,-0.0031 -0.391553,0.07495 -0.541016,0.234375 L 20.5,21.617277 18.001953,19.234464 C 17.85249,19.075039 17.656001,18.996989 17.460937,19.000089 Z m 11.81225,0 c -0.311761,0 -0.562808,0.278076 -0.5625,0.623047 v 3.376919 H 26.5625 c -0.31176,0 -0.5625,0.278078 -0.5625,0.623047 0,0.18592 0.07343,0.350936 0.189453,0.464843 l 2.417969,2.742222 c 0.100784,0.105292 0.235223,0.169922 0.384766,0.169922 0.149541,0 0.283982,-0.06463 0.384765,-0.169922 l 2.433594,-2.742222 C 31.92658,23.974039 32,23.809022 32,23.623102 32,23.278133 31.749261,23.000899 31.4375,23.000055 h -1.43725 v -3.376919 c 0,-0.344971 -0.25074,-0.623047 -0.5625,-0.623047 z"
+     sodipodi:nodetypes="ssssscccccccccssssscccccssccssccsccsscsss" />
 </svg>

--- a/elementary-xfce/mimes/48/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/48/text-x-bibtex.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3901"
+   height="48"
+   width="48"
+   version="1.1">
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.110645"
+       x2="23.99999"
+       y1="5.9404659"
+       x1="23.99999"
+       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3112"
+       xlink:href="#linearGradient5060" />
+    <radialGradient
+       r="117.14286"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429"
+       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3115"
+       xlink:href="#linearGradient5060" />
+    <linearGradient
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715"
+       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3118"
+       xlink:href="#linearGradient5048" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="32.508301"
+     height="3.5700529"
+     x="7.7378473"
+     y="42.429947"
+     id="rect2879"
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
+     id="path2881"
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
+     id="path2883"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+  <path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     id="path4160"
+     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
+     id="path4160-6-1"
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
+  <g
+     id="g4141">
+    <path
+       id="path3475"
+       d="m 22,8.5 2.96875,0 z m 3.34375,0 1.875,0 z m 2.21875,0 0.84375,0 z m 1.15625,0 1.9375,0 z M 31,8.5 l 2.1875,0 z m 2.53125,0 L 36,8.5 Z M 22,10.5 l 2.65625,0 z m 2.96875,0 1.625,0 z m 1.96875,0 1.59375,0 z m 1.9375,0 0.875,0 z m 1.1875,0 1.75,0 z m 2.15625,0 L 36,10.5 Z M 22,12.5 l 2.443359,0 z m 2.755859,0 2.46875,0 z m 2.78125,0 5.0625,0 z m 5.375,0 3.09375,0 z M 22,14.5 l 4.3125,0 z m 4.625,0 4.625,0 z m 4.96875,0 4.40625,0 z m -12.251953,3.996047 3.09375,0.0039 z M 11,18.499953 l 1.59375,0 z m 2.09375,0 5.90625,0 z m 9.623047,0 4.824219,0 z m 5.158203,0 5.90625,0 z m 6.40625,0 1.71875,0 z M 11,20.484375 l 3.09375,0 z m 3.40625,0 5.0625,0 z m 5.375,0 2.46875,0 z m 2.78125,0 2.3125,0 z m 2.625,0 1.96875,0 z m 2.28125,0 3.09375,0.03125 z m 3.375,0.03125 5.15625,0 z M 11,22.5 l 2.34375,0 z m 2.6875,0 2.15625,0 z m 2.53125,0 1.9375,0 z m 2.25,0 0.84375,0 z m 1.1875,0 1.875,0 z m 2.25,0 4.90625,0 z m 5.25,0 3.75,0 z m 4.0625,0 1.1875,0 z m 1.5,0 L 36,22.5 Z M 11,24.5 l 3.9375,0 z m 4.25,0 4.21875,0 z m 4.53125,0 1.625,0 z m 1.9375,0 3.96875,0 z m 4.28125,0 5,0 z m 5.34375,0 L 36,24.5 Z M 11,26.5 l 4.28125,0 z m 4.625,0 4.625,0 z m 4.9375,0 1.84375,0 z m 2.15625,0 4.34375,0 z m 4.625,0 2.96875,0 z m 3.3125,0 1.1875,0 z m 1.5,0 0.65625,0 z m 1,0 L 36,26.5 Z M 11,28.5 l 3.65625,0 z m 4.0625,0 1.75,0 z m 2.0625,0 0.875,0 z m 1.21875,0 1.59375,0 z m 1.9375,0 1.625,0 z m 1.9375,0 2.59375,0 z m 2.9375,0 3.375,0 z m 3.6875,0 2.25,0 z m 2.5625,0 L 36,28.5 Z M 11,32.484375 l 3.09375,0 z m 3.40625,0 5.0625,0 z m 5.375,0 2.46875,0 z m 2.78125,0 2.4375,0 z M 11,34.5 l 3.65625,0 z m 4.0625,0 1.75,0 z m 2.0625,0 0.875,0 z m 1.21875,0 1.59375,0 z m 1.9375,0 1.625,0 z m 1.9375,0 L 25,34.5 Z M 11,36.5 l 3.875,0 z m 4.21875,0 1.21875,0 z m 1.53125,0 2.78125,0 z m 3.09375,0 L 25,36.5 Z M 11,38.5 l 3.875,0 z m 4.21875,0 1.75,0 z m 2.0625,0 2.75,0 z m 3.0625,0 2.96875,0 z m 3.3125,0 1.34375,0 z"
+       style="fill:none;stroke:#7e8087;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 26.394551,38.121266 c 1.303371,-0.606028 2.666926,-1.242773 2.666926,-2.606325 0,-0.424218 -0.181808,-0.424218 -0.969639,-0.484822 -0.878734,-0.0606 -1.242767,-0.636323 -1.242767,-1.424154 C 26.849071,32.515122 27.545997,32 28.39443,32 c 1.272651,0 2.212409,1.121144 2.212409,2.666508 0,1.182165 -0.575724,2.393792 -1.605965,3.272951 C 28.303947,38.515179 27.728223,38.727288 26.758167,39 l -0.363616,-0.878734 z m 5.394033,0 c 1.302952,-0.606028 2.666507,-1.242773 2.666507,-2.606325 0,-0.424218 -0.181808,-0.424218 -0.969638,-0.484822 -0.878738,-0.0606 -1.24235,-0.636323 -1.24235,-1.424154 0,-1.090843 0.696926,-1.605965 1.54536,-1.605965 1.272651,0 2.211988,1.121144 2.211988,2.666508 0,1.182165 -0.575722,2.393792 -1.605963,3.272951 C 33.697559,38.515179 33.121837,38.727288 32.152199,39 l -0.363615,-0.878734 z"
+       id="path3253" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 15.212539,8.878787 c -1.303449,0.6060586 -2.667087,1.242425 -2.667087,2.60606 0,0.424244 0.181819,0.424244 0.969697,0.484851 0.878788,0.06061 1.242846,0.636362 1.242846,1.424243 C 14.757995,14.484847 14.061027,15 13.21254,15 11.939814,15 11,13.878367 11,12.332914 c 0,-1.18182 0.575756,-2.393943 1.606058,-3.2727304 0.696973,-0.5753342 1.27315,-0.7874559 2.242847,-1.0601843 l 0.363634,0.8787877 z m 5.394363,0 c -1.303032,0.6060586 -2.666669,1.242425 -2.666669,2.60606 0,0.424244 0.181818,0.424244 0.969696,0.484851 0.878791,0.06061 1.242425,0.636362 1.242425,1.424243 0,1.090906 -0.696968,1.606059 -1.545453,1.606059 -1.272728,0 -2.212121,-1.121633 -2.212121,-2.667086 0,-1.18182 0.575756,-2.393943 1.606059,-3.2727304 0.696972,-0.5753342 1.272728,-0.7874559 2.242425,-1.0601843 l 0.363637,0.8787877 z"
+       id="path3255" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/48/text-x-install.svg
+++ b/elementary-xfce/mimes/48/text-x-install.svg
@@ -1,86 +1,61 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3901"
    height="48"
    width="48"
-   version="1.1">
-  <defs
-     id="defs3903">
-    <linearGradient
-       id="linearGradient3403">
-      <stop
+   version="1.1"
+   xml:space="preserve"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><defs
+     id="defs3903"><linearGradient
+       id="linearGradient3403"><stop
          id="stop3405"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
+         offset="0" /><stop
          id="stop3407"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
-      <stop
+         offset="0" /><stop
          id="stop3409"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
-      <stop
+         offset="1" /><stop
          id="stop3411"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600">
-      <stop
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient3600"><stop
          offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602" />
-      <stop
+         id="stop3602" /><stop
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
+         id="stop3604" /></linearGradient><linearGradient
+       id="linearGradient5060"><stop
          offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
+         id="stop5062" /><stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
+         id="stop5064" /></linearGradient><linearGradient
+       id="linearGradient5048"><stop
          offset="0"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
+         id="stop5050" /><stop
          offset="0.5"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
+         id="stop5056" /><stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-6">
-      <stop
+         id="stop5052" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
          id="stop3106-3"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
-      <stop
+         offset="0" /><stop
          id="stop3108-9"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
+         offset="1" /></linearGradient><linearGradient
        y2="42.110645"
        x2="23.99999"
        y1="5.9404659"
@@ -88,8 +63,7 @@
        gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3106"
-       xlink:href="#linearGradient3403" />
-    <linearGradient
+       xlink:href="#linearGradient3403" /><linearGradient
        y2="47.013336"
        x2="25.132275"
        y1="0.98520643"
@@ -97,8 +71,7 @@
        gradientTransform="matrix(0.97142632,0,0,0.93431938,0.68576678,-1.3569996)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3109"
-       xlink:href="#linearGradient3600" />
-    <radialGradient
+       xlink:href="#linearGradient3600" /><radialGradient
        r="117.14286"
        fy="486.64789"
        fx="605.71429"
@@ -107,8 +80,7 @@
        gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient3112"
-       xlink:href="#linearGradient5060" />
-    <radialGradient
+       xlink:href="#linearGradient5060" /><radialGradient
        r="117.14286"
        fy="486.64789"
        fx="605.71429"
@@ -117,8 +89,7 @@
        gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient3115"
-       xlink:href="#linearGradient5060" />
-    <linearGradient
+       xlink:href="#linearGradient5060" /><linearGradient
        y2="609.50507"
        x2="302.85715"
        y1="366.64789"
@@ -126,8 +97,7 @@
        gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3118"
-       xlink:href="#linearGradient5048" />
-    <linearGradient
+       xlink:href="#linearGradient5048" /><linearGradient
        y2="2.9062471"
        x2="-51.786404"
        y1="50.786446"
@@ -135,57 +105,31 @@
        gradientTransform="matrix(0.80749686,0,0,0.89471714,59.410232,-2.9773433)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3170"
-       xlink:href="#linearGradient3104-6" />
-    <linearGradient
-       osb:paint="solid"
-       id="linearGradient4526">
-      <stop
-         id="stop4528"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-    </linearGradient>
-  </defs>
-  <metadata
-     id="metadata3906">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <rect
+       xlink:href="#linearGradient3104-6" /></defs><metadata
+     id="metadata3906"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
      width="32.508301"
      height="3.5700529"
      x="7.7378473"
      y="42.429947"
      id="rect2879"
-     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
+     style="opacity:0.3;fill:url(#linearGradient3118);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" /><path
      d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
      id="path2881"
-     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
+     style="opacity:0.3;fill:url(#radialGradient3115);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" /><path
      d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
      id="path2883"
-     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-  <path
-     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 C 41,44 18.333334,44 7,44 7,29.666666 7,15.333333 7,1 z"
+     style="opacity:0.3;fill:url(#radialGradient3112);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" /><path
+     d="m 7,1.0000001 c 7.791126,0 33.999959,0.00274 33.999959,0.00274 L 41,44 H 7 Z"
      id="path4160"
-     style="fill:url(#linearGradient3109);fill-opacity:1;stroke:none;display:inline" />
-  <path
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none" /><path
      d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
      id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-  <path
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" /><path
      d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z"
      id="path4160-6-1"
-     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-  <path
-     d="M 32,24 24.006769,33 16,24 h 5 V 14 h 6 v 10 z"
-     id="path3288-2-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e8087;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-</svg>
+     style="fill:none;stroke:url(#linearGradient3170);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" /><path
+     id="path873-5"
+     style="opacity:1;fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 32.333333,25.289888 c 0,-0.718697 -0.557732,-1.297288 -1.250548,-1.297288 H 26.99336 V 15.297286 C 26.99336,14.578589 26.43561,14 25.742811,14 l -3.505867,0 c -0.692801,0 -1.251233,0.578589 -1.250551,1.297286 V 23.9926 l -4.069175,0 c -0.692801,0 -1.250551,0.578591 -1.250551,1.297288 0,0.387348 0.162333,0.733125 0.4201,0.970431 l 7.039649,7.384952 C 23.350384,33.86462 23.651401,34 23.983717,34 c 0.332332,0 0.633349,-0.135384 0.857317,-0.354729 l 7.0722,-7.384952 c 0.257849,-0.237306 0.420099,-0.583083 0.420099,-0.970431 z" /></svg>

--- a/elementary-xfce/mimes/64/application-ovf.svg
+++ b/elementary-xfce/mimes/64/application-ovf.svg
@@ -1,0 +1,415 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg3844"
+   sodipodi:docname="application-x-qemu-disk.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="35.443727"
+     inkscape:cy="35.974057"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="704"
+     inkscape:window-y="114"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3844" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3033"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503"
+       id="linearGradient3093"
+       xlink:href="#linearGradient3977-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         id="stop3979-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3096"
+       xlink:href="#linearGradient3600-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3153"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3156"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3842"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)" />
+    <mask
+       id="holes">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect80" />
+      <circle
+         id="hole"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(72)"
+         id="use83"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(144)"
+         id="use85"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-144)"
+         id="use87"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-72)"
+         id="use89"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-6">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997" />
+      <circle
+         id="hole-7"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(72)"
+         id="use24000"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(144)"
+         id="use24002"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-144)"
+         id="use24004"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-72)"
+         id="use24006"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-5">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-3" />
+      <circle
+         id="hole-5"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(72)"
+         id="use24000-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(144)"
+         id="use24002-2"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-144)"
+         id="use24004-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-72)"
+         id="use24006-1"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-2">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-7" />
+      <circle
+         id="hole-0"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(72)"
+         id="use24000-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(144)"
+         id="use24002-3"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-144)"
+         id="use24004-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-72)"
+         id="use24006-0"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879"
+     y="57.000004"
+     x="9.8999996"
+     height="5"
+     width="44.199997" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none"
+     id="path4160-6"
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-8"
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="32"
+     height="32"
+     x="16"
+     y="14"
+     rx="2.8235295"
+     ry="2.8235295" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="32"
+     cy="30"
+     r="11" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="32"
+     cy="30"
+     r="4" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="32"
+     cy="30"
+     r="3" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="32"
+     cy="30"
+     r="2" />
+</svg>

--- a/elementary-xfce/mimes/64/application-sql.svg
+++ b/elementary-xfce/mimes/64/application-sql.svg
@@ -1,1 +1,408 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg3844"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="29.168154"
+     inkscape:cy="46.580658"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="482"
+     inkscape:window-y="410"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3844"
+     showguides="false" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3033"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503"
+       id="linearGradient3093"
+       xlink:href="#linearGradient3977-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         id="stop3979-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3096"
+       xlink:href="#linearGradient3600-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3153"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3156"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3842"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)" />
+    <mask
+       id="holes">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect80" />
+      <circle
+         id="hole"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(72)"
+         id="use83"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(144)"
+         id="use85"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-144)"
+         id="use87"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-72)"
+         id="use89"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-6">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997" />
+      <circle
+         id="hole-7"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(72)"
+         id="use24000"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(144)"
+         id="use24002"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-144)"
+         id="use24004"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-72)"
+         id="use24006"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-5">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-3" />
+      <circle
+         id="hole-5"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(72)"
+         id="use24000-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(144)"
+         id="use24002-2"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-144)"
+         id="use24004-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-72)"
+         id="use24006-1"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-2">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-7" />
+      <circle
+         id="hole-0"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(72)"
+         id="use24000-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(144)"
+         id="use24002-3"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-144)"
+         id="use24004-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-72)"
+         id="use24006-0"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879"
+     y="57.000004"
+     x="9.8999996"
+     height="5"
+     width="44.199997" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none"
+     id="path4160-6"
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-8"
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:1"
+     d="m 18,24.87888 -3.85e-4,16 c 0,2.543137 7.294072,4.62112 13.999999,4.62112 C 38.705541,45.5 46,43.076065 46,40.87888 v -16 c 0,0 -6.390516,5.39305 -14.000386,5.39305 C 24.389744,30.27193 18,24.87888 18,24.87888 Z"
+     id="path3996-3"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 17.5,23.640351 v 6.385965 c 0,2.783606 7.355671,5.662098 14.499614,5.649077 C 39.105569,35.662443 46.5,32.809922 46.5,30.026316 v -6.385965"
+     id="path4358-6"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247-7"
+     d="M 46.5,23.885965 C 46.5021,20.358432 39.871146,17.5 31.999614,17.5 24.128082,17.5 17.497915,20.358432 17.5,23.885965 c -0.0021,3.527534 6.628082,6.385965 14.499614,6.385965 7.871532,0 14.502471,-2.858431 14.500386,-6.385965 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 17.5,28.061404 v 6.959059 c 0,2.783606 7.355671,5.580232 14.499614,5.567211 C 39.105569,40.574724 46.5,37.804069 46.5,35.020463 v -6.959059"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992-5"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994-3"
+     style="fill:none;stroke:#7239b3;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 17.5,32.973684 v 6.877193 c 0,2.783605 7.355671,5.662096 14.499614,5.649079 C 39.105569,45.486986 46.5,42.634482 46.5,39.850877 v -6.877193"
+     sodipodi:nodetypes="cscsc" />
+</svg>

--- a/elementary-xfce/mimes/64/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/64/application-vnd.flatpak.ref.svg
@@ -1,15 +1,37 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3844"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="application-vnd.flatpak.ref.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview36"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.65625"
+     inkscape:cx="31.953079"
+     inkscape:cy="31.953079"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3844" />
   <defs
      id="defs3846">
     <linearGradient
@@ -144,7 +166,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -177,6 +198,6 @@
      style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
      id="path7680"
-     d="M 31.933594 14 L 18.054688 22.011719 L 18 37.988281 L 32 46 L 46 38.001953 L 45.939453 22.011719 L 31.933594 14 z M 31.933594 15.269531 L 31.933594 26.837891 L 33.564453 27.8125 L 31.933594 28.751953 L 20.185547 21.964844 L 31.933594 15.269531 z M 45 22.832031 L 45 37.464844 L 32 44.908203 L 32 30.273438 L 45 22.832031 z "
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26771665;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="M 32.066406,14 45.945312,22.011719 46,37.988281 32,46 18,38.001953 18.060547,22.011719 Z m 0,1.269531 v 11.56836 l -1.630859,0.974609 1.630859,0.939453 11.748047,-6.787109 z M 19,22.832031 v 14.632813 l 13,7.443359 V 30.273438 Z"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/64/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/64/application-vnd.flatpak.svg
@@ -5,12 +5,34 @@
    viewBox="0 0 64 64"
    width="64"
    id="svg97"
+   sodipodi:docname="application-vnd.flatpak.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview54"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.65625"
+     inkscape:cx="31.953079"
+     inkscape:cy="31.953079"
+     inkscape:window-width="1920"
+     inkscape:window-height="1030"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg97" />
   <metadata
      id="metadata101">
     <rdf:RDF>
@@ -288,7 +310,7 @@
      d="M 57.12815,15.499995 54.5449,9.900383 C 53.8641,8.4226288 53.22993,7.2870226 52.49219,6.5800731 51.75444,5.8731236 50.93777,5.499995 49.48047,5.499995 h -35 c -1.45922,0 -2.29097,0.372627 -3.03125,1.0761719 -0.74028,0.7035449 -1.36976,1.8309474 -2.02734,3.3105471 v 0.002 l -2.61004,5.611281" />
   <path
      id="path7680"
-     d="m 31.9801,21.5 -13.87891,8.011719 -0.0547,15.976562 14,8.011719 14,-7.998047 -0.0605,-15.990234 z m 0,1.269531 v 11.56836 L 33.61096,35.3125 31.9801,36.251953 20.23205,29.464844 Z m 13.0664,7.5625 v 14.632813 l -13,7.443359 V 37.773438 Z"
+     d="m 32.11288,21.5 13.87891,8.011719 0.0547,15.976562 -14,8.011719 -14,-7.998047 0.0605,-15.990234 z m 0,1.269531 v 11.56836 l -1.63086,0.974609 1.63086,0.939453 11.74805,-6.787109 z m -13.0664,7.5625 v 14.632813 l 13,7.443359 V 37.773438 Z"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   <path
      d="m 29.537,4 h 5 L 35,14 l 0.037,6.49 c -0.59,0 -1.181,-1.046 -1.772,-1.046 -0.604,0 -1.209,1.046 -1.814,1.046 -0.486,0 -0.973,-0.916 -1.46,-0.916 -0.318,0 -0.636,0.916 -0.954,0.916 L 29,14 Z"

--- a/elementary-xfce/mimes/64/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/64/application-x-bittorrent.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    width="64"
    viewBox="0 0 64 64.000282"
    version="1.0"
    style="display:inline;enable-background:new"
    id="svg11300"
-   height="64.000282">
+   height="64.000282"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="15.070147"
+     inkscape:cx="31.751515"
+     inkscape:cy="33.974453"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="222"
+     inkscape:window-y="393"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g153" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -183,16 +205,23 @@
        id="path4160-6-1-7"
        d="m 200.59997,148.49968 c 10.77009,0 47.00003,0.004 47.00003,0.004 l 5e-5,58.99622 h -47.00008 v -58.99997 z" />
     <path
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10554"
-       d="m 224,158.35548 c 0,0 -2,0 -2,1.91113 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0.002 -2,-1.91113 v 26.75584 h 12 v -26.75584 c 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91113 0,-1.91113 -2,-1.91113 -2,-1.91113 z" />
+       d="m 224,159.35572 c 0,0 -2,0 -2,1.91113 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0.002 -2,-1.91113 v 26.73311 h 12 v -26.73311 c 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91113 0,-1.91113 -2,-1.91113 -2,-1.91113 z"
+       sodipodi:nodetypes="csccccccsc" />
     <path
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-       id="path10518"
-       d="M 210,182 224,199.28906 238,182 l -8,0.002 v -5.73502 c 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91113 0,-1.91113 -2,-1.91113 -2,-1.91113 0,0 -2,0 -2,1.91113 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91276 V 182 Z" />
-    <path
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
        id="path10536"
-       d="m 220,166.99999 c 0,0 -2,-0.002 -2,1.91113 V 182 h 12 v -13.08888 c 0,-1.91113 -2,-1.91113 -2,-1.91113 0,0 -2,0 -2,1.91113 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91113 0,-1.91113 -2,-1.91113 -2,-1.91113 z" />
+       d="m 220,167.99972 c 0,0 -2,-0.002 -2,1.91113 v 13.08888 h 12 v -13.08888 c 0,-1.91113 -2,-1.91113 -2,-1.91113 0,0 -2,0 -2,1.91113 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91113 0,-1.91113 -2,-1.91113 -2,-1.91113 z" />
+    <path
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       id="path10518"
+       d="m 230,182.99959 v -5.73274 c 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91113 0,-1.91113 -2,-1.91113 -2,-1.91113 0,0 -2,0 -2,1.91113 0,1.91113 -2,1.91113 -2,1.91113 0,0 -2,0 -2,-1.91276 v 5.73465 z"
+       sodipodi:nodetypes="cccscscccc" />
+    <path
+       id="path873-5-3-3-7-5"
+       style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="m 213,179.99972 c -0.92335,0 -1.5,0.74267 -1.5,1.66602 0,0.49764 0.21689,0.94316 0.56055,1.24804 l 10.79687,11.63086 c 0.2985,0.28181 0.69967,0.45508 1.14258,0.45508 0.4429,0 0.84408,-0.17327 1.14258,-0.45508 l 10.79687,-11.63086 c 0.34366,-0.30488 0.56055,-0.7504 0.56055,-1.24804 0,-0.92335 -0.35422,-1.44208 -1.25,-1.66602 z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/64/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/64/application-x-partial-download.svg
@@ -1,17 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    height="64.000282"
    id="svg11300"
    style="display:inline;enable-background:new"
    version="1.0"
    viewBox="0 0 64 64.000282"
-   width="64">
+   width="64"
+   sodipodi:docname="application-x-partial-download.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="15.070147"
+     inkscape:cx="8.5931478"
+     inkscape:cy="18.911561"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="229"
+     inkscape:window-y="299"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g950" />
   <metadata
      id="metadata155">
     <rdf:RDF>
@@ -185,16 +207,28 @@
        id="g950">
       <path
          id="rect874"
-         d="M 30 10 L 30 14 L 34 14 L 34 10 L 30 10 z M 34 14 L 34 18 L 38 18 L 38 14 L 34 14 z M 34 18 L 30 18 L 30 22 L 34 22 L 34 18 z M 30 18 L 30 14 L 26 14 L 26 18 L 30 18 z M 30 33.96875 L 30 34 L 34 34 L 34 33.96875 L 30 33.96875 z "
-         style="opacity:0.2;fill:#68b723;fill-opacity:0.97254902;stroke:none;stroke-width:1;stroke-opacity:1" />
+         d="m 30,12 v 4 h 4 v -4 z m 4,4 v 4 h 4 v -4 z m 0,4 h -4 v 4 h 4 z m -4,0 v -4 h -4 v 4 z"
+         style="opacity:0.2;fill:#68b723;fill-opacity:0.972549;stroke:none;stroke-width:1;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccccccccccccccc" />
+      <path
+         id="rect874-7"
+         d="m 30,24 h 4 z m 4,0 v 4 h 4 v -4 z m 0,4 h -4 v 4 h 4 z m -4,0 v -4 h -4 v 4 z"
+         style="display:inline;opacity:0.2;fill:#68b723;fill-opacity:0.972549;stroke:none;stroke-width:1;stroke-opacity:1;enable-background:new"
+         sodipodi:nodetypes="cccccccccccccccccc" />
       <path
          id="rect858"
-         d="M 26 18 L 26 22 L 30 22 L 30 18 L 26 18 z M 30 22 L 30 26 L 34 26 L 38 26 L 38 22 L 38 18 L 34 18 L 34 22 L 30 22 z M 30 26 L 26 26 L 26 30 L 30 30 L 30 26 z "
-         style="opacity:0.6;fill:#68b723;fill-opacity:0.97254902;stroke:none;stroke-width:0.99999994;stroke-opacity:1" />
+         d="m 26,20 v 4 h 4 v -4 z m 12,4 v -4 h -4 v 4 z"
+         style="opacity:0.6;fill:#68b723;fill-opacity:0.972549;stroke:none;stroke-width:1;stroke-opacity:1"
+         sodipodi:nodetypes="cccccccccc" />
       <path
          id="path10518"
-         d="M 30 26 L 30 30 L 34 30 L 34 26 L 30 26 z M 34 30 L 34 34 L 30 34 L 30 30 L 26 30 L 26 33.710938 L 18 33.710938 L 32 51 L 46 33.710938 L 38 33.712891 L 38 30 L 34 30 z "
-         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate" />
+         d="m 30,24 v 4 h 4 v -4 z m 4,4 v 4 h -4 v -4 h -4 v 4 h 12 v -4 z"
+         style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+         sodipodi:nodetypes="cccccccccccccc" />
+      <path
+         id="path873-5-3-3-7"
+         style="font-variation-settings:normal;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+         d="m 44.500392,33.666693 c 0,-0.923348 -0.354417,-1.442755 -1.250196,-1.666693 -7.416667,0 -14.833333,0 -22.25,0 C 20.076848,32 19.5,32.743345 19.5,33.666693 c 0,0.497647 0.216248,0.941884 0.559906,1.246764 L 30.8576,46.544067 c 0.298496,0.281808 0.699689,0.455735 1.142596,0.455735 0.442905,0 0.844099,-0.173928 1.142595,-0.455735 l 10.797695,-11.63061 c 0.343656,-0.30488 0.559906,-0.749117 0.559906,-1.246764 z" />
     </g>
   </g>
 </svg>

--- a/elementary-xfce/mimes/64/application-x-perl.svg
+++ b/elementary-xfce/mimes/64/application-x-perl.svg
@@ -1,1 +1,435 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg3844"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="45.254835"
+     inkscape:cx="44.967571"
+     inkscape:cy="18.406873"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="27"
+     inkscape:window-y="673"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3844" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3033"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503"
+       id="linearGradient3093"
+       xlink:href="#linearGradient3977-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         id="stop3979-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3096"
+       xlink:href="#linearGradient3600-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3153"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3156"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3842"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)" />
+    <mask
+       id="holes">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect80" />
+      <circle
+         id="hole"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(72)"
+         id="use83"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(144)"
+         id="use85"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-144)"
+         id="use87"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-72)"
+         id="use89"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-6">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997" />
+      <circle
+         id="hole-7"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(72)"
+         id="use24000"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(144)"
+         id="use24002"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-144)"
+         id="use24004"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-72)"
+         id="use24006"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-5">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-3" />
+      <circle
+         id="hole-5"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(72)"
+         id="use24000-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(144)"
+         id="use24002-2"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-144)"
+         id="use24004-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-72)"
+         id="use24006-1"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-2">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-7" />
+      <circle
+         id="hole-0"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(72)"
+         id="use24000-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(144)"
+         id="use24002-3"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-144)"
+         id="use24004-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-72)"
+         id="use24006-0"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879"
+     y="57.000004"
+     x="9.8999996"
+     height="5"
+     width="44.199997" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none"
+     id="path4160-6"
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-8"
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 16.636052,13.299204 c -1.197906,0.01353 -2.008773,0.258117 -2.008773,0.258117 0,0 2.223352,7.142359 6.392755,6.435153 l 0.401755,-1.47528 c -0.03922,3.420036 1.15579,7.615621 1.55404,8.915089 -1.331951,3.415787 -3.185963,8.925242 -2.622443,11.945751 0.440338,2.360239 1.332946,4.171121 2.969011,5.437169 h -0.217433 c -1.111839,4.526121 2.223847,5.657535 8.894892,3.394474 6.671044,2.263061 10.006732,1.131648 8.894891,-3.394474 h -0.217433 c 1.636065,-1.266048 2.528673,-3.07693 2.969011,-5.437169 0.563521,-3.020509 -1.29049,-8.529964 -2.622442,-11.945751 0.398251,-1.299468 1.593261,-5.495053 1.55404,-8.915089 l 0.401755,1.47528 c 4.169402,0.707206 6.392755,-6.435153 6.392755,-6.435153 0,0 -4.083771,-1.224453 -7.454536,1.673318 -0.640254,-1.138703 -2.186047,-1.931435 -3.247148,-1.931435 -2.254354,0 -3.33537,0.964605 -6.670893,0.964605 -3.335523,0 -4.416538,-0.964605 -6.670893,-0.964605 -1.061103,0 -2.606894,0.792732 -3.247149,1.931435 -1.868389,-1.606212 -3.956019,-1.94827 -5.445762,-1.931435 z"
+     sodipodi:nodetypes="sccccscccccscccccssscs" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 24.217021,24.448434 c 0,0 -4.718416,10.347034 -3.863281,14.930622 0.594711,3.187687 2.010358,5.375539 4.975136,6.568715 1.757369,0.707256 6.671126,-1.131543 6.671126,-1.131543 v -7.92081 0 0 c 0,0 -4.447418,-1.485152 -5.350799,-7.213593 0,0 0.478006,4.895473 1.381388,5.036915"
+     id="path925"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 22.271278,15.39608 c -3.405054,-3.111746 -7.643999,-1.838759 -7.643999,-1.838759 0,0 2.223709,7.142872 6.393162,6.435657"
+     id="path927"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 23.105168,45.1 c -1.111854,4.526177 2.223708,5.65772 8.894834,3.394632 6.671124,2.263088 10.006687,1.131545 8.894833,-3.394632"
+     id="path932"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 25.566149,19.148004 c 2.106966,-0.9962 4.346154,0.225115 4.270559,0.350037 0,0 -0.727552,3.070634 -2.447185,2.805734 -1.61086,-0.248144 -1.822023,-2.459456 -1.823374,-3.155771 z"
+     id="path938-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsc" />
+  <path
+     sodipodi:nodetypes="ccsscsscc"
+     inkscape:connector-curvature="0"
+     id="path947"
+     d="m 40.894835,27.843066 v 0 c 0,0 2.877923,-8.688531 1.111854,-12.446986 C 41.43019,14.169205 39.782981,13.3 38.671126,13.3 c -2.254381,0 -3.335561,0.964536 -6.671124,0.964536 -3.335563,0 -4.416744,-0.964536 -6.671126,-0.964536 -1.111855,0 -2.759063,0.869205 -3.335562,2.09608 -1.766069,3.758455 1.111854,12.446986 1.111854,12.446986 v 0"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path949"
+     d="m 39.782981,24.448434 c 0,0 4.718418,10.347034 3.863282,14.930622 -0.594711,3.187687 -2.010357,5.375539 -4.975137,6.568715 -1.757368,0.707256 -6.671124,-1.131543 -6.671124,-1.131543 v -7.92081 0 0 c 0,0 4.447416,-1.485152 5.350798,-7.213593 0,0 -0.527143,4.995487 -1.430525,5.13693"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path951"
+     d="m 41.728726,15.39608 c 3.405053,-3.111746 7.643996,-1.838759 7.643996,-1.838759 0,0 -2.223708,7.142872 -6.393161,6.435657"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path955"
+     d="m 38.433854,19.148004 c -2.106966,-0.9962 -4.346155,0.225115 -4.27056,0.350037 0,0 0.727554,3.070634 2.447186,2.805734 1.610861,-0.248144 1.822024,-2.459456 1.823374,-3.155771 z"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.2;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+</svg>

--- a/elementary-xfce/mimes/64/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/64/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/64/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/64/application-x-sharedlib.svg
@@ -1,1 +1,275 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3844"
+   height="64"
+   width="64"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3846">
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842-5"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156-7"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153-2"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient3096-5"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient3093-4"
+       y2="42.175503"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3033-8"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       gradientTransform="matrix(0.66673363,0,0,0.66673363,-29.937786,-3.4297008)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(0.61901164,0,0,0.61901164,5.5651336,6.3224549)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(0.61896334,0,0,0.61896334,20.915061,32.924712)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="44.199997"
+     height="5"
+     x="9.8999996"
+     y="57.000004"
+     id="rect2879-8"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156-7);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
+     id="path2883-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6-6"
+     style="display:inline;fill:url(#linearGradient3096-5);fill-opacity:1;stroke:none" />
+  <path
+     d="M 54.499999,58.50002 H 9.4999998 V 1.4999799 H 54.499999 Z"
+     id="rect6741-1-8-64"
+     style="fill:none;stroke:url(#linearGradient3093-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1-9"
+     style="display:inline;fill:none;stroke:url(#linearGradient3033-8);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     transform="matrix(0.87157445,-0.49026318,0.87157445,0.49026318,0,0)"
+     ry="5.5910778"
+     rx="5.5910778"
+     y="45.279682"
+     x="-30.189953"
+     height="21.625437"
+     width="21.625437"
+     id="rect48-5-5"
+     style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.08172;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-7-9-6-8"
+     style="opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal"
+     d="M 32 28 C 30.238338 28 28.47683 28.379362 27.126953 29.138672 L 18.025391 34.259766 C 17.887915 34.337096 17.762147 34.418109 17.638672 34.5 C 17.761144 34.582077 17.887944 34.66292 18.025391 34.740234 L 27.126953 39.861328 C 29.826612 41.379895 34.173389 41.379895 36.873047 39.861328 L 45.974609 34.740234 C 46.112056 34.66292 46.238856 34.582077 46.361328 34.5 C 46.237853 34.418109 46.112085 34.337096 45.974609 34.259766 L 36.873047 29.138672 C 35.52317 28.379362 33.761662 28 32 28 z " />
+  <rect
+     transform="matrix(0.87157434,-0.49026336,0.87157434,0.49026336,0,0)"
+     ry="5.5912681"
+     rx="5.5912681"
+     y="39.160458"
+     x="-24.071075"
+     height="21.625788"
+     width="21.625788"
+     id="rect48-5-1-7"
+     style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-7-9-7"
+     style="opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.999992;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal"
+     d="M 32 22 C 30.238338 22 28.47683 22.379362 27.126953 23.138672 L 18.486328 28 L 27.126953 32.861328 C 29.826612 34.379895 34.173389 34.379895 36.873047 32.861328 L 45.513672 28 L 36.873047 23.138672 C 35.52317 22.379362 33.761662 22 32 22 z " />
+  <rect
+     transform="matrix(0.87157434,-0.49026336,0.87157434,0.49026336,0,0)"
+     ry="5.5912681"
+     rx="5.5912681"
+     y="32.021439"
+     x="-16.932056"
+     height="21.625788"
+     width="21.625788"
+     id="rect48-5-1-8-2"
+     style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+</svg>

--- a/elementary-xfce/mimes/64/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/64/application-x-vdi-disk.svg
@@ -1,0 +1,396 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg3844"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="35.355339"
+     inkscape:cy="38.006989"
+     inkscape:window-width="1317"
+     inkscape:window-height="893"
+     inkscape:window-x="521"
+     inkscape:window-y="135"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3844" />
+  <defs
+     id="defs3846">
+    <linearGradient
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471"
+       id="linearGradient3033"
+       xlink:href="#linearGradient3104-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503"
+       id="linearGradient3093"
+       xlink:href="#linearGradient3977-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         id="stop3979-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-6"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3983-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3985-6"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3096"
+       xlink:href="#linearGradient3600-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         id="stop3602-3"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-7"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3153"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient3156"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         id="stop5050"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient3842"
+       xlink:href="#linearGradient5048"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)" />
+    <mask
+       id="holes">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect80" />
+      <circle
+         id="hole"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(72)"
+         id="use83"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(144)"
+         id="use85"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-144)"
+         id="use87"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole"
+         transform="rotate(-72)"
+         id="use89"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-6">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997" />
+      <circle
+         id="hole-7"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(72)"
+         id="use24000"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(144)"
+         id="use24002"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-144)"
+         id="use24004"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-7"
+         transform="rotate(-72)"
+         id="use24006"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-5">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-3" />
+      <circle
+         id="hole-5"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(72)"
+         id="use24000-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(144)"
+         id="use24002-2"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-144)"
+         id="use24004-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-5"
+         transform="rotate(-72)"
+         id="use24006-1"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+    <mask
+       id="holes-2">
+      <rect
+         x="-60"
+         y="-60"
+         width="120"
+         height="120"
+         fill="#ffffff"
+         id="rect23997-7" />
+      <circle
+         id="hole-0"
+         cy="-40"
+         r="3"
+         cx="0" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(72)"
+         id="use24000-9"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(144)"
+         id="use24002-3"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-144)"
+         id="use24004-6"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+      <use
+         xlink:href="#hole-0"
+         transform="rotate(-72)"
+         id="use24006-0"
+         x="0"
+         y="0"
+         width="100%"
+         height="100%" />
+    </mask>
+  </defs>
+  <metadata
+     id="metadata3849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879"
+     y="57.000004"
+     x="9.8999996"
+     height="5"
+     width="44.199997" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881"
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883"
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z" />
+  <path
+     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none"
+     id="path4160-6"
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z" />
+  <path
+     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-1-8"
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z" />
+  <path
+     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="path4160-6-1"
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="32"
+     height="32"
+     x="16"
+     y="14"
+     rx="2.8235295"
+     ry="2.8235295" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 16,25.5 h 5 l 4.5,12 L 31,22.000219 34.75,32.5 l 4,-10.499781 4.25,12.5 h 5"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/64/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/64/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/64/text-markdown.svg
+++ b/elementary-xfce/mimes/64/text-markdown.svg
@@ -1,15 +1,36 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3130"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   sodipodi:docname="text-markdown.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview40"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="10.65625"
+     inkscape:cx="27.44868"
+     inkscape:cy="32"
+     inkscape:window-width="1360"
+     inkscape:window-height="893"
+     inkscape:window-x="730"
+     inkscape:window-y="89"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3130" />
   <defs
      id="defs3132">
     <linearGradient
@@ -155,17 +176,30 @@
          offset="1"
          style="stop-color:#505f6f;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4613"
+       id="linearGradient580"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5,0,0,0.5,1.0000004,-2.4998799)"
+       x1="64"
+       y1="112"
+       x2="64"
+       y2="8" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="8"
+       x2="64"
+       y1="112"
+       x1="64"
+       id="linearGradient4615-7"
+       xlink:href="#linearGradient4613"
+       gradientTransform="matrix(0.5,0,0,0.5,-0.9999996,-2.4998799)" />
   </defs>
   <metadata
      id="metadata3135">
     <rdf:RDF>
       <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
+         rdf:about="" />
     </rdf:RDF>
   </metadata>
   <rect
@@ -197,6 +231,17 @@
      style="fill:none;stroke:url(#linearGradient3018);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
   <path
      id="rect4550"
-     d="m 16.5,20.000009 c -1.367703,0 -2.5,1.132297 -2.5,2.5 V 37.50001 c 0,1.367702 1.132297,2.5 2.5,2.5 h 31 c 1.367703,0 2.5,-1.132298 2.5,-2.5 V 22.500009 c 0,-1.367703 -1.132297,-2.5 -2.5,-2.5 z m 0,2 h 31 c 0.294297,0 0.5,0.205704 0.5,0.5 V 37.50001 c 0,0.294297 -0.205703,0.5 -0.5,0.5 h -31 c -0.294297,0 -0.5,-0.205703 -0.5,-0.5 V 22.500009 c 0,-0.294297 0.205703,-0.5 0.5,-0.5 z M 20,25.00001 v 10 h 3 v -5.5 l 3,3.25 3,-3.25 v 5.5 h 3 v -10 h -3 l -3,3.3125 -3,-3.3125 z m 18,0 v 5 h -3 l 4.5,5.5 4.5,-5.5 h -3 v -5 z"
-     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+     d="m 17.5,20.000009 c -1.367703,0 -2.5,1.132297 -2.5,2.5 V 37.50001 c 0,1.367702 1.132297,2.5 2.5,2.5 h 29 c 1.367703,0 2.5,-1.132298 2.5,-2.5 V 22.500009 c 0,-1.367703 -1.132297,-2.5 -2.5,-2.5 z m 0,2 h 29 c 0.294297,0 0.5,0.205704 0.5,0.5 V 37.50001 c 0,0.294297 -0.205703,0.5 -0.5,0.5 h -29 c -0.294297,0 -0.5,-0.205703 -0.5,-0.5 V 22.500009 c 0,-0.294297 0.205703,-0.5 0.5,-0.5 z"
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     sodipodi:nodetypes="ssssssssssssssssss" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient4615-7);fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 38.75,25.000109 h 1.5 c 0.415682,0 0.849503,0.359715 0.75,0.779297 v 4.216797 h 1.75 c 0.415682,0 0.75,0.346126 0.75,0.777344 0,0.232407 -0.09724,0.439646 -0.251953,0.582031 l -3.244141,3.43164 c -0.13438,0.131616 -0.31428,0.212891 -0.513672,0.212891 -0.199389,0 -0.379293,-0.08128 -0.513672,-0.212891 l -3.224609,-3.43164 C 35.597251,31.213193 35.5,31.005954 35.5,30.773547 c 0,-0.431218 0.33432,-0.777344 0.75,-0.777344 H 38 v -4.216797 c -4.1e-4,-0.431219 0.334318,-0.779297 0.75,-0.779297 z"
+     id="path574"
+     sodipodi:nodetypes="ssscssccsccssccs" />
+  <path
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient580);fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 22,25.000109 h 1.302734 c 0.260086,-0.0038 0.52142,0.09369 0.720704,0.292969 L 27,28.271593 29.976562,25.293078 c 0.199284,-0.199282 0.460618,-0.29681 0.720704,-0.292969 H 32 c 0.553995,0 1,0.446005 1,1 v 8 c 0,0.553995 -1,1 -1,1 h -1 c 0,0 -0.879672,-0.45923 -1,-1 v -4.494141 l -2.476562,2.634766 c -0.12199,0.119476 -0.28144,0.195617 -0.458985,0.208984 -0.0179,0.0018 -0.03643,0.0034 -0.05469,0.0039 -0.02492,0 -0.04996,-0.0014 -0.07422,-0.0039 -0.177545,-0.01337 -0.336995,-0.08951 -0.458985,-0.208984 L 24,29.505968 v 4.494141 c 0,0.553995 -1,1 -1,1 h -1 c 0,0 -1,-0.446005 -1,-1 v -8 c 0,-0.553995 0.446005,-1 1,-1 z"
+     id="path572"
+     sodipodi:nodetypes="scccccsssssscccccccssssss" />
 </svg>

--- a/elementary-xfce/mimes/64/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/64/text-x-bibtex.svg
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3130"
+   height="64"
+   width="64"
+   version="1.1">
+  <defs
+     id="defs3132">
+    <linearGradient
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3048"
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404" />
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient3051"
+       y2="42.100208"
+       x2="23.99999"
+       y1="5.8641062"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3977-4">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-7" />
+      <stop
+         offset="0.01214366"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-6" />
+      <stop
+         offset="0.98781353"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-5" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient3054"
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275" />
+    <linearGradient
+       id="linearGradient3600-9">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-3" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-7" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3057"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3060"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3128"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+  </defs>
+  <metadata
+     id="metadata3135">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="44.199997"
+     height="5"
+     x="9.8999996"
+     y="57.000004"
+     id="rect2879"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3128);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
+     id="path2881"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3060);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
+     id="path2883"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3057);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6"
+     style="display:inline;fill:url(#linearGradient3054);fill-opacity:1;stroke:none" />
+  <path
+     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
+     id="rect6741-1-8"
+     style="fill:none;stroke:url(#linearGradient3051);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3048);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     id="g4141"
+     transform="translate(0.00131,-6.9e-5)">
+    <path
+       id="path3475"
+       d="m 31,11.5 3.082031,0 z m 3.595703,0 2.560547,0 z m 3.029297,0 1.154297,0 z m 1.580078,0 2.648438,0 z m 3.117188,0 2.988281,0 z m 3.457031,0 3.203125,0 z M 31,14.5 l 2.654297,0 z m 3.082031,0 2.21875,0 z m 2.691407,0 2.173828,0 z m 2.646484,0 1.193359,0 z m 1.621094,0 2.390625,0 z m 2.945312,0 4.996094,0 z M 31,17.5 l 2.203125,0 z m 2.630859,0 3.373047,0 z m 3.798829,0 6.916015,0 z m 7.34375,0 L 49,17.5 Z M 31,20.5 l 1.970703,0 z m 2.398438,0 2.519531,0 z m 2.947265,0 6.318359,0 z m 6.787109,0 5.84961,0 z M 15,25.5 l 5.849609,0 z m 6.318359,0 6.31836,0 z m 6.746094,0 2.435547,0 z M 31,25.5 l 3.996094,0 z m 4.550781,0 1.949219,0 z m 2.501953,0 L 42,25.5 Z m 4.447266,0 6.482422,0 z m -27.5,3 3.201172,0 z m 3.671875,0 2.945313,0 z m 3.457031,0 2.646485,0 z m 3.074219,0 1.152344,0 z m 1.623047,0 2.560547,0 z m 3.074219,0 6.701171,0 z m 7.169921,0 5.123047,0 z m 5.548829,0 1.625,0 z m 2.050781,0 L 49,28.5 Z M 15,31.5 l 5.378906,0 z m 5.806641,0 5.763671,0 z m 6.1875,0 2.222656,0 z m 2.648437,0 5.421875,0 z m 5.847656,0 6.832032,0 z m 7.300782,0 L 49,31.5 Z M 15,34.5 l 5.849609,0 z m 6.318359,0 6.31836,0 z m 6.746094,0 2.517578,0 z m 2.943359,0 5.935547,0 z m 6.31836,0 4.05664,0 z m 4.527344,0 1.621093,0 z m 2.048828,0 0.894531,0 z m 1.363281,0 L 49,34.5 Z M 15,37.5 l 4.994141,0 z m 5.548828,0 2.390625,0 z m 2.81836,0 1.195312,0 z m 1.664062,0 2.177734,0 z m 2.646484,0 2.222657,0 z m 2.646485,0 3.544922,0 z m 4.013672,0 4.609375,0 z m 5.037109,0 3.074219,0 z m 3.501953,0 L 49,37.5 Z M 15,42.478516 l 4.226562,0 z m 4.654297,0 6.916015,0 z m 7.339844,0 3.375,0 z m 3.802734,0 2.203125,0 z M 15,45.5 l 4.994141,0 z m 5.548828,0 2.390625,0 z m 2.81836,0 1.195312,0 z m 1.664062,0 2.177734,0 z m 2.646484,0 2.222657,0 z m 2.646485,0 L 33,45.5 Z M 15,48.5 l 5.292969,0 z m 5.763672,0 1.666016,0 z m 2.089844,0 3.800781,0 z m 4.226562,0 L 33,48.5 Z M 15,51.5 l 5.292969,0 z m 5.763672,0 2.390625,0 z m 2.818359,0 3.753907,0 z m 4.181641,0 L 33,51.5 Z"
+       style="fill:none;stroke:#7e8087;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 35.277231,50.744734 c 1.861958,-0.865754 3.809894,-1.77539 3.809894,-3.723321 0,-0.606026 -0.259726,-0.606026 -1.385198,-0.692602 -1.255334,-0.08657 -1.775382,-0.909034 -1.775382,-2.034506 0,-1.558347 0.995609,-2.294236 2.207656,-2.294236 1.818073,0 3.160585,1.601635 3.160585,3.809297 0,1.688807 -0.822464,3.419703 -2.294236,4.675644 -0.99561,0.822458 -1.818073,1.125471 -3.203868,1.515059 l -0.519451,-1.255335 z m 7.705761,0 c 1.86136,-0.865754 3.809296,-1.77539 3.809296,-3.723321 0,-0.606026 -0.259725,-0.606026 -1.385197,-0.692602 -1.25534,-0.08657 -1.774786,-0.909034 -1.774786,-2.034506 0,-1.558347 0.995609,-2.294236 2.207657,-2.294236 1.818073,0 3.159983,1.601635 3.159983,3.809297 0,1.688807 -0.822459,3.419703 -2.294232,4.675644 -0.995614,0.822458 -1.818073,1.125471 -3.203271,1.515059 l -0.51945,-1.255335 z"
+       id="path3253" />
+    <path
+       style="fill:#7e8087;fill-opacity:1"
+       d="m 21.016603,12.256717 c -1.86207,0.865798 -3.810124,1.774893 -3.810124,3.722941 0,0.606063 0.259741,0.606063 1.385281,0.692644 1.255411,0.08658 1.775495,0.909089 1.775495,2.034634 0,1.558437 -0.995669,2.29437 -2.207794,2.29437 -1.818179,0 -3.160771,-1.602334 -3.160771,-3.810124 0,-1.688313 0.822508,-3.419916 2.294369,-4.675327 0.995675,-0.821906 1.818786,-1.124937 3.204067,-1.514549 l 0.519477,1.255411 z m 7.706232,0 c -1.861473,0.865798 -3.809527,1.774893 -3.809527,3.722941 0,0.606063 0.259741,0.606063 1.385281,0.692644 1.255416,0.08658 1.774893,0.909089 1.774893,2.034634 0,1.558437 -0.995669,2.29437 -2.20779,2.29437 -1.818183,0 -3.160174,-1.602334 -3.160174,-3.810124 0,-1.688313 0.822509,-3.419916 2.294371,-4.675327 0.995674,-0.821906 1.818183,-1.124937 3.203464,-1.514549 l 0.519482,1.255411 z"
+       id="path3255" />
+  </g>
+</svg>

--- a/elementary-xfce/mimes/64/text-x-install.svg
+++ b/elementary-xfce/mimes/64/text-x-install.svg
@@ -1,26 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    id="svg3844"
    height="64"
    width="64"
-   version="1.1">
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs3846">
-    <linearGradient
-       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3104-6"
-       id="linearGradient3033"
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404" />
     <linearGradient
        id="linearGradient3104-6">
       <stop
@@ -32,15 +23,6 @@
          style="stop-color:#000000;stop-opacity:0.24031007"
          id="stop3108-9" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.8108184,-6.9729501)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977-4"
-       id="linearGradient3093"
-       y2="42.175503"
-       x2="23.99999"
-       y1="5.8641062"
-       x1="23.99999" />
     <linearGradient
        id="linearGradient3977-4">
       <stop
@@ -61,15 +43,6 @@
          id="stop3985-6" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.4572141,-2.1793201)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-9"
-       id="linearGradient3096"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <linearGradient
        id="linearGradient3600-9">
       <stop
          offset="0"
@@ -80,16 +53,6 @@
          style="stop-color:#dbdbdb;stop-opacity:1"
          id="stop3604-7" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.220859,49.45142)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3153"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
     <linearGradient
        id="linearGradient5060">
       <stop
@@ -101,16 +64,6 @@
          style="stop-color:#000000;stop-opacity:0"
          id="stop5064" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.779136,49.45142)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3156"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
     <linearGradient
        id="linearGradient5048">
       <stop
@@ -126,15 +79,62 @@
          style="stop-color:#000000;stop-opacity:0"
          id="stop5052" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.084616,49.45142)"
+    <radialGradient
+       gradientTransform="matrix(-0.03132632,0,0,0.02058823,28.77914,49.45142)"
        gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156-3-1"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.03132633,0,0,0.02058823,35.22086,49.45142)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153-2-3"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
        xlink:href="#linearGradient5048"
-       id="linearGradient3842"
-       y2="609.50507"
-       x2="302.85715"
+       id="linearGradient2415"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09153846,0,0,0.02058823,-1.08462,49.45142)"
+       x1="302.85715"
        y1="366.64789"
-       x1="302.85715" />
+       x2="302.85715"
+       y2="609.50507" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9"
+       id="linearGradient2417"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3142827,0,0,1.2602393,0.45721,-2.1793201)"
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336" />
+    <linearGradient
+       xlink:href="#linearGradient3977-4"
+       id="linearGradient2419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2162162,0,0,1.5405376,2.81082,-6.9729501)"
+       x1="23.99999"
+       y1="5.8641062"
+       x2="23.99999"
+       y2="42.175503" />
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient2421"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0843523,0,0,1.1997367,79.550862,-4.1628601)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
   </defs>
   <metadata
      id="metadata3849">
@@ -144,39 +144,38 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <rect
      width="44.199997"
      height="5"
-     x="9.8999996"
+     x="9.8999939"
      y="57.000004"
-     id="rect2879"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     id="rect2879-0-6"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient2415);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.6132281,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.8002408,-2.4995 3.9,-2.4995 z"
-     id="path2881"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     d="m 9.9,57.00022 c 0,0 0,4.9997 0,4.9997 -1.61323,0.01 -3.9,-1.1202 -3.9,-2.5002 0,-1.38 1.80024,-2.4995 3.9,-2.4995 z"
+     id="path2881-6-5"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156-3-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
      d="m 54.099999,57.00022 c 0,0 0,4.9997 0,4.9997 C 55.713227,62.00992 58,60.87972 58,59.49972 c 0,-1.38 -1.800241,-2.4995 -3.900001,-2.4995 z"
-     id="path2883"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     id="path2883-2-6"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153-2-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
   <path
-     d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
-     id="path4160-6"
-     style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
+     d="m 9,0.9998799 c 10.54094,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.66667,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
+     id="path4160-6-6-9"
+     style="display:inline;fill:url(#linearGradient2417);fill-opacity:1;stroke:none" />
   <path
-     d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
-     id="rect6741-1-8"
-     style="fill:none;stroke:url(#linearGradient3093);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="M 54.499999,58.50002 H 9.5 V 1.4999799 h 44.999999 z"
+     id="rect6741-1-8-1-3"
+     style="fill:none;stroke:url(#linearGradient2419);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     d="m 8.4999684,0.4998999 c 10.7700936,0 47.0000286,0.004 47.0000286,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333384,0 -47.0000776,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
-     id="path4160-6-1"
-     style="display:inline;fill:none;stroke:url(#linearGradient3033);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     d="m 8.49997,0.4998999 c 10.77009,0 47.000027,0.004 47.000027,0.004 l 4.9e-5,58.9962201 c 0,0 -31.333386,0 -47.000076,0 0,-19.6668 0,-39.3334 0,-58.9999701 z"
+     id="path4160-6-1-8-7"
+     style="display:inline;fill:none;stroke:url(#linearGradient2421);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7e8087;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     id="path3288-2-2-1"
-     d="M 42,32 32.07376,44 22,32 l 7,0 0,-12 6,0 0,12 z" />
+     id="path873-5-3-3-7-4"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 44.500196,33.666841 c 0,-0.923348 -0.354417,-1.442755 -1.250196,-1.666693 H 36 V 18.666642 c 0,-0.923348 -0.57661,-1.666693 -1.49996,-1.666693 h -5.00008 c -0.92335,0 -1.48842,0.743417 -1.49996,1.666693 v 13.333506 h -7 c -0.92335,0 -1.5002,0.743345 -1.5002,1.666693 0,0.497647 0.21625,0.941884 0.55991,1.246764 l 10.79769,11.63061 c 0.2985,0.281808 0.69969,0.455735 1.1426,0.455735 0.4429,0 0.8441,-0.173928 1.14259,-0.455735 l 10.7977,-11.63061 c 0.343656,-0.30488 0.559906,-0.749117 0.559906,-1.246764 z" />
 </svg>

--- a/elementary-xfce/mimes/96/application-ovf.svg
+++ b/elementary-xfce/mimes/96/application-ovf.svg
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="application-x-qemu-disk.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="7.1041666"
+     inkscape:cx="59.753666"
+     inkscape:cy="53.982405"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="445"
+     inkscape:window-y="125"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901"
+     inkscape:snap-center="true"
+     inkscape:snap-object-midpoints="true" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00541497" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.273762"
+       x2="23.99999"
+       y1="5.6275582"
+       x1="23.99999"
+       gradientTransform="matrix(1.8648648,0,0,2.3513513,3.2432558,-11.432408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.9999954,0,0,1.9120955,1.0813194e-4,-3.8236272)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6380632,0,0,1.8097673,119.83211,-6.5336729)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.13730769,0,0,0.02882352,-1.626924,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04698948,0,0,0.02882352,43.168704,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.04698949,0,0,0.02882352,52.831289,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="66.299995"
+     height="7"
+     x="14.849998"
+     y="86"
+     id="rect2879-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.85,86.000298 c 0,0 0,6.999581 0,6.999581 -2.419842,0.014 -5.85,-1.56828 -5.85,-3.50028 0,-1.932 2.700361,-3.499301 5.85,-3.499301 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 81.149999,86.000298 c 0,0 0,6.999581 0,6.999581 C 83.56984,93.013879 87,91.431599 87,89.499599 c 0,-1.932 -2.700361,-3.499301 -5.850001,-3.499301 z"
+     id="path2883-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 13,0.99999999 h 69.999918 l 8.5e-5,87.99999901 H 13 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 82.499999,88.499999 H 13.500001 V 1.5 h 68.999998 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 12.499959,0.4999623 83.499966,0.5 l 7.5e-5,89.000043 H 12.499959 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="48"
+     height="48.000004"
+     x="24"
+     y="20"
+     rx="4"
+     ry="4" />
+  <circle
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="path2176"
+     cx="48"
+     cy="44"
+     r="16" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.49999;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle2330"
+     cx="48"
+     cy="44"
+     r="6" />
+  <circle
+     style="fill:#feffff;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3777"
+     cx="48"
+     cy="44"
+     r="4.5" />
+  <circle
+     style="fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1.5;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.5;paint-order:stroke markers fill"
+     id="circle3951"
+     cx="48"
+     cy="44"
+     r="3" />
+</svg>

--- a/elementary-xfce/mimes/96/application-sql.svg
+++ b/elementary-xfce/mimes/96/application-sql.svg
@@ -1,1 +1,221 @@
-office-database.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="application-sql.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234044"
+     inkscape:cx="29.561626"
+     inkscape:cy="60.019058"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="517"
+     inkscape:window-y="348"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00541497" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.273762"
+       x2="23.99999"
+       y1="5.6275582"
+       x1="23.99999"
+       gradientTransform="matrix(1.8648648,0,0,2.3513513,3.2432558,-11.432408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.9999954,0,0,1.9120955,1.0813194e-4,-3.8236272)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6380632,0,0,1.8097673,119.83211,-6.5336729)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.13730769,0,0,0.02882352,-1.626924,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04698948,0,0,0.02882352,43.168704,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.04698949,0,0,0.02882352,52.831289,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="66.299995"
+     height="7"
+     x="14.849998"
+     y="86"
+     id="rect2879-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.85,86.000298 c 0,0 0,6.999581 0,6.999581 -2.419842,0.014 -5.85,-1.56828 -5.85,-3.50028 0,-1.932 2.700361,-3.499301 5.85,-3.499301 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 81.149999,86.000298 c 0,0 0,6.999581 0,6.999581 C 83.56984,93.013879 87,91.431599 87,89.499599 c 0,-1.932 -2.700361,-3.499301 -5.850001,-3.499301 z"
+     id="path2883-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 13,0.99999999 h 69.999918 l 8.5e-5,87.99999901 H 13 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 82.499999,88.499999 H 13.500001 V 1.5 h 68.999998 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 12.499959,0.4999623 83.499966,0.5 l 7.5e-5,89.000043 H 12.499959 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="fill:#e4c6fa;fill-opacity:0.996932;stroke:none;stroke-width:0.999991"
+     d="m 26,38.000005 v 24 c 0,4.702314 11.411678,8.499993 22,8.499993 10.588322,0 22,-3.758065 22,-8.499993 v -24 c 0,0 -9.984398,8 -22,8 -12.015602,0 -22,-8 -22,-8 z"
+     id="path3996"
+     sodipodi:nodetypes="cczccsc" />
+  <path
+     style="fill:none;stroke:#7239b3;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 25.499967,36.000005 v 9.5 c 0,4.473653 11.220107,9.020926 22.500033,9 11.219946,-0.02081 22.500033,-4.526347 22.500033,-9 v -9.5"
+     id="path4358"
+     sodipodi:nodetypes="csssc" />
+  <path
+     style="fill:#cd9ef7;fill-opacity:1;fill-rule:nonzero;stroke:#7239b3;stroke-width:0.999991;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path4247"
+     d="M 70.500033,35.763157 C 70.503333,30.093906 60.428753,25.5 48,25.5 35.571246,25.5 25.496675,30.093906 25.499967,35.763157 25.496667,41.432407 35.571246,46.500005 48,46.500005 c 12.428753,0 22.503325,-5.067598 22.500033,-10.736848 z"
+     sodipodi:nodetypes="cscsc" />
+  <path
+     d="m 25.499967,42.000005 v 11.5 c 0,4.473652 11.220107,9.020926 22.500033,9 11.219946,-0.02081 22.500033,-4.526348 22.500033,-9 v -11.5"
+     style="fill:none;stroke:#7239b3;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="path3992"
+     sodipodi:nodetypes="csssc" />
+  <path
+     id="path3994"
+     style="fill:none;stroke:#7239b3;stroke-width:0.999991;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 25.499967,50.000005 v 11.5 c 0,4.47365 11.220107,9.020843 22.500033,8.999922 11.219946,-0.02084 22.500033,-4.526272 22.500033,-8.999922 v -11.5"
+     sodipodi:nodetypes="cscsc" />
+</svg>

--- a/elementary-xfce/mimes/96/application-vnd.flatpak.ref.svg
+++ b/elementary-xfce/mimes/96/application-vnd.flatpak.ref.svg
@@ -5,7 +5,7 @@
    width="96"
    version="1.1"
    sodipodi:docname="application-vnd.flatpak.ref.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,12 +23,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="5.0234044"
-     inkscape:cx="28.068614"
-     inkscape:cy="69.872933"
+     inkscape:cx="28.168148"
+     inkscape:cy="69.773399"
      inkscape:window-width="1396"
      inkscape:window-height="896"
      inkscape:window-x="522"
-     inkscape:window-y="134"
+     inkscape:window-y="132"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3901" />
   <defs
@@ -195,6 +195,6 @@
      sodipodi:nodetypes="ccccc" />
   <path
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26769;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
-     d="M 47.900468,22 27.08211,34.017546 27,57.982433 48,70 69,58.002946 68.9092,34.017546 Z m 0,1.904342 v 17.352509 l 2.446292,1.461909 -2.446292,1.409146 -17.62208,-10.180618 z m 19.599626,11.34372 v 21.949186 l -19.5,11.165075 V 46.410155 Z"
+     d="M 48.099532,22 68.91789,34.017546 69,57.982433 48,70 27,58.002946 l 0.0908,-23.9854 z m 0,1.904342 v 17.352509 l -2.446292,1.461909 2.446292,1.409146 17.62208,-10.180618 z m -19.599626,11.34372 v 21.949186 l 19.5,11.165075 V 46.410155 Z"
      id="path7680" />
 </svg>

--- a/elementary-xfce/mimes/96/application-vnd.flatpak.svg
+++ b/elementary-xfce/mimes/96/application-vnd.flatpak.svg
@@ -5,7 +5,7 @@
    height="96"
    id="svg3049"
    sodipodi:docname="application-vnd.flatpak.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -24,12 +24,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="1.616991"
-     inkscape:cx="7.1119754"
-     inkscape:cy="129.25242"
+     inkscape:cx="6.802759"
+     inkscape:cy="128.9432"
      inkscape:window-width="1801"
      inkscape:window-height="858"
      inkscape:window-x="76"
-     inkscape:window-y="172"
+     inkscape:window-y="170"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3049" />
   <defs
@@ -195,26 +195,6 @@
          offset="1"
          style="stop-color:#d4d4d4;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-82"
-       id="linearGradient3365"
-       gradientUnits="userSpaceOnUse"
-       x1="32"
-       y1="3.9635763"
-       x2="32"
-       y2="59.570023"
-       gradientTransform="matrix(-1.5294121,0,0,-1.529412,96.941181,106.91923)" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-82">
-      <stop
-         id="stop3118"
-         style="stop-color:#505050;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3120"
-         style="stop-color:#8e8e8e;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata3054">
@@ -315,6 +295,6 @@
      d="m 84.500005,28.387204 -4.395431,-9.571806 c -0.966308,-2.120862 -1.866432,-3.750676 -2.913563,-4.765284 -1.047139,-1.014609 -2.726474,-1.55012 -4.794925,-1.55012 H 23.588073 c -2.071177,0 -3.601609,0.534792 -4.652342,1.544514 -1.050733,1.009723 -1.9442,2.627763 -2.877552,4.751273 v 0.0028 l -4.558184,9.70139" />
   <path
      id="path7680"
-     d="m 47.906247,36 -19.828126,11.515624 -0.07812,22.968752 20,11.515623 19.999998,-11.496093 -0.0859,-22.988282 z m 0,2.26616 v 16.186964 l 2.038328,1.227784 -1.944578,1.121026 -16,-9.301934 z M 65.999998,48.725106 V 69.34375 L 47.999997,79.699219 V 59.080574 Z"
+     d="m 48.093753,36 19.828126,11.515624 0.07812,22.968752 -20,11.515623 -19.999998,-11.496093 0.0859,-22.988282 z m 0,2.26616 v 16.186964 l -2.038328,1.227784 1.944578,1.121026 16,-9.301934 z M 30.000002,48.725106 V 69.34375 L 48.000003,79.699219 V 59.080574 Z"
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#4d88cf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.26772;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/mimes/96/application-x-bittorrent.svg
+++ b/elementary-xfce/mimes/96/application-x-bittorrent.svg
@@ -4,8 +4,8 @@
    height="96"
    width="96"
    version="1.1"
-   sodipodi:docname="gnome-mime-application-x-bittorrent.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   sodipodi:docname="application-x-bittorrent.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -22,13 +22,13 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="2"
-     inkscape:cx="-33"
-     inkscape:cy="112.5"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="55.419494"
+     inkscape:cy="70.09196"
      inkscape:window-width="1396"
      inkscape:window-height="896"
-     inkscape:window-x="522"
-     inkscape:window-y="134"
+     inkscape:window-x="255"
+     inkscape:window-y="589"
      inkscape:window-maximized="0"
      inkscape:current-layer="g3365" />
   <defs
@@ -197,17 +197,24 @@
      transform="matrix(2,0,0,2,-15,-14)"
      id="g3365">
     <path
-       d="M 21,33.250004 31.5,46.000008 42,33.250004 36,33.25 v -4.50015 c 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.5 0,-1.5 -1.5,-1.5 -1.5,-1.5 0,0 -1.5,0 -1.5,1.5 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.501278 v 4.501278 z"
+       d="m 31.5,16 c 0,0 -1.5,0 -1.5,1.5 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0.0012 -1.5,-1.5 V 34 h 9 V 17.5 C 36,19 34.5,19 34.5,19 34.5,19 33,19 33,17.5 33,16 31.5,16 31.5,16 Z"
+       id="path11077"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="csccccccsc" />
+    <path
+       d="m 28.5,22.25 c 0,0 -1.5,-0.0011 -1.5,1.5 V 33 h 9 v -9.25 c 0,-1.5 -1.5,-1.5 -1.5,-1.5 0,0 -1.5,0 -1.5,1.5 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.5 0,-1.5 -1.5,-1.5 -1.5,-1.5 z"
+       id="path11071"
+       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="csccscscsc" />
+    <path
+       d="M 36,32.000075 V 28.25 c 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.5 0,-1.5 -1.5,-1.5 -1.5,-1.5 0,0 -1.5,0 -1.5,1.5 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.501278 v 3.751203 z"
        id="path11053"
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccscscccc" />
+       sodipodi:nodetypes="cccscscccc" />
     <path
-       d="m 31.5,14.5 c 0,0 -1.5,0 -1.5,1.5 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0.0012 -1.5,-1.5 v 21 h 9 V 16 c 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.5 0,-1.5 -1.5,-1.5 -1.5,-1.5 z"
-       id="path11077"
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none;enable-background:accumulate" />
-    <path
-       d="m 28.5,21.25 c 0,0 -1.5,-0.0011 -1.5,1.5 v 9 h 9 v -9 c 0,-1.5 -1.5,-1.5 -1.5,-1.5 0,0 -1.5,0 -1.5,1.5 0,1.5 -1.5,1.5 -1.5,1.5 0,0 -1.5,0 -1.5,-1.5 0,-1.5 -1.5,-1.5 -1.5,-1.5 z"
-       id="path11071"
-       style="color:#bebebe;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499999;marker:none;enable-background:accumulate" />
+       id="path873-5"
+       style="font-variation-settings:normal;vector-effect:none;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:0.499998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="M 23.408338,31 C 22.628997,31 22,31.649942 22,32.457844 c 0,0.435427 0.182416,0.824429 0.472375,1.09119 l 7.920525,8.301374 c 0.251942,0.246576 0.590696,0.399592 0.964522,0.399592 0.373844,0 0.71258,-0.153016 0.964525,-0.399592 l 7.955678,-8.301374 C 40.567681,33.282273 40.75,32.893271 40.75,32.457844 40.75,31.649942 40.121019,31 39.341662,31 Z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/96/application-x-partial-download.svg
+++ b/elementary-xfce/mimes/96/application-x-partial-download.svg
@@ -5,7 +5,7 @@
    width="96"
    version="1.1"
    sodipodi:docname="application-x-partial-download.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -22,13 +22,13 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="4"
-     inkscape:cx="44"
-     inkscape:cy="57.25"
+     inkscape:zoom="16"
+     inkscape:cx="42.34375"
+     inkscape:cy="48.59375"
      inkscape:window-width="1396"
      inkscape:window-height="896"
-     inkscape:window-x="157"
-     inkscape:window-y="486"
+     inkscape:window-x="495"
+     inkscape:window-y="52"
      inkscape:window-maximized="0"
      inkscape:current-layer="g3365" />
   <defs
@@ -198,18 +198,38 @@
      id="g3365">
     <path
        id="path10725"
-       d="m 30.499845,27 v 3 h 2 v -3 z m 2,3 v 3.000033 h -2 V 30 h -3 v 3.000033 H 21 L 31.499845,46 42,33.000033 35.499845,33 v -3 z"
+       d="m 30.499845,25 v 3 h 2 v -3 z m 2,3 v 3.000033 h -2 V 28 h -3 v 3.000033 l 8,-3.3e-5 v -3 z"
        style="color:#bebebe;display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccccccccccccc" />
+       sodipodi:nodetypes="cccccccccccccc" />
     <path
        id="rect867"
-       d="M 30.499845,14.5 V 18 h 2 v -3.5 z m 2,3.5 v 3 h 3 v -3 z m 0,3 h -2 L 30.5,24 h 2 z m -2,0 v -3 h -3 v 3 z"
+       d="M 30.499845,15.5 V 19 h 2 v -3.5 z m 2,3.5 v 3 h 3 v -3 z m -2,3 v -3 h -3 v 3 z"
        style="display:inline;opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1;marker:none;enable-background:new"
-       sodipodi:nodetypes="cccccccccccccccccccc" />
+       sodipodi:nodetypes="ccccccccccccccc" />
     <path
        id="rect875"
-       d="m 27.499845,21 v 3 h 3 v -3 z m 3,3 v 3 h 2 3 v -6 h -3 v 3 z m 0,3 h -3 v 3 h 3 z"
+       d="m 30.499845,25 h 2 V 22 H 30.5 Z m 0,0 h -3 v 3 h 3 z"
        style="display:inline;opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1;marker:none;enable-background:new"
-       sodipodi:nodetypes="cccccccccccccccccc" />
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       id="path856"
+       d="m 30.499845,22 h -3 v 3 h 3 z"
+       style="display:inline;opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1;marker:none;enable-background:new"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path1355"
+       d="m 32.499845,28 h 3 v -3 h -3 z"
+       style="display:inline;opacity:0.6;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1;marker:none;enable-background:new"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path1611"
+       d="m 35.499845,22 h -3 v 3 h 3 z"
+       style="display:inline;opacity:0.2;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1;marker:none;enable-background:new"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path873-5"
+       style="font-variation-settings:normal;vector-effect:none;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:0.499998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+       d="M 23.533338,31 C 22.753997,31 22.125,31.649942 22.125,32.457844 c 0,0.435427 0.182416,0.824429 0.472375,1.09119 l 7.920525,8.301374 c 0.251942,0.246576 0.590696,0.399592 0.964522,0.399592 0.373844,0 0.71258,-0.153016 0.964525,-0.399592 l 7.955678,-8.301374 C 40.692681,33.282273 40.875,32.893271 40.875,32.457844 40.875,31.649942 40.246019,31 39.466662,31 Z"
+       sodipodi:nodetypes="csccsccscc" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/96/application-x-perl.svg
+++ b/elementary-xfce/mimes/96/application-x-perl.svg
@@ -1,1 +1,249 @@
-text-x-script.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="application-x-perl.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="5.0234044"
+     inkscape:cx="29.163489"
+     inkscape:cy="60.019058"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="415"
+     inkscape:window-y="140"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00541497" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.273762"
+       x2="23.99999"
+       y1="5.6275582"
+       x1="23.99999"
+       gradientTransform="matrix(1.8648648,0,0,2.3513513,3.2432558,-11.432408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.9999954,0,0,1.9120955,1.0813194e-4,-3.8236272)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6380632,0,0,1.8097673,119.83211,-6.5336729)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.13730769,0,0,0.02882352,-1.626924,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04698948,0,0,0.02882352,43.168704,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.04698949,0,0,0.02882352,52.831289,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="66.299995"
+     height="7"
+     x="14.849998"
+     y="86"
+     id="rect2879-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.85,86.000298 c 0,0 0,6.999581 0,6.999581 -2.419842,0.014 -5.85,-1.56828 -5.85,-3.50028 0,-1.932 2.700361,-3.499301 5.85,-3.499301 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 81.149999,86.000298 c 0,0 0,6.999581 0,6.999581 C 83.56984,93.013879 87,91.431599 87,89.499599 c 0,-1.932 -2.700361,-3.499301 -5.850001,-3.499301 z"
+     id="path2883-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 13,0.99999999 h 69.999918 l 8.5e-5,87.99999901 H 13 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 82.499999,88.499999 H 13.500001 V 1.5 h 68.999998 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 12.499959,0.4999623 83.499966,0.5 l 7.5e-5,89.000043 H 12.499959 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="path925-6"
+     style="display:inline;fill:#8cd5ff;fill-opacity:0.2;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 27.887302,23.513963 c -1.568159,0.01763 -2.629653,0.336233 -2.629653,0.336233 0,0 2.910555,9.303884 8.368653,8.382653 l 0.525931,-1.92175 c -0.05135,4.455058 1.513026,9.920373 2.034369,11.613104 -1.743636,4.449523 -4.170693,11.626331 -3.432998,15.560951 0.57644,3.074531 1.744938,5.433448 3.886685,7.082645 h -0.284638 c -1.455492,5.895885 2.911202,7.369704 11.64416,4.421762 8.732957,2.947942 13.099653,1.474123 11.64416,-4.421762 h -0.284638 c 2.141746,-1.649197 3.310245,-4.008114 3.886684,-7.082645 0.737695,-3.93462 -1.689361,-11.111428 -3.432997,-15.560951 0.521343,-1.692731 2.085713,-7.158046 2.034369,-11.613104 l 0.525931,1.92175 c 5.458097,0.921231 8.368653,-8.382653 8.368653,-8.382653 0,0 -5.345999,-1.595015 -9.758613,2.179722 -0.838147,-1.483314 -2.861719,-2.515955 -4.25079,-2.515955 -2.951139,0 -4.36628,1.256528 -8.732759,1.256528 -4.36648,0 -5.78162,-1.256528 -8.732759,-1.256528 -1.389073,0 -3.412644,1.032641 -4.25079,2.515955 -2.445878,-2.092307 -5.178762,-2.537884 -7.12896,-2.515955 z"
+     sodipodi:nodetypes="sccccscccccscccccssscs" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 36.774296,37.737549 c 0,0 -6.805565,14.838292 -5.572168,21.411443 0.857777,4.571343 2.899619,7.708857 7.17584,9.419947 2.534724,1.014247 9.622034,-1.622706 9.622034,-1.622706 v -11.358932 0 0 c 0,0 -6.414689,-2.1298 -7.717673,-10.344743 0,0 0.689446,7.020414 1.992431,7.223251"
+     id="path925"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csscccccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 33.96787,24.755911 c -4.911247,-4.462438 -11.025249,-2.636896 -11.025249,-2.636896 0,0 3.207346,10.243324 9.221117,9.229134"
+     id="path927"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 35.170623,66.946233 c -1.603672,6.490821 3.207345,8.113525 12.829379,4.868116 9.622033,3.245409 14.433051,1.622705 12.829378,-4.868116"
+     id="path932"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccc" />
+  <path
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 38.720196,30.136402 c 3.038963,-1.428613 6.268634,0.322829 6.1596,0.501976 0,0 -1.049378,4.403481 -3.529674,4.023597 -2.323408,-0.355855 -2.627977,-3.527012 -2.629926,-4.525573 z"
+     id="path938-7"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccsc" />
+  <path
+     sodipodi:nodetypes="ccsscsscc"
+     inkscape:connector-curvature="0"
+     id="path947"
+     d="m 60.82938,42.605662 v 0 c 0,0 4.150945,-12.459894 1.603673,-17.849751 C 61.601544,22.996493 59.225707,21.75 57.622035,21.75 c -3.251585,0 -4.811016,1.383206 -9.622033,1.383206 -4.811017,0 -6.370447,-1.383206 -9.622034,-1.383206 -1.603672,0 -3.979509,1.246493 -4.811017,3.005911 -2.547273,5.389857 1.603672,17.849751 1.603672,17.849751 v 0"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="csscccccc"
+     inkscape:connector-curvature="0"
+     id="path949"
+     d="m 59.225707,37.737549 c 0,0 6.805565,14.838292 5.572168,21.411443 -0.857775,4.571343 -2.89962,7.708857 -7.17584,9.419947 -2.534723,1.014247 -9.622033,-1.622706 -9.622033,-1.622706 v -11.358932 0 0 c 0,0 6.414688,-2.1298 7.717673,-10.344743 0,0 -0.760321,7.16384 -2.063305,7.366679"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccc"
+     inkscape:connector-curvature="0"
+     id="path951"
+     d="m 62.032135,24.755911 c 4.911246,-4.462438 11.025245,-2.636896 11.025245,-2.636896 0,0 -3.207344,10.243324 -9.221115,9.229134"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+  <path
+     sodipodi:nodetypes="ccsc"
+     inkscape:connector-curvature="0"
+     id="path955"
+     d="m 57.279808,30.136402 c -3.038963,-1.428613 -6.268635,0.322829 -6.159601,0.501976 0,0 1.049379,4.403481 3.529675,4.023597 2.323409,-0.355855 2.627978,-3.527012 2.629926,-4.525573 z"
+     style="display:inline;fill:none;fill-rule:evenodd;stroke:#3689e6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new" />
+</svg>

--- a/elementary-xfce/mimes/96/application-x-qemu-disk.svg
+++ b/elementary-xfce/mimes/96/application-x-qemu-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/96/application-x-sharedlib.svg
+++ b/elementary-xfce/mimes/96/application-x-sharedlib.svg
@@ -1,1 +1,294 @@
-application-x-executable.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="application-x-sharedlib.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="26.375"
+     inkscape:cy="52.875"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="158"
+     inkscape:window-y="321"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00541497" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.273762"
+       x2="23.99999"
+       y1="5.6275582"
+       x1="23.99999"
+       gradientTransform="matrix(1.8648648,0,0,2.3513513,3.2432558,-11.432408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.9999954,0,0,1.9120955,1.0813194e-4,-3.8236272)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6380632,0,0,1.8097673,119.83211,-6.5336729)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.13730769,0,0,0.02882352,-1.626924,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04698948,0,0,0.02882352,43.168704,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.04698949,0,0,0.02882352,52.831289,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(1.0001045,0,0,1.0001045,-45.926856,-4.1246116)"
+       gradientUnits="userSpaceOnUse"
+       y2="72.611374"
+       x2="28.465853"
+       y1="102.04572"
+       x1="-0.96849668"
+       id="linearGradient1108-6-4-1-8"
+       xlink:href="#linearGradient1819" />
+    <linearGradient
+       id="linearGradient1819">
+      <stop
+         style="stop-color:#7239b3;stop-opacity:1"
+         offset="0"
+         id="stop1815" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop1817" />
+    </linearGradient>
+    <linearGradient
+       y2="52.555481"
+       x2="-16.355318"
+       y1="84.61676"
+       x1="-48.416599"
+       gradientTransform="matrix(0.92851207,0,0,0.92851207,7.8377549,9.9938469)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient965-7-1"
+       xlink:href="#linearGradient1813" />
+    <linearGradient
+       id="linearGradient1813">
+      <stop
+         style="stop-color:#a56de2;stop-opacity:1"
+         offset="0"
+         id="stop1809" />
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="1"
+         id="stop1811" />
+    </linearGradient>
+    <linearGradient
+       y2="-2.2776909"
+       x2="-29.166981"
+       y1="29.666771"
+       x1="-61.111443"
+       gradientTransform="matrix(0.92843962,0,0,0.92843962,30.862514,49.897001)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1194-3-2"
+       xlink:href="#linearGradient1807" />
+    <linearGradient
+       id="linearGradient1807">
+      <stop
+         style="stop-color:#cd9ef7;stop-opacity:1"
+         offset="0"
+         id="stop1803" />
+      <stop
+         style="stop-color:#8cd5ff;stop-opacity:1"
+         offset="1"
+         id="stop1805" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="66.299995"
+     height="7"
+     x="14.849998"
+     y="86"
+     id="rect2879-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.85,86.000298 c 0,0 0,6.999581 0,6.999581 -2.419842,0.014 -5.85,-1.56828 -5.85,-3.50028 0,-1.932 2.700361,-3.499301 5.85,-3.499301 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 81.149999,86.000298 c 0,0 0,6.999581 0,6.999581 C 83.56984,93.013879 87,91.431599 87,89.499599 c 0,-1.932 -2.700361,-3.499301 -5.850001,-3.499301 z"
+     id="path2883-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 13,0.99999999 h 69.999918 l 8.5e-5,87.99999901 H 13 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 82.499999,88.499999 H 13.500001 V 1.5 h 68.999998 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 12.499959,0.4999623 83.499966,0.5 l 7.5e-5,89.000043 H 12.499959 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     transform="matrix(0.87157717,-0.49025833,0.87157717,0.49025833,0,0)"
+     ry="8.386651"
+     rx="8.386651"
+     y="68.939743"
+     x="-46.305111"
+     height="32.438286"
+     width="32.438"
+     id="rect48-5-5"
+     style="vector-effect:none;fill:url(#linearGradient1108-6-4-1-8);fill-opacity:1;stroke:none;stroke-width:1.08172;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <rect
+     transform="matrix(0.87157435,-0.49026335,0.87157435,0.49026335,0,0)"
+     ry="8.3868532"
+     rx="8.3868532"
+     y="59.250568"
+     x="-36.616306"
+     height="32.438492"
+     width="32.438492"
+     id="rect48-5-1-7"
+     style="vector-effect:none;fill:url(#linearGradient965-7-1);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+  <path
+     id="rect48-5-1-8-2-7"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.99999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;-inkscape-stroke:none;marker:none;paint-order:normal;stop-color:#000000"
+     d="m 48.000002,33.499834 c -2.642478,0 -5.284766,0.569049 -7.30957,1.708008 l -12.297363,6.916992 12.297364,6.916992 c 4.049607,2.277919 10.569536,2.277919 14.619142,2e-6 L 67.606934,42.124833 55.309573,35.207842 C 53.284769,34.068884 50.64248,33.499834 48.000002,33.499834 Z" />
+  <path
+     id="rect48-5-1-8-2-7-6"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#452981;fill-opacity:1;stroke:none;stroke-width:0.99999;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;-inkscape-stroke:none;marker:none;paint-order:normal;stop-color:#000000"
+     d="m 48.000002,33.499834 c -2.642478,0 -5.284766,0.569049 -7.30957,1.708008 l -12.297363,6.916992 12.297364,6.916992 c 4.049607,2.277919 10.569536,2.277919 14.619142,2e-6 L 67.606934,42.124833 55.309573,35.207842 C 53.284769,34.068883 50.64248,33.499834 48.000002,33.499834 Z" />
+  <rect
+     transform="matrix(0.87157435,-0.49026335,0.87157435,0.49026335,0,0)"
+     ry="8.3868532"
+     rx="8.3868532"
+     y="48.542103"
+     x="-25.907835"
+     height="32.438492"
+     width="32.438492"
+     id="rect48-5-1-8-2"
+     style="vector-effect:none;fill:url(#linearGradient1194-3-2);fill-opacity:1;stroke:none;stroke-width:1.08174;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.501961;marker:none;paint-order:normal" />
+</svg>

--- a/elementary-xfce/mimes/96/application-x-shellscript.svg
+++ b/elementary-xfce/mimes/96/application-x-shellscript.svg
@@ -23,12 +23,12 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="20.093618"
-     inkscape:cx="35.583437"
-     inkscape:cy="41.431065"
+     inkscape:cx="35.608321"
+     inkscape:cy="41.381298"
      inkscape:window-width="1396"
      inkscape:window-height="896"
      inkscape:window-x="367"
-     inkscape:window-y="426"
+     inkscape:window-y="132"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3901" />
   <defs
@@ -221,7 +221,7 @@
      x="24"
      y="24"
      rx="4"
-     ry="4.4000001" />
+     ry="4" />
   <path
      style="color:#000000;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:14.3117px;line-height:125%;font-family:'Open Sans';-inkscape-font-specification:'Open Sans Bold';letter-spacing:0px;word-spacing:0px;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
      id="path3987-0"

--- a/elementary-xfce/mimes/96/application-x-vdi-disk.svg
+++ b/elementary-xfce/mimes/96/application-x-vdi-disk.svg
@@ -1,0 +1,210 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="application-ovf.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="3.5520833"
+     inkscape:cx="78.686218"
+     inkscape:cy="53.067449"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="612"
+     inkscape:window-y="68"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00541497" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.273762"
+       x2="23.99999"
+       y1="5.6275582"
+       x1="23.99999"
+       gradientTransform="matrix(1.8648648,0,0,2.3513513,3.2432558,-11.432408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.9999954,0,0,1.9120955,1.0813194e-4,-3.8236272)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6380632,0,0,1.8097673,119.83211,-6.5336729)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.13730769,0,0,0.02882352,-1.626924,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04698948,0,0,0.02882352,43.168704,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.04698949,0,0,0.02882352,52.831289,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="66.299995"
+     height="7"
+     x="14.849998"
+     y="86"
+     id="rect2879-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.85,86.000298 c 0,0 0,6.999581 0,6.999581 -2.419842,0.014 -5.85,-1.56828 -5.85,-3.50028 0,-1.932 2.700361,-3.499301 5.85,-3.499301 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 81.149999,86.000298 c 0,0 0,6.999581 0,6.999581 C 83.56984,93.013879 87,91.431599 87,89.499599 c 0,-1.932 -2.700361,-3.499301 -5.850001,-3.499301 z"
+     id="path2883-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 13,0.99999999 h 69.999918 l 8.5e-5,87.99999901 H 13 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 82.499999,88.499999 H 13.500001 V 1.5 h 68.999998 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 12.499959,0.4999623 83.499966,0.5 l 7.5e-5,89.000043 H 12.499959 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <rect
+     style="fill:#3689e6;fill-opacity:1;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.8;paint-order:stroke markers fill"
+     id="rect880"
+     width="48"
+     height="48.000004"
+     x="24"
+     y="20"
+     rx="4"
+     ry="4" />
+  <path
+     style="fill:none;stroke:#ffffff;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+     d="m 24,35.999998 h 8 L 38,55 l 8,-23 6,16 6,-16 6,19 h 8"
+     id="path1493"
+     sodipodi:nodetypes="cccccccc" />
+</svg>

--- a/elementary-xfce/mimes/96/application-x-vmdk-disk.svg
+++ b/elementary-xfce/mimes/96/application-x-vmdk-disk.svg
@@ -1,0 +1,1 @@
+application-ovf.svg

--- a/elementary-xfce/mimes/96/text-markdown.svg
+++ b/elementary-xfce/mimes/96/text-markdown.svg
@@ -5,7 +5,7 @@
    width="96"
    version="1.1"
    sodipodi:docname="text-markdown.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -22,15 +22,15 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="5.6568543"
-     inkscape:cx="63.816387"
-     inkscape:cy="37.476659"
+     inkscape:zoom="16"
+     inkscape:cx="34.15625"
+     inkscape:cy="41.96875"
      inkscape:window-width="1396"
      inkscape:window-height="896"
-     inkscape:window-x="613"
-     inkscape:window-y="138"
+     inkscape:window-x="181"
+     inkscape:window-y="132"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g3365" />
+     inkscape:current-layer="svg3901" />
   <defs
      id="defs3903">
     <linearGradient
@@ -158,9 +158,9 @@
        cx="605.71429" />
     <linearGradient
        gradientUnits="userSpaceOnUse"
-       y2="8"
+       y2="18.803528"
        x2="64"
-       y1="112"
+       y1="103.33609"
        x1="64"
        id="linearGradient4615-3"
        xlink:href="#linearGradient4613"
@@ -176,6 +176,15 @@
          offset="1"
          style="stop-color:#505f6f;stop-opacity:1" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4613"
+       id="linearGradient910"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39583338,0,0,0.39999563,7.166664,5.0004003)"
+       x1="64"
+       y1="112"
+       x2="64"
+       y2="8" />
   </defs>
   <metadata
      id="metadata3906">
@@ -218,7 +227,13 @@
      id="g3365">
     <path
        id="rect4550-5"
-       d="m 20.5,23 c -1.090703,0 -2,0.909297 -2,2 v 12 c 0,1.090705 0.909297,2 2,2 h 22 c 1.090703,0 2,-0.909295 2,-2 V 25 c 0,-1.090703 -0.909297,-2 -2,-2 z m 0,2 h 22 v 12 h -22 z m 2,2 v 8 h 2 v -5.154297 l 2.5,2.71875 2.5,-2.71875 V 35 h 2 v -8 h -2 L 27,29.78125 24.5,27 Z m 14,0 v 4 H 34 l 3.5,4 3.5,-4 h -2.5 v -4 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       d="m 20.5,23 c -1.090703,0 -2,0.909297 -2,2 v 12 c 0,1.090705 0.909297,2 2,2 h 22 c 1.090703,0 2,-0.909295 2,-2 V 25 c 0,-1.090703 -0.909297,-2 -2,-2 z m 0,2 h 22 v 12 h -22 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4615-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       sodipodi:nodetypes="sssssssssccccc" />
+    <path
+       id="path906"
+       style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient910);fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+       d="M 23.791992,27.000089 C 23.353413,27.000089 23,27.356703 23,27.799893 v 6.400392 c 0,0.44319 0.353413,0.799804 0.791992,0.799804 h 0.917 c 0.43858,0 0.790954,-0.356614 0.791016,-0.799804 v -3.595704 l 1.835929,2.108398 c 0.09658,0.09558 0.223506,0.156298 0.364063,0.166993 0.01921,0.002 0.03028,0.0029 0.05,0.0029 0.01445,-4e-4 0.03583,-0.0015 0.05,-0.0029 0.140557,-0.0107 0.267485,-0.07141 0.364061,-0.166993 l 1.835932,-2.108398 v 3.595704 c -2e-6,0.44319 0.352434,0.799804 0.791014,0.799804 h 0.916998 c 0.438579,0 0.791992,-0.356614 0.791992,-0.799804 v -6.400392 c 0,-0.44319 -0.353413,-0.799804 -0.791992,-0.799804 h -1.155274 c -0.205902,-0.0031 -0.412546,0.07495 -0.570312,0.234375 l -2.232422,2.382812 -2.237305,-2.382812 c -0.157763,-0.159422 -0.364408,-0.237425 -0.570309,-0.234375 z m 12.770258,0 c -0.311761,0 -0.562558,0.278076 -0.56225,0.623047 v 3.376919 h -1.4375 c -0.31176,0 -0.5625,0.278078 -0.5625,0.623046 0,0.18592 0.07343,0.350937 0.189453,0.464844 l 2.425781,2.742222 c 0.100784,0.105292 0.235222,0.169922 0.384766,0.169922 0.14954,0 0.283982,-0.06463 0.384765,-0.169922 l 2.425782,-2.742222 C 39.92658,31.974039 40,31.809021 40,31.623101 40,31.278133 39.749261,31.000899 39.4375,31.000055 H 38 v -3.376919 c 0,-0.344971 -0.25049,-0.623047 -0.56225,-0.623047 z"
+       sodipodi:nodetypes="ssssssccccccccssssscccccssccssccsccsscsss" />
   </g>
 </svg>

--- a/elementary-xfce/mimes/96/text-x-bibtex.svg
+++ b/elementary-xfce/mimes/96/text-x-bibtex.svg
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg3901"
+   height="96"
+   width="96"
+   version="1.1"
+   sodipodi:docname="text-x-bibtex.svg"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#">
+  <sodipodi:namedview
+     id="namedview41"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="35.375"
+     inkscape:cy="98.625"
+     inkscape:window-width="1396"
+     inkscape:window-height="896"
+     inkscape:window-x="544"
+     inkscape:window-y="448"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3901" />
+  <defs
+     id="defs3903">
+    <linearGradient
+       id="linearGradient3403">
+      <stop
+         id="stop3405"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3407"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.00541497" />
+      <stop
+         id="stop3409"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3411"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         id="stop3106-3"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         offset="0" />
+      <stop
+         id="stop3108-9"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="42.273762"
+       x2="23.99999"
+       y1="5.6275582"
+       x1="23.99999"
+       gradientTransform="matrix(1.8648648,0,0,2.3513513,3.2432558,-11.432408)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3106"
+       xlink:href="#linearGradient3403" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(1.9999954,0,0,1.9120955,1.0813194e-4,-3.8236272)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3109"
+       xlink:href="#linearGradient3600" />
+    <linearGradient
+       y2="2.9062471"
+       x2="-51.786404"
+       y1="50.786446"
+       x1="-51.786404"
+       gradientTransform="matrix(1.6380632,0,0,1.8097673,119.83211,-6.5336729)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3170"
+       xlink:href="#linearGradient3104-6" />
+    <linearGradient
+       gradientTransform="matrix(0.13730769,0,0,0.02882352,-1.626924,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3842"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <radialGradient
+       gradientTransform="matrix(-0.04698948,0,0,0.02882352,43.168704,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3156"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(0.04698949,0,0,0.02882352,52.831289,75.431978)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3153"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+  </defs>
+  <metadata
+     id="metadata3906">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="" />
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="66.299995"
+     height="7"
+     x="14.849998"
+     y="86"
+     id="rect2879-2"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3842);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 14.85,86.000298 c 0,0 0,6.999581 0,6.999581 -2.419842,0.014 -5.85,-1.56828 -5.85,-3.50028 0,-1.932 2.700361,-3.499301 5.85,-3.499301 z"
+     id="path2881-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 81.149999,86.000298 c 0,0 0,6.999581 0,6.999581 C 83.56984,93.013879 87,91.431599 87,89.499599 c 0,-1.932 -2.700361,-3.499301 -5.850001,-3.499301 z"
+     id="path2883-1"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3153);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 13,0.99999999 h 69.999918 l 8.5e-5,87.99999901 H 13 Z"
+     id="path4160"
+     style="display:inline;fill:url(#linearGradient3109);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 82.499999,88.499999 H 13.500001 V 1.5 h 68.999998 z"
+     id="rect6741-1"
+     style="fill:none;stroke:url(#linearGradient3106);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 12.499959,0.4999623 83.499966,0.5 l 7.5e-5,89.000043 H 12.499959 Z"
+     id="path4160-6-1"
+     style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     id="path3475"
+     d="m 44,17.5 h 5.9375 z m 6.6875,0 h 3.75 z m 4.4375,0 h 1.6875 z m 2.3125,0 h 3.875 z M 62,17.5 h 4.375 z m 5.0625,0 H 72 Z M 44,21.5 h 5.3125 z m 5.9375,0 h 3.25 z m 3.9375,0 h 3.1875 z m 3.875,0 h 1.75 z m 2.375,0 h 3.5 z m 4.3125,0 H 72 Z M 44,25.5 h 4.886718 z m 5.511718,0 h 4.9375 z m 5.5625,0 h 10.125 z m 10.75,0 h 6.1875 z M 44,29.5 h 8.625 z m 9.25,0 h 9.25 z m 9.9375,0 H 72 Z m -24.503906,7.992094 6.1875,0.0078 z M 22,37.499906 h 3.1875 z m 4.1875,0 H 38 Z m 19.246094,0 h 9.648438 z m 10.316406,0 h 11.8125 z m 12.8125,0 H 72 Z M 22,41.46875 h 6.1875 z m 6.8125,0 h 10.125 z m 10.75,0 H 44.5 Z m 5.5625,0 h 4.625 z m 5.25,0 h 3.9375 z m 4.5625,0 6.1875,0.0625 z m 6.75,0.0625 H 72 Z M 22,45.5 h 4.6875 z m 5.375,0 h 4.3125 z m 5.0625,0 h 3.875 z m 4.5,0 h 1.6875 z m 2.375,0 h 3.75 z m 4.5,0 h 9.8125 z m 10.5,0 h 7.5 z m 8.125,0 h 2.375 z m 3,0 H 72 Z M 22,49.5 h 7.875 z m 8.5,0 h 8.4375 z m 9.0625,0 h 3.25 z m 3.875,0 H 51.375 Z M 52,49.5 h 10 z m 10.6875,0 H 72 Z M 22,53.5 h 8.5625 z m 9.25,0 h 9.25 z m 9.875,0 h 3.6875 z m 4.3125,0 h 8.6875 z m 9.25,0 h 5.9375 z m 6.625,0 h 2.375 z m 3,0 h 1.3125 z m 2,0 H 72 Z M 22,57.5 h 7.3125 z m 8.125,0 h 3.5 z m 4.125,0 H 36 Z m 2.4375,0 h 3.1875 z m 3.875,0 h 3.25 z m 3.875,0 h 5.1875 z m 5.875,0 h 6.75 z m 7.375,0 h 4.5 z m 5.125,0 H 72 Z M 22,65.46875 h 6.1875 z m 6.8125,0 h 10.125 z m 10.75,0 H 44.5 Z m 5.5625,0 H 50 Z M 22,69.5 h 7.3125 z m 8.125,0 h 3.5 z m 4.125,0 H 36 Z m 2.4375,0 h 3.1875 z m 3.875,0 h 3.25 z m 3.875,0 H 50 Z M 22,73.5 h 7.75 z m 8.4375,0 h 2.4375 z m 3.0625,0 h 5.5625 z m 6.1875,0 H 50 Z M 22,77.5 h 7.75 z m 8.4375,0 h 3.5 z m 4.125,0 h 5.5 z m 6.125,0 h 5.9375 z m 6.625,0 H 50 Z"
+     style="fill:none;stroke:#7e8087;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     style="fill:#7e8087;fill-opacity:1;stroke-width:1"
+     d="m 52.789102,77.242532 c 2.606742,-1.212056 5.333852,-2.485546 5.333852,-5.21265 0,-0.848436 -0.363616,-0.848436 -1.939278,-0.969644 -1.757468,-0.1212 -2.485534,-1.272646 -2.485534,-2.848308 0,-2.181686 1.393852,-3.21193 3.090718,-3.21193 2.545302,0 4.424818,2.242288 4.424818,5.333016 0,2.36433 -1.151448,4.787584 -3.21193,6.545902 C 56.607894,78.030358 55.456446,78.454576 53.516334,79 Z m 10.788066,0 c 2.605904,-1.212056 5.333014,-2.485546 5.333014,-5.21265 0,-0.848436 -0.363616,-0.848436 -1.939276,-0.969644 -1.757476,-0.1212 -2.4847,-1.272646 -2.4847,-2.848308 0,-2.181686 1.393852,-3.21193 3.09072,-3.21193 2.545302,0 4.423976,2.242288 4.423976,5.333016 0,2.36433 -1.151444,4.787584 -3.211926,6.545902 C 67.395118,78.030358 66.243674,78.454576 64.304398,79 Z"
+     id="path3253" />
+  <path
+     style="fill:#7e8087;fill-opacity:1;stroke-width:1"
+     d="m 30.425078,17.757575 c -2.606898,1.212118 -5.334174,2.48485 -5.334174,5.21212 0,0.848488 0.363638,0.848488 1.939394,0.969702 1.757576,0.12122 2.485692,1.272724 2.485692,2.848486 0,2.181812 -1.393936,3.212118 -3.09091,3.212118 -2.545452,0 -4.42508,-2.243266 -4.42508,-5.334172 0,-2.36364 1.151512,-4.787886 3.212116,-6.54546 C 26.606062,16.9697 27.758416,16.545457 29.69781,16 Z m 10.788726,0 c -2.606064,1.212118 -5.333338,2.48485 -5.333338,5.21212 0,0.848488 0.363636,0.848488 1.939392,0.969702 1.757582,0.12122 2.48485,1.272724 2.48485,2.848486 0,2.181812 -1.393936,3.212118 -3.090906,3.212118 -2.545456,0 -4.424242,-2.243266 -4.424242,-5.334172 0,-2.36364 1.151512,-4.787886 3.212118,-6.54546 C 37.395622,16.9697 38.547134,16.545457 40.486528,16 Z"
+     id="path3255" />
+</svg>

--- a/elementary-xfce/mimes/96/text-x-install.svg
+++ b/elementary-xfce/mimes/96/text-x-install.svg
@@ -5,7 +5,7 @@
    width="96"
    version="1.1"
    sodipodi:docname="text-x-install.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -22,13 +22,13 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="5.6568543"
-     inkscape:cx="58.336309"
-     inkscape:cy="69.826795"
+     inkscape:zoom="16"
+     inkscape:cx="46.09375"
+     inkscape:cy="46.03125"
      inkscape:window-width="1396"
      inkscape:window-height="896"
-     inkscape:window-x="564"
-     inkscape:window-y="210"
+     inkscape:window-x="522"
+     inkscape:window-y="132"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3901" />
   <defs
@@ -194,8 +194,13 @@
      style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      sodipodi:nodetypes="ccccc" />
   <path
-     d="M 65.25,48 48,67.5 30.75,48 H 43 V 29 h 10 v 19 z"
-     id="path3288-2-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#7e8087;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="cccccccc" />
+     id="path873-5-3-3-7-4"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="M 53.999907,48.000327 V 27.5 c 0,-1.385 -0.864901,-2.5 -2.249905,-2.5 h -7.5 c -1.385003,0 -2.232594,1.115108 -2.249904,2.5 V 48 Z"
+     sodipodi:nodetypes="csssccc" />
+  <path
+     id="path873-5"
+     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
+     d="M 32.066676,48 C 30.507994,48 29.25,49.299884 29.25,50.915688 c 0,0.870854 0.364832,1.648858 0.94475,2.18238 L 46.0358,69.700816 C 46.539684,70.193968 47.217192,70.5 47.964844,70.5 c 0.747688,0 1.42516,-0.306032 1.92905,-0.799184 L 65.80525,53.098068 C 66.385362,52.564546 66.75,51.786542 66.75,50.915688 66.75,49.299884 65.492038,48 63.933324,48 Z"
+     sodipodi:nodetypes="csccsccscc" />
 </svg>


### PR DESCRIPTION
New

- Bibtex (icon from upstream)
- Perl (using the Yaru icon as a base)
- SQL
- Virtual Disk Image icons (Qemu, VMWare, Virtualbox)

Updated (using elements/styles from upstream)

- Flatpak (logo was reversed)
- Install (use darker colors, rounded arrows from upstream)
- Partial Download and Bittorrent (use rounded arrow tips from upstream)
- Markdown (use rounded arrows and 'M' from upstream)

---

Images! Just linking because they're a bit large.

- [New (part 1)](https://github.com/shimmerproject/elementary-xfce/assets/1984060/af93e293-415f-430b-bacc-1bb138f433d9)
- [New (part 2)](https://github.com/shimmerproject/elementary-xfce/assets/1984060/6450759b-8da7-4ba4-ba82-e2d941b3bfc6)




 

- [Updated current (part 1)](https://github.com/shimmerproject/elementary-xfce/assets/1984060/86bce9af-4f28-49bf-98ee-963fed56c19e)
- [Updated proposed (part 1)](https://github.com/shimmerproject/elementary-xfce/assets/1984060/3bfd87d9-69fb-47a0-8841-892e20b1df64)


 

- [Updated current (part 2)](https://github.com/shimmerproject/elementary-xfce/assets/1984060/3df01709-5c46-4b3b-b5d4-2b8343fb9dde)
- [Updated proposed (part 2)](https://github.com/shimmerproject/elementary-xfce/assets/1984060/262c7a54-3f02-4952-9533-2ea93112a70c)
