### PR TITLE
Status: Add update-notifier icon

### DIFF
--- a/elementary-xfce/status/128/un-reboot.svg
+++ b/elementary-xfce/status/128/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg

--- a/elementary-xfce/status/16/software-update-available.svg
+++ b/elementary-xfce/status/16/software-update-available.svg
@@ -1,15 +1,38 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg7357">
+   id="svg7357"
+   sodipodi:docname="software-update-available.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="4.4296875"
+     inkscape:cy="8.484375"
+     inkscape:window-width="1426"
+     inkscape:window-height="1050"
+     inkscape:window-x="-205"
+     inkscape:window-y="424"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7357" />
   <defs
      id="defs7359">
     <linearGradient
@@ -24,38 +47,10 @@
          id="stop837" />
     </linearGradient>
     <linearGradient
-       y2="19.271681"
-       x2="61.219437"
-       y1="15.833592"
-       x1="61.219437"
-       gradientTransform="matrix(2.3268746,0,0,2.3268746,-135.94475,-32.842783)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3293"
-       xlink:href="#linearGradient4806" />
-    <linearGradient
-       id="linearGradient4806">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4808" />
-      <stop
-         offset="0.12499987"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4810" />
-      <stop
-         offset="0.87499982"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4812" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4814" />
-    </linearGradient>
-    <linearGradient
        x1="2065.6956"
-       y1="3220.5276"
+       y1="3219.6023"
        x2="2065.6956"
-       y2="3244.8506"
+       y2="3245.6455"
        id="linearGradient11527-6-5-3"
        xlink:href="#linearGradient839"
        gradientUnits="userSpaceOnUse"
@@ -69,32 +64,30 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <path
+     id="path833"
      style="opacity:0.98999999;vector-effect:none;fill:url(#linearGradient11527-6-5-3);fill-opacity:1;stroke:none;stroke-width:0.99999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;font-variant-east_asian:normal"
-     d="M 8,0.49996722 5.9913242,3.149515 2.6972424,2.6972425 3.1495149,5.9913243 0.49996721,8 3.1495149,10.008676 2.6972424,13.302758 5.9913242,12.850485 8,15.500033 10.008676,12.850485 13.302757,13.302758 12.850485,10.008676 15.500033,8 12.850485,5.9913243 13.302757,2.6972425 10.008676,3.149515 Z"
-     id="path833" />
+     d="M 8 0 A 0.50004997 0.50004997 0 0 0 7.6015625 0.19726562 L 5.7695312 2.6152344 L 2.765625 2.2011719 A 0.50004997 0.50004997 0 0 0 2.2011719 2.765625 L 2.6152344 5.7695312 L 0.19726562 7.6015625 A 0.50004997 0.50004997 0 0 0 0.19726562 8.3984375 L 2.6152344 10.230469 L 2.2011719 13.234375 A 0.50004997 0.50004997 0 0 0 2.765625 13.798828 L 5.7695312 13.384766 L 7.6015625 15.802734 A 0.50004997 0.50004997 0 0 0 8.3984375 15.802734 L 10.230469 13.384766 L 13.234375 13.798828 A 0.50004997 0.50004997 0 0 0 13.798828 13.234375 L 13.384766 10.230469 L 15.802734 8.3984375 A 0.50004997 0.50004997 0 0 0 15.802734 7.6015625 L 13.384766 5.7695312 L 13.798828 2.765625 A 0.50004997 0.50004997 0 0 0 13.234375 2.2011719 L 10.230469 2.6152344 L 8.3984375 0.19726562 A 0.50004997 0.50004997 0 0 0 8 0 z " />
   <path
-     id="path841"
-     d="M 8,0.49996722 5.9913242,3.149515 2.6972424,2.6972425 3.1495149,5.9913243 0.49996721,8 3.1495149,10.008676 2.6972424,13.302758 5.9913242,12.850485 8,15.500033 10.008676,12.850485 13.302757,13.302758 12.850485,10.008676 15.500033,8 12.850485,5.9913243 13.302757,2.6972425 10.008676,3.149515 Z"
-     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
-  <path
-     d="M 8,2.15625 6.7890625,3.7539062 A 1.0004397,1.0004397 0 0 1 5.8554688,4.140625 L 3.8671875,3.8671875 4.140625,5.8554688 A 1.0004397,1.0004397 0 0 1 3.7539062,6.7890625 L 2.15625,8 3.7539062,9.2109375 A 1.0004397,1.0004397 0 0 1 4.140625,10.144531 l -0.2734375,1.988281 1.9882813,-0.273437 a 1.0004397,1.0004397 0 0 1 0.9335937,0.386719 L 8,13.84375 9.2109375,12.246094 a 1.0004397,1.0004397 0 0 1 0.9335935,-0.386719 l 1.988281,0.273437 -0.273437,-1.988281 A 1.0004397,1.0004397 0 0 1 12.246094,9.2109375 L 13.84375,8 12.246094,6.7890625 A 1.0004397,1.0004397 0 0 1 11.859375,5.8554688 L 12.132812,3.8671875 10.144531,4.140625 A 1.0004397,1.0004397 0 0 1 9.2109375,3.7539062 Z"
-     id="path841-5"
-     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3293);stroke-width:0.99999996;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;font-variant-east_asian:normal" />
-  <path
-     d="m 8,14.000624 c -0.4016709,0 -0.8020585,-0.163613 -1.09375,-0.464844 a 1.0001,1.0001 0 0 1 -0.048828,-0.05469 l -2.5,-3 A 1.0001,1.0001 0 0 1 4.34375,10.465468 C 3.9441082,9.9654829 3.976531,9.3506208 4.1796875,8.9107802 4.382844,8.4709397 4.8302303,8.0470604 5.4707031,8.0279677 a 1.0001,1.0001 0 0 1 0.029297,0 H 6 V 5.5279676 a 1.0001,1.0001 0 0 1 0,-0.0098 c 0.00673,-0.702023 0.506517,-1.316273 1.1914062,-1.466797 a 1.0001,1.0001 0 0 1 0.1230469,-0.01953 c 0.092225,-0.0086 0.1851192,-0.0086 0.2773438,0 L 7.5,4.0279676 h 1 a 1.0001,1.0001 0 0 1 0.037109,0 C 9.3222229,4.0576356 9.9703399,4.7057316 10,5.4908586 a 1.0001,1.0001 0 0 1 0,0.03711 v 2.4999991 h 0.5 a 1.0001,1.0001 0 0 1 0.0293,0 c 0.640473,0.019093 1.087859,0.442972 1.291015,0.8828125 0.203157,0.4398406 0.23558,1.0547027 -0.164062,1.5546878 a 1.0001,1.0001 0 0 1 -0.01367,0.01563 l -2.4999999,3 A 1.0001,1.0001 0 0 1 9.09375,13.53578 C 8.8020601,13.837007 8.4016744,14.000624 8,14.000624 Z"
+     d="m 8,14.000624 c -0.4016709,0 -0.8020585,-0.163613 -1.09375,-0.464844 L 4.34375,10.437937 C 3.9441082,9.9379501 3.976531,9.323088 4.1796875,8.8832474 4.382844,8.4434069 4.8302303,8.0195275 5.4707031,8.0004349 H 6 V 4.5181995 C 6.00673,3.8161765 6.506517,3.150524 7.1914062,3 H 8.537109 C 9.3222229,3.029668 9.9703399,3.7057635 10,4.4908905 v 3.5095444 h 0.5293 c 0.640473,0.019093 1.087859,0.4429719 1.291015,0.8828125 0.203157,0.4398406 0.23558,1.0547027 -0.164062,1.5546876 L 9.0937501,13.535778 C 8.8020601,13.837007 8.4016744,14.000624 8,14.000624 Z"
      id="path818-1-1-2"
-     style="opacity:0.05;vector-effect:none;fill:#a62100;fill-opacity:1;stroke:none;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+     style="opacity:0.2;vector-effect:none;fill:#a62100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     sodipodi:nodetypes="sccsccccccccsccs" />
   <path
      id="path818-1-1"
-     d="m 8,13 c 0.1362185,0 0.272437,-0.05424 0.375,-0.160156 l 2.5,-3.0000003 c 0.231,-0.289 -0.006,-0.8015 -0.375,-0.8125 H 9 V 5.527344 c -0.010267,-0.271776 -0.2282237,-0.48973 -0.5,-0.5 h -1 c -0.031265,-0.0029 -0.062485,-0.0029 -0.09375,0 C 7.1709498,5.079058 7.00231,5.286439 7,5.527344 V 9.0273437 H 5.5 c -0.369,0.011 -0.606,0.5235 -0.375,0.8125 l 2.5,3.0000003 C 7.727563,12.945761 7.8637815,13 8,13 Z"
-     style="opacity:0.15;vector-effect:none;fill:#a62100;fill-opacity:1;stroke:none;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+     d="m 8,13 c 0.1362185,0 0.272437,-0.05424 0.375,-0.160156 L 11.6255,8.81225 c 0.231,-0.289 -0.006,-0.8015 -0.375,-0.8125 H 9.5 V 4.5 C 9.489733,4.228224 9.2717763,4.01027 9,4 H 6.906125 C 6.6708248,4.051714 6.502185,4.259095 6.499875,4.5 V 7.99975 H 4.7495 c -0.369,0.011 -0.606,0.5235 -0.375,0.8125 L 7.625,12.839844 C 7.727563,12.945761 7.8637815,13 8,13 Z"
+     style="opacity:0.3;vector-effect:none;fill:#a62100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     sodipodi:nodetypes="sccccccccccccs" />
   <path
      id="path818-1"
-     d="m 8,12.000222 c 0.1362185,0 0.272437,-0.05424 0.375,-0.160156 l 2.5,-3.0000003 c 0.231,-0.289 -0.006,-0.8015 -0.375,-0.8125 H 9 V 4.5275656 c -0.010267,-0.271776 -0.2282237,-0.48973 -0.5,-0.5 h -1 c -0.031265,-0.0029 -0.062485,-0.0029 -0.09375,0 -0.2353002,0.051714 -0.40394,0.259095 -0.40625,0.5 V 8.0275657 H 5.5 c -0.369,0.011 -0.606,0.5235 -0.375,0.8125 l 2.5,3.0000003 C 7.727563,11.945983 7.8637815,12.000222 8,12.000222 Z"
-     style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal" />
+     d="m 8,12.000222 c -0.1362185,0 -0.272437,-0.05424 -0.375,-0.160156 L 5.125,8.81225 C 4.894,8.52325 5.131,8.01075 5.5,7.99975 H 7 V 4.5275656 C 7.010267,4.2557896 7.2296589,4.0102158 7.5,4 h 1 C 8.7535789,4 9,4.2665857 9,4.5275656 V 7.99975 h 1.5 c 0.369,0.011 0.606,0.5235 0.375,0.8125 l -2.5,3.027816 C 8.272437,11.945983 8.1362185,12.000222 8,12.000222 Z"
+     style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     sodipodi:nodetypes="sccccccccccccs" />
+  <path
+     style="color:#000000;opacity:0.5;fill:#a62100;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 7.9999994,-0.99964483 a 0.56251193,0.56251193 0 0 0 -0.448207,0.2219062 L 5.4909195,1.9422621 2.111791,1.4764786 A 0.56251193,0.56251193 0 0 0 1.4768314,2.1114384 l 0.4657836,3.3791282 -2.72000068,2.060873 a 0.56251193,0.56251193 0 0 0 0,0.8964138 L 1.942615,10.508727 1.4768314,13.887855 a 0.56251193,0.56251193 0 0 0 0.6349596,0.63496 l 3.3791285,-0.465784 2.0608729,2.72 a 0.56251193,0.56251193 0 0 0 0.8964138,0 l 2.0608748,-2.72 3.379128,0.465784 a 0.56251193,0.56251193 0 0 0 0.634959,-0.63496 l -0.465782,-3.379128 2.72,-2.0608736 a 0.56251193,0.56251193 0 0 0 0,-0.8964138 l -2.72,-2.060873 0.465782,-3.3791282 A 0.56251193,0.56251193 0 0 0 13.888209,1.4764786 L 10.509081,1.9422621 8.4482062,-0.77773863 a 0.56251193,0.56251193 0 0 0 -0.4482068,-0.2219062 z m 0,1.49402294 1.8104042,2.38823969 A 0.56251193,0.56251193 0 0 0 10.33551,3.10013 L 13.305979,2.6936677 12.899518,5.664137 a 0.56251193,0.56251193 0 0 0 0.217512,0.5251052 l 2.388239,1.8104043 -2.388239,1.8104044 a 0.56251193,0.56251193 0 0 0 -0.217512,0.5251051 l 0.406461,2.97047 -2.970469,-0.406462 a 0.56251193,0.56251193 0 0 0 -0.5251064,0.217511 l -1.8104042,2.38824 -1.8104043,-2.38824 A 0.56251193,0.56251193 0 0 0 5.6644899,12.899164 l -2.9704693,0.406462 0.4064623,-2.97047 A 0.56251193,0.56251193 0 0 0 2.8829707,9.8100509 L 0.49473097,7.9996465 2.8829707,6.1892422 A 0.56251193,0.56251193 0 0 0 3.1004829,5.664137 L 2.6940206,2.6936679 5.6644899,3.1001301 A 0.56251193,0.56251193 0 0 0 6.1895951,2.8826178 Z"
+     id="path841" />
 </svg>

--- a/elementary-xfce/status/16/software-update-urgent.svg
+++ b/elementary-xfce/status/16/software-update-urgent.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   id="svg7357"
-   height="16"
-   width="16"
    version="1.1"
+   width="16"
+   height="16"
+   id="svg7357"
    sodipodi:docname="software-update-urgent.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -17,73 +17,44 @@
   <sodipodi:namedview
      id="namedview21"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="77.163027"
-     inkscape:cx="4.6524873"
-     inkscape:cy="10.076069"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     inkscape:window-x="0"
+     inkscape:zoom="32"
+     inkscape:cx="0.484375"
+     inkscape:cy="12.09375"
+     inkscape:window-width="1426"
+     inkscape:window-height="1050"
+     inkscape:window-x="430"
      inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg7357"
-     inkscape:showpageshadow="2"
-     inkscape:deskcolor="#d1d1d1" />
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7357" />
   <defs
      id="defs7359">
     <linearGradient
-       xlink:href="#linearGradient4806"
-       id="linearGradient3293"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3268746,0,0,2.3268746,-135.94475,-32.842783)"
-       x1="61.219437"
-       y1="15.833592"
-       x2="61.219437"
-       y2="19.271681" />
-    <linearGradient
-       id="linearGradient4806">
+       id="linearGradient839">
       <stop
-         id="stop4808"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4810"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.12499987" />
-      <stop
-         id="stop4812"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.87499982" />
-      <stop
-         id="stop4814"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.81996151,0,0,0.61300006,-1684.8015,-1973.6141)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient947"
-       id="linearGradient11527-6-5-3"
-       y2="3244.8506"
-       x2="2065.6956"
-       y1="3220.5276"
-       x1="2065.6956" />
-    <linearGradient
-       id="linearGradient947">
-      <stop
-         offset="0"
          style="stop-color:#ed5353;stop-opacity:1"
-         id="stop943" />
+         offset="0"
+         id="stop835" />
       <stop
-         offset="1"
          style="stop-color:#c6262e;stop-opacity:1"
-         id="stop945" />
+         offset="1"
+         id="stop837" />
     </linearGradient>
+    <linearGradient
+       x1="2065.6956"
+       y1="3219.6023"
+       x2="2065.6956"
+       y2="3245.6455"
+       id="linearGradient11527-6-5-3"
+       xlink:href="#linearGradient839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.81996151,0,0,0.61300006,-1684.8015,-1973.6141)" />
   </defs>
   <metadata
      id="metadata7362">
@@ -98,29 +69,25 @@
   </metadata>
   <path
      id="path833"
-     d="M 8,0.49996722 5.9913242,3.149515 2.6972424,2.6972425 3.1495149,5.9913243 0.49996721,8 3.1495149,10.008676 2.6972424,13.302758 5.9913242,12.850485 8,15.500033 10.008676,12.850485 13.302757,13.302758 12.850485,10.008676 15.500033,8 12.850485,5.9913243 13.302757,2.6972425 10.008676,3.149515 Z"
-     style="opacity:0.98999999;vector-effect:none;fill:url(#linearGradient11527-6-5-3);fill-opacity:1.0;stroke:none;stroke-width:0.99999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;font-variant-east_asian:normal" />
+     style="opacity:0.98999999;vector-effect:none;fill:url(#linearGradient11527-6-5-3);fill-opacity:1;stroke:none;stroke-width:0.99999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;font-variant-east_asian:normal"
+     d="M 8 0 A 0.50004997 0.50004997 0 0 0 7.6015625 0.19726562 L 5.7695312 2.6152344 L 2.765625 2.2011719 A 0.50004997 0.50004997 0 0 0 2.2011719 2.765625 L 2.6152344 5.7695312 L 0.19726562 7.6015625 A 0.50004997 0.50004997 0 0 0 0.19726562 8.3984375 L 2.6152344 10.230469 L 2.2011719 13.234375 A 0.50004997 0.50004997 0 0 0 2.765625 13.798828 L 5.7695312 13.384766 L 7.6015625 15.802734 A 0.50004997 0.50004997 0 0 0 8.3984375 15.802734 L 10.230469 13.384766 L 13.234375 13.798828 A 0.50004997 0.50004997 0 0 0 13.798828 13.234375 L 13.384766 10.230469 L 15.802734 8.3984375 A 0.50004997 0.50004997 0 0 0 15.802734 7.6015625 L 13.384766 5.7695312 L 13.798828 2.765625 A 0.50004997 0.50004997 0 0 0 13.234375 2.2011719 L 10.230469 2.6152344 L 8.3984375 0.19726562 A 0.50004997 0.50004997 0 0 0 8 0 z " />
   <path
-     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;font-variant-east_asian:normal"
-     d="M 8,0.49996722 5.9913242,3.149515 2.6972424,2.6972425 3.1495149,5.9913243 0.49996721,8 3.1495149,10.008676 2.6972424,13.302758 5.9913242,12.850485 8,15.500033 10.008676,12.850485 13.302757,13.302758 12.850485,10.008676 15.500033,8 12.850485,5.9913243 13.302757,2.6972425 10.008676,3.149515 Z"
-     id="path841" />
-  <path
-     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3293);stroke-width:0.99999996;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal;font-variant-east_asian:normal"
-     id="path841-5"
-     d="M 8,2.15625 6.7890625,3.7539062 A 1.0004397,1.0004397 0 0 1 5.8554688,4.140625 L 3.8671875,3.8671875 4.140625,5.8554688 A 1.0004397,1.0004397 0 0 1 3.7539062,6.7890625 L 2.15625,8 3.7539062,9.2109375 A 1.0004397,1.0004397 0 0 1 4.140625,10.144531 l -0.2734375,1.988281 1.9882813,-0.273437 a 1.0004397,1.0004397 0 0 1 0.9335937,0.386719 L 8,13.84375 9.2109375,12.246094 a 1.0004397,1.0004397 0 0 1 0.9335935,-0.386719 l 1.988281,0.273437 -0.273437,-1.988281 A 1.0004397,1.0004397 0 0 1 12.246094,9.2109375 L 13.84375,8 12.246094,6.7890625 A 1.0004397,1.0004397 0 0 1 11.859375,5.8554688 L 12.132812,3.8671875 10.144531,4.140625 A 1.0004397,1.0004397 0 0 1 9.2109375,3.7539062 Z" />
-  <path
-     style="opacity:0.05;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:0.843237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="m 8,14.000624 c -0.4016709,0 -0.8020585,-0.163613 -1.09375,-0.464844 L 4.34375,10.437937 C 3.9441082,9.9379501 3.976531,9.323088 4.1796875,8.8832474 4.382844,8.4434069 4.8302303,8.0195275 5.4707031,8.0004349 H 6 V 4.5181995 C 6.00673,3.8161765 6.506517,3.150524 7.1914062,3 H 8.537109 C 9.3222229,3.029668 9.9703399,3.7057635 10,4.4908905 v 3.5095444 h 0.5293 c 0.640473,0.019093 1.087859,0.4429719 1.291015,0.8828125 0.203157,0.4398406 0.23558,1.0547027 -0.164062,1.5546876 L 9.0937501,13.535778 C 8.8020601,13.837007 8.4016744,14.000624 8,14.000624 Z"
      id="path818-1-1-2"
-     d="m 8,12.972328 c -0.4016709,0 -0.8020585,-0.163613 -1.09375,-0.464844 -0.016939,-0.01763 -0.033226,-0.03587 -0.048828,-0.05469 l -2.5,-3 C 4.3528107,9.4476341 4.3482532,9.4424264 4.34375,9.437172 3.9441082,8.9371873 3.976531,8.3223252 4.1796875,7.8824846 4.382844,7.4426441 4.8302303,7.0187648 5.4707031,6.9996721 c 0.00977,-1.431e-4 0.019532,-1.431e-4 0.029297,0 H 6 V 4.502577 c -1.6e-5,-0.00327 -1.6e-5,-0.00653 0,-0.0098 0.00673,-0.702023 0.506517,-1.316273 1.1914062,-1.466797 0.04057,-0.00906 0.081665,-0.015584 0.1230469,-0.01953 0.092225,-0.0086 0.1851192,-0.0086 0.2773438,0 L 7.5,3.002577 h 1 c 0.012369,-2.295e-4 0.02474,-2.295e-4 0.037109,0 C 9.3222229,3.032245 9.9703399,3.680341 10,4.465468 c 2.3e-4,0.012369 2.3e-4,0.024741 0,0.03711 v 2.4970941 h 0.5 c 0.0098,-1.431e-4 0.01953,-1.431e-4 0.0293,0 0.640473,0.019093 1.087859,0.442972 1.291015,0.8828125 0.203157,0.4398406 0.23558,1.0547027 -0.164062,1.5546874 -0.0045,0.00526 -0.0091,0.010467 -0.01367,0.01563 l -2.4999999,3 C 9.1269792,12.47162 9.1106905,12.48986 9.09375,12.507484 8.8020601,12.808711 8.4016744,12.972328 8,12.972328 Z"
-     sodipodi:nodetypes="sccccsccccccccccccccccsccccs" />
+     style="opacity:0.2;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     sodipodi:nodetypes="sccsccccccccsccs" />
   <path
-     style="opacity:0.15;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:0.843237;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
-     d="m 8,12.973328 c 0.1362185,0 0.272437,-0.05424 0.375,-0.160156 l 2.5,-3.0000001 c 0.231,-0.289 -0.006,-0.8015001 -0.375,-0.8125 H 9 V 5.502175 c -0.010267,-0.271776 -0.2282237,-0.48973 -0.5,-0.5 h -1 c -0.031265,-0.0029 -0.062485,-0.0029 -0.09375,0 C 7.1709498,5.053889 7.00231,5.26127 7,5.502175 V 9.0006719 H 5.5 c -0.369,0.011 -0.606,0.5235 -0.375,0.8125 l 2.5,3.0000001 C 7.727563,12.919089 7.8637815,12.973328 8,12.973328 Z"
      id="path818-1-1"
-     sodipodi:nodetypes="scccccccccccccs" />
+     d="m 8,13 c 0.1362185,0 0.272437,-0.05424 0.375,-0.160156 L 11.6255,8.81225 c 0.231,-0.289 -0.006,-0.8015 -0.375,-0.8125 H 9.5 V 4.5 C 9.489733,4.228224 9.2717763,4.01027 9,4 H 6.906125 C 6.6708248,4.051714 6.502185,4.259095 6.499875,4.5 V 7.99975 H 4.7495 c -0.369,0.011 -0.606,0.5235 -0.375,0.8125 L 7.625,12.839844 C 7.727563,12.945761 7.8637815,13 8,13 Z"
+     style="opacity:0.3;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     sodipodi:nodetypes="sccccccccccccs" />
   <path
-     style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
-     d="m 8,11.973328 c 0.1362185,0 0.272437,-0.05424 0.375,-0.160156 l 2.5,-2.9999998 c 0.231,-0.289 -0.006,-0.8015 -0.375,-0.8125 H 9 V 4.502175 c -0.010267,-0.271776 -0.2282237,-0.48973 -0.5,-0.5 h -1 c -0.031265,-0.0029 -0.062485,-0.0029 -0.09375,0 C 7.1709498,4.053889 7.00231,4.26127 7,4.502175 V 8.0006722 H 5.5 c -0.369,0.011 -0.606,0.5235 -0.375,0.8125 l 2.5,2.9999998 C 7.727563,11.919089 7.8637815,11.973328 8,11.973328 Z"
      id="path818-1"
-     sodipodi:nodetypes="scccccccccccccs" />
+     d="m 8,12.000222 c -0.1362185,0 -0.272437,-0.05424 -0.375,-0.160156 L 5.125,8.81225 C 4.894,8.52325 5.131,8.01075 5.5,7.99975 H 7 V 4.5275656 C 7.010267,4.2557896 7.2296589,4.0102158 7.5,4 h 1 C 8.7535789,4 9,4.2665857 9,4.5275656 V 7.99975 h 1.5 c 0.369,0.011 0.606,0.5235 0.375,0.8125 l -2.5,3.027816 C 8.272437,11.945983 8.1362185,12.000222 8,12.000222 Z"
+     style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     sodipodi:nodetypes="sccccccccccccs" />
+  <path
+     style="color:#000000;opacity:0.5;fill:#7a0000;stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 7.9999994,-0.99964483 a 0.56251193,0.56251193 0 0 0 -0.448207,0.2219062 L 5.4909195,1.9422621 2.111791,1.4764786 A 0.56251193,0.56251193 0 0 0 1.4768314,2.1114384 l 0.4657836,3.3791282 -2.72000068,2.060873 a 0.56251193,0.56251193 0 0 0 0,0.8964138 L 1.942615,10.508727 1.4768314,13.887855 a 0.56251193,0.56251193 0 0 0 0.6349596,0.63496 l 3.3791285,-0.465784 2.0608729,2.72 a 0.56251193,0.56251193 0 0 0 0.8964138,0 l 2.0608748,-2.72 3.379128,0.465784 a 0.56251193,0.56251193 0 0 0 0.634959,-0.63496 l -0.465782,-3.379128 2.72,-2.0608736 a 0.56251193,0.56251193 0 0 0 0,-0.8964138 l -2.72,-2.060873 0.465782,-3.3791282 A 0.56251193,0.56251193 0 0 0 13.888209,1.4764786 L 10.509081,1.9422621 8.4482062,-0.77773863 a 0.56251193,0.56251193 0 0 0 -0.4482068,-0.2219062 z m 0,1.49402294 1.8104042,2.38823969 A 0.56251193,0.56251193 0 0 0 10.33551,3.10013 L 13.305979,2.6936677 12.899518,5.664137 a 0.56251193,0.56251193 0 0 0 0.217512,0.5251052 l 2.388239,1.8104043 -2.388239,1.8104044 a 0.56251193,0.56251193 0 0 0 -0.217512,0.5251051 l 0.406461,2.97047 -2.970469,-0.406462 a 0.56251193,0.56251193 0 0 0 -0.5251064,0.217511 l -1.8104042,2.38824 -1.8104043,-2.38824 A 0.56251193,0.56251193 0 0 0 5.6644899,12.899164 l -2.9704693,0.406462 0.4064623,-2.97047 A 0.56251193,0.56251193 0 0 0 2.8829707,9.8100509 L 0.49473097,7.9996465 2.8829707,6.1892422 A 0.56251193,0.56251193 0 0 0 3.1004829,5.664137 L 2.6940206,2.6936679 5.6644899,3.1001301 A 0.56251193,0.56251193 0 0 0 6.1895951,2.8826178 Z"
+     id="path841" />
 </svg>

--- a/elementary-xfce/status/16/un-reboot.svg
+++ b/elementary-xfce/status/16/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg

--- a/elementary-xfce/status/22/software-update-available.svg
+++ b/elementary-xfce/status/22/software-update-available.svg
@@ -1,142 +1,151 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
-   width="22"
+   id="svg7107"
    height="22"
-   id="svg2">
+   width="22"
+   version="1.1"
+   sodipodi:docname="software-update-available.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="3.46875"
+     inkscape:cy="8.625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="365"
+     inkscape:window-y="16"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7107" />
+  <defs
+     id="defs7109">
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         id="stop866"
+         offset="0"
+         style="stop-color:#ffa154;stop-opacity:1" />
+      <stop
+         id="stop868"
+         offset="1"
+         style="stop-color:#f37329;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3108"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14338261,0,0,0.04779421,-3.2173912,10.102127)" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
+      <stop
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4806-6"
+       id="linearGradient3293-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1920039,0,0,3.1920039,-186.46325,-45.028085)"
+       x1="61.219437"
+       y1="15.590681"
+       x2="61.219437"
+       y2="19.514591" />
+    <linearGradient
+       id="linearGradient4806-6">
+      <stop
+         id="stop4808-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07614208" />
+      <stop
+         id="stop4812-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.92857152" />
+      <stop
+         id="stop4814-5"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.1479412,0,0,0.85819634,-2358.9118,-2763.2478)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient870"
+       id="linearGradient11527-6-5-3-6"
+       y2="3244.8506"
+       x2="2065.6956"
+       y1="3220.5276"
+       x1="2065.6956" />
+  </defs>
   <metadata
-     id="metadata81433">
+     id="metadata7112">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient3875">
-      <stop
-         style="stop-color:#e89200;stop-opacity:0.78431374;"
-         offset="0"
-         id="stop3877" />
-      <stop
-         style="stop-color:#d48500;stop-opacity:0.78431374;"
-         offset="1"
-         id="stop3879" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4873">
-      <stop
-         id="stop4875"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4877"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3690">
-      <stop
-         id="stop3692"
-         style="stop-color:#ffeb9f;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3694"
-         style="stop-color:#ffd57e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3696"
-         style="stop-color:#ffbc43;stop-opacity:1"
-         offset="0.66093999" />
-      <stop
-         id="stop3698"
-         style="stop-color:#ff921a;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3603">
-      <stop
-         id="stop3605"
-         style="stop-color:#a7651c;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3607"
-         style="stop-color:#c8a700;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4873"
-       id="linearGradient3854"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9828053,0,0,0.98278296,-50.130803,14.450302)"
-       x1="63.397362"
-       y1="-12.489107"
-       x2="63.397362"
-       y2="5.4675598" />
-    <radialGradient
-       xlink:href="#linearGradient3690"
-       id="radialGradient3857"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1143025,-1.4708595,0,16.868821,-25.842215)"
-       cx="23.895569"
-       cy="3.9900031"
-       fx="23.895569"
-       fy="3.9900031"
-       r="20.397499" />
-    <linearGradient
-       xlink:href="#linearGradient3603"
-       id="linearGradient3859"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46688836,0,0,0.46688836,-0.20523346,-0.2054075)"
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143" />
-    <linearGradient
-       xlink:href="#linearGradient3875"
-       id="linearGradient3893"
-       gradientUnits="userSpaceOnUse"
-       x1="11.059574"
-       y1="4.3095746"
-       x2="11.059574"
-       y2="18.021055"
-       gradientTransform="matrix(-1,0,0,-1,22,22.272)" />
-    <linearGradient
-       xlink:href="#linearGradient3875"
-       id="linearGradient3895"
-       gradientUnits="userSpaceOnUse"
-       x1="11.059574"
-       y1="4.3095746"
-       x2="11.059574"
-       y2="18.021055"
-       gradientTransform="translate(0,-0.228064)" />
-  </defs>
   <path
-     d="m 11.000089,1.5016532 c -5.2408125,0 -9.4982619,4.2574473 -9.4982619,9.4982588 0,5.240813 4.2574494,9.498264 9.4982619,9.498261 5.240809,0 9.498263,-4.257448 9.498258,-9.498261 0,-5.2408115 -4.257449,-9.4982588 -9.498258,-9.4982588 z"
-     id="path2555"
-     style="fill:url(#radialGradient3857);fill-opacity:1;stroke:url(#linearGradient3859);stroke-width:1.00365424;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="M 20,19 A 9,3 0 0 1 2,19 9,3 0 1 1 20,19 Z"
+     id="path3818-0-2-5"
+     style="opacity:0.5;fill:url(#radialGradient3108);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     d="m 19.595211,10.999608 c 0,4.747109 -3.848453,8.595429 -8.595016,8.595429 -4.7469988,0 -8.595233,-3.848362 -8.595233,-8.595429 0,-4.7468893 3.8482342,-8.5948192 8.595233,-8.5948192 4.746563,0 8.595016,3.8479299 8.595016,8.5948192 l 0,0 z"
-     id="path2463"
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3854);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5-3-6);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="M 11.000001,0.50000012 8.1878665,4.2093507 3.5761723,3.5761728 4.2093499,8.1878658 0.50000012,11 4.2093499,13.812133 3.5761723,18.423828 8.1878665,17.790649 11.000001,21.5 13.812136,17.790649 18.423829,18.423828 17.790649,13.812133 21.5,11 17.790649,8.1878658 l 0.63318,-4.611693 -4.611693,0.6331779 z"
+     id="path888" />
   <path
-     style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient3895);stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:10"
-     d="m 11.0625,4.271936 c -3.702814,0 -6.727511,2.879143 -6.8125,6.46875 l 2.5625,-0.375 c 0.327151,-2.0155453 2.090605,-3.4884362 4.25,-3.4884362 0.797831,-0.019272 1.544972,0.017571 2.152463,0.4830307 C 11.036905,9.6588899 10.1406,10.637143 10,10.748 12.834508,10.402422 15.029389,10.064412 17.75,9.6854998 17.233458,6.5294884 14.449212,4.271936 11.0625,4.271936 z"
-     id="path3885" />
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="M 11.000001,0.49996712 8.1878575,4.2093293 3.5761489,3.5761494 4.2093285,8.1878568 0.49996712,11 4.2093285,13.812142 3.5761489,18.423851 8.1878575,17.79067 11.000001,21.500033 13.812144,17.79067 18.423852,18.423851 17.79067,13.812142 21.500033,11 17.79067,8.1878568 18.423852,3.5761494 13.812144,4.2093293 Z"
+     id="path841" />
   <path
-     id="path3889"
-     d="m 10.9375,17.772 c 3.702814,0 6.727511,-2.879143 6.8125,-6.46875 l -2.5625,0.375 c -0.327151,2.015545 -2.090605,3.488436 -4.25,3.488436 -0.797831,0.01927 -1.544972,-0.01757 -2.152463,-0.483031 C 10.963095,12.385046 11.8594,11.406793 12,11.295936 9.165492,11.641514 6.970611,11.979524 4.25,12.358436 4.766542,15.514448 7.550788,17.772 10.9375,17.772 z"
-     style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient3893);stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:10" />
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3293-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     id="path841-5"
+     d="M 10.999998,2.152968 8.9396217,4.8724521 A 0.8716046,0.8716046 0 0 1 8.1277954,5.2100434 L 4.7438461,4.7438459 5.2100436,8.1277952 A 0.8716046,0.8716046 0 0 1 4.8724524,8.9396215 l -2.7194842,2.0603765 2.7194842,2.060379 a 0.8716046,0.8716046 0 0 1 0.3375912,0.811825 l -0.4661975,3.38395 3.3839493,-0.466198 a 0.8716046,0.8716046 0 0 1 0.8118263,0.337592 l 2.0603763,2.719485 2.06038,-2.719485 a 0.8716046,0.8716046 0 0 1 0.811825,-0.337592 l 3.383949,0.466198 -0.466197,-3.38395 a 0.8716046,0.8716046 0 0 1 0.337592,-0.811825 L 19.847032,10.999998 17.127547,8.9396215 A 0.8716046,0.8716046 0 0 1 16.789955,8.1277952 L 17.256152,4.7438459 13.872203,5.2100434 A 0.8716046,0.8716046 0 0 1 13.060378,4.8724521 Z" />
+  <path
+     style="opacity:0.05;vector-effect:none;fill:#a62100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     id="path818-7-6-1"
+     d="m 11,18.030971 c -0.477697,0 -0.95406,-0.194596 -1.3027342,-0.554688 a 1.0313531,1.0313531 0 0 1 -0.04297,-0.04687 L 6.6542967,13.923549 a 1.0313531,1.0313531 0 0 1 -0.021484,-0.02539 c -0.4660889,-0.583117 -0.4329484,-1.312347 -0.1875,-1.84375 0.2454484,-0.531404 0.7767579,-1.028523 1.5234375,-1.050782 a 1.0313531,1.0313531 0 0 1 0.03125,0 h 0.96875 V 7.7848774 a 1.0313531,1.0313531 0 0 1 0,-0.0098 c 0.00802,-0.836393 0.6038096,-1.568681 1.4199218,-1.748047 a 1.0313531,1.0313531 0 0 1 0.126953,-0.01953 c 0.108916,-0.01 0.219207,-0.01 0.328125,0 L 10.75,6.0036004 h 0.5 a 1.0313531,1.0313531 0 0 1 0.03906,0 c 0.936535,0.03539 1.706895,0.805504 1.742188,1.742188 a 1.0313531,1.0313531 0 0 1 0,0.03906 V 11.003598 H 14 a 1.0313531,1.0313531 0 0 1 0.03125,0 c 0.746676,0.02226 1.277989,0.519377 1.523438,1.050782 0.245448,0.531404 0.278587,1.260635 -0.1875,1.84375 a 1.0313531,1.0313531 0 0 1 -0.02148,0.02539 l -3,3.505859 a 1.0313531,1.0313531 0 0 1 -0.04297,0.04687 C 11.954079,17.836337 11.477699,18.030971 11,18.030971 Z" />
+  <path
+     style="opacity:0.15;vector-effect:none;fill:#a62100;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="m 11.000001,17 c 0.204456,0 0.408909,-0.08141 0.562851,-0.240386 L 14.56285,13.253067 C 14.909566,12.819296 14.55385,12.050069 14,12.033557 H 12 V 7.7840244 c -0.01537,-0.407918 -0.34255,-0.735052 -0.750468,-0.750468 h -0.499065 c -0.04693,-0.0043 -0.09378,-0.0043 -0.140711,0 -0.353169,0.07762 -0.606287,0.388886 -0.6097562,0.750468 V 12.033557 H 7.9999999 c -0.553846,0.01651 -0.909567,0.785739 -0.562851,1.21951 l 3.0000031,3.506547 C 10.591087,16.91859 10.795548,17 11.000001,17 Z"
+     id="path818-7-6" />
+  <path
+     style="opacity:0.99;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="m 11.000001,16.003 c 0.204456,0 0.408909,-0.08141 0.562851,-0.240386 L 14.56285,12.256067 C 14.909566,11.822296 14.55385,11.053069 14,11.036557 H 12 V 6.787024 C 11.98463,6.379106 11.65745,6.051972 11.249532,6.036556 h -0.499065 c -0.04693,-0.0043 -0.09378,-0.0043 -0.140711,0 -0.353169,0.07762 -0.606287,0.388886 -0.6097562,0.750468 v 4.249533 H 7.9999999 c -0.553846,0.01651 -0.909567,0.785739 -0.562851,1.21951 l 3.0000031,3.506547 C 10.591087,15.92159 10.795548,16.003 11.000001,16.003 Z"
+     id="path818-7" />
 </svg>

--- a/elementary-xfce/status/22/software-update-urgent.svg
+++ b/elementary-xfce/status/22/software-update-urgent.svg
@@ -1,152 +1,151 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
-   width="22"
+   id="svg7107"
    height="22"
-   id="svg2">
+   width="22"
+   version="1.1"
+   sodipodi:docname="software-update-urgent.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview27"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="10.186757"
+     inkscape:cy="14.363106"
+     inkscape:window-width="1270"
+     inkscape:window-height="873"
+     inkscape:window-x="558"
+     inkscape:window-y="80"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg7107" />
+  <defs
+     id="defs7109">
+    <linearGradient
+       id="linearGradient870">
+      <stop
+         id="stop866"
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1" />
+      <stop
+         id="stop868"
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="99.157013"
+       cy="186.17059"
+       r="62.769119"
+       fx="99.157013"
+       fy="186.17059"
+       id="radialGradient3108"
+       xlink:href="#linearGradient3820-7-2-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.14338261,0,0,0.04779421,-3.2173912,10.102127)" />
+    <linearGradient
+       id="linearGradient3820-7-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#3d3d3d;stop-opacity:1"
+         id="stop3822-2-6-36" />
+      <stop
+         offset="0.5"
+         style="stop-color:#686868;stop-opacity:0.49803922"
+         id="stop3864-8-7-6" />
+      <stop
+         offset="1"
+         style="stop-color:#686868;stop-opacity:0"
+         id="stop3824-1-2-4" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4806-6"
+       id="linearGradient3293-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1920039,0,0,3.1920039,-186.46325,-45.028085)"
+       x1="61.219437"
+       y1="15.590681"
+       x2="61.219437"
+       y2="19.514591" />
+    <linearGradient
+       id="linearGradient4806-6">
+      <stop
+         id="stop4808-7"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4810-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07614208" />
+      <stop
+         id="stop4812-3"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.92857152" />
+      <stop
+         id="stop4814-5"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(1.1479412,0,0,0.85819634,-2358.9118,-2763.2478)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient870"
+       id="linearGradient11527-6-5-3-6"
+       y2="3244.8506"
+       x2="2065.6956"
+       y1="3220.5276"
+       x1="2065.6956" />
+  </defs>
   <metadata
-     id="metadata81433">
+     id="metadata7112">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient4873">
-      <stop
-         id="stop4875"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4877"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4873"
-       id="linearGradient3854"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9828053,0,0,0.98278296,-50.130803,14.450302)"
-       x1="63.397362"
-       y1="-12.489107"
-       x2="63.397362"
-       y2="5.4675598" />
-    <radialGradient
-       xlink:href="#linearGradient3853"
-       id="radialGradient3857"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,1.1143025,-1.4708595,0,16.868821,-25.842215)"
-       cx="23.895569"
-       cy="3.9900031"
-       fx="23.895569"
-       fy="3.9900031"
-       r="20.397499" />
-    <linearGradient
-       xlink:href="#linearGradient3861"
-       id="linearGradient3859"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46688836,0,0,0.46688836,-0.20523346,-0.2054075)"
-       x1="18.379412"
-       y1="44.980297"
-       x2="18.379412"
-       y2="3.0816143" />
-    <linearGradient
-       id="linearGradient3895-9-0-3-7-3-32">
-      <stop
-         offset="0"
-         style="stop-color:#dc5639;stop-opacity:1"
-         id="stop3897-0-5-7-8-3-9" />
-      <stop
-         offset="1"
-         style="stop-color:#9d0f0f;stop-opacity:1"
-         id="stop3899-8-7-06-9-2-3" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3861"
-       id="linearGradient3893"
-       gradientUnits="userSpaceOnUse"
-       x1="11.059574"
-       y1="4.3095746"
-       x2="11.059574"
-       y2="18.021055"
-       gradientTransform="matrix(-1,0,0,-1,22,22.272)" />
-    <linearGradient
-       xlink:href="#linearGradient3895-9-0-3-7-3-32"
-       id="linearGradient3895"
-       gradientUnits="userSpaceOnUse"
-       x1="11.059574"
-       y1="4.3095746"
-       x2="11.059574"
-       y2="18.021055"
-       gradientTransform="translate(0,-0.228064)" />
-    <linearGradient
-       x1="24"
-       y1="6"
-       x2="24"
-       gradientUnits="userSpaceOnUse"
-       y2="51"
-       id="linearGradient3853">
-      <stop
-         offset="0"
-         style="stop-color:#f8b17e"
-         id="stop3244-2" />
-      <stop
-         offset=".31210"
-         style="stop-color:#e35d4f"
-         id="stop3246-5" />
-      <stop
-         offset=".57054"
-         style="stop-color:#c6262e"
-         id="stop3248-4" />
-      <stop
-         offset="1"
-         style="stop-color:#690b54"
-         id="stop3250-6" />
-    </linearGradient>
-    <linearGradient
-       x1="17"
-       y1="45"
-       x2="17"
-       gradientUnits="userSpaceOnUse"
-       y2="6"
-       id="linearGradient3861">
-      <stop
-         offset="0"
-         style="stop-color:#791235"
-         id="stop2492-8" />
-      <stop
-         offset="1"
-         style="stop-color:#dd3b27"
-         id="stop2494-1" />
-    </linearGradient>
-  </defs>
   <path
-     d="m 11.000089,1.5016532 c -5.2408125,0 -9.4982619,4.2574473 -9.4982619,9.4982588 0,5.240813 4.2574494,9.498264 9.4982619,9.498261 5.240809,0 9.498263,-4.257448 9.498258,-9.498261 0,-5.2408115 -4.257449,-9.4982588 -9.498258,-9.4982588 z"
-     id="path2555"
-     style="fill:url(#radialGradient3857);fill-opacity:1.0;stroke:url(#linearGradient3859);stroke-width:1.00365423999999992;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+     d="M 20,19 A 9,3 0 0 1 2,19 9,3 0 1 1 20,19 Z"
+     id="path3818-0-2-5"
+     style="opacity:0.5;fill:url(#radialGradient3108);fill-opacity:1;stroke:none;stroke-width:1" />
   <path
-     d="m 19.595211,10.999608 c 0,4.747109 -3.848453,8.595429 -8.595016,8.595429 -4.7469988,0 -8.595233,-3.848362 -8.595233,-8.595429 0,-4.7468893 3.8482342,-8.5948192 8.595233,-8.5948192 4.746563,0 8.595016,3.8479299 8.595016,8.5948192 l 0,0 z"
-     id="path2463"
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3854);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+     style="opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5-3-6);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="M 11.000001,0.50000012 8.1878665,4.2093507 3.5761723,3.5761728 4.2093499,8.1878658 0.50000012,11 4.2093499,13.812133 3.5761723,18.423828 8.1878665,17.790649 11.000001,21.5 13.812136,17.790649 18.423829,18.423828 17.790649,13.812133 21.5,11 17.790649,8.1878658 l 0.63318,-4.611693 -4.611693,0.6331779 z"
+     id="path888" />
   <path
-     style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient3895);stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:10"
-     d="m 11.0625,4.271936 c -3.702814,0 -6.727511,2.879143 -6.8125,6.46875 l 2.5625,-0.375 c 0.327151,-2.0155453 2.090605,-3.4884362 4.25,-3.4884362 0.797831,-0.019272 1.544972,0.017571 2.152463,0.4830307 C 11.036905,9.6588899 10.1406,10.637143 10,10.748 12.834508,10.402422 15.029389,10.064412 17.75,9.6854998 17.233458,6.5294884 14.449212,4.271936 11.0625,4.271936 z"
-     id="path3885" />
+     style="opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="M 11.000001,0.49996712 8.1878575,4.2093293 3.5761489,3.5761494 4.2093285,8.1878568 0.49996712,11 4.2093285,13.812142 3.5761489,18.423851 8.1878575,17.79067 11.000001,21.500033 13.812144,17.79067 18.423852,18.423851 17.79067,13.812142 21.500033,11 17.79067,8.1878568 18.423852,3.5761494 13.812144,4.2093293 Z"
+     id="path841" />
   <path
-     id="path3889"
-     d="m 10.9375,17.772 c 3.702814,0 6.727511,-2.879143 6.8125,-6.46875 l -2.5625,0.375 c -0.327151,2.015545 -2.090605,3.488436 -4.25,3.488436 -0.797831,0.01927 -1.544972,-0.01757 -2.152463,-0.483031 C 10.963095,12.385046 11.8594,11.406793 12,11.295936 9.165492,11.641514 6.970611,11.979524 4.25,12.358436 4.766542,15.514448 7.550788,17.772 10.9375,17.772 z"
-     style="fill:#ffffff;fill-opacity:1;stroke:url(#linearGradient3893);stroke-width:0.5;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:10" />
+     style="opacity:0.3;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3293-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     id="path841-5"
+     d="M 10.999998,2.152968 8.9396217,4.8724521 A 0.8716046,0.8716046 0 0 1 8.1277954,5.2100434 L 4.7438461,4.7438459 5.2100436,8.1277952 A 0.8716046,0.8716046 0 0 1 4.8724524,8.9396215 l -2.7194842,2.0603765 2.7194842,2.060379 a 0.8716046,0.8716046 0 0 1 0.3375912,0.811825 l -0.4661975,3.38395 3.3839493,-0.466198 a 0.8716046,0.8716046 0 0 1 0.8118263,0.337592 l 2.0603763,2.719485 2.06038,-2.719485 a 0.8716046,0.8716046 0 0 1 0.811825,-0.337592 l 3.383949,0.466198 -0.466197,-3.38395 a 0.8716046,0.8716046 0 0 1 0.337592,-0.811825 L 19.847032,10.999998 17.127547,8.9396215 A 0.8716046,0.8716046 0 0 1 16.789955,8.1277952 L 17.256152,4.7438459 13.872203,5.2100434 A 0.8716046,0.8716046 0 0 1 13.060378,4.8724521 Z" />
+  <path
+     style="opacity:0.05;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     id="path818-7-6-1"
+     d="m 11,18.030971 c -0.477697,0 -0.95406,-0.194596 -1.3027342,-0.554688 a 1.0313531,1.0313531 0 0 1 -0.04297,-0.04687 L 6.6542967,13.923549 a 1.0313531,1.0313531 0 0 1 -0.021484,-0.02539 c -0.4660889,-0.583117 -0.4329484,-1.312347 -0.1875,-1.84375 0.2454484,-0.531404 0.7767579,-1.028523 1.5234375,-1.050782 a 1.0313531,1.0313531 0 0 1 0.03125,0 h 0.96875 V 7.7848774 a 1.0313531,1.0313531 0 0 1 0,-0.0098 c 0.00802,-0.836393 0.6038096,-1.568681 1.4199218,-1.748047 a 1.0313531,1.0313531 0 0 1 0.126953,-0.01953 c 0.108916,-0.01 0.219207,-0.01 0.328125,0 L 10.75,6.0036004 h 0.5 a 1.0313531,1.0313531 0 0 1 0.03906,0 c 0.936535,0.03539 1.706895,0.805504 1.742188,1.742188 a 1.0313531,1.0313531 0 0 1 0,0.03906 V 11.003598 H 14 a 1.0313531,1.0313531 0 0 1 0.03125,0 c 0.746676,0.02226 1.277989,0.519377 1.523438,1.050782 0.245448,0.531404 0.278587,1.260635 -0.1875,1.84375 a 1.0313531,1.0313531 0 0 1 -0.02148,0.02539 l -3,3.505859 a 1.0313531,1.0313531 0 0 1 -0.04297,0.04687 C 11.954079,17.836337 11.477699,18.030971 11,18.030971 Z" />
+  <path
+     style="opacity:0.15;vector-effect:none;fill:#7a0000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="m 11.000001,17 c 0.204456,0 0.408909,-0.08141 0.562851,-0.240386 L 14.56285,13.253067 C 14.909566,12.819296 14.55385,12.050069 14,12.033557 H 12 V 7.7840244 c -0.01537,-0.407918 -0.34255,-0.735052 -0.750468,-0.750468 h -0.499065 c -0.04693,-0.0043 -0.09378,-0.0043 -0.140711,0 -0.353169,0.07762 -0.606287,0.388886 -0.6097562,0.750468 V 12.033557 H 7.9999999 c -0.553846,0.01651 -0.909567,0.785739 -0.562851,1.21951 l 3.0000031,3.506547 C 10.591087,16.91859 10.795548,17 11.000001,17 Z"
+     id="path818-7-6" />
+  <path
+     style="opacity:0.99;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:normal"
+     d="m 11.000001,16.003 c 0.204456,0 0.408909,-0.08141 0.562851,-0.240386 L 14.56285,12.256067 C 14.909566,11.822296 14.55385,11.053069 14,11.036557 H 12 V 6.787024 C 11.98463,6.379106 11.65745,6.051972 11.249532,6.036556 h -0.499065 c -0.04693,-0.0043 -0.09378,-0.0043 -0.140711,0 -0.353169,0.07762 -0.606287,0.388886 -0.6097562,0.750468 v 4.249533 H 7.9999999 c -0.553846,0.01651 -0.909567,0.785739 -0.562851,1.21951 l 3.0000031,3.506547 C 10.591087,15.92159 10.795548,16.003 11.000001,16.003 Z"
+     id="path818-7" />
 </svg>

--- a/elementary-xfce/status/22/un-reboot.svg
+++ b/elementary-xfce/status/22/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg

--- a/elementary-xfce/status/24/un-reboot.svg
+++ b/elementary-xfce/status/24/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg

--- a/elementary-xfce/status/32/un-reboot.svg
+++ b/elementary-xfce/status/32/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg

--- a/elementary-xfce/status/48/un-reboot.svg
+++ b/elementary-xfce/status/48/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg

--- a/elementary-xfce/status/64/un-reboot.svg
+++ b/elementary-xfce/status/64/un-reboot.svg
@@ -1,0 +1,1 @@
+software-update-available.svg


### PR DESCRIPTION
Add icon for update-notifier status notifier and dialog. A symlink to `software-update-available` it should now match the update available notification of Package Update Indicator.

Make 16px icons a little bigger to match other panel notification sizes. (some of the border spills out but still looks better than before when in use)

Fix issue where 22px update "available" and "urgent" icons didn't match other sizes.