### PR TITLE
Places: Use coloful "pictures" folder icon

### DIFF
--- a/elementary-xfce/places/16/folder-pictures.svg
+++ b/elementary-xfce/places/16/folder-pictures.svg
@@ -1,1 +1,767 @@
-../../mimes/16/image-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg3508">
+  <defs
+     id="defs3510">
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3125-0"
+       xlink:href="#linearGradient3101-46"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13513513,0,0,0.13513507,2.3075663,8.5733088)" />
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3101-46"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.836132,-1.021284)">
+      <stop
+         id="stop4013-8-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015-11-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.50775999" />
+      <stop
+         id="stop4017-4-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456999" />
+      <stop
+         id="stop4019-3-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="19.758543"
+       y1="24.734938"
+       x2="19.758543"
+       y2="46.702221"
+       id="linearGradient3166-5"
+       xlink:href="#linearGradient4270-7-5-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.36363634,0,0,0.36363634,6.0903963,-0.98144076)" />
+    <linearGradient
+       id="linearGradient4270-7-5-1">
+      <stop
+         id="stop4272-8-7-3"
+         style="stop-color:#000000;stop-opacity:0.32800001"
+         offset="0" />
+      <stop
+         id="stop4274-6-3-6"
+         style="stop-color:#000000;stop-opacity:0.68000001"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="16.626165"
+       y1="15.298182"
+       x2="20.054544"
+       y2="24.627615"
+       id="linearGradient3131-6"
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-1-5-7-842-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1363452,0,0,0.18378386,8.7206963,8.0022988)" />
+    <linearGradient
+       id="linearGradient8265-821-176-38-919-66-249-7-7-1-5-7-842-3">
+      <stop
+         id="stop5135-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5137-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="79"
+       y1="31.999891"
+       x2="122.7144"
+       y2="31.999891"
+       id="linearGradient3134-8"
+       xlink:href="#linearGradient4174-396-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.0909091,0.0909091,0,9.0922063,20.72727)" />
+    <linearGradient
+       id="linearGradient4174-396-4">
+      <stop
+         id="stop5101-1"
+         style="stop-color:#000000;stop-opacity:0.736"
+         offset="0" />
+      <stop
+         id="stop5103-2"
+         style="stop-color:#000000;stop-opacity:0.096"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="68.313301"
+       y1="52.925316"
+       x2="68.313301"
+       y2="65.922028"
+       id="linearGradient3137-5"
+       xlink:href="#linearGradient3990-3-968-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04376593,0,0,0.03282445,9.0727163,9.4576488)" />
+    <linearGradient
+       id="linearGradient3990-3-968-6">
+      <stop
+         id="stop5069-2"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5071-8"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="95.838364"
+       cy="95.388451"
+       r="9.4981718"
+       fx="95.838364"
+       fy="95.388451"
+       id="radialGradient3140-6"
+       xlink:href="#linearGradient4278-757-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13501499,-2.0132531e-8,1.8916035e-8,0.12685679,-0.95926362,-0.15043076)" />
+    <linearGradient
+       id="linearGradient4278-757-5">
+      <stop
+         id="stop5107-6"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop5109-76"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0.5" />
+      <stop
+         id="stop5111-8"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.896"
+       cy="3.99"
+       r="20.396999"
+       id="radialGradient3143-4"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-691-923-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.11731521,-0.15485401,0,12.619156,8.1211788)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-691-923-3">
+      <stop
+         id="stop5181-3"
+         style="stop-color:#432f91;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5183-3"
+         style="stop-color:#1972a2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-166.57561"
+       y1="49.331501"
+       x2="-166.57561"
+       y2="73.350845"
+       id="linearGradient3146-2-5"
+       xlink:href="#linearGradient3087-408-4-672-8-5-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09879011,0,0,0.09995268,28.493296,5.7924988)" />
+    <linearGradient
+       x1="7.0776"
+       y1="3.0816"
+       x2="7.0776"
+       y2="45.368999"
+       id="linearGradient3087-408-4-672-8-5-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.22110724,0,0,0.22110728,6.6934256,6.693263)">
+      <stop
+         id="stop5153-9-6-3"
+         style="stop-color:#232323;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5155-8-8-9"
+         style="stop-color:#747474;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="24.780325"
+       cy="4.0774455"
+       r="20.396999"
+       fx="24.780325"
+       fy="4.0774455"
+       id="radialGradient3149-8"
+       xlink:href="#linearGradient3707-319-631-407-324-616-79-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.19508946,-0.25751464,0,13.024246,5.2222488)" />
+    <linearGradient
+       id="linearGradient3707-319-631-407-324-616-79-9">
+      <stop
+         id="stop5194-0"
+         style="stop-color:#787878;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5196-7"
+         style="stop-color:#474747;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3152-9"
+       xlink:href="#linearGradient3101-4-766-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13513513,0,0,0.13513726,2.3075663,8.5732488)" />
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3101-4-766-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5135135,0,0,0.5135135,-24.836132,-1.021284)">
+      <stop
+         id="stop5091-0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5093-26"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.50775999" />
+      <stop
+         id="stop5095-96"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456999" />
+      <stop
+         id="stop5097-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="10.229324"
+       cy="22.955328"
+       r="19.99999"
+       fx="10.229324"
+       fy="22.955328"
+       id="radialGradient3155-3"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-921-551-3-685-166-313-25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.14982901,-0.17475775,0,16.025876,8.9813488)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-921-551-3-685-166-313-25">
+      <stop
+         id="stop5075-6"
+         style="stop-color:#3e3e3e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5077-2"
+         style="stop-color:#343434;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5079-4"
+         style="stop-color:#272727;stop-opacity:1"
+         offset="0.704952" />
+      <stop
+         id="stop5081-3"
+         style="stop-color:#1d1d1d;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="83.589935"
+       y1="73.438828"
+       x2="83.589935"
+       y2="118.82703"
+       id="linearGradient3157-8"
+       xlink:href="#linearGradient4077-488-880-992-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06666669,0,0,0.06666669,5.6012863,5.5999988)" />
+    <linearGradient
+       id="linearGradient4077-488-880-992-3">
+      <stop
+         id="stop5085-9"
+         style="stop-color:#1b1b1b;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5087-8"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.896"
+       cy="3.99"
+       r="20.396999"
+       id="radialGradient3160-7"
+       xlink:href="#radialGradient3093-718-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.35196648,-0.46458952,0,13.855056,0.36310924)" />
+    <radialGradient
+       cx="23.896"
+       cy="3.99"
+       r="20.396999"
+       id="radialGradient3093-718-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.2316483,-1.625754,0,18.486966,-28.721977)">
+      <stop
+         id="stop5115-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5117-2"
+         style="stop-color:#dddddd;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop5119-0"
+         style="stop-color:#abacae;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop5121-3"
+         style="stop-color:#89898b;stop-opacity:1"
+         offset="1" />
+    </radialGradient>
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       id="radialGradient3169-1"
+       xlink:href="#radialGradient3109-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30037568,0,0,0.0750938,-6.9799537,14.5144)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       id="radialGradient3109-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1294118,0,0,0.2823525,-58.729414,19.694118)">
+      <stop
+         id="stop8840-3-5"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8842-5-9"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </radialGradient>
+    <linearGradient
+       x1="-107.45584"
+       y1="-37.385227"
+       x2="-107.45584"
+       y2="38.561256"
+       id="linearGradient6549"
+       xlink:href="#linearGradient3871-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0657842,0,0,0.06827881,16.561056,6.4975778)" />
+    <linearGradient
+       id="linearGradient3871-6-7">
+      <stop
+         id="stop3873-3-2"
+         style="stop-color:#0b85e9;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3875-4-0"
+         style="stop-color:#69d1ef;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-96.557358"
+       y1="110.92493"
+       x2="-96.557358"
+       y2="39.991924"
+       id="linearGradient6554"
+       xlink:href="#linearGradient3825-5-8-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0657842,0,0,0.06827881,16.561056,6.4975778)" />
+    <linearGradient
+       id="linearGradient3825-5-8-3">
+      <stop
+         id="stop3827-2-3-1"
+         style="stop-color:#e89c42;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3829-5-0-9"
+         style="stop-color:#faca67;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3174-3"
+       xlink:href="#linearGradient3977-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29729729,0,0,0.24324323,0.86615638,3.1621588)" />
+    <linearGradient
+       id="linearGradient3977-7-7">
+      <stop
+         id="stop3979-6-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-3-44"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03626217" />
+      <stop
+         id="stop3983-8-5"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95056331" />
+      <stop
+         id="stop3985-2-08"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3182-5"
+       xlink:href="#linearGradient3600-9-29"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34285637,0,0,0.2172834,-0.22726362,3.4518588)" />
+    <linearGradient
+       id="linearGradient3600-9-29">
+      <stop
+         id="stop3602-0-00"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-9-14"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-76.834877"
+       y1="6.6805849"
+       x2="-76.844345"
+       y2="52.887863"
+       id="linearGradient3185-6"
+       xlink:href="#linearGradient4623-7-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31606802,1.8694201e-4,6.4779015e-5,0.23894327,38.785246,1.9477188)" />
+    <linearGradient
+       id="linearGradient4623-7-4">
+      <stop
+         id="stop4625-3-72"
+         style="stop-color:#000000;stop-opacity:0.27058825"
+         offset="0" />
+      <stop
+         id="stop4627-1-421"
+         style="stop-color:#000000;stop-opacity:0.368"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="-76.834877"
+       y1="6.6805849"
+       x2="-76.844345"
+       y2="52.887863"
+       id="linearGradient4054-9"
+       xlink:href="#linearGradient4623-7-6-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31606802,1.8694201e-4,6.4779015e-5,0.23894327,33.450626,-13.765542)" />
+    <linearGradient
+       id="linearGradient4623-7-6-0">
+      <stop
+         id="stop4625-3-2-8"
+         style="stop-color:#000000;stop-opacity:0.27058825"
+         offset="0" />
+      <stop
+         id="stop4627-1-97-2"
+         style="stop-color:#000000;stop-opacity:0.368"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient4056-1"
+       xlink:href="#linearGradient3600-9-2-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34285637,0,0,0.2172834,-5.5618863,-12.261401)" />
+    <linearGradient
+       id="linearGradient3600-9-2-4">
+      <stop
+         id="stop3602-0-80-8"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3604-9-1-5"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977-7-1-5">
+      <stop
+         id="stop3979-6-5-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3981-3-4-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03626217" />
+      <stop
+         id="stop3983-8-3-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95056331" />
+      <stop
+         id="stop3985-2-1-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3506"
+       xlink:href="#linearGradient3977-7-1-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29729729,0,0,0.24324323,-4.4684666,-12.551097)" />
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3110"
+       xlink:href="#linearGradient3101-46"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13513513,0,0,0.13513507,2.3075663,8.5733088)" />
+    <linearGradient
+       x1="19.758543"
+       y1="24.734938"
+       x2="19.758543"
+       y2="46.702221"
+       id="linearGradient3113"
+       xlink:href="#linearGradient4270-7-5-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.36363634,0,0,0.36363634,6.0903963,-0.98144076)" />
+    <linearGradient
+       x1="16.626165"
+       y1="15.298182"
+       x2="20.054544"
+       y2="24.627615"
+       id="linearGradient3116"
+       xlink:href="#linearGradient8265-821-176-38-919-66-249-7-7-1-5-7-842-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1363452,0,0,0.18378386,8.7206963,8.0022988)" />
+    <linearGradient
+       x1="79"
+       y1="31.999891"
+       x2="122.7144"
+       y2="31.999891"
+       id="linearGradient3119"
+       xlink:href="#linearGradient4174-396-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.0909091,0.0909091,0,9.0922063,20.72727)" />
+    <linearGradient
+       x1="68.313301"
+       y1="52.925316"
+       x2="68.313301"
+       y2="65.922028"
+       id="linearGradient3122"
+       xlink:href="#linearGradient3990-3-968-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.04376593,0,0,0.03282445,9.0727163,9.4576488)" />
+    <radialGradient
+       cx="95.838364"
+       cy="95.388451"
+       r="9.4981718"
+       fx="95.838364"
+       fy="95.388451"
+       id="radialGradient3125"
+       xlink:href="#linearGradient4278-757-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13501499,-2.0132531e-8,1.8916035e-8,0.12685679,-0.95926362,-0.15043076)" />
+    <radialGradient
+       cx="23.896"
+       cy="3.99"
+       r="20.396999"
+       id="radialGradient3128"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-691-923-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.11731521,-0.15485401,0,12.619156,8.1211788)" />
+    <linearGradient
+       x1="-166.57561"
+       y1="49.331501"
+       x2="-166.57561"
+       y2="73.350845"
+       id="linearGradient3131"
+       xlink:href="#linearGradient3087-408-4-672-8-5-2"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.09879011,0,0,0.09995268,28.493296,5.7924988)" />
+    <radialGradient
+       cx="24.780325"
+       cy="4.0774455"
+       r="20.396999"
+       fx="24.780325"
+       fy="4.0774455"
+       id="radialGradient3134"
+       xlink:href="#linearGradient3707-319-631-407-324-616-79-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.19508946,-0.25751464,0,13.024246,5.2222488)" />
+    <linearGradient
+       x1="71.204002"
+       y1="6.2375998"
+       x2="71.204002"
+       y2="44.341"
+       id="linearGradient3137"
+       xlink:href="#linearGradient3101-4-766-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13513513,0,0,0.13513726,2.3075663,8.5732488)" />
+    <radialGradient
+       cx="10.229324"
+       cy="22.955328"
+       r="19.99999"
+       fx="10.229324"
+       fy="22.955328"
+       id="radialGradient3140"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-641-289-620-227-114-444-680-744-921-551-3-685-166-313-25"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.14982901,-0.17475775,0,16.025876,8.9813488)" />
+    <linearGradient
+       x1="83.589935"
+       y1="73.438828"
+       x2="83.589935"
+       y2="118.82703"
+       id="linearGradient3142"
+       xlink:href="#linearGradient4077-488-880-992-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.06666669,0,0,0.06666669,5.6012863,5.5999988)" />
+    <radialGradient
+       cx="23.896"
+       cy="3.99"
+       r="20.396999"
+       id="radialGradient3145"
+       xlink:href="#radialGradient3093-718-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.35196648,-0.46458952,0,13.855056,0.36310924)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       id="radialGradient3148"
+       xlink:href="#radialGradient3109-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30037568,0,0,0.0750938,-6.9799537,14.5144)" />
+    <linearGradient
+       x1="-107.45584"
+       y1="-37.385227"
+       x2="-107.45584"
+       y2="38.561256"
+       id="linearGradient3153"
+       xlink:href="#linearGradient3871-6-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0657842,0,0,0.06827881,16.561056,6.4975778)" />
+    <linearGradient
+       x1="-96.557358"
+       y1="110.92493"
+       x2="-96.557358"
+       y2="39.991924"
+       id="linearGradient3156"
+       xlink:href="#linearGradient3825-5-8-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.0657842,0,0,0.06827881,16.561056,6.4975778)" />
+    <linearGradient
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3159"
+       xlink:href="#linearGradient3977-7-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.29729729,0,0,0.24324323,0.86615638,3.1621588)" />
+    <linearGradient
+       x1="25.132275"
+       y1="0.98520643"
+       x2="25.132275"
+       y2="47.013336"
+       id="linearGradient3162"
+       xlink:href="#linearGradient3600-9-29"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.34285637,0,0,0.2172834,-0.22726362,3.4518588)" />
+    <linearGradient
+       x1="-76.834877"
+       y1="6.6805849"
+       x2="-76.844345"
+       y2="52.887863"
+       id="linearGradient3165"
+       xlink:href="#linearGradient4623-7-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31606802,1.8694201e-4,6.4779015e-5,0.23894327,38.785246,1.9477188)" />
+  </defs>
+  <metadata
+     id="metadata3513">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(0.77529172,0.44761488,-0.44761488,0.77529172,2.9288863,11.68471)"
+     id="g4048">
+    <path
+       d="m 9.1667057,-1.2132226 -13.0000781,0 0,-11.0000784 13.0000781,0 z"
+       id="rect6741-1-2-0-0"
+       style="color:#000000;fill:none;stroke:url(#linearGradient4054-9);stroke-width:1.11694443;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m -3.3333333,-11.713262 c 2.74980887,0 11.999986,6.25e-4 11.999986,6.25e-4 l 1.4e-5,9.9993754 c 0,0 -7.99999973,0 -12,0 0,-3.333331 0,-6.6666614 0,-9.9999924 z"
+       id="path4160-9-79"
+       style="fill:url(#linearGradient4056-1);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="m -1.8333334,-10.213262 c 2.06235697,0 8.9999891,4.41e-4 8.9999891,4.41e-4 l 1.1e-5,6.9995594 c 0,0 -5.9999992,0 -9.0000001,0 0,-2.333333 0,-4.6666652 0,-6.9999984 z"
+       id="path4160-62-0-7"
+       style="color:#000000;fill:#49bdea;fill-opacity:1;fill-rule:nonzero;stroke:#158bb9;stroke-width:1.11703146;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 8.1666667,-2.2132616 -11,0 0,-9.0000004 11,0 z"
+       id="rect6741-1-2-7"
+       style="fill:none;stroke:url(#linearGradient3506);stroke-width:1.11703157;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  </g>
+  <path
+     d="m 14.501326,14.50004 -13.0000797,0 0,-11.0000812 13.0000797,0 z"
+     id="rect6741-1-2-0-7"
+     style="color:#000000;fill:none;stroke:url(#linearGradient3165);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 2.0012863,3.9999988 c 2.74981,0 11.9999897,6.2e-4 11.9999897,6.2e-4 L 14.001286,14 c 0,0 -7.9999997,0 -11.9999997,0 0,-3.33333 0,-6.6666612 0,-9.9999912 z"
+     id="path4160-9-97"
+     style="fill:url(#linearGradient3162);fill-opacity:1;stroke:none;display:inline" />
+  <path
+     d="m 13.501286,13.5 -10.9999997,0 0,-9.0000012 10.9999997,0 z"
+     id="rect6741-1-2-2"
+     style="fill:none;stroke:url(#linearGradient3159);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+  <path
+     d="m 3.0012863,4.9999988 0,8.0000012 9.9999997,0 0,-8.0000012 z"
+     id="rect3055-2-9-6"
+     style="color:#000000;fill:url(#linearGradient3156);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 3.0012863,4.9999988 0,4.082555 c 0.14848,0.07106 0.33651,0.135627 0.53977,0.135627 0.46418,0 0.91812,-0.389189 1.69318,-0.389189 0.77506,0 1.35801,0.489434 2.33523,0.489434 0.97722,0 1.19716,-0.707616 2.4431797,-0.707616 1.24602,0 1.12886,0.448157 1.90909,0.448157 0.53744,0 0.76696,-0.194811 1.07955,-0.318427 l 0,-3.740541 z"
+     id="path3867-3-5-9"
+     style="fill:url(#linearGradient3153);fill-opacity:1;stroke:none" />
+  <path
+     d="m 10.012646,8.3501218 c -1.2460197,0 -1.4659597,0.707616 -2.4431797,0.707616 -0.97722,0 -1.56017,-0.489434 -2.33523,-0.489434 -0.77506,0 -1.229,0.389189 -1.69318,0.389189 -0.20326,0 -0.39129,-0.06457 -0.53977,-0.135627 l 0,0.871499 c 0.22336,0.06164 0.51301,0.112039 0.85795,0.112039 0.8795,0 0.75402,-0.306634 1.51137,-0.306634 0.75734,0 1.20343,0.501229 2.22727,0.501229 1.26814,0 1.55916,-0.807863 2.5624997,-0.807863 0.78346,0 0.84229,0.442261 1.70454,0.442261 0.5825,0 0.77595,-0.232336 1.13637,-0.383293 l 0,-0.771252 c -0.31259,0.123616 -0.54211,0.318427 -1.07955,0.318427 -0.78023,0 -0.66307,-0.448157 -1.90909,-0.448157 z"
+     id="rect3055-2-6-8-1"
+     style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 3.5012863,5.5002098 c 2.06237,0 9.0000597,4.47e-4 9.0000597,4.47e-4 L 12.501356,12.5 c 0,0 -6.0000397,0 -9.0000697,0 0,-2.333263 0,-4.6665262 0,-6.9997882 z"
+     id="path4160-62-4"
+     style="opacity:0.3;color:#000000;fill:none;stroke:#000000;stroke-width:0.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+</svg>

--- a/elementary-xfce/places/22/folder-pictures.svg
+++ b/elementary-xfce/places/22/folder-pictures.svg
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="22"
+   id="svg3816"
    height="22"
-   id="svg3810"
+   width="22"
+   version="1.1"
    sodipodi:docname="folder-pictures.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -15,130 +15,309 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview43"
+     id="namedview31415"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="120.56171"
-     inkscape:cx="7.3904064"
-     inkscape:cy="15.20798"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="714"
-     inkscape:window-y="126"
+     inkscape:zoom="25.279067"
+     inkscape:cx="13.825668"
+     inkscape:cy="8.6632943"
+     inkscape:window-width="1585"
+     inkscape:window-height="1051"
+     inkscape:window-x="287"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3810"
-     inkscape:showpageshadow="2"
-     inkscape:deskcolor="#d1d1d1" />
+     inkscape:current-layer="svg3816" />
   <defs
-     id="defs3812">
+     id="defs3818">
     <linearGradient
-       id="linearGradient3600">
+       id="linearGradient4574-39-1">
       <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#7a0f01;stop-opacity:1"
+         id="stop4576-75-8" />
       <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#d31807;stop-opacity:1"
+         id="stop4578-96-3" />
     </linearGradient>
     <linearGradient
+       id="linearGradient4470-86-9">
+      <stop
+         offset="0"
+         style="stop-color:#ec4502;stop-opacity:1"
+         id="stop4472-0-4" />
+      <stop
+         offset="1"
+         style="stop-color:#fe7617;stop-opacity:1"
+         id="stop4474-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3871-6-7">
+      <stop
+         offset="0"
+         style="stop-color:#0b85e9;stop-opacity:1"
+         id="stop3873-3-2" />
+      <stop
+         offset="1"
+         style="stop-color:#69d1ef;stop-opacity:1"
+         id="stop3875-4-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3825-5-8-9">
+      <stop
+         offset="0"
+         style="stop-color:#e89c42;stop-opacity:1"
+         id="stop3827-2-3-55" />
+      <stop
+         offset="1"
+         style="stop-color:#faca67;stop-opacity:1"
+         id="stop3829-5-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977-7-61">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-6-49" />
+      <stop
+         offset="0.03626217"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-3-78" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-8-86" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-2-07" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4623-7-15">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.27058825"
+         id="stop4625-3-7" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.368"
+         id="stop4627-1-42" />
+    </linearGradient>
+    <linearGradient
+       y2="88.801025"
+       x2="-175.25337"
+       y1="113.97943"
+       x1="-184.92441"
+       gradientTransform="matrix(0.07502968,0,0,0.07558974,20.869769,7.8579919)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3277"
+       xlink:href="#linearGradient4574-39-1" />
+    <linearGradient
+       gradientTransform="matrix(0.07511055,0.00586778,-0.00619394,0.07150456,24.004891,9.5467573)"
+       y2="75.190559"
+       x2="-208.49672"
+       y1="88.750069"
+       x1="-211.28862"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3281"
+       xlink:href="#linearGradient4470-86-9" />
+    <linearGradient
+       y2="38.561256"
+       x2="-107.45584"
+       y1="-37.385227"
+       x1="-107.45584"
+       gradientTransform="matrix(0.11183314,0,0,0.11948791,26.051608,7.6135166)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3289"
+       xlink:href="#linearGradient3871-6-7" />
+    <linearGradient
+       y2="39.991924"
+       x2="-96.557358"
+       y1="110.92493"
+       x1="-96.557358"
+       gradientTransform="matrix(0.11183314,0,0,0.11095306,26.051608,7.4335652)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3294"
+       xlink:href="#linearGradient3825-5-8-9" />
+    <linearGradient
+       y2="43"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999"
+       gradientTransform="matrix(0.45945948,0,0,0.35135138,-0.02702251,2.5675701)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3297"
+       xlink:href="#linearGradient3977-7-61" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.54285589,0,0,0.3259251,-1.5285409,3.1777887)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3300"
+       xlink:href="#linearGradient3600-9-51" />
+    <linearGradient
+       y2="52.887863"
+       x2="-76.844345"
+       y1="6.6805849"
+       x1="-76.834877"
+       gradientTransform="matrix(0.46194465,2.5492041e-4,9.4676834e-5,0.32583108,55.991851,1.3832741)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3303"
+       xlink:href="#linearGradient4623-7-15" />
+    <linearGradient
+       y2="52.887863"
+       x2="-76.844345"
+       y1="6.6805849"
+       x1="-76.834877"
+       gradientTransform="matrix(0.47467232,0.10551084,-0.07512695,0.33933623,60.451903,11.735858)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4202"
+       xlink:href="#linearGradient4623-7-15" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.52998804,0.11749552,-0.0705431,0.31819937,1.015142,0.62425986)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4204"
+       xlink:href="#linearGradient3600-9-51" />
+    <linearGradient
+       y2="43"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999"
+       gradientTransform="matrix(0.45953175,0.10719657,-0.07923668,0.3760808,2.6264624,0.20753969)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4206"
+       xlink:href="#linearGradient3977-7-61" />
+    <linearGradient
+       gradientTransform="matrix(0.03279364,0,0,0.01512557,0.14744624,14.28089)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3028"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03279364,0,0,0.01512557,0.15390003,14.28089)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3030"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03279364,0,0,0.01512557,23.846113,14.28089)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3032"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3871-6-7"
+       id="linearGradient32757"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10797055,0.02893053,-0.03091087,0.11536054,26.761193,10.822766)"
+       x1="-107.45584"
+       y1="-37.385227"
+       x2="-107.45584"
+       y2="38.561256" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3825-5-8-9"
+       id="linearGradient32759"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.10797055,0.02893053,-0.02870295,0.1071205,26.807745,10.649031)"
+       x1="-96.557358"
+       y1="110.92493"
+       x2="-96.557358"
+       y2="39.991924" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3977-7-61"
+       id="linearGradient32761"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.44359025,0.11885924,-0.09089268,0.33921493,2.8886484,-0.79525851)"
+       x1="23.99999"
+       y1="5.5641499"
+       x2="23.99999"
+       y2="43" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient32763"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.52410623,0.14043336,-0.08431503,0.31466693,1.2811306,-0.59455146)"
        x1="25.132275"
        y1="0.98520643"
        x2="25.132275"
-       y2="47.013336"
-       id="linearGradient3806"
-       xlink:href="#linearGradient3600"
+       y2="47.013336" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4623-7-15"
+       id="linearGradient32765"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40816232,0,0,0.45629548,1.204104,0.8489076)" />
-    <linearGradient
-       id="linearGradient3104-9">
-      <stop
-         id="stop3106-5"
-         style="stop-color:#000000;stop-opacity:0.33950618"
-         offset="0" />
-      <stop
-         id="stop3108-5"
-         style="stop-color:#000000;stop-opacity:0.24691358"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471"
-       id="linearGradient3019"
-       xlink:href="#linearGradient3104-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3214623,0,0,0.3988701,25.096716,0.94977172)" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7">
-      <stop
-         id="stop5440-4-4"
-         style="stop-color:#272727;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5442-3-5"
-         style="stop-color:#454545;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="149.98465"
-       y1="-104.23534"
-       x2="149.98465"
-       y2="-174.9679"
-       id="linearGradient5104-88-8"
-       xlink:href="#linearGradient3707-319-631-407-324-616-674-812-821-107-178-392-400-6-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.19344702,0,0,0.2102702,-15.512174,35.942804)" />
-    <linearGradient
-       id="linearGradient4785-3">
-      <stop
-         id="stop4787-5"
-         style="stop-color:#262626;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4789-1"
-         style="stop-color:#4d4d4d;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3610-302-9-7">
-      <stop
-         id="stop3796-3-8"
-         style="stop-color:#1d1d1d;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3798-1-9"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4785-3"
-       id="linearGradient3291"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.16336646,2.5609971e-4,6.0470953e-4,-0.13983381,22.046047,18.978461)"
-       x1="45.414135"
-       y1="15.270427"
-       x2="45.567307"
-       y2="96.25267" />
-    <linearGradient
-       xlink:href="#linearGradient3610-302-9-7"
-       id="linearGradient3293"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.37086839,5.8139199e-4,0.00176661,-0.40851062,2.1224964,-0.05285177)"
-       x1="-24.032034"
-       y1="-13.090545"
-       x2="-24.097931"
-       y2="-40.163883" />
+       gradientTransform="matrix(0.44592364,0.11974826,-0.08419931,0.31460065,57.279061,12.55308)"
+       x1="-76.834877"
+       y1="6.6805849"
+       x2="-76.844345"
+       y2="52.887863" />
   </defs>
   <metadata
-     id="metadata3815">
+     id="metadata3821">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -149,26 +328,116 @@
     </rdf:RDF>
   </metadata>
   <path
-     style="display:inline;fill:url(#linearGradient3806);fill-opacity:1;stroke:none;stroke-width:0.999999"
-     id="path4160"
-     d="M 1,19.999999 C 1,16.562738 1.0012755,2.000018 1.0012755,2.000018 L 21.000001,1.9999999 V 19.999999 Z" />
-  <path
-     style="display:inline;fill:none;stroke:url(#linearGradient3019);stroke-width:0.999917;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="path4160-8"
-     d="m 1.499961,19.500041 c 0,-3.296266 0.00121,-17.0000646 0.00121,-17.0000646 l 18.998869,-1.7e-5 V 19.500041 Z" />
-  <path
-     style="fill:url(#linearGradient3291);fill-opacity:1;stroke:url(#linearGradient3293);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="M 17.500003,16.5 H 4.499999 l 1.1e-6,-11.000002 13.0000019,7e-7 z"
-     id="rect3582-50-4-3"
+     d="M 17.878314,18.672913 0.4999493,14.016411 4.1216869,0.49994725 21.500051,5.1564501 Z"
+     id="path32715"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient32765);stroke-width:0.999917;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
      sodipodi:nodetypes="ccccc" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient5104-88-8);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.644804;marker:none;enable-background:accumulate"
-     id="path4019-3"
-     d="m 10.633605,6.0000182 c -0.507148,0 -0.9182742,0.8878449 -0.9182742,1.9830608 0,0.1822264 0.00738,0.3591381 0.028695,0.5267486 C 9.6350379,8.3909247 9.5318014,8.2632628 9.3996765,8.1534973 8.5957842,7.4856426 7.685859,7.3011827 7.3766024,7.735196 7.0673465,8.1692064 7.4766353,9.0658943 8.2805301,9.7337464 c 0.1525328,0.1267249 0.3042353,0.2185661 0.4591371,0.3098546 -0.1754754,0.02423 -0.359962,0.06561 -0.5452259,0.123942 -0.9737367,0.306618 -1.6485281,0.992572 -1.5065452,1.51828 0.1419837,0.525708 1.0493372,0.693935 2.023074,0.387316 -2.4643868,1.709673 -2.5200634,2.519478 -3.2238496,3.926868 h 1.9090866 c 1.4539173,-2.221993 0.7584874,-4.442416 1.8456421,-1.386072 0.4770723,0.185775 1.1480948,-0.503507 1.4921958,-1.533772 0.03095,-0.09267 0.04803,-0.187466 0.07173,-0.27887 0.03716,0.08844 0.06992,0.174886 0.114785,0.263376 0.487102,0.960657 1.248229,1.53338 1.693069,1.270399 0.444842,-0.262979 0.401014,-1.254796 -0.08607,-2.21545 -0.02778,-0.05479 -0.05666,-0.102788 -0.08608,-0.154926 0.05397,0.01812 0.10189,0.0307 0.157828,0.04648 0.981443,0.276494 1.880691,0.08058 2.008725,-0.44929 0.128036,-0.529868 -0.568145,-1.179814 -1.549588,-1.456309 -0.01502,-0.0043 -0.02806,-0.01148 -0.04306,-0.01551 0.01323,-0.0081 0.02983,-0.0073 0.04306,-0.0155 C 13.93685,9.5269614 14.44551,8.6896907 14.191936,8.2154498 13.93836,7.7412083 13.018574,7.8072767 12.140165,8.3548837 11.858801,8.5302877 11.629407,8.7314517 11.437111,8.9436039 11.510041,8.6592809 11.551896,8.331106 11.551896,7.9830608 11.551896,6.8878451 11.14077,6 10.63362,6 Z m 0.02869,3.3154282 c 0.633935,0 1.147841,0.5549042 1.147841,1.2394116 0,0.68451 -0.513906,1.239413 -1.147841,1.239413 -0.633938,0 -1.1478453,-0.554903 -1.1478453,-1.239413 0,-0.6845074 0.5139073,-1.2394116 1.1478453,-1.2394116 z"
-     sodipodi:nodetypes="csccscccsccccsccssccscccsscsccsssss" />
+     d="M 4.475099,1.1120699 C 8.6785852,2.2383868 20.887672,5.5107606 20.887672,5.5107606 L 17.524914,18.060794 1.1120755,13.663002 4.4750954,1.1120835 Z"
+     id="path32717"
+     style="display:inline;fill:url(#linearGradient32763);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="cccccc" />
   <path
-     style="fill:#f2f2f2;fill-opacity:1;stroke:none;stroke-width:0.644804"
-     id="path4019"
-     d="m 10.648936,6.5000294 c -0.508702,0 -0.9210888,0.8905674 -0.9210888,1.9891386 0,0.182786 0.00741,0.3602399 0.028783,0.5283654 C 9.6473046,8.8982672 9.5437518,8.7702129 9.4112219,8.6601098 8.6048656,7.9902092 7.6921514,7.8051847 7.3819468,8.2405259 7.071743,8.675868 7.4822862,9.5753047 8.288645,10.245204 c 0.1530004,0.127111 0.305168,0.219236 0.4605447,0.310803 -0.1760132,0.02429 -0.3610656,0.06582 -0.5468971,0.124321 -0.9767215,0.30756 -1.6535813,0.995616 -1.5111631,1.522935 0.1424189,0.527319 1.0525537,0.696063 2.0292752,0.388503 C 6.7132364,13.767913 5.9260564,15.588294 5.2201128,17 h 1.5978056 c 0.3594928,-0.931899 0.7187677,-1.947434 2.0895822,-3.662308 -0.1940171,0.871565 -0.068531,1.641465 0.3454103,1.802658 0.4785346,0.186343 1.1516151,-0.505054 1.4967691,-1.538476 0.03105,-0.09296 0.04818,-0.18804 0.07195,-0.279721 0.03728,0.08869 0.07012,0.175418 0.115136,0.264182 0.488595,0.963602 1.252055,1.538077 1.69826,1.274291 0.446204,-0.263786 0.402241,-1.258639 -0.08634,-2.222242 -0.02786,-0.05496 -0.05683,-0.103082 -0.08635,-0.155399 0.05413,0.01817 0.102203,0.0308 0.158313,0.04661 0.98445,0.277346 1.886455,0.08083 2.01488,-0.450662 0.128431,-0.531493 -0.569887,-1.183429 -1.554337,-1.460774 -0.01506,-0.0043 -0.02813,-0.01152 -0.04318,-0.01555 0.01326,-0.0081 0.02992,-0.0073 0.04318,-0.01555 0.881102,-0.549284 1.391322,-1.3891205 1.136972,-1.8648173 C 13.963813,8.246544 13.041205,8.3128175 12.160105,8.862102 11.877878,9.0380448 11.647781,9.2398244 11.454897,9.4526266 11.528047,9.1674321 11.570034,8.8382504 11.570034,8.4891385 11.570034,7.3905665 11.157647,6.5 10.648943,6.5 Z m 0.02878,3.3255917 c 0.635878,0 1.151359,0.5566039 1.151359,1.2432109 0,0.686607 -0.515481,1.243211 -1.151359,1.243211 -0.635882,0 -1.1513636,-0.556604 -1.1513636,-1.243211 0,-0.686607 0.5154816,-1.2432109 1.1513636,-1.2432109 z"
-     sodipodi:nodetypes="csccssccsccccssccssccsccccscsccsssss" />
+     d="M 17.17152,17.448716 1.7241534,13.30962 4.8284823,1.7241455 20.275848,5.8632409 Z"
+     id="path32719"
+     style="fill:none;stroke:url(#linearGradient32761);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 5.1818648,2.3362205 2.3362302,12.956238 16.818136,16.836639 19.66377,6.2166222 Z"
+     id="path32721"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient32759);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:9.99997;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="M 5.1837393,2.3292249 3.3355039,9.2269087 c 0.2115381,0.18536 0.4909149,0.377141 0.8245193,0.46653 0.7618521,0.204136 1.6830914,-0.253784 2.9551819,0.08707 1.2720954,0.3408563 2.0072975,1.4241483 3.6111959,1.8539103 1.6039,0.429762 2.285226,-0.669069 4.330307,-0.121093 2.045075,0.547974 1.490795,1.211004 2.771381,1.554135 l 1.837557,-6.8578341 z"
+     id="path32723"
+     style="fill:url(#linearGradient32757);fill-opacity:1;stroke:none;stroke-width:0.999997"
+     sodipodi:nodetypes="ccssssccc" />
+  <path
+     d="M 5.5352464,2.9483026 C 8.8537872,3.8374999 19.051494,6.5706748 19.051494,6.5706748 L 16.46475,16.224569 2.9483064,12.602861 5.5352478,2.9482971 Z"
+     id="path32725"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:0.999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="cccccc" />
+  <g
+     id="g4219"
+     style="opacity:0.2"
+     transform="translate(0,-2.0000007)">
+    <rect
+       width="15.834642"
+       height="3.6733527"
+       x="4.0826831"
+       y="19.826649"
+       id="rect4173-4"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3028);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
+    <path
+       d="m 19.917326,19.826774 c 0,0 0,3.67315 0,3.67315 1.688791,0.0069 4.082675,-0.822966 4.082674,-1.836811 0,-1.013845 -1.884564,-1.836339 -4.082674,-1.836339 z"
+       id="path5058-9"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3030);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
+    <path
+       d="m 4.0826831,19.826774 c 0,0 0,3.67315 0,3.67315 C 2.3938915,23.506839 7.845175e-6,22.676958 7.845175e-6,21.663113 7.845175e-6,20.649268 1.8845715,19.826774 4.0826831,19.826774 Z"
+       id="path5018-53"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3032);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
+  </g>
+  <path
+     d="M 20.500039,18.500038 H 1.499961 V 3.4999618 h 19.000078 z"
+     id="rect6741-1-2-0-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3303);stroke-width:0.999921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 2.000001,3.9999996 c 4.353864,0 17.999987,9.374e-4 17.999987,9.374e-4 L 20.000012,18 H 2.000001 V 4.0000137 Z"
+     id="path4160-9-1"
+     style="display:inline;fill:url(#linearGradient3300);fill-opacity:1;stroke:none"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     d="m 19.500001,17.5 h -17 V 4.4999995 h 17 z"
+     id="rect6741-1-2-1"
+     style="fill:none;stroke:url(#linearGradient3297);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="M 3,4.9999991 V 17 H 19 V 4.9999991 Z"
+     id="rect3055-2-9-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3294);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     d="m 7.1083831,12.363051 c -0.072735,-0.0055 -0.1545133,9.6e-5 -0.2369661,0.02791 -0.3218422,0.108583 -0.3587506,0.322485 -0.3874877,0.425147 -0.028735,0.102661 -0.03468,0.182453 -0.039352,0.266639 -0.00934,0.16837 -0.00208,0.345343 0.00586,0.522198 0.00651,0.145267 0.012305,0.274201 0.015154,0.388068 -0.1109878,0.02573 -0.2333009,0.05337 -0.3741562,0.08352 -0.1765366,0.03779 -0.3550044,0.07562 -0.5196116,0.127425 -0.082303,0.02591 -0.1596166,0.05205 -0.2578436,0.108081 -0.049113,0.02801 -0.1056789,0.06133 -0.1719029,0.134692 -0.066224,0.07336 -0.1464577,0.211318 -0.1418904,0.37801 0.00892,0.325417 0.2104863,0.423818 0.3043152,0.481402 0.093829,0.05758 0.1695117,0.08689 0.2522818,0.116983 0.1655411,0.06019 0.3481483,0.108991 0.5275569,0.156173 0.1478643,0.03889 0.2774025,0.07553 0.3923923,0.108032 -0.00861,0.108299 -0.020522,0.227991 -0.033877,0.36434 -0.016818,0.171667 -0.033277,0.343048 -0.032406,0.508155 4.358e-4,0.08255 0.00232,0.161276 0.027923,0.267473 0.012793,0.0531 0.030065,0.114011 0.082828,0.196597 0.052764,0.08259 0.1634885,0.199626 0.3315883,0.246981 0.327506,0.09226 0.4885528,-0.05824 0.5751618,-0.125296 0.086609,-0.06705 0.1399475,-0.129181 0.195682,-0.194736 0.1114677,-0.131109 0.2153497,-0.280706 0.3180987,-0.428356 0.08451,-0.121437 0.159635,-0.228819 0.227664,-0.322673 0.105677,0.04112 0.221967,0.08844 0.354559,0.142659 0.16612,0.06793 0.334191,0.137202 0.4993305,0.18713 0.08257,0.02496 0.15975,0.0473 0.273754,0.05676 0.057,0.0047 0.125389,0.0089 0.224101,-0.01344 0.09871,-0.02238 0.247783,-0.0876 0.346922,-0.224925 0.1933589,-0.267841 0.09361,-0.462656 0.05331,-0.561792 -0.0403,-0.09913 -0.08453,-0.16528 -0.132836,-0.235875 -0.09661,-0.14119 -0.214817,-0.28105 -0.330592,-0.419343 -0.09508,-0.113567 -0.177277,-0.214454 -0.249953,-0.304715 0.07386,-0.08297 0.156307,-0.173356 0.251541,-0.276592 0.119443,-0.12948 0.239503,-0.25933 0.340618,-0.393436 0.05056,-0.06705 0.09837,-0.131725 0.143176,-0.231999 0.0224,-0.05014 0.04672,-0.109408 0.05498,-0.205728 0.0083,-0.09632 -0.01097,-0.252744 -0.117596,-0.385017 -0.207895,-0.257896 -0.431564,-0.225033 -0.542991,-0.21928 -0.111427,0.0058 -0.192512,0.02499 -0.278081,0.04681 -0.1711355,0.04364 -0.3487155,0.105044 -0.5230345,0.166951 -0.143691,0.05103 -0.269999,0.0958 -0.38314,0.133665 -0.05991,-0.09235 -0.124539,-0.195955 -0.19807,-0.313929 -0.0922,-0.147923 -0.185361,-0.296418 -0.2879308,-0.429275 -0.051285,-0.06643 -0.098347,-0.128599 -0.1847,-0.200134 -0.043178,-0.03577 -0.096085,-0.07714 -0.1898116,-0.114313 -0.046863,-0.01859 -0.1118206,-0.03544 -0.1845559,-0.04095 z m 0.8407957,1.151171 c 0.0025,-3.58e-4 0.01724,0.0039 0.02057,0.0038 -0.0059,0.0015 -0.02274,0.0061 -0.02613,0.0068 -0.0083,0.0017 -0.01458,-0.0077 0.0056,-0.01062 z m 0.307236,0.09917 c 0.0256,0.02035 0.02393,0.02946 0.01886,0.02358 -0.0023,-0.0027 -0.01429,-0.01772 -0.01886,-0.02358 z m -1.5929124,0.319922 c 0.020658,-0.0093 0.022418,0.0032 0.015768,0.0057 -0.00348,0.0013 -0.023299,0.0062 -0.030936,0.0086 0.003,-0.0018 0.012711,-0.01318 0.015173,-0.01429 z m -0.1975606,0.243224 c -3.811e-4,0.0061 4.039e-4,0.02313 2.04e-5,0.02653 -0.00102,0.0091 -0.00917,0.0022 -2.04e-5,-0.02653 z m 2.6127193,0.480456 c -0.0047,-0.0078 0.0064,-0.0064 0.01674,0.02121 -0.0035,-0.0052 -0.01495,-0.01826 -0.01674,-0.02121 z m 0.008,0.31013 c -0.01235,0.02884 -0.02274,0.03152 -0.01843,0.02509 0.002,-0.003 0.01389,-0.01901 0.01843,-0.02509 z M 6.4859854,15.47361 c 2.138e-4,0.0035 -4.271e-4,0.02329 -3.604e-4,0.03092 -0.00801,-0.03061 -1.219e-4,-0.03857 3.604e-4,-0.03092 z m 0.1741897,0.267846 c 0.00559,0.0021 0.021678,0.0073 0.024803,0.0086 0.00882,0.0037 0.00116,0.0086 -0.024803,-0.0086 z m 1.6399797,0.289504 c 0.0065,-0.0069 0.0075,0.0045 -0.01824,0.02289 0.0046,-0.0053 0.01564,-0.02015 0.01824,-0.02289 z m -0.338006,0.09519 c 0.0038,9.19e-4 0.02335,0.0089 0.03153,0.01131 -0.03279,-0.0022 -0.03929,-0.01322 -0.03153,-0.01131 z"
+     id="path5297"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:44.3704;marker:none;enable-background:accumulate" />
+  <path
+     id="rect3055-2-6-9-0-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate"
+     d="m 3,5.0000005 v 7.7636715 c 0.3797136,0.107869 0.872579,0.195312 1.4589844,0.195312 1.4951485,0 1.2808656,-0.537109 2.5683594,-0.537109 1.2874847,0 2.0465852,0.878906 3.7871092,0.878906 2.155843,0 2.64979,-1.414062 4.355469,-1.414062 1.331887,0 1.4326,0.773437 2.898437,0.773437 0.397358,0 0.6862,-0.06664 0.931641,-0.162109 V 5.0000005 Z" />
+  <path
+     d="m 3,4.9927532 v 7.1444698 c 0.252426,0.124353 0.572074,0.237347 0.917613,0.237347 0.789107,0 1.560808,-0.681081 2.878407,-0.681081 1.317604,0 2.3086091,0.856511 3.969887,0.856511 1.661278,0 2.035169,-1.238329 4.153412,-1.238329 2.118237,0 2.754284,0.784275 4.080681,0.784275 0,0 0,-4.6266067 0,-7.1031928 z"
+     id="path3867-3-5-3"
+     style="fill:url(#linearGradient3289);fill-opacity:1;stroke:none"
+     sodipodi:nodetypes="ccssssccc" />
+  <path
+     id="path4213-1-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate"
+     d="m 14.919922,9.8066413 c -1.112767,0 -1.813659,0.3368987 -2.386719,0.6503897 -0.573055,0.313491 -1.005346,0.587891 -1.767578,0.587891 -0.7833211,0 -1.4012486,-0.199289 -2.0175781,-0.41211 C 8.1317215,10.419991 7.5153313,10.1875 6.796875,10.1875 c -0.7062363,0 -1.2756298,0.178179 -1.7402344,0.351562 -0.4646095,0.173384 -0.8233272,0.330079 -1.1386718,0.330079 -0.2855198,0 -0.564763,-0.104375 -0.7929688,-0.216797 A 0.29415704,0.31426635 0 0 0 3,10.621094 v 1.353515 c 0.3911316,0.104566 0.88225,0.185547 1.4589844,0.185547 0.7805112,0 1.1763288,-0.152296 1.4765625,-0.289062 0.3002337,-0.136765 0.4863005,-0.248047 1.0917969,-0.248047 0.5812204,0 1.0490794,0.202273 1.6230468,0.423828 C 9.2243522,12.268431 9.8979411,12.5 10.814453,12.5 c 1.138097,0 1.879102,-0.384834 2.492188,-0.742188 0.613085,-0.357353 1.0865,-0.671874 1.863281,-0.671874 0.612613,0 0.89758,0.166243 1.27539,0.361328 0.377801,0.195084 0.841672,0.412109 1.623047,0.412109 0.381417,0 0.679355,-0.05728 0.931641,-0.142578 v -1.257813 c -0.224005,0.07868 -0.481407,0.132813 -0.835938,0.132813 -0.608939,0 -0.798526,-0.156012 -1.197265,-0.361328 -0.398744,-0.205315 -0.953781,-0.4238287 -2.046875,-0.4238277 z" />
+  <path
+     id="rect3055-2-6-94-0-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate"
+     d="m 14.919922,10.425781 c -2.118241,0 -2.493021,1.238281 -4.154297,1.238281 -1.6612762,0 -2.6511473,-0.857421 -3.96875,-0.857421 -1.3175977,0 -2.0898,0.68164 -2.8789062,0.68164 C 3.5724301,11.488281 3.2524257,11.376306 3,11.251953 v 0.710938 c 0.3797136,0.107869 0.872579,0.197265 1.4589844,0.197265 1.4951485,0 1.2808656,-0.537109 2.5683594,-0.537109 1.2874847,0 2.0465852,0.876953 3.7871092,0.876953 2.155843,0 2.64979,-1.414062 4.355469,-1.414062 1.331887,0 1.4326,0.773437 2.898437,0.773437 0.397358,0 0.6862,-0.06664 0.931641,-0.162109 v -0.605469 c -0.228823,0.07009 -0.496934,0.119141 -0.835938,0.119141 -1.326395,0 -1.125905,-0.785157 -3.24414,-0.785157 z" />
+  <path
+     id="rect3055-2-6-8-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate"
+     d="m 14.919922,10.925781 c -2.118241,0 -2.493021,1.238281 -4.154297,1.238281 -1.6612762,0 -2.6511473,-0.857421 -3.96875,-0.857421 -1.3175977,0 -2.0898,0.68164 -2.8789062,0.68164 C 3.5724301,11.988281 3.2524257,11.876306 3,11.751953 v 0.710938 c 0.3797136,0.107868 0.872579,0.197265 1.4589844,0.197265 1.4951485,0 1.2808656,-0.537109 2.5683594,-0.537109 C 8.3148285,12.123047 9.073929,13 10.814453,13 c 2.155843,0 2.64979,-1.414063 4.355469,-1.414062 1.331887,0 1.4326,0.773437 2.898437,0.773437 0.397358,0 0.6862,-0.06664 0.931641,-0.162109 v -0.605469 c -0.228823,0.07009 -0.496934,0.119141 -0.835938,0.119141 -1.326395,0 -1.125905,-0.785157 -3.24414,-0.785157 z" />
+  <path
+     d="m 3.5,5.5000056 c 3.4372601,0 14.999982,6.926e-4 14.999982,6.926e-4 l 1.7e-5,10.9993078 c 0,0 -9.9999987,0 -14.999999,0 0,-3.66667 0,-7.3333378 0,-11.0000061 z"
+     id="path4160-62-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 6.9702406,12.845344 c -0.1801063,0.06076 0.030127,1.367687 -0.083875,1.513688 -0.1100705,0.140971 -1.464343,0.283889 -1.4595331,0.459442 0.00498,0.181816 1.3780039,0.393059 1.4885954,0.54133 0.1067819,0.143163 -0.1690945,1.414799 0.00778,1.464626 0.1831851,0.0516 0.8197981,-1.124468 1.0021461,-1.178833 0.176065,-0.05249 1.3595611,0.587471 1.4640661,0.442713 C 9.4976521,15.938386 8.519228,15.001462 8.521333,14.819592 8.523333,14.643988 9.5303701,13.76957 9.4180831,13.630278 9.3017911,13.486016 8.060351,14.080847 7.879305,14.022809 7.704496,13.966769 7.144143,12.786674 6.9702406,12.845344 Z"
+     id="path5640-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:44.3704;marker:none;enable-background:accumulate" />
+  <path
+     d="m 7.0218295,12.504789 c 0.1739611,-0.05869 0.7361161,1.123036 0.9109851,1.179094 0.181107,0.05806 1.4218135,-0.538302 1.5381455,-0.39399 0.112325,0.139339 -0.8947775,1.013919 -0.8968115,1.189583 -0.0021,0.181932 0.9766135,1.120715 0.8683435,1.270688 -0.104539,0.144807 -1.2891185,-0.496399 -1.4652435,-0.44389 -0.182409,0.05438 -0.818233,1.230941 -1.0014803,1.179319 -0.1769347,-0.04984 0.098058,-1.320712 -0.00876,-1.463924 C 6.8563813,14.873348 5.4847,14.661718 5.4797171,14.47984 c -0.00482,-0.175612 1.3497237,-0.319845 1.4598315,-0.460864 0.1140359,-0.14605 -0.097885,-1.453403 0.082282,-1.514187 z"
+     id="path4468-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3281);fill-opacity:1;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 7.0393131,12.470596 -0.04821,0.04636 c -3.44e-4,0.0011 -0.0019,0.0014 -0.0019,0.0021 -0.096792,0.234217 0.058261,1.259164 -0.03946,1.3843 -0.0042,0.0052 -0.01001,0.01243 -0.017541,0.01766 l 0.039461,0.0265 c 0.7903285,0.236715 0.098571,-1.427744 0.07889,-1.474818 -0.0037,-6.98e-4 -0.0074,-0.0025 -0.01094,-0.0021 z"
+     id="path4480-14"
+     style="opacity:0.5;fill:#9d0f06;fill-opacity:1;stroke:none" />
+  <path
+     d="m 5.7536305,14.427205 c -0.1663436,0.0015 -0.262602,0.0094 -0.262602,0.0094 v 0.0022 0.0378 c 0.097563,0.179325 1.3903695,0.384497 1.4982481,0.529129 0.108053,0.144867 -0.1695997,1.430665 0.00936,1.481083 0.185362,0.05222 0.828383,-1.137887 1.012899,-1.192899 0.177047,-0.05278 1.3609145,0.586923 1.4794925,0.451177 l -0.002,-0.0022 C 8.4907356,14.519122 6.4746473,14.421091 5.7538347,14.427206 Z"
+     id="path4517-2"
+     style="opacity:0.75;fill:url(#linearGradient3277);fill-opacity:1;stroke:none" />
 </svg>

--- a/elementary-xfce/places/24/folder-pictures.svg
+++ b/elementary-xfce/places/24/folder-pictures.svg
@@ -1,1 +1,361 @@
-../../mimes/24/image-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   id="svg3816"
+   height="24"
+   width="24"
+   version="1.1">
+  <defs
+     id="defs3818">
+    <linearGradient
+       id="linearGradient4574-39-1">
+      <stop
+         offset="0"
+         style="stop-color:#7a0f01;stop-opacity:1"
+         id="stop4576-75-8" />
+      <stop
+         offset="1"
+         style="stop-color:#d31807;stop-opacity:1"
+         id="stop4578-96-3" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4470-86-9">
+      <stop
+         offset="0"
+         style="stop-color:#ec4502;stop-opacity:1"
+         id="stop4472-0-4" />
+      <stop
+         offset="1"
+         style="stop-color:#fe7617;stop-opacity:1"
+         id="stop4474-9-9" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3871-6-7">
+      <stop
+         offset="0"
+         style="stop-color:#0b85e9;stop-opacity:1"
+         id="stop3873-3-2" />
+      <stop
+         offset="1"
+         style="stop-color:#69d1ef;stop-opacity:1"
+         id="stop3875-4-0" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3825-5-8-9">
+      <stop
+         offset="0"
+         style="stop-color:#e89c42;stop-opacity:1"
+         id="stop3827-2-3-55" />
+      <stop
+         offset="1"
+         style="stop-color:#faca67;stop-opacity:1"
+         id="stop3829-5-0-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977-7-61">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3979-6-49" />
+      <stop
+         offset="0.03626217"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3981-3-78" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3983-8-86" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3985-2-07" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4623-7-15">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.27058825"
+         id="stop4625-3-7" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.368"
+         id="stop4627-1-42" />
+    </linearGradient>
+    <linearGradient
+       y2="88.801025"
+       x2="-175.25337"
+       y1="113.97943"
+       x1="-184.92441"
+       gradientTransform="matrix(0.07502968,0,0,0.07558974,21.869769,9.8579913)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3277"
+       xlink:href="#linearGradient4574-39-1" />
+    <linearGradient
+       gradientTransform="matrix(0.07511055,0.00586778,-0.00619394,0.07150456,25.004891,11.546757)"
+       y2="75.190559"
+       x2="-208.49672"
+       y1="88.750069"
+       x1="-211.28862"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3281"
+       xlink:href="#linearGradient4470-86-9" />
+    <linearGradient
+       y2="38.561256"
+       x2="-107.45584"
+       y1="-37.385227"
+       x1="-107.45584"
+       gradientTransform="matrix(0.11183314,0,0,0.11948791,27.051608,9.6135161)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3289"
+       xlink:href="#linearGradient3871-6-7" />
+    <linearGradient
+       y2="39.991924"
+       x2="-96.557358"
+       y1="110.92493"
+       x1="-96.557358"
+       gradientTransform="matrix(0.11183314,0,0,0.11095306,27.051608,9.4335646)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3294"
+       xlink:href="#linearGradient3825-5-8-9" />
+    <linearGradient
+       y2="43"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999"
+       gradientTransform="matrix(0.48648651,0,0,0.37837838,0.82432896,4.4189213)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3297"
+       xlink:href="#linearGradient3977-7-61" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.54285589,0,0,0.3259251,-0.528541,5.1777881)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3300"
+       xlink:href="#linearGradient3600-9-51" />
+    <linearGradient
+       y2="52.887863"
+       x2="-76.844345"
+       y1="6.6805849"
+       x1="-76.834877"
+       gradientTransform="matrix(0.48625742,2.7191503e-4,9.9659804e-5,0.34755305,59.859833,3.2421617)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3303"
+       xlink:href="#linearGradient4623-7-15" />
+    <linearGradient
+       y2="52.887863"
+       x2="-76.844345"
+       y1="6.6805849"
+       x1="-76.834877"
+       gradientTransform="matrix(0.47467232,0.10551084,-0.07512695,0.33933623,60.451903,11.735858)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4202"
+       xlink:href="#linearGradient4623-7-15" />
+    <linearGradient
+       y2="47.013336"
+       x2="25.132275"
+       y1="0.98520643"
+       x1="25.132275"
+       gradientTransform="matrix(0.52998804,0.11749552,-0.0705431,0.31819937,1.0760283,0.555165)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4204"
+       xlink:href="#linearGradient3600-9-51" />
+    <linearGradient
+       y2="43"
+       x2="23.99999"
+       y1="5.5641499"
+       x1="23.99999"
+       gradientTransform="matrix(0.47495484,0.10529495,-0.08189607,0.3694093,2.5610785,0.107101)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4206"
+       xlink:href="#linearGradient3977-7-61" />
+    <linearGradient
+       gradientTransform="matrix(0.03279364,0,0,0.01512557,0.14744624,14.28089)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5048"
+       id="linearGradient3028"
+       y2="609.50507"
+       x2="302.85715"
+       y1="366.64789"
+       x1="302.85715" />
+    <linearGradient
+       id="linearGradient5048">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5050" />
+      <stop
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5056" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5052" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.03279364,0,0,0.01512557,0.15390003,14.28089)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3030"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop5062" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop5064" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.03279364,0,0,0.01512557,23.846113,14.28089)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5060"
+       id="radialGradient3032"
+       fy="486.64789"
+       fx="605.71429"
+       r="117.14286"
+       cy="486.64789"
+       cx="605.71429" />
+  </defs>
+  <metadata
+     id="metadata3821">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g4219"
+     style="opacity:0.2">
+    <rect
+       width="15.834642"
+       height="3.6733527"
+       x="4.0826831"
+       y="19.826649"
+       id="rect4173-4"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3028);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.96237946;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
+    <path
+       d="m 19.917326,19.826774 c 0,0 0,3.67315 0,3.67315 1.688791,0.0069 4.082675,-0.822966 4.082674,-1.836811 0,-1.013845 -1.884564,-1.836339 -4.082674,-1.836339 z"
+       id="path5058-9"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3030);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.96237946;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
+    <path
+       d="m 4.0826831,19.826774 c 0,0 0,3.67315 0,3.67315 C 2.3938915,23.506839 7.845175e-6,22.676958 7.845175e-6,21.663113 7.845175e-6,20.649268 1.8845715,19.826774 4.0826831,19.826774 Z"
+       id="path5018-53"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3032);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.96237946;stroke-miterlimit:4;stroke-dasharray:none;marker:none" />
+  </g>
+  <g
+     transform="translate(0,0.52522907)"
+     id="g4195">
+    <path
+       d="M 20.025957,21.47481 0.49996093,17.146002 3.9630117,1.525189 23.489008,5.853998 z"
+       id="path4151"
+       style="color:#000000;fill:none;stroke:url(#linearGradient4202);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 4.3429706,2.121603 C 8.5936307,3.063951 22.892369,6.234865 22.892369,6.234865 l -3.246368,14.643531 c 0,0 -12.3664183,-2.741569 -18.5496246,-4.112353 C 2.1785738,11.884566 3.2607712,7.003089 4.3429675,2.121616 z"
+       id="path4153"
+       style="fill:url(#linearGradient4204);fill-opacity:1;stroke:none;display:inline" />
+    <path
+       d="M 19.266073,20.282028 1.6927442,16.386115 4.7228988,2.717971 22.296228,6.613884 z"
+       id="path4155"
+       style="fill:none;stroke:url(#linearGradient4206);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+    <path
+       d="M 5.1028262,3.314337 2.2891113,16.006185 18.886144,19.685659 21.699859,6.993811 z"
+       id="path4157"
+       style="color:#000000;fill:#49bdea;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 5.4827526,3.910713 C 9.0622551,4.704269 21.103308,7.37448 21.103308,7.37448 l -2.597092,11.714812 c 0,0 -10.4138244,-2.308689 -15.6207372,-3.463034 C 3.7512374,11.721073 4.6169958,7.81589 5.4827541,3.910706 z"
+       id="path4171"
+       style="color:#000000;fill:none;stroke:#158bb9;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+  <path
+     d="m 22.500039,21.500039 -20.0000781,0 0,-16.0000778 20.0000781,0 z"
+     id="rect6741-1-2-0-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3303);stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 3.0000009,5.999999 c 4.353864,0 18.9999761,9.375e-4 18.9999761,9.375e-4 l 2.4e-5,14.9990625 c 0,0 -12.6666681,0 -19.0000001,0 0,-4.999997 0,-9.999994 0,-14.9999859 z"
+     id="path4160-9-1"
+     style="display:inline;fill:url(#linearGradient3300);fill-opacity:1;stroke:none" />
+  <path
+     d="m 21.500001,20.499999 -18.0000001,0 0,-14 18.0000001,0 z"
+     id="rect6741-1-2-1"
+     style="fill:none;stroke:url(#linearGradient3297);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <path
+     d="m 3.9999999,6.9999985 0,12.9999995 17.0000001,0 0,-12.9999995 z"
+     id="rect3055-2-9-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3294);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 8.108383,14.363051 c -0.072735,-0.0055 -0.1545133,9.6e-5 -0.2369661,0.02791 -0.3218422,0.108583 -0.3587506,0.322485 -0.3874877,0.425147 -0.028735,0.102661 -0.03468,0.182453 -0.039352,0.266639 -0.00934,0.16837 -0.00208,0.345343 0.00586,0.522198 0.00651,0.145267 0.012305,0.274201 0.015154,0.388068 -0.1109878,0.02573 -0.2333009,0.05337 -0.3741562,0.08352 -0.1765366,0.03779 -0.3550044,0.07562 -0.5196116,0.127425 -0.082303,0.02591 -0.1596166,0.05205 -0.2578436,0.108081 -0.049113,0.02801 -0.1056789,0.06133 -0.1719029,0.134692 -0.066224,0.07336 -0.1464577,0.211318 -0.1418904,0.37801 0.00892,0.325417 0.2104863,0.423818 0.3043152,0.481402 0.093829,0.05758 0.1695117,0.08689 0.2522818,0.116983 0.1655411,0.06019 0.3481483,0.108991 0.5275569,0.156173 0.1478643,0.03889 0.2774025,0.07553 0.3923923,0.108032 -0.00861,0.108299 -0.020522,0.227991 -0.033877,0.36434 -0.016818,0.171667 -0.033277,0.343048 -0.032406,0.508155 4.358e-4,0.08255 0.00232,0.161276 0.027923,0.267473 0.012793,0.0531 0.030065,0.114011 0.082828,0.196597 0.052764,0.08259 0.1634885,0.199626 0.3315883,0.246981 0.327506,0.09226 0.4885528,-0.05824 0.5751618,-0.125296 0.086609,-0.06705 0.1399475,-0.129181 0.195682,-0.194736 0.1114677,-0.131109 0.2153497,-0.280706 0.3180987,-0.428356 0.08451,-0.121437 0.159635,-0.228819 0.227664,-0.322673 0.105677,0.04112 0.221967,0.08844 0.354559,0.142659 0.16612,0.06793 0.334191,0.137202 0.4993305,0.18713 0.08257,0.02496 0.15975,0.0473 0.273754,0.05676 0.057,0.0047 0.125389,0.0089 0.224101,-0.01344 0.09871,-0.02238 0.247783,-0.0876 0.346922,-0.224925 0.193359,-0.267841 0.09361,-0.462656 0.05331,-0.561792 -0.0403,-0.09913 -0.08453,-0.16528 -0.132836,-0.235875 -0.09661,-0.14119 -0.214817,-0.28105 -0.330592,-0.419343 -0.09508,-0.113567 -0.177277,-0.214454 -0.249953,-0.304715 0.07386,-0.08297 0.156307,-0.173356 0.251541,-0.276592 0.119443,-0.12948 0.239503,-0.25933 0.340618,-0.393436 0.05056,-0.06705 0.09837,-0.131725 0.143176,-0.231999 0.0224,-0.05014 0.04672,-0.109408 0.05498,-0.205728 0.0083,-0.09632 -0.01097,-0.252744 -0.117596,-0.385017 -0.207895,-0.257896 -0.431564,-0.225033 -0.542991,-0.21928 -0.111427,0.0058 -0.192512,0.02499 -0.278081,0.04681 -0.1711355,0.04364 -0.3487155,0.105044 -0.5230345,0.166951 -0.143691,0.05103 -0.269999,0.0958 -0.38314,0.133665 -0.05991,-0.09235 -0.124539,-0.195955 -0.19807,-0.313929 -0.0922,-0.147923 -0.185361,-0.296418 -0.2879308,-0.429275 -0.051285,-0.06643 -0.098347,-0.128599 -0.1847,-0.200134 -0.043178,-0.03577 -0.096085,-0.07714 -0.1898116,-0.114313 -0.046863,-0.01859 -0.1118206,-0.03544 -0.1845559,-0.04095 z m 0.8407957,1.151171 c 0.0025,-3.58e-4 0.01724,0.0039 0.02057,0.0038 -0.0059,0.0015 -0.02274,0.0061 -0.02613,0.0068 -0.0083,0.0017 -0.01458,-0.0077 0.0056,-0.01062 z m 0.307236,0.09917 c 0.0256,0.02035 0.02393,0.02946 0.01886,0.02358 -0.0023,-0.0027 -0.01429,-0.01772 -0.01886,-0.02358 z m -1.5929124,0.319922 c 0.020658,-0.0093 0.022418,0.0032 0.015768,0.0057 -0.00348,0.0013 -0.023299,0.0062 -0.030936,0.0086 0.003,-0.0018 0.012711,-0.01318 0.015173,-0.01429 z m -0.1975606,0.243224 c -3.811e-4,0.0061 4.039e-4,0.02313 2.04e-5,0.02653 -0.00102,0.0091 -0.00917,0.0022 -2.04e-5,-0.02653 z m 2.6127193,0.480456 c -0.0047,-0.0078 0.0064,-0.0064 0.01674,0.02121 -0.0035,-0.0052 -0.01495,-0.01826 -0.01674,-0.02121 z m 0.008,0.31013 c -0.01235,0.02884 -0.02274,0.03152 -0.01843,0.02509 0.002,-0.003 0.01389,-0.01901 0.01843,-0.02509 z M 7.4859853,17.47361 c 2.138e-4,0.0035 -4.271e-4,0.02329 -3.604e-4,0.03092 -0.00801,-0.03061 -1.219e-4,-0.03857 3.604e-4,-0.03092 z m 0.1741897,0.267846 c 0.00559,0.0021 0.021678,0.0073 0.024803,0.0086 0.00882,0.0037 0.00116,0.0086 -0.024803,-0.0086 z m 1.6399797,0.289504 c 0.0065,-0.0069 0.0075,0.0045 -0.01824,0.02289 0.0046,-0.0053 0.01564,-0.02015 0.01824,-0.02289 z m -0.338006,0.09519 c 0.0038,9.19e-4 0.02335,0.0089 0.03153,0.01131 -0.03279,-0.0022 -0.03929,-0.01322 -0.03153,-0.01131 z"
+     id="path5297"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:44.37043762;marker:none;enable-background:accumulate" />
+  <path
+     d="m 3.9999999,6.9996716 0,7.7637184 c 0.379714,0.107869 0.872114,0.196069 1.45852,0.196069 1.49515,0 1.281828,-0.536609 2.569323,-0.536609 1.287486,0 2.0458371,0.877149 3.7863631,0.877149 2.155845,0 2.650569,-1.413759 4.35625,-1.413759 1.331888,0 1.431886,0.773956 2.897725,0.773956 0.990241,0 1.319101,-0.406589 1.931819,-0.670762 l 0,-6.9897624 z"
+     id="rect3055-2-6-9-0-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 3.9999999,6.9927526 0,7.1444704 c 0.252426,0.124353 0.572074,0.237347 0.917613,0.237347 0.789107,0 1.560808,-0.681081 2.878407,-0.681081 1.317604,0 2.3086091,0.856511 3.9698871,0.856511 1.661278,0 2.035169,-1.238329 4.153412,-1.238329 2.118237,0 1.919054,0.784275 3.245451,0.784275 0.913651,0 1.303838,-0.34092 1.83523,-0.557248 l 0,-6.5459454 z"
+     id="path3867-3-5-3"
+     style="fill:url(#linearGradient3289);fill-opacity:1;stroke:none" />
+  <path
+     d="m 15.919319,11.806635 c -1.112768,0 -1.812739,0.336631 -2.385799,0.650123 -0.573056,0.313491 -1.00538,0.588206 -1.767613,0.588206 -0.783322,0 -1.40242,-0.199955 -2.0187501,-0.412776 -0.616326,-0.212822 -1.23268,-0.443735 -1.951137,-0.443735 -0.706237,0 -1.274028,0.177476 -1.738633,0.35086 -0.46461,0.173384 -0.824429,0.330221 -1.139774,0.330221 -0.28552,0 -0.563838,-0.104285 -0.792044,-0.216707 a 0.29415704,0.31426635 0 0 0 -0.125569,-0.03096 l 0,1.351843 c 0.391132,0.104566 0.881785,0.185749 1.45852,0.185749 0.780512,0 1.177609,-0.152178 1.477843,-0.288944 0.300234,-0.136765 0.485983,-0.247665 1.09148,-0.247665 0.581221,0 1.048758,0.20154 1.622726,0.423095 C 10.224531,14.267501 10.897693,14.5 11.814206,14.5 c 1.138098,0 1.878958,-0.385644 2.492044,-0.742998 0.613086,-0.357354 1.087424,-0.670762 1.864206,-0.670762 0.612614,0 0.897189,0.166095 1.275,0.36118 0.377801,0.195085 0.841349,0.412776 1.622725,0.412776 0.995062,0 1.431212,-0.394433 1.931819,-0.639803 l 0,-1.186733 a 0.29415704,0.31426635 0 0 0 -0.10625,0.02064 c -0.582708,0.237219 -0.883811,0.53661 -1.72898,0.53661 -0.60894,0 -0.798986,-0.155864 -1.197726,-0.36118 -0.398744,-0.205315 -0.95463,-0.423096 -2.047725,-0.423096 z"
+     id="path4213-1-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 15.919319,12.425798 c -2.118243,0 -2.492134,1.238329 -4.153412,1.238329 -1.661278,0 -2.6522831,-0.856511 -3.9698871,-0.856511 -1.317599,0 -2.0893,0.681081 -2.878407,0.681081 -0.345539,0 -0.665187,-0.112993 -0.917613,-0.237346 l 0,0.712039 c 0.379714,0.107869 0.872114,0.196069 1.45852,0.196069 1.49515,0 1.281828,-0.536609 2.569323,-0.536609 1.287486,0 2.0458371,0.87715 3.7863631,0.87715 2.155845,0 2.650569,-1.41376 4.35625,-1.41376 1.331888,0 1.431886,0.773956 2.897725,0.773956 0.990241,0 1.319101,-0.406588 1.931819,-0.670761 l 0,-0.53661 c -0.531392,0.216329 -0.921579,0.557248 -1.83523,0.557248 -1.326397,0 -1.127214,-0.784275 -3.245451,-0.784275 z"
+     id="rect3055-2-6-94-0-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 15.919319,12.925799 c -2.118243,0 -2.492134,1.238329 -4.153412,1.238329 -1.661278,0 -2.6522831,-0.856511 -3.9698871,-0.856511 -1.317599,0 -2.0893,0.681081 -2.878407,0.681081 -0.345539,0 -0.665187,-0.112993 -0.917613,-0.237346 l 0,0.712039 c 0.379714,0.107868 0.872114,0.196069 1.45852,0.196069 1.49515,0 1.281828,-0.536609 2.569323,-0.536609 1.287486,0 2.0458371,0.877149 3.7863631,0.877149 2.155845,0 2.650569,-1.413758 4.35625,-1.413758 1.331888,0 1.431886,0.773955 2.897725,0.773955 0.990241,0 1.319101,-0.406588 1.931819,-0.670761 l 0,-0.53661 c -0.531392,0.216329 -0.921579,0.557248 -1.83523,0.557248 -1.326397,0 -1.127214,-0.784275 -3.245451,-0.784275 z"
+     id="rect3055-2-6-8-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 4.4999999,7.5000056 c 3.666411,0 15.9999821,7.556e-4 15.9999821,7.556e-4 L 20.5,19.499999 c 0,0 -10.6666661,0 -16.0000001,0 0,-4.000001 0,-8 0,-11.9999996 z"
+     id="path4160-62-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 7.9702405,14.845344 c -0.1801063,0.06076 0.030127,1.367687 -0.083875,1.513688 -0.1100705,0.140971 -1.464343,0.283889 -1.4595331,0.459442 0.00498,0.181816 1.3780039,0.393059 1.4885954,0.54133 0.1067819,0.143163 -0.1690945,1.414799 0.00778,1.464626 0.1831851,0.0516 0.8197981,-1.124468 1.0021461,-1.178833 0.176065,-0.05249 1.3595611,0.587471 1.4640661,0.442713 0.108232,-0.149924 -0.8701921,-1.086848 -0.8680871,-1.268718 0.002,-0.175604 1.0090371,-1.050022 0.8967501,-1.189314 -0.116292,-0.144262 -1.3577321,0.450569 -1.5387781,0.392531 -0.174809,-0.05604 -0.735162,-1.236135 -0.9090635,-1.177465 z"
+     id="path5640-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:44.37043762;marker:none;enable-background:accumulate" />
+  <path
+     d="m 8.0218294,14.504789 c 0.1739611,-0.05869 0.7361161,1.123036 0.9109851,1.179094 0.181107,0.05806 1.4218135,-0.538302 1.5381455,-0.39399 0.112325,0.139339 -0.8947775,1.013919 -0.8968115,1.189583 -0.0021,0.181932 0.9766135,1.120715 0.8683435,1.270688 -0.104539,0.144807 -1.2891185,-0.496399 -1.4652435,-0.44389 -0.182409,0.05438 -0.818233,1.230941 -1.0014803,1.179319 -0.1769347,-0.04984 0.098058,-1.320712 -0.00876,-1.463924 -0.110627,-0.148321 -1.4823083,-0.359951 -1.4872912,-0.541829 -0.00482,-0.175612 1.3497237,-0.319845 1.4598315,-0.460864 0.1140359,-0.14605 -0.097885,-1.453403 0.082282,-1.514187 z"
+     id="path4468-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3281);fill-opacity:1;stroke:none;stroke-width:10;marker:none;enable-background:accumulate" />
+  <path
+     d="m 8.039313,14.470596 -0.04821,0.04636 c -3.44e-4,0.0011 -0.0019,0.0014 -0.0019,0.0021 -0.096792,0.234217 0.058261,1.259164 -0.03946,1.3843 -0.0042,0.0052 -0.01001,0.01243 -0.017541,0.01766 l 0.039461,0.0265 c 0.7903285,0.236715 0.098571,-1.427744 0.07889,-1.474818 -0.0037,-6.98e-4 -0.0074,-0.0025 -0.01094,-0.0021 z"
+     id="path4480-14"
+     style="opacity:0.5;fill:#9d0f06;fill-opacity:1;stroke:none" />
+  <path
+     d="m 6.7536304,16.427205 c -0.1663436,0.0015 -0.262602,0.0094 -0.262602,0.0094 l 0,0.0022 0,0.0378 c 0.097563,0.179325 1.3903695,0.384497 1.4982481,0.529129 0.108053,0.144867 -0.1695997,1.430665 0.00936,1.481083 0.185362,0.05222 0.828383,-1.137887 1.012899,-1.192899 0.177047,-0.05278 1.3609145,0.586923 1.4794925,0.451177 l -0.002,-0.0022 C 9.4907355,16.519122 7.4746472,16.421091 6.7538346,16.427206 Z"
+     id="path4517-2"
+     style="opacity:0.75;fill:url(#linearGradient3277);fill-opacity:1;stroke:none" />
+</svg>


### PR DESCRIPTION
Use same icon as upstream uses for `folder-pictures` at 16px-24px.

This changes the look in the Places sidebar and for the folder icon in the file manager at these small pixel sizes.

---

A few possible issues. This doesn't match the image mimetype like the current one does. It is the same icon that was use for the "Graphics" category so it might be good to come up with something different for that category in the future. Just wanted to bring those up in case anyone thought these might be reasons not to merge this.