### PR TITLE
Mimes: Use 'applications-other' for executables

### DIFF
--- a/elementary-xfce/mimes/128/application-x-executable.svg
+++ b/elementary-xfce/mimes/128/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/128/application-default-icon.svg
+../../categories/128/applications-other.svg

--- a/elementary-xfce/mimes/16/application-x-executable.svg
+++ b/elementary-xfce/mimes/16/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/16/application-default-icon.svg
+../../categories/16/applications-other.svg

--- a/elementary-xfce/mimes/24/application-x-executable.svg
+++ b/elementary-xfce/mimes/24/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/24/application-default-icon.svg
+../../categories/24/applications-other.svg

--- a/elementary-xfce/mimes/32/application-x-executable.svg
+++ b/elementary-xfce/mimes/32/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/32/application-default-icon.svg
+../../categories/32/applications-other.svg

--- a/elementary-xfce/mimes/48/application-x-executable.svg
+++ b/elementary-xfce/mimes/48/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/48/application-default-icon.svg
+../../categories/48/applications-other.svg

--- a/elementary-xfce/mimes/64/application-x-executable.svg
+++ b/elementary-xfce/mimes/64/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/64/application-default-icon.svg
+../../categories/64/applications-other.svg

--- a/elementary-xfce/mimes/96/application-x-executable.svg
+++ b/elementary-xfce/mimes/96/application-x-executable.svg
@@ -1,1 +1,1 @@
-../../apps/96/application-default-icon.svg
+../../categories/96/applications-other.svg


### PR DESCRIPTION
Symlink the Mime icon `application-x-executable` to the Category icon `applications-other`. It uses the same design as what is used currently but has better contrast, looks better on dark themes, and is used more widely in the theme to represent applications.

This will change the icon used for executable and binary mimes, as well as some executable-related actions like "Create Launcher..." on Xfdesktop right click.

---

The `applications-other` icon is used for:
- "All Applications" in Whisker Menu
- "Launcher" Xfce panel plugin
- "Applications" when right clicking on Xfdesktop

The white-square-with-gear is also used for .desktop files on Xfdesktop and thunar, and also more closely matches the icon used for other executable mimes like Appimage, Debs, RPMs, etc.