### PR TITLE
Apps: New icon for 'Show Desktop' panel plugin

### DIFF
--- a/elementary-xfce/apps/128/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/128/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,0 @@
-../../places/128/user-desktop.svg

--- a/elementary-xfce/apps/16/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/16/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,187 @@
-../../places/16/user-desktop.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg6436"
+   sodipodi:docname="org.xfce.panel.showdesktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview34"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="11.645165"
+     inkscape:cy="8.3637474"
+     inkscape:window-width="1473"
+     inkscape:window-height="1080"
+     inkscape:window-x="445"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6436" />
+  <defs
+     id="defs6438">
+    <linearGradient
+       id="linearGradient3924-0">
+      <stop
+         id="stop3926-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0001" />
+      <stop
+         id="stop3930-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3932-62"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="40.103859"
+       y1="6.9629579"
+       x2="40.103859"
+       y2="41.055611"
+       id="linearGradient3030"
+       xlink:href="#linearGradient3924-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135136,0,0,0.35135139,-0.432432,-0.4324275)" />
+    <linearGradient
+       id="linearGradient872">
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0"
+         id="stop868" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop870" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient872"
+       id="linearGradient874-3"
+       x1="16"
+       y1="3"
+       x2="16"
+       y2="29.567492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.51724138,0,0,0.57168784,-0.2758622,-1.3647919)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2376"
+       id="linearGradient2378"
+       x1="8.1284275"
+       y1="13.14259"
+       x2="8.1284275"
+       y2="14.930977"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2376">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop2372" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop2374" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6441">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient874-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="0.5"
+     x="0.5"
+     ry="2"
+     rx="2"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:0.15;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect1181"
+     width="14"
+     height="4"
+     x="1"
+     y="9"
+     rx="0.75"
+     ry="1" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:#000000;fill-opacity:0;stroke:#002e99;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6"
+     y="0.5"
+     x="0.5"
+     ry="2"
+     rx="2"
+     height="15"
+     width="15" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3030);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4"
+     y="1.5"
+     x="1.5"
+     height="13.000001"
+     width="13"
+     rx="1"
+     ry="1" />
+  <path
+     style="color:#000000;opacity:0.7;fill:url(#linearGradient2378);fill-opacity:1;-inkscape-stroke:none"
+     d="M 2.2382813,12 C 1.5867612,12 1,12.499163 1,13.166016 1,13.832482 1.1679203,15 2.6082048,15 H 13.414825 C 14.748955,15 15,13.876243 15,13.166016 15,12.499163 14.411286,12 13.759766,12 Z"
+     id="path4306"
+     sodipodi:nodetypes="sccccss" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect2147"
+     width="2"
+     height="2"
+     x="3"
+     y="10"
+     ry="0.5"
+     rx="0.5" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect2253"
+     width="2"
+     height="2"
+     x="7"
+     y="10"
+     ry="0.5"
+     rx="0.5" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect2255"
+     width="2"
+     height="2"
+     x="11"
+     y="10"
+     ry="0.5"
+     rx="0.5" />
+</svg>

--- a/elementary-xfce/apps/22/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/22/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,188 @@
-../../places/22/user-desktop.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="22"
+   height="22"
+   id="svg6436"
+   sodipodi:docname="org.xfce.panel.showdesktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9676"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="51.25"
+     inkscape:cy="-2.75"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6436" />
+  <defs
+     id="defs6438">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient993">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop989" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop991" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-0">
+      <stop
+         id="stop3926-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3930-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3932-62"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="40.103859"
+       y1="6.5882206"
+       x2="40.103859"
+       y2="41.317535"
+       id="linearGradient3030"
+       xlink:href="#linearGradient3924-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945948,0,0,0.45945948,-0.0270288,-0.02702285)" />
+    <linearGradient
+       id="linearGradient872">
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0"
+         id="stop868" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop870" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient872"
+       id="linearGradient874-3"
+       x1="16"
+       y1="3"
+       x2="16"
+       y2="29.567492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.65517241,0,0,0.72413793,0.5172388,-0.8620723)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient993"
+       id="linearGradient995"
+       x1="12"
+       y1="18.931791"
+       x2="12"
+       y2="20.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-2.5033951e-6,-1.0000025)" />
+  </defs>
+  <metadata
+     id="metadata6441">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient874-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="1.4999975"
+     x="1.4999975"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     style="opacity:0.15;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect1181"
+     width="18"
+     height="7.9999995"
+     x="1.9999975"
+     y="11.999996"
+     rx="1.5"
+     ry="1.5" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:#000000;fill-opacity:0;stroke:#002e99;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6"
+     y="1.4999975"
+     x="1.4999975"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3030);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4"
+     y="2.4999971"
+     x="2.4999976"
+     height="17"
+     width="17"
+     rx="1"
+     ry="1" />
+  <path
+     d="m 4.2391282,16.499663 c -0.4094789,0 -0.7391306,0.297334 -0.7391306,0.666667 v 2.333667 H 18.499562 V 17.16633 c 0,-0.369333 -0.329652,-0.666667 -0.739131,-0.666667 z"
+     id="path4306"
+     style="opacity:0.7;fill:#ffffff;fill-opacity:0.588235;stroke:url(#linearGradient995);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="ssccsss" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect6443"
+     width="4"
+     height="4"
+     x="3.9999976"
+     y="12.999998"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect6653"
+     width="4"
+     height="4"
+     x="8.9999971"
+     y="12.999998"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect6655"
+     width="4"
+     height="4"
+     x="13.999997"
+     y="12.999998"
+     rx="1"
+     ry="1" />
+</svg>

--- a/elementary-xfce/apps/24/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/24/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,251 @@
-../../places/24/user-desktop.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg6436"
+   sodipodi:docname="org.xfce.panel.showdesktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9676"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="59.5625"
+     inkscape:cy="-2.6875"
+     inkscape:window-width="1920"
+     inkscape:window-height="1012"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="g4325" />
+  <defs
+     id="defs6438">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient993">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop989" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop991" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5747">
+      <stop
+         id="stop5749"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5751"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.993"
+       cy="43.5"
+       r="2.5"
+       id="radialGradient4358-2"
+       xlink:href="#linearGradient5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2022704,0,0,0.59999988,13.99287,-4.59993)" />
+    <radialGradient
+       cx="4.993"
+       cy="43.5"
+       r="2.5"
+       id="radialGradient4360-3"
+       xlink:href="#linearGradient5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2022704,0,0,0.59999988,-10.00712,-47.60006)" />
+    <linearGradient
+       x1="25.058001"
+       y1="43.528"
+       x2="25.058001"
+       y2="39.999001"
+       id="linearGradient4362-5"
+       xlink:href="#linearGradient5747"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57142853,0,0,0.42857134,-1.7142578,2.85721)"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3924-0">
+      <stop
+         id="stop3926-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3930-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3932-62"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="40.103859"
+       y1="6.5882206"
+       x2="40.103859"
+       y2="41.317535"
+       id="linearGradient3030"
+       xlink:href="#linearGradient3924-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945948,0,0,0.45945948,0.9729737,0.97297965)" />
+    <linearGradient
+       id="linearGradient872">
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0"
+         id="stop868" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop870" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient872"
+       id="linearGradient874-3"
+       x1="16"
+       y1="3"
+       x2="16"
+       y2="29.567492"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.65517241,0,0,0.72413793,1.5172413,0.1379302)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient993"
+       id="linearGradient995"
+       x1="12"
+       y1="18.931791"
+       x2="12"
+       y2="20.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(1)" />
+  </defs>
+  <metadata
+     id="metadata6441">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4325"
+     transform="translate(0,-0.10006294)">
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient4358-2);fill-opacity:1"
+       id="rect2801-0"
+       y="20.000063"
+       x="20"
+       height="2.9999993"
+       width="3" />
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient4360-3);fill-opacity:1"
+       id="rect3696-08"
+       transform="scale(-1)"
+       y="-23.000063"
+       x="-4"
+       height="2.9999993"
+       width="3" />
+    <rect
+       style="opacity:0.4;fill:url(#linearGradient4362-5);fill-opacity:1;stroke-width:1"
+       id="rect3700-96"
+       y="20.000063"
+       x="4"
+       height="2.9999993"
+       width="16" />
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient874-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21"
+     y="2.5"
+     x="2.5"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     style="opacity:0.15;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+     id="rect1181"
+     width="18"
+     height="7.9999995"
+     x="3"
+     y="12.999999"
+     rx="1.5"
+     ry="1.5" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:#000000;fill-opacity:0;stroke:#002e99;stroke-width:0.999995;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6"
+     y="2.5"
+     x="2.5"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3030);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4"
+     y="3.4999998"
+     x="3.5"
+     height="17"
+     width="17"
+     rx="1"
+     ry="1" />
+  <path
+     d="m 5.2391307,17.499666 c -0.4094789,0 -0.7391306,0.297334 -0.7391306,0.666667 V 20.5 H 19.499565 v -2.333667 c 0,-0.369333 -0.329652,-0.666667 -0.739131,-0.666667 z"
+     id="path4306"
+     style="opacity:0.7;fill:#ffffff;fill-opacity:0.588235;stroke:url(#linearGradient995);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="ssccsss" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect6443"
+     width="4"
+     height="4"
+     x="5"
+     y="14.000001"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect6653"
+     width="4"
+     height="4"
+     x="10"
+     y="14.000001"
+     rx="1"
+     ry="1" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-linecap:square;stroke-opacity:0.695649;stop-color:#000000"
+     id="rect6655"
+     width="4"
+     height="4"
+     x="15"
+     y="14.000001"
+     rx="1"
+     ry="1" />
+</svg>

--- a/elementary-xfce/apps/32/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/32/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,311 @@
-../../places/32/user-desktop.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   id="svg4354"
+   height="32"
+   width="32"
+   version="1.1"
+   sodipodi:docname="org.xfce.panel.showdesktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9898"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="25.9375"
+     inkscape:cx="15.055422"
+     inkscape:cy="16"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4354" />
+  <defs
+     id="defs4356">
+    <linearGradient
+       id="linearGradient872">
+      <stop
+         id="stop868"
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         id="stop870"
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.29999995,0,0,0.29999995,34.258887,19.300002)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-1-846-5-4-5-44"
+       id="linearGradient4251"
+       y2="-61.256123"
+       x2="19.874987"
+       y1="38.245197"
+       x1="19.874987" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-1-846-5-4-5-44">
+      <stop
+         offset="0"
+         style="stop-color:#365a7c;stop-opacity:1"
+         id="stop3788-4-8-9-7" />
+      <stop
+         offset="1"
+         style="stop-color:#5ea1ca;stop-opacity:1"
+         id="stop3790-2-1-9-6" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.29999995,0,0,0.29999995,28.258887,19.300002)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-1-846-5-4-5-4"
+       id="linearGradient4253"
+       y2="-61.256123"
+       x2="19.874987"
+       y1="38.245197"
+       x1="19.874987" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-1-846-5-4-5-4">
+      <stop
+         offset="0"
+         style="stop-color:#365a7c;stop-opacity:1"
+         id="stop3788-4-8-9-8" />
+      <stop
+         offset="1"
+         style="stop-color:#5ea1ca;stop-opacity:1"
+         id="stop3790-2-1-9-10" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.29999995,0,0,0.29999995,22.258887,19.300002)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-1-846-5-4-5-6"
+       id="linearGradient4255"
+       y2="-61.256123"
+       x2="19.874987"
+       y1="38.245197"
+       x1="19.874987" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-1-846-5-4-5-6">
+      <stop
+         offset="0"
+         style="stop-color:#365a7c;stop-opacity:1"
+         id="stop3788-4-8-9-1" />
+      <stop
+         offset="1"
+         style="stop-color:#5ea1ca;stop-opacity:1"
+         id="stop3790-2-1-9-1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.29999995,0,0,0.29999995,16.258887,19.300002)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3707-319-631-407-1-846-5-4-5"
+       id="linearGradient4257"
+       y2="-61.256123"
+       x2="19.874987"
+       y1="38.245197"
+       x1="19.874987" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-1-846-5-4-5">
+      <stop
+         offset="0"
+         style="stop-color:#365a7c;stop-opacity:1"
+         id="stop3788-4-8-9" />
+      <stop
+         offset="1"
+         style="stop-color:#5ea1ca;stop-opacity:1"
+         id="stop3790-2-1-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.72972972,0,0,0.64864869,-1.5135104,0.93243894)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3141"
+       y2="41.729153"
+       x2="23.99999"
+       y1="6.270823"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.04197389"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.04372487,0,0,0.01647059,31.794815,21.294422)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-6-6-5"
+       id="radialGradient2910"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060-6-6-5">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-3-0-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-1-4-9" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.04372487,0,0,0.01647059,0.20519206,21.294422)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-6-6-5"
+       id="radialGradient2913"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5048-7-7-5">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-5-6-4" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-9-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-6-9-5" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.04372487,0,0,0.01647059,0.19658512,21.294422)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-7-7-5"
+       id="linearGradient4352"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="29.567492"
+       x2="16"
+       y1="3"
+       x1="16"
+       id="linearGradient874"
+       xlink:href="#linearGradient872" />
+  </defs>
+  <metadata
+     id="metadata4359">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     width="21.11286"
+     height="4.0000005"
+     x="5.4435763"
+     y="27.333334"
+     id="rect2512-9-5"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#linearGradient4352);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 26.556432,27.333467 c 0,0 0,3.999779 0,3.999779 C 28.808154,31.340773 32,30.437099 32,29.333099 c 0,-1.104 -2.512752,-1.999632 -5.443568,-1.999632 z"
+     id="path2514-7-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2913);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 5.4435678,27.333467 c 0,0 0,3.999779 0,3.999779 C 3.1918461,31.340773 0,30.437099 0,29.333099 c 0,-1.104 2.5127521,-1.999632 5.4435678,-1.999632 z"
+     id="path2516-8-9"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2910);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <rect
+     width="29"
+     height="26"
+     rx="2"
+     ry="2.0799999"
+     x="1.5"
+     y="3.5"
+     id="rect5505"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient874);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 5.5,25.5 c -0.554,0 -1,0.446 -1,1 v 2 h 23 v -2 c 0,-0.554 -0.446,-1 -1,-1 z"
+     id="path4306"
+     style="opacity:0.7;fill:#ffffff;fill-opacity:0.58823529;stroke:#ffffff;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     d="M 9.118401,22.000001 H 4.8815972 C 4.3931925,22.000001 4,22.393194 4,22.881598 v 4.236805 C 4,27.606808 4.3931925,28 4.8815972,28 H 9.118401 C 9.606807,28 10,27.606808 10,27.118403 V 22.881598 C 10,22.393194 9.606807,22.000001 9.118401,22.000001 Z"
+     id="path3184"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4257);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="M 8.206706,23.492713 H 5.7932951 c -0.1665219,0 -0.3005814,0.13406 -0.3005814,0.300581 v 2.413411 c 0,0.166522 0.1340595,0.300581 0.3005814,0.300581 H 8.206706 c 0.1665209,0 0.3005805,-0.134059 0.3005805,-0.300581 v -2.413411 c 0,-0.166521 -0.1340596,-0.300581 -0.3005805,-0.300581 z"
+     id="path3176"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="M 15.118401,22.000001 H 10.881597 C 10.393193,22.000001 10,22.393194 10,22.881598 v 4.236805 C 10,27.606808 10.393193,28 10.881597,28 h 4.236804 C 15.606807,28 16,27.606808 16,27.118403 v -4.236805 c 0,-0.488404 -0.393193,-0.881597 -0.881599,-0.881597 z"
+     id="path3184-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4255);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 14.206706,23.492713 h -2.413411 c -0.166522,0 -0.300581,0.13406 -0.300581,0.300581 v 2.413411 c 0,0.166522 0.134059,0.300581 0.300581,0.300581 h 2.413411 c 0.166521,0 0.300581,-0.134059 0.300581,-0.300581 v -2.413411 c 0,-0.166521 -0.13406,-0.300581 -0.300581,-0.300581 z"
+     id="path3176-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="M 21.118401,22.000001 H 16.881597 C 16.393193,22.000001 16,22.393194 16,22.881598 v 4.236805 C 16,27.606808 16.393193,28 16.881597,28 h 4.236804 C 21.606807,28 22,27.606808 22,27.118403 v -4.236805 c 0,-0.488404 -0.393193,-0.881597 -0.881599,-0.881597 z"
+     id="path3184-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4253);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 20.206706,23.492713 h -2.413411 c -0.166522,0 -0.300581,0.13406 -0.300581,0.300581 v 2.413411 c 0,0.166522 0.134059,0.300581 0.300581,0.300581 h 2.413411 c 0.166521,0 0.300581,-0.134059 0.300581,-0.300581 v -2.413411 c 0,-0.166521 -0.13406,-0.300581 -0.300581,-0.300581 z"
+     id="path3176-4"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="M 27.118401,22.000001 H 22.881597 C 22.393193,22.000001 22,22.393194 22,22.881598 v 4.236805 C 22,27.606808 22.393193,28 22.881597,28 h 4.236804 C 27.606807,28 28,27.606808 28,27.118403 v -4.236805 c 0,-0.488404 -0.393193,-0.881597 -0.881599,-0.881597 z"
+     id="path3184-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient4251);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 26.206706,23.492713 h -2.413411 c -0.166522,0 -0.300581,0.13406 -0.300581,0.300581 v 2.413411 c 0,0.166522 0.134059,0.300581 0.300581,0.300581 h 2.413411 c 0.166521,0 0.300581,-0.134059 0.300581,-0.300581 v -2.413411 c 0,-0.166521 -0.13406,-0.300581 -0.300581,-0.300581 z"
+     id="path3176-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="29"
+     height="26"
+     rx="2"
+     ry="2.0799999"
+     x="1.5"
+     y="3.5"
+     id="rect5505-1"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <rect
+     width="26.999998"
+     height="24"
+     rx="1"
+     ry="1.0434783"
+     x="2.5"
+     y="4.5"
+     id="rect6741-7"
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3141);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+</svg>

--- a/elementary-xfce/apps/48/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/48/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,281 @@
-../../places/48/user-desktop.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4354"
+   viewBox="0 0 48 48"
+   sodipodi:docname="org.xfce.panel.showdesktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10129"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="17.291667"
+     inkscape:cx="22.583133"
+     inkscape:cy="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4354" />
+  <defs
+     id="defs4356">
+    <linearGradient
+       id="linearGradient872">
+      <stop
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0"
+         id="stop868" />
+      <stop
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1"
+         id="stop870" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.270823"
+       x2="23.99999"
+       y2="41.729153"
+       id="linearGradient3141"
+       xlink:href="#linearGradient3924"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0945946,0,0,0.97297304,-2.2702656,1.398658)" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         id="stop3926"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.04197389" />
+      <stop
+         id="stop3930"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95056331" />
+      <stop
+         id="stop3932"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2910"
+       xlink:href="#linearGradient5060-6-6-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.0655873,0,0,0.02470589,47.692222,31.941633)" />
+    <linearGradient
+       id="linearGradient5060-6-6-5">
+      <stop
+         id="stop5062-3-0-3"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064-1-4-9"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       r="117.14286"
+       fx="605.71429"
+       fy="486.64789"
+       id="radialGradient2913"
+       xlink:href="#linearGradient5060-6-6-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0655873,0,0,0.02470589,0.30778809,31.941633)" />
+    <linearGradient
+       id="linearGradient5048-7-7-5">
+      <stop
+         id="stop5050-5-6-4"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5056-9-0-1"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop5052-6-9-5"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="302.85715"
+       y1="366.64789"
+       x2="302.85715"
+       y2="609.50507"
+       id="linearGradient4352"
+       xlink:href="#linearGradient5048-7-7-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0655873,0,0,0.02470589,0.29487768,31.941633)" />
+    <linearGradient
+       gradientTransform="scale(1.5)"
+       xlink:href="#linearGradient872"
+       id="linearGradient874"
+       x1="16"
+       y1="3"
+       x2="16"
+       y2="29.567492"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <metadata
+     id="metadata4359">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#linearGradient4352);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2512-9-5"
+     y="41"
+     x="8.1653643"
+     height="6.000001"
+     width="31.669289" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2913);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2514-7-4"
+     d="m 39.834648,41.0002 c 0,0 0,5.999669 0,5.999669 C 43.212231,47.011159 48,45.655648 48,43.999648 48,42.343648 44.230872,41.0002 39.834648,41.0002 Z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.40206185;fill:url(#radialGradient2910);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2516-8-9"
+     d="m 8.1653517,41.0002 c 0,0 0,5.999669 0,5.999669 C 4.7877691,47.011159 0,45.655648 0,43.999648 0,42.343648 3.7691282,41.0002 8.1653517,41.0002 Z" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient874);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505"
+     y="5.5"
+     x="2.5"
+     ry="2.0799999"
+     rx="2"
+     height="39"
+     width="43" />
+  <path
+     style="opacity:0.7;fill:#ffffff;fill-opacity:0.58823529;stroke:#ffffff;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="path4306"
+     d="m 8,38.5 c -0.831,0 -1.5,0.669 -1.5,1.5 v 3.5 h 35 V 40 c 0,-0.831 -0.669,-1.5 -1.5,-1.5 z" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect5505-1"
+     y="5.5"
+     x="2.5"
+     ry="2.0799999"
+     rx="2"
+     height="39"
+     width="43" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3141);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="6.5"
+     x="3.5"
+     ry="1.0434783"
+     rx="1"
+     height="37"
+     width="41" />
+  <g
+     id="g926">
+    <rect
+       style="opacity:0.3;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect914"
+       width="7"
+       height="7"
+       x="7"
+       y="34"
+       rx="1"
+       ry="1.04348" />
+    <rect
+       style="opacity:0.3;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect916"
+       width="7"
+       height="7"
+       x="16"
+       y="34"
+       rx="1"
+       ry="1.04348" />
+    <rect
+       style="opacity:0.3;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect918"
+       width="7"
+       height="7"
+       x="25"
+       y="34"
+       rx="1"
+       ry="1.04348" />
+    <rect
+       style="opacity:0.3;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect920"
+       width="7"
+       height="7"
+       x="34"
+       y="34"
+       rx="1"
+       ry="1.04348" />
+  </g>
+  <g
+     id="g932">
+    <rect
+       style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect906"
+       width="5"
+       height="5"
+       x="8"
+       y="35"
+       rx="1"
+       ry="1.04348" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect908"
+       width="5"
+       height="5"
+       x="17"
+       y="35"
+       rx="1"
+       ry="1.04348" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect910"
+       width="5"
+       height="5"
+       x="26"
+       y="35"
+       rx="1"
+       ry="1.04348" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+       id="rect912"
+       width="5"
+       height="5"
+       x="35"
+       y="35"
+       rx="1"
+       ry="1.04348" />
+  </g>
+  <g
+     style="fill:#fafafa"
+     id="g948" />
+</svg>

--- a/elementary-xfce/apps/64/org.xfce.panel.showdesktop.svg
+++ b/elementary-xfce/apps/64/org.xfce.panel.showdesktop.svg
@@ -1,1 +1,212 @@
-../../places/64/user-desktop.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 64 64"
+   id="svg2453"
+   height="64"
+   width="64"
+   version="1.0"
+   sodipodi:docname="org.xfce.panel.showdesktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10339"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="12.96875"
+     inkscape:cx="30.110843"
+     inkscape:cy="32"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2453" />
+  <metadata
+     id="metadata35">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2455">
+    <linearGradient
+       id="linearGradient848">
+      <stop
+         id="stop844"
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1" />
+      <stop
+         id="stop846"
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3462">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3464" />
+      <stop
+         offset="0.02083333"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3466" />
+      <stop
+         offset="0.97916663"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3468" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3470" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5060-2">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5048-8">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050-4" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056-5" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052-1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03212956,0,0,0.02058823,40.136784,48.451416)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3172"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       gradientTransform="matrix(-0.03212956,0,0,0.02058823,23.863217,48.451416)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060-2"
+       id="radialGradient3175"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       gradientTransform="matrix(0.11390532,0,0,0.02058823,-9.1686406,48.451416)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048-8"
+       id="linearGradient3178"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       y2="42.068645"
+       x2="40.290417"
+       y1="5.8237457"
+       x1="40.290417"
+       gradientTransform="matrix(1.5405405,0,0,1.3243243,-4.9729751,1.2874721)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3133"
+       xlink:href="#linearGradient3462" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="58.424374"
+       x2="33.169186"
+       y1="7.4842215"
+       x1="33.169186"
+       id="linearGradient850"
+       xlink:href="#linearGradient848" />
+  </defs>
+  <rect
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient3178);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect2879-0"
+     y="56"
+     x="4.5"
+     height="5"
+     width="55" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3175);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2881-4"
+     d="m 4.5,56.000216 c 0,0 0,4.9997 0,4.9997 -1.654593,0.01 -4,-1.1202 -4,-2.5002 0,-1.38 1.8464008,-2.4995 4,-2.4995 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3172);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path2883-6"
+     d="m 59.5,56.000216 c 0,0 0,4.9997 0,4.9997 1.654592,0.01 4,-1.1202 4,-2.5002 0,-1.38 -1.846401,-2.4995 -4,-2.4995 z" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient850);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect5505-21-3-8-5-2"
+     y="7.4999981"
+     x="2.5"
+     ry="2"
+     rx="2"
+     height="51"
+     width="59" />
+  <rect
+     style="opacity:0.5;fill:none;stroke:url(#linearGradient3133);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3"
+     y="8.5712519"
+     x="3.5"
+     ry="1"
+     rx="1"
+     height="49"
+     width="57" />
+  <path
+     d="m 10.543478,52.5 c -1.1320873,0 -2.0434782,0.892001 -2.0434782,2 v 4 H 55.499998 v -4 c 0,-1.107999 -0.91139,-2 -2.043476,-2 z"
+     id="path4306"
+     style="opacity:0.7;fill:#ffffff;fill-opacity:0.58823529;stroke:#ffffff;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0;fill-rule:nonzero;stroke:#002e99;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect5505-21-3-8-9-1-1"
+     y="7.5"
+     x="2.5"
+     ry="2"
+     rx="2"
+     height="51"
+     width="59" />
+  <path
+     transform="translate(0,-0.99250408)"
+     d="m 16.677734,48.033203 c -1.723438,0.01293 -3.450127,-0.02592 -5.171875,0.01953 -1.049566,0.09994 -1.629431,1.208223 -1.472656,2.179688 0.0359,1.810501 -0.07236,3.634521 0.05469,5.4375 0.194928,1.010383 1.305241,1.436138 2.234375,1.296875 1.780723,-0.03587 3.574454,0.07232 5.347656,-0.05469 1.010383,-0.194928 1.436138,-1.305241 1.296875,-2.234375 -0.03587,-1.780723 0.07232,-3.574454 -0.05469,-5.347656 -0.194928,-1.010383 -1.305241,-1.436138 -2.234375,-1.296875 z m 12,0 c -1.723438,0.01293 -3.450127,-0.02592 -5.171875,0.01953 -1.049566,0.09994 -1.629431,1.208223 -1.472656,2.179688 0.0359,1.810501 -0.07236,3.634521 0.05469,5.4375 0.194928,1.010383 1.305241,1.436138 2.234375,1.296875 1.780723,-0.03587 3.574454,0.07232 5.347656,-0.05469 1.010383,-0.194928 1.436138,-1.305241 1.296875,-2.234375 -0.03587,-1.780723 0.07232,-3.574454 -0.05469,-5.347656 -0.194928,-1.010383 -1.305241,-1.436138 -2.234375,-1.296875 z m 11,0 c -1.723438,0.01293 -3.450127,-0.02592 -5.171875,0.01953 -1.049566,0.09994 -1.629431,1.208223 -1.472656,2.179688 0.0359,1.810501 -0.07236,3.634521 0.05469,5.4375 0.194928,1.010383 1.305241,1.436138 2.234375,1.296875 1.780723,-0.03587 3.574454,0.07232 5.347656,-0.05469 1.010383,-0.194928 1.436138,-1.305241 1.296875,-2.234375 -0.03587,-1.780723 0.07232,-3.574454 -0.05469,-5.347656 -0.194928,-1.010383 -1.305241,-1.436138 -2.234375,-1.296875 z m 12,0 c -1.723438,0.01293 -3.450127,-0.02592 -5.171875,0.01953 -1.049566,0.09994 -1.629431,1.208223 -1.472656,2.179688 0.0359,1.810501 -0.07236,3.634521 0.05469,5.4375 0.194928,1.010383 1.305241,1.436138 2.234375,1.296875 1.780723,-0.03587 3.574454,0.07232 5.347656,-0.05469 1.010383,-0.194928 1.436138,-1.305241 1.296875,-2.234375 -0.03587,-1.780723 0.07232,-3.574454 -0.05469,-5.347656 -0.194928,-1.010383 -1.305241,-1.436138 -2.234375,-1.296875 z"
+     id="path3176-4-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path3176-4"
+     d="M 11.697266,47.000001 C 11.310593,47.000001 11,47.399337 11,47.896486 v 7.20703 c 0,0.497152 0.310593,0.896485 0.697266,0.896485 h 5.605468 C 17.689405,56.000001 18,55.600668 18,55.103516 v -7.20703 c 0,-0.497149 -0.310595,-0.896485 -0.697266,-0.896485 z m 12,0 C 23.310593,47.000001 23,47.399337 23,47.896486 v 7.20703 c 0,0.497152 0.310593,0.896485 0.697266,0.896485 h 5.605468 C 29.689405,56.000001 30,55.600668 30,55.103516 v -7.20703 c 0,-0.497149 -0.310595,-0.896485 -0.697266,-0.896485 z m 11,0 C 34.310593,47.000001 34,47.399337 34,47.896486 v 7.20703 c 0,0.497152 0.310593,0.896485 0.697266,0.896485 h 5.605468 C 40.689405,56.000001 41,55.600668 41,55.103516 v -7.20703 c 0,-0.497149 -0.310595,-0.896485 -0.697266,-0.896485 z m 12,0 C 46.310593,47.000001 46,47.399337 46,47.896486 v 7.20703 c 0,0.497152 0.310593,0.896485 0.697266,0.896485 h 5.605468 C 52.689405,56.000001 53,55.600668 53,55.103516 v -7.20703 c 0,-0.497149 -0.310595,-0.896485 -0.697266,-0.896485 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path3176"
+     d="M 12.091797 48.492188 C 11.759558 48.492188 11.492187 48.75956 11.492188 49.091797 L 11.492188 53.908203 C 11.492188 54.240443 11.759558 54.507812 12.091797 54.507812 L 16.908203 54.507812 C 17.24044 54.507812 17.507813 54.240443 17.507812 53.908203 L 17.507812 49.091797 C 17.507812 48.75956 17.24044 48.492187 16.908203 48.492188 L 12.091797 48.492188 z M 24.091797 48.492188 C 23.759558 48.492188 23.492188 48.75956 23.492188 49.091797 L 23.492188 53.908203 C 23.492188 54.240443 23.759558 54.507812 24.091797 54.507812 L 28.908203 54.507812 C 29.24044 54.507812 29.507813 54.240443 29.507812 53.908203 L 29.507812 49.091797 C 29.507812 48.75956 29.24044 48.492187 28.908203 48.492188 L 24.091797 48.492188 z M 35.091797 48.492188 C 34.759558 48.492188 34.492188 48.75956 34.492188 49.091797 L 34.492188 53.908203 C 34.492188 54.240443 34.759558 54.507812 35.091797 54.507812 L 39.908203 54.507812 C 40.24044 54.507812 40.507813 54.240443 40.507812 53.908203 L 40.507812 49.091797 C 40.507812 48.75956 40.24044 48.492187 39.908203 48.492188 L 35.091797 48.492188 z M 47.091797 48.492188 C 46.759558 48.492188 46.492188 48.75956 46.492188 49.091797 L 46.492188 53.908203 C 46.492188 54.240443 46.759558 54.507812 47.091797 54.507812 L 51.908203 54.507812 C 52.24044 54.507812 52.507813 54.240443 52.507812 53.908203 L 52.507812 49.091797 C 52.507812 48.75956 52.24044 48.492187 51.908203 48.492188 L 47.091797 48.492188 z "
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:#ffffff;stroke-width:0.98542714;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+</svg>


### PR DESCRIPTION
Use upstream `preferences-desktop` as new icon for the Xfce "Show Desktop" panel plugin.

May want to consider also using this for the `user-desktop` Places icon.