### PR TITLE
Actions: New save and save-as icons from upstream

### DIFF
--- a/elementary-xfce/actions/16/document-save-as.svg
+++ b/elementary-xfce/actions/16/document-save-as.svg
@@ -1,274 +1,244 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   id="svg8860"
+   height="16"
+   width="16"
+   version="1.1"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3942"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
-     id="defs3944">
+     id="defs8862">
     <linearGradient
-       xlink:href="#linearGradient3104-9"
-       id="linearGradient3092"
+       gradientTransform="matrix(0.50256996,0,0,0.39304699,93.351608,-16.857632)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471" />
+       xlink:href="#linearGradient4632-0-6-4-4-4"
+       id="linearGradient5954"
+       y2="80.030975"
+       x2="-162.6788"
+       y1="58.56691"
+       x1="-162.6788" />
     <linearGradient
-       id="linearGradient3104-9">
+       id="linearGradient4632-0-6-4-4-4">
       <stop
-         id="stop3106-5"
-         style="stop-color:#000000;stop-opacity:0.33950618"
+         offset="0"
+         style="stop-color:#efdfc4;stop-opacity:1"
+         id="stop4634-4-4-7-4" />
+      <stop
+         offset="1"
+         style="stop-color:#e7c591;stop-opacity:1"
+         id="stop4636-3-1-5-9" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89189031,0,0,0.94046961,3.144123,5.34654)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#34542"
+       id="linearGradient10270-0-8"
+       x1="11.050709"
+       x2="11.050709"
+       y1="2.8214202"
+       y2="8.1379128" />
+    <linearGradient
+       id="34542">
+      <stop
+         id="stop3456-4-9-38-1-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop3458-39-80-3-5-5"
+         offset="0.002736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412" />
+      <stop
+         id="stop3460-7-0-2-4-2"
+         offset="0.99001008"
+         style="stop-color:#ffffff;stop-opacity:0.15686275" />
+      <stop
+         id="stop3462-0-9-8-7-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="translate(-7.999857,-193)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#46464"
+       id="linearGradient4724"
+       x1="16"
+       x2="16"
+       y1="198"
+       y2="200.5" />
+    <linearGradient
+       id="46464">
+      <stop
+         id="stop4648-8-0-3-6"
+         offset="0"
+         style="stop-color:#f9f9f9;stop-opacity:1" />
+      <stop
+         id="stop4650-1-7-3-4"
+         offset="1"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.2237174,0,0,-0.31959766,13.556498,18.641602)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4213-9"
+       id="radialGradient4132"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       id="linearGradient4213-9">
+      <stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3108-5"
-         style="stop-color:#000000;stop-opacity:0.24691358"
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3977"
-       id="linearGradient3095"
+       y2="10.24962"
+       x2="21.304239"
+       y1="10.24962"
+       x1="7.4056783"
+       gradientTransform="matrix(0,0.61157583,-0.6008607,0,14.611229,-2.0291991)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
-       x1="23.99999"
-       y1="6.2052388"
-       x2="23.99999"
-       y2="41.589603" />
+       id="linearGradient72-3"
+       xlink:href="#linearGradient885" />
     <linearGradient
-       id="linearGradient3977">
+       id="linearGradient885">
       <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop877"
+         style="stop-color:#9bdb4d;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3981"
+         id="stop883"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="57.037033"
+       x2="17.949821"
+       y1="57.037033"
+       x1="25.631071"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-15.519345,17.010467)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940"
+       xlink:href="#linearGradient1356-6" />
+    <linearGradient
+       id="linearGradient1356-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348-7" />
+      <stop
+         offset="0.00000001"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.02929282" />
+         id="stop1350-5" />
       <stop
-         id="stop3983"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97230476" />
+         id="stop1352-3" />
       <stop
-         id="stop3985"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop1354-5" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3600">
-      <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
+       xlink:href="#linearGradient1597-2"
+       id="linearGradient940-2-6"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3940"
-       xlink:href="#linearGradient3600" />
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-18.864984,24.525548)"
+       x1="33.632401"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
+       id="linearGradient1597-2">
       <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient3974"
-       x1="11.527722"
-       y1="4.1549506"
-       x2="11.45495"
-       y2="12.35396"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3982"
-       x1="6.3199091"
-       y1="12.721604"
-       x2="6.3199091"
-       y2="5.0559406"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient6451">
-      <stop
-         offset="0"
-         style="stop-color:#eeeeec;stop-opacity:1"
-         id="stop6453" />
-      <stop
-         offset="1"
+         id="stop1589-9"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop6455" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient6451"
-       id="linearGradient4163"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.3264428,0,0,0.30577113,0.00215068,0.31825876)"
-       x1="21.478369"
-       y1="1.6845057"
-       x2="21.478369"
-       y2="6.5747066" />
-    <linearGradient
-       xlink:href="#linearGradient3104-9"
-       id="linearGradient4187"
-       x1="15"
-       y1="-2.3966887"
-       x2="15"
-       y2="5.8225775"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4110">
-      <stop
-         id="stop4112"
-         style="stop-color:#90dbec;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4114"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.25" />
+         id="stop1591-1"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0001" />
       <stop
-         id="stop4116"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.62520313" />
+         id="stop1593-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
       <stop
-         id="stop4118"
-         style="stop-color:#2b63a0;stop-opacity:1"
+         id="stop1595-7"
+         style="stop-color:#ffffff;stop-opacity:0.55000001;"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4110"
-       id="linearGradient4514"
-       gradientUnits="userSpaceOnUse"
-       x1="10"
-       y1="1"
-       x2="10"
-       y2="5"
-       gradientTransform="matrix(0.77777778,0,0,0.66666667,-0.33333406,-0.33333327)" />
-    <linearGradient
-       id="linearGradient4299-652-3">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3618-28" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3620-1" />
-    </linearGradient>
-    <linearGradient
-       y2="12.500629"
-       x2="11.703956"
-       y1="19.198923"
-       x1="11.703956"
-       gradientTransform="matrix(0.64707876,0,0,0.65120188,0.25217445,0.97306639)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3020"
-       xlink:href="#linearGradient4299-652-3" />
   </defs>
   <metadata
-     id="metadata3947">
+     id="metadata8865">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <g
-       id="g4545">
-      <path
-         d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z"
-         id="path4160"
-         style="fill:url(#linearGradient3940);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z"
-         id="rect6741-1"
-         style="fill:none;stroke:url(#linearGradient3095);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <path
-         d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z"
-         id="path4160-8"
-         style="fill:none;stroke:url(#linearGradient3092);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-      <path
-         id="path3870"
-         d="m 7.5,5.5 0,3 -2.5,0 3,3.5 3,-3.5 -2.5,0 0,-3 z"
-         style="color:#000000;fill:url(#linearGradient3974);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3982);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         style="fill:url(#linearGradient4163);fill-opacity:1;stroke:url(#linearGradient4187);stroke-width:0.942;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-         id="rect5480"
-         y="0.4711445"
-         x="1.4711443"
-         ry="0.8637253"
-         rx="0.87945455"
-         height="3.0577111"
-         width="13.057712" />
-      <rect
-         style="fill:#d3d7cf;fill-opacity:1;stroke:none;display:inline"
-         id="rect6467"
-         y="1"
-         x="1.9999988"
-         height="2"
-         width="5" />
-      <rect
-         style="fill:#6a6a6a;fill-opacity:1;stroke:none;display:inline"
-         id="rect6469"
-         y="1"
-         x="7.9999986"
-         height="2"
-         width="1" />
-      <rect
-         style="opacity:0.35;fill:url(#linearGradient4514);fill-opacity:1;stroke:none"
-         id="rect4100"
-         width="7"
-         height="2"
-         x="2"
-         y="1" />
-    </g>
-    <path
-       d="m 6.9047105,5.1853304 c -0.386083,0.07297 -0.592869,0.479614 -0.545973,0.848587 0,0.585407 0,1.822214 0,2.407621 -0.37457,0.0239 -1.461904,-0.09532 -1.752951,0.214177 -0.301839,0.294858 -0.228972,0.802358 0.07788,1.062239 0.952573,1.0628256 1.900603,2.1299086 2.856026,3.1900656 0.306851,0.309924 0.843257,0.21666 1.077572,-0.13371 0.958854,-1.077092 1.9277315,-2.145732 2.8802975,-3.2281266 0.332778,-0.430544 -0.0272,-1.129816 -0.56859,-1.104645 -0.202213,0 -1.0514515,0 -1.2536635,0 -0.0029,-0.660918 0.0058,-1.973608 -0.0045,-2.63429 -0.03348,-0.413264 -0.451169,-0.67454 -0.838781,-0.621918 -1.073693,3.1e-5 -0.854002,-4.3e-5 -1.927387,0 z"
-       id="path3524"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3020);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
+  <path
+     d="M 15.52332,5.5 V 2.726667 c 0,-0.1385 -0.1115,-0.25 -0.25,-0.25 h -6.75 v -0.71875 c 0,-0.1385 -0.1115,-0.25 -0.25,-0.25 h -6.5 c -0.1385,0 -0.25,0.1115 -0.25,0.25 v 0.71875 h -0.75 c -0.1385,0 -0.25,0.1115 -0.25,0.25 V 5.5"
+     id="rect4170"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#7e8087;stroke-width:0.99200022;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4724);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992168;marker:none;enable-background:accumulate"
+     id="rect4170-0-9"
+     d="m 2.000143,2 v 1 h -1 v 4 h 14 V 3 h -7 V 2 Z" />
+  <path
+     d="m 0.5,6.4999999 15,1e-7 v 8 L 0.4999996,14.48885 Z"
+     id="rect3086-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient5954);fill-opacity:1;stroke:#987124;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient10270-0-8);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3086-9-2"
+     d="m 14.500143,7.5 v 6 L 1.523453,13.46122 1.500143,7.5 Z" />
+  <rect
+     style="fill:#206b00;fill-opacity:0.3;stroke-width:1;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect24127"
+     width="4"
+     height="4"
+     x="6"
+     y="5.8829784e-05"
+     rx="0.80000001"
+     ry="0.80000001" />
+  <rect
+     style="fill:#ffffff;fill-opacity:1;stroke-width:1;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect787"
+     width="4"
+     height="0.99993867"
+     x="6"
+     y="0.9999975" />
+  <path
+     d="m 4.5000001,7.001488 a 3.5000001,5.0000241 0 1 1 6.9999999,0 3.5000001,5.0000241 0 0 1 -6.9999999,0 z"
+     id="path3501-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4132);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;marker:none" />
+  <path
+     id="path873-5-5-0"
+     style="font-variation-settings:normal;fill:url(#linearGradient72-3);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.6;stop-color:#000000"
+     d="m 7.9980473,10.49996 c -0.080838,0 -0.1508278,-0.03231 -0.2089844,-0.08789 L 3.6015624,6.072226 C 3.5393434,6.012787 3.5000004,5.9293499 3.5000004,5.8300385 c 0,-0.1845228 0.130217,-0.3300405 0.304688,-0.3300405 H 6.2011723 C 6.3640102,5.500114 6.5000004,5.3618591 6.5000004,5.1835542 V 0.80663951 c 0,-0.174818 0.1290258,-0.306641 0.3007812,-0.306641 H 9.201 c 0.1717556,0 0.2990001,0.131823 0.299,0.306641 V 5.2148042 C 9.515028,5.3784845 9.6495049,5.5001068 9.8027382,5.499998 H 12.19922 c 0.174468,0 0.30078,0.1455175 0.30078,0.3300405 0,0.1845764 -0.07628,0.1785565 -0.103516,0.2421875 l -4.1874992,4.339843 c -0.054667,0.05559 -0.1295192,0.08789 -0.2109375,0.08789 z" />
+  <path
+     d="M 6.5000004,6.499959 H 5.4 L 8.0000004,9.195 10.6,6.499959 H 9.5000004"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2" />
+  <path
+     d="m 9.5,6.4999592 c -0.4109944,0 -0.9993996,-0.6055885 -0.9995019,-1.1198537 0,0 -0.02477,-2.2222313 -9.955e-4,-3.880108 H 7.5004981 l -9.955e-4,3.880108 C 7.4994404,5.8451495 6.996992,6.4999592 6.5000002,6.4999592"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-2-6);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2-6-9" />
+  <path
+     id="path67732"
+     style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.6;stop-color:#000000"
+     d="m 7.9980473,10.49996 c -0.080838,0 -0.1508278,-0.03231 -0.2089844,-0.08789 L 3.6015624,6.072226 C 3.5393434,6.012787 3.5000004,5.9293499 3.5000004,5.8300385 c 0,-0.1845228 0.130217,-0.3300405 0.304688,-0.3300405 H 6.2011723 C 6.3640102,5.500114 6.5000004,5.3618591 6.5000004,5.1835542 V 0.80663951 c 0,-0.174818 0.1290258,-0.306641 0.3007812,-0.306641 H 9.201 c 0.1717556,0 0.2990001,0.131823 0.299,0.306641 V 5.2148042 C 9.515028,5.3784845 9.6495049,5.5001068 9.8027382,5.499998 H 12.19922 c 0.174468,0 0.30078,0.1455175 0.30078,0.3300405 0,0.1845764 -0.07628,0.1785565 -0.103516,0.2421875 l -4.1874992,4.339843 c -0.054667,0.05559 -0.1295192,0.08789 -0.2109375,0.08789 z" />
 </svg>

--- a/elementary-xfce/actions/16/document-save.svg
+++ b/elementary-xfce/actions/16/document-save.svg
@@ -1,185 +1,257 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   id="svg4157"
+   height="16"
+   width="16"
+   version="1.1"
+   xml:space="preserve"
+   sodipodi:docname="document-save.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="16px"
-   height="16px"
-   id="svg3942"
-   version="1.1">
-  <defs
-     id="defs3944">
-    <linearGradient
-       xlink:href="#linearGradient3104-9"
-       id="linearGradient3092"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview346"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="4.890625"
+     inkscape:cy="4.90625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="608"
+     inkscape:window-y="4"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" /><defs
+     id="defs4159"><linearGradient
+       gradientTransform="matrix(0.2972973,0,0,0.29729729,0.86482831,0.86480165)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.25378586,0,0,0.30501865,19.128979,-0.68547704)"
-       x1="-51.786404"
-       y1="50.786446"
-       x2="-51.786404"
-       y2="2.9062471" />
-    <linearGradient
-       id="linearGradient3104-9">
-      <stop
-         id="stop3106-5"
-         style="stop-color:#000000;stop-opacity:0.33950618"
-         offset="0" />
-      <stop
-         id="stop3108-5"
-         style="stop-color:#000000;stop-opacity:0.24691358"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3977"
-       id="linearGradient3095"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.24324324,0,0,0.35135133,2.1621636,-0.43242804)"
-       x1="23.99999"
-       y1="6.2052388"
-       x2="23.99999"
-       y2="41.589603" />
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.02929282" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97230476" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600">
-      <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275"
-       gradientTransform="matrix(0.28571361,0,0,0.30419701,1.1428727,0.2326048)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3940"
-       xlink:href="#linearGradient3600" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient3974"
-       x1="11.527722"
-       y1="4.1549506"
-       x2="11.45495"
-       y2="12.35396"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3982"
-       x1="6.3199091"
-       y1="12.721604"
-       x2="6.3199091"
-       y2="5.0559406"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4299-652-6">
-      <stop
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="40.762653"
+       x2="15.856476"
+       y1="7.2576861"
+       x1="15.856476" /><linearGradient
+       id="linearGradient4095"><stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3618-0" />
-      <stop
+         id="stop4097" /><stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" /><stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" /><stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3620-26" />
-    </linearGradient>
-    <linearGradient
-       y2="12.500629"
-       x2="11.703956"
-       y1="19.198923"
-       x1="11.703956"
-       gradientTransform="matrix(0.64707876,0,0,0.65120188,0.25217445,0.97306599)"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3020"
-       xlink:href="#linearGradient4299-652-6" />
-  </defs>
-  <metadata
-     id="metadata3947">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="layer1">
-    <path
-       style="fill:url(#linearGradient3940);fill-opacity:1;stroke:none;display:inline"
-       id="path4160"
-       d="m 3,1 c 2.2915074,0 9.999988,8.904e-4 9.999988,8.904e-4 L 13,15 C 13,15 6.3333332,15 3,15 3,10.333334 3,5.6666664 3,1 z" />
-    <path
-       style="fill:none;stroke:url(#linearGradient3095);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-1"
-       d="m 12.5,14.5 -9.0000001,0 0,-13 L 12.5,1.5 z" />
-    <path
-       style="fill:none;stroke:url(#linearGradient3092);stroke-width:0.99992192;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-       id="path4160-8"
-       d="m 2.4999621,0.49997396 c 2.5206756,0 11.0000629,9.54e-4 11.0000629,9.54e-4 l 1.3e-5,14.99909804 c 0,0 -7.3333841,0 -11.000076,0 0,-5.000017 0,-10.000035 0,-15.00005204 z" />
-    <path
-       style="color:#000000;fill:url(#linearGradient3974);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3982);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 7.5,5.5 0,3 -2.5,0 3,3.5 3,-3.5 -2.5,0 0,-3 z"
-       id="path3870" />
-    <path
-       d="m 6.9047105,5.1853297 c -0.386083,0.072967 -0.592869,0.4796142 -0.545973,0.8485878 0,0.585407 0,1.8222138 0,2.4076208 -0.37457,0.0239 -1.461904,-0.09532 -1.752951,0.214177 -0.301839,0.294858 -0.228972,0.802358 0.07788,1.062239 0.952573,1.0628257 1.900603,2.1299087 2.856026,3.1900657 0.306851,0.309924 0.843257,0.21666 1.077572,-0.13371 0.958854,-1.077092 1.9277315,-2.145732 2.8802975,-3.2281267 0.332778,-0.430544 -0.0272,-1.129816 -0.56859,-1.104645 -0.202213,0 -1.0514515,0 -1.2536635,0 -0.0029,-0.6609178 0.0058,-1.9736086 -0.0045,-2.6342899 -0.03348,-0.4132639 -0.451169,-0.6745403 -0.838781,-0.6219187 -1.073693,3.13e-5 -0.854002,-4.24e-5 -1.927387,0 z"
-       id="path3524"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3020);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-  </g>
-</svg>
+       gradientTransform="matrix(0.55250111,0,0,0.61217849,-28.849928,-16.517777)"
+       x1="70.385941"
+       y1="51.484623"
+       x2="70.385941"
+       y2="30.248877" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.30676621,0,0,0.29504823,-14.701869,0.57514745)"
+       x1="74.838791"
+       y1="4.8290029"
+       x2="74.838791"
+       y2="48.889816" /><linearGradient
+       id="linearGradient4213-9"><stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" /><stop
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" /></linearGradient><radialGradient
+       gradientTransform="matrix(-0.2237174,0,0,-0.31959766,13.556498,18.641602)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4213-9"
+       id="radialGradient4132"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" /><linearGradient
+       id="linearGradient885"><stop
+         id="stop877"
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="0" /><stop
+         id="stop883"
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="1" /></linearGradient><linearGradient
+       y2="10.24962"
+       x2="21.304239"
+       y1="10.24962"
+       x1="7.4056783"
+       gradientTransform="matrix(0,0.61157583,-0.6008607,0,14.611229,-2.0291991)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient72-3"
+       xlink:href="#linearGradient885" /><linearGradient
+       y2="57.037033"
+       x2="17.949821"
+       y1="57.037033"
+       x1="25.631071"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-15.519345,17.010467)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940"
+       xlink:href="#linearGradient1356-6" /><linearGradient
+       id="linearGradient1356-6"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348-7" /><stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350-5" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352-3" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354-5" /></linearGradient><linearGradient
+       xlink:href="#linearGradient1597-2"
+       id="linearGradient940-2-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-18.864984,24.525548)"
+       x1="33.632401"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" /><linearGradient
+       id="linearGradient1597-2"><stop
+         id="stop1589-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop1591-1"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0001" /><stop
+         id="stop1593-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" /><stop
+         id="stop1595-7"
+         style="stop-color:#ffffff;stop-opacity:0.55000001;"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient2184"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3067662,0,0,0.29504822,-14.701833,0.57521483)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><linearGradient
+       x1="23.99999"
+       y1="7.5572624"
+       x2="23.99999"
+       y2="40.752987"
+       id="linearGradient3304"
+       xlink:href="#linearGradient3924-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486763,0.86486875)" /><linearGradient
+       id="linearGradient3924-4-8"><stop
+         id="stop3926-0-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop3928-6-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06316455" /><stop
+         id="stop3930-2-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95056331" /><stop
+         id="stop3932-9-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient2140"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-36.453699,-22.660759)"
+       x1="56.408016"
+       y1="42.392338"
+       x2="56.408016"
+       y2="26.595999" /></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient2184);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="2.0000024"
+     x="1.9999986"
+     ry="1.5"
+     rx="1.5"
+     height="12"
+     width="12" /><rect
+     width="11"
+     height="11"
+     x="2.4999986"
+     y="2.4999986"
+     id="rect6741-0-3-5"
+     style="fill:none;stroke:url(#linearGradient3304);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" /><rect
+     width="13.000003"
+     height="13.000003"
+     rx="2"
+     ry="2"
+     x="1.4999986"
+     y="1.4999986"
+     id="rect5505-21-2-8"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient2140);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000" /><rect
+     style="opacity:1;fill:#206b00;fill-opacity:0.3;stroke-width:1;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect24127"
+     width="4"
+     height="4"
+     x="6"
+     y="5.8829784e-05"
+     rx="0.80000001"
+     ry="0.80000001" /><rect
+     style="opacity:1;fill:#ffffff;stroke-width:1;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000;fill-opacity:1"
+     id="rect787"
+     width="4"
+     height="0.99993867"
+     x="6"
+     y="0.9999975" /><path
+     d="m 4.5000001,7.001488 a 3.5000001,5.0000241 0 1 1 6.9999999,0 3.5000001,5.0000241 0 0 1 -6.9999999,0 z"
+     id="path3501-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4132);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;marker:none" /><path
+     id="path873-5-5-0"
+     style="font-variation-settings:normal;fill:url(#linearGradient72-3);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.60000002;stop-color:#000000"
+     d="m 7.9980473,10.49996 c -0.080838,0 -0.1508278,-0.03231 -0.2089844,-0.08789 L 3.6015624,6.072226 C 3.5393434,6.012787 3.5000004,5.9293499 3.5000004,5.8300385 c 0,-0.1845228 0.130217,-0.3300405 0.304688,-0.3300405 H 6.2011723 C 6.3640102,5.500114 6.5000004,5.3618591 6.5000004,5.1835542 V 0.80663951 c 0,-0.174818 0.1290258,-0.306641 0.3007812,-0.306641 H 9.201 c 0.1717556,0 0.2990001,0.131823 0.299,0.306641 V 5.2148042 C 9.515028,5.3784845 9.6495049,5.5001068 9.8027382,5.499998 H 12.19922 c 0.174468,0 0.30078,0.1455175 0.30078,0.3300405 0,0.1845764 -0.07628,0.1785565 -0.103516,0.2421875 l -4.1874992,4.339843 c -0.054667,0.05559 -0.1295192,0.08789 -0.2109375,0.08789 z"
+     sodipodi:nodetypes="sccsscsssscccssccs" /><path
+     d="M 6.5000004,6.499959 H 5.4 L 8.0000004,9.195 10.6,6.499959 H 9.5000004"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2"
+     sodipodi:nodetypes="ccccc" /><path
+     d="m 9.5,6.4999592 c -0.4109944,0 -0.9993996,-0.6055885 -0.9995019,-1.1198537 0,0 -0.02477,-2.2222313 -9.955e-4,-3.880108 H 7.5004981 l -9.955e-4,3.880108 C 7.4994404,5.8451495 6.996992,6.4999592 6.5000002,6.4999592"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-2-6);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path873-5-5-2-6-9"
+     sodipodi:nodetypes="cccccc" /><path
+     id="path67732"
+     style="font-variation-settings:normal;vector-effect:none;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.60000002;stop-color:#000000"
+     d="m 7.9980473,10.49996 c -0.080838,0 -0.1508278,-0.03231 -0.2089844,-0.08789 L 3.6015624,6.072226 C 3.5393434,6.012787 3.5000004,5.9293499 3.5000004,5.8300385 c 0,-0.1845228 0.130217,-0.3300405 0.304688,-0.3300405 H 6.2011723 C 6.3640102,5.500114 6.5000004,5.3618591 6.5000004,5.1835542 V 0.80663951 c 0,-0.174818 0.1290258,-0.306641 0.3007812,-0.306641 H 9.201 c 0.1717556,0 0.2990001,0.131823 0.299,0.306641 V 5.2148042 C 9.515028,5.3784845 9.6495049,5.5001068 9.8027382,5.499998 H 12.19922 c 0.174468,0 0.30078,0.1455175 0.30078,0.3300405 0,0.1845764 -0.07628,0.1785565 -0.103516,0.2421875 l -4.1874992,4.339843 c -0.054667,0.05559 -0.1295192,0.08789 -0.2109375,0.08789 z"
+     sodipodi:nodetypes="sccsscsssscccssccs" /></svg>

--- a/elementary-xfce/actions/22/document-save-as.svg
+++ b/elementary-xfce/actions/22/document-save-as.svg
@@ -1,255 +1,284 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="22"
    height="22"
-   id="svg3828">
-  <defs
-     id="defs3830">
-    <linearGradient
-       id="linearGradient4110">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1"
-         id="stop4112" />
-      <stop
-         offset="0.25"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         id="stop4114" />
-      <stop
-         offset="0.62520313"
-         style="stop-color:#3689e6;stop-opacity:1"
-         id="stop4116" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         id="stop4118" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4046">
-      <stop
-         id="stop4048"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4050"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.33333334" />
-      <stop
-         id="stop4052"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop4054"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03626217" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
-         id="stop3602-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-6"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1"
-         id="stop3762" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6451">
-      <stop
-         id="stop6453"
-         style="stop-color:#eeeeec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6455"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4299-652-6">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3618-8" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3620-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient4079"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,-0.6571711,-1.1511383)"
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336" />
-    <linearGradient
-       xlink:href="#linearGradient3977"
-       id="linearGradient4081"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40540511,0,0,0.51351351,1.2696871,-1.8243195)"
-       x1="23.99999"
-       y1="5.5641499"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       xlink:href="#linearGradient4046"
-       id="linearGradient4083"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1,-1.5)"
-       x1="17"
-       y1="4"
-       x2="17"
-       y2="18" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient4085"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1,-1.5)"
-       x1="7"
-       y1="18"
-       x2="7"
-       y2="7" />
-    <linearGradient
-       xlink:href="#linearGradient6451"
-       id="linearGradient4088"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4764428,0,0,0.4057711,-0.67284828,-0.2317409)"
-       x1="21.478369"
-       y1="1.6845057"
-       x2="21.478369"
-       y2="6.5747066" />
-    <linearGradient
-       xlink:href="#linearGradient4110"
-       id="linearGradient4090"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-1,-1.5)"
-       x1="10"
-       y1="1"
-       x2="10"
-       y2="5" />
-    <linearGradient
-       xlink:href="#linearGradient4299-652-6"
-       id="linearGradient4092"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.93016706,-1.6162484)"
-       x1="11.703956"
-       y1="19.198923"
-       x2="11.703956"
-       y2="12.500629" />
-  </defs>
+   id="svg11300"
+   style="display:inline;enable-background:new"
+   version="1.0"
+   viewBox="0 0 22 22"
+   width="22"
+   sodipodi:docname="document-save-as.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9180"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="17.708333"
+     inkscape:cx="9.9952941"
+     inkscape:cy="11.124706"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg11300" />
   <metadata
-     id="metadata3833">
+     id="metadata154">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>elementary Icon Template</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="g4067"
-     transform="translate(0,0.50000304)">
-    <path
-       style="fill:url(#linearGradient4079);fill-opacity:1;stroke:none;display:inline"
-       id="path4160-3"
-       d="m 2.4999601,-4.31e-5 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-    <path
-       style="fill:none;stroke:url(#linearGradient4081);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-1"
-       d="m 18.5,20 -15.0000004,0 0,-19 L 18.5,1 z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-       id="path4160-3-1"
-       d="m 19.500019,4.5 2.1e-5,16.500033 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-9.500014 0,-16.500033" />
-    <path
-       style="color:#000000;fill:url(#linearGradient4083);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4085);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3288-2-2"
-       d="m 15.5,11.022385 -4.500001,5 -4.499999,-5 3,0 0,-5.0223848 3,0 0,5.0223848 z" />
-    <rect
-       style="fill:url(#linearGradient4088);fill-opacity:1;stroke:none;display:inline"
-       id="rect3997"
-       y="-0.028855562"
-       x="1.4711444"
-       ry="0.86372536"
-       rx="1.0141573"
-       height="4.0577111"
-       width="19.057711" />
-    <rect
-       width="19.057711"
-       height="4.0577111"
-       rx="1.0141573"
-       ry="0.86372536"
-       x="1.4711444"
-       y="-0.028855562"
-       id="rect5480"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.94228888;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-    <rect
-       width="6.0000014"
-       height="1"
-       x="2.9999988"
-       y="1.5000007"
-       id="rect6467"
-       style="fill:#c8cdc3;fill-opacity:1;stroke:none;display:inline" />
-    <rect
-       width="1"
-       height="2"
-       x="10.000001"
-       y="1.0000007"
-       id="rect6469"
-       style="fill:#6a6a6a;fill-opacity:1;stroke:none;display:inline" />
-    <rect
-       y="0.5"
-       x="2"
-       height="3"
-       width="9"
-       id="rect4100"
-       style="opacity:0.35;fill:url(#linearGradient4090);fill-opacity:1;stroke:none" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4092);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3524"
-       d="m 9.350708,4.8521966 c -0.5966541,0.112049 -0.9162261,0.736506 -0.8437501,1.30311 0,0.8989643 0,2.7982324 0,3.6971954 -0.578865,0.0367 -2.259239,-0.146354 -2.709023,0.328895 -0.466467,0.45279 -0.353856,1.232121 0.120358,1.631199 1.472113,1.632101 2.937205,3.270737 4.4137231,4.898738 0.474211,0.475926 1.303176,0.33271 1.665288,-0.205327 1.48182,-1.654007 2.97913,-3.295036 4.451232,-4.957186 0.514277,-0.661155 -0.04205,-1.734972 -0.878703,-1.696319 -0.3125,0 -1.62492,0 -1.93742,0 -0.0045,-1.014919 0.009,-3.0307161 -0.0069,-4.0452734 -0.05174,-0.634617 -0.69724,-1.035839 -1.29626,-0.955032 -1.659293,4.8e-5 -1.319779,-6.5e-5 -2.978595,0 z" />
-  </g>
+  <title
+     id="title4162">elementary Icon Template</title>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4712">
+      <stop
+         id="stop4708"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4710"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="34542">
+      <stop
+         id="stop3456-4-9-38-1-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop3458-39-80-3-5-5"
+         offset="0.002736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412" />
+      <stop
+         id="stop3460-7-0-2-4-2"
+         offset="0.99001008"
+         style="stop-color:#ffffff;stop-opacity:0.15686275" />
+      <stop
+         id="stop3462-0-9-8-7-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687" />
+    </linearGradient>
+    <linearGradient
+       id="46464">
+      <stop
+         id="stop4648-8-0-3-6"
+         offset="0"
+         style="stop-color:#f9f9f9;stop-opacity:1" />
+      <stop
+         id="stop4650-1-7-3-4"
+         offset="1"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.62762637,0,0,0.7245642,1.973068,4.62736)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#34542"
+       id="linearGradient4440-9"
+       x1="27.129089"
+       x2="27.129089"
+       y1="8.795126"
+       y2="22.596525" />
+    <linearGradient
+       gradientTransform="matrix(0.49096263,0,0,0.48984879,-25.706222,0.28723)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#46464"
+       id="linearGradient4414-2"
+       x1="62.542889"
+       x2="62.542889"
+       y1="13.703746"
+       y2="17.786638" />
+    <linearGradient
+       id="linearGradient4632-0-6-4-4-4">
+      <stop
+         id="stop4634-4-4-7-4"
+         style="stop-color:#efdfc4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4636-3-1-5-9"
+         style="stop-color:#e7c591;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="110.26328"
+       x2="51.622452"
+       y1="84.425446"
+       x1="51.622452"
+       gradientTransform="matrix(0.50413225,0,0,0.49333391,-17.682185,-32.483135)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient964"
+       xlink:href="#linearGradient4632-0-6-4-4-4" />
+    <linearGradient
+       xlink:href="#linearGradient1140"
+       id="linearGradient1086"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3210282,0,0,1.2679796,-77.729877,-5.32619)"
+       x1="69.753395"
+       y1="9.7211266"
+       x2="69.771744"
+       y2="20.089539" />
+    <linearGradient
+       id="linearGradient1140">
+      <stop
+         id="stop1132"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1134"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop1136"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1138"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.28763665,0,0,-0.28763651,18.144075,21.977019)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient4132"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       xlink:href="#linearGradient1046"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,28.776682,43.245448)"
+       x1="-17.673822"
+       y1="40.745449"
+       x2="-17.673822"
+       y2="27.995216" />
+    <linearGradient
+       id="linearGradient1046">
+      <stop
+         id="stop1042"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" />
+      <stop
+         id="stop1044"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1356"
+       id="linearGradient4081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-12.51934,19.010508)"
+       x1="25.631071"
+       y1="57.037033"
+       x2="12.286115"
+       y2="57.037033" />
+    <linearGradient
+       id="linearGradient1356">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1597"
+       id="linearGradient4079"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-15.864978,26.525589)"
+       x1="36.618416"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" />
+    <linearGradient
+       id="linearGradient1597">
+      <stop
+         id="stop1589"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591"
+         style="stop-color:#ffffff;stop-opacity:0.23999999;"
+         offset="0.0001" />
+      <stop
+         id="stop1593"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#7e8087;stroke-width:0.992;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3186"
+     d="m 2.036298,3.50437 c -0.277,0 -0.5,0.223 -0.5,0.5 v 1.49562 h -0.5 c -0.277,0 -0.5,0.223 -0.5,0.5 v 2.5074 h 21 v -2.5074 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 h -11.5 V 4.00437 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4414-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect3409-5-2"
+     d="m 2.036298,3.99999 v 2 h -1 v 4 h 20 v -4 h -12 v -2 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1086);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect3409-3"
+     d="m 2.536298,4.49999 v 2 h -1 v 3.33929 h 19 V 6.49999 h -12 v -2 z" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient964);fill-opacity:1;fill-rule:nonzero;stroke:#987124;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.498039;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect4198"
+     d="m 0.5,9.49999 v 0.5 8.00026 l 0.25,3.49974 h 20.5 L 21.5,18.00025 V 9.49999 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient4440-9);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3309-8"
+     d="m 1.5,10.49999 -0.05376,7.50492 0.303763,2.49508 h 18.5 l 0.258854,-2.44427 -0.0089,-7.55573 z" />
+  <path
+     d="m 6.500008,11.500969 a 4.5000001,4.5 0 1 1 9,0 4.5000001,4.5 0 0 1 -9,0 z"
+     id="path3501-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient4132);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;marker:none" />
+  <path
+     id="path873-5-5-4"
+     style="font-variation-settings:normal;fill:url(#linearGradient1556);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 16.999605,7.870809 c 0,0.129184 -0.10128,0.265019 -0.126255,0.321426 -0.0054,0.0048 -0.01065,0.01041 -0.01578,0.01553 l -5.60301,6.438003 c -0.06681,0.0657 -0.155041,0.104464 -0.254552,0.104464 -0.0988,0 -0.183919,-0.03876 -0.255001,-0.104464 L 5.1393885,8.207765 c -0.0051,-0.0051 -0.01037,-0.01072 -0.01577,-0.01553 -0.07606,-0.07024 -0.123358,-0.204059 -0.123358,-0.321428 0,-0.218072 0.158254,-0.370816 0.371495,-0.370816 H 9.134532 C 9.333556,7.500128 9.500293,7.317821 9.500293,7.107098 V 0.861385 C 9.500293,0.654781 9.657561,0.5 9.867485,0.5 h 2.265766 c 0.209926,0 0.367194,0.154781 0.367194,0.361385 v 6.281009 c 0.01837,0.19344 0.177037,0.357729 0.364321,0.3576 h 3.767645 c 0.190944,0 0.367194,0.223285 0.367194,0.370815 z" />
+  <path
+     d="m 9.500008,8.5 h -2.78 l 4.279998,4.91 4.280002,-4.91 h -2.779876"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4081);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4075" />
+  <path
+     d="m 12.499883,8.5 c -0.410995,0 -0.99965,-0.735733 -0.999752,-1.249998 0,0 -0.02402,-4.092125 -2.48e-4,-5.750002 H 10.500505 L 10.49951,7.250002 C 10.499448,7.715045 9.996999,8.5 9.500007,8.5"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4077" />
 </svg>

--- a/elementary-xfce/actions/22/document-save.svg
+++ b/elementary-xfce/actions/22/document-save.svg
@@ -1,166 +1,255 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="22"
+   id="svg4157"
    height="22"
-   id="svg3828">
-  <defs
-     id="defs3830">
-    <linearGradient
-       id="linearGradient3251">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1"
-         id="stop3253" />
-      <stop
-         offset="0.33333334"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         id="stop3255" />
-      <stop
-         offset="0.66666669"
-         style="stop-color:#3689e6;stop-opacity:1"
-         id="stop3257" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         id="stop3259" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03626217" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
-         id="stop3602-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-6"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1"
-         id="stop3762" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4299-652-6">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3618-8" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3620-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3776"
+   width="22"
+   version="1.1"
+   xml:space="preserve"
+   sodipodi:docname="document-save.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview62"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="14.53125"
+     inkscape:cy="6.0625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="578"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157"
+     showguides="true" /><defs
+     id="defs4159"><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,-0.0270628,0.97297586)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,0.3428289,0.3488617)"
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336" />
-    <linearGradient
-       xlink:href="#linearGradient3977"
-       id="linearGradient3778"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
-       x1="23.99999"
-       y1="5.5641499"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.167725"
        x2="23.99999"
-       y2="43" />
-    <linearGradient
-       xlink:href="#linearGradient3251"
-       id="linearGradient3780"
+       y1="6.7566175"
+       x1="23.99999" /><linearGradient
+       id="linearGradient4095"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" /><stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" /><stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="5.4035802"
-       x2="17"
-       y2="19" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3782"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-166-749-9"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       x1="7"
-       y1="18"
-       x2="7"
-       y2="7" />
-    <linearGradient
-       xlink:href="#linearGradient4299-652-6"
-       id="linearGradient3784"
+       xlink:href="#linearGradient3688-464-309-7-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-464-309-7-6"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-75" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4-9" /></linearGradient><linearGradient
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.06983298,-0.1162475)"
-       x1="11.703956"
-       y1="19.198923"
-       x2="11.703956"
-       y2="12.500629" />
-  </defs>
-  <metadata
-     id="metadata3833">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="g3769"
-     transform="translate(-1,-0.99999495)">
-    <path
-       style="fill:url(#linearGradient3776);fill-opacity:1;stroke:none;display:inline"
-       id="path4160-3"
-       d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-    <path
-       style="fill:none;stroke:url(#linearGradient3778);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-1"
-       d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-       id="path4160-3-1"
-       d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-    <path
-       style="color:#000000;fill:url(#linearGradient3780);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3782);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3288-2-2"
-       d="m 16.5,12.522385 -4.500001,5 -4.499999,-5 3,0 0,-5.0223848 3,0 0,5.0223848 z" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3784);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3524"
-       d="m 10.350708,6.3521977 c -0.5966541,0.112049 -0.9162261,0.736506 -0.8437501,1.30311 0,0.898964 0,2.7982323 0,3.6971953 -0.578865,0.0367 -2.259239,-0.146354 -2.709023,0.328895 -0.466467,0.45279 -0.353856,1.232121 0.120358,1.631199 1.472113,1.632101 2.937205,3.270736 4.4137231,4.898737 0.474211,0.475926 1.303176,0.33271 1.665288,-0.205327 1.48182,-1.654007 2.97913,-3.295035 4.451232,-4.957185 0.514277,-0.661155 -0.04205,-1.734972 -0.878703,-1.696319 -0.3125,0 -1.62492,0 -1.93742,0 -0.0045,-1.014919 0.009,-3.0307163 -0.0069,-4.0452733 -0.05174,-0.634617 -0.69724,-1.035839 -1.29626,-0.955032 -1.659293,4.8e-5 -1.319779,-6.5e-5 -2.978595,0 z" />
-  </g>
-</svg>
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-1"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-42.857308,-23.833435)"
+       x1="70.385941"
+       y1="51.425007"
+       x2="70.385941"
+       y2="29.002073" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46014931,0,0,0.44257234,-23.052785,0.86281849)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><linearGradient
+       id="linearGradient4213-9"><stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" /><stop
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" /></linearGradient><radialGradient
+       gradientTransform="matrix(-0.28763665,0,0,-0.28763651,18.14403,21.977019)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4213-9"
+       id="radialGradient4132"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,28.776637,43.245448)"
+       x1="-17.673822"
+       y1="40.745449"
+       x2="-17.673822"
+       y2="27.995216" /><linearGradient
+       id="linearGradient1046"><stop
+         id="stop1042"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" /><stop
+         id="stop1044"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1356"
+       id="linearGradient4081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-12.519385,19.010508)"
+       x1="25.631071"
+       y1="57.037033"
+       x2="12.286115"
+       y2="57.037033" /><linearGradient
+       id="linearGradient1356"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348" /><stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1597"
+       id="linearGradient4079"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-15.865023,26.525589)"
+       x1="36.618416"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" /><linearGradient
+       id="linearGradient1597"><stop
+         id="stop1589"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop1591"
+         style="stop-color:#ffffff;stop-opacity:0.23999999;"
+         offset="0.0001" /><stop
+         id="stop1593"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" /><stop
+         id="stop1595"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="3"
+     x="1.9999629"
+     ry="1.5"
+     rx="1.5"
+     height="18"
+     width="18" /><rect
+     width="19.000002"
+     height="19.000002"
+     rx="2"
+     ry="2"
+     x="1.499961"
+     y="2.5000257"
+     id="rect5505-21-8-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1271);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><rect
+     width="17"
+     height="17"
+     x="2.4999623"
+     y="3.4999995"
+     id="rect6741-9"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" /><path
+     d="m 6.4999629,11.500969 a 4.5000001,4.5 0 1 1 9.0000001,0 4.5000001,4.5 0 0 1 -9.0000001,0 z"
+     id="path3501-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient4132);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;marker:none" /><path
+     id="path873-5-5-4"
+     style="font-variation-settings:normal;fill:url(#linearGradient1556);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 16.99956,7.870809 c 0,0.129184 -0.10128,0.265019 -0.126255,0.321426 -0.0054,0.0048 -0.01065,0.01041 -0.01578,0.01553 l -5.60301,6.438003 c -0.06681,0.0657 -0.155041,0.104464 -0.254552,0.104464 -0.0988,0 -0.183919,-0.03876 -0.255001,-0.104464 L 5.1393434,8.207765 c -0.0051,-0.0051 -0.01037,-0.01072 -0.01577,-0.01553 -0.07606,-0.07024 -0.123358,-0.204059 -0.123358,-0.321428 0,-0.218072 0.158254,-0.370816 0.371495,-0.370816 h 3.7627765 c 0.199024,1.37e-4 0.365761,-0.18217 0.365761,-0.392893 V 0.861385 C 9.5002479,0.654781 9.6575159,0.5 9.8674399,0.5 h 2.2657661 c 0.209926,0 0.367194,0.154781 0.367194,0.361385 v 6.281009 c 0.01837,0.19344 0.177037,0.357729 0.364321,0.3576 h 3.767645 c 0.190944,0 0.367194,0.223285 0.367194,0.370815 z"
+     sodipodi:nodetypes="scccscccsscsssssccss" /><path
+     d="m 9.4999629,8.5 h -2.78 l 4.2799981,4.91 4.280002,-4.91 h -2.779876"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4081);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4075"
+     sodipodi:nodetypes="ccccc" /><path
+     d="m 12.499838,8.5 c -0.410995,0 -0.99965,-0.735733 -0.999752,-1.249998 0,0 -0.02402,-4.092125 -2.48e-4,-5.750002 H 10.50046 l -9.95e-4,5.750002 C 10.499403,7.715045 9.9969539,8.5 9.4999619,8.5"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4077"
+     sodipodi:nodetypes="cccccc" /></svg>

--- a/elementary-xfce/actions/24/document-save-as.svg
+++ b/elementary-xfce/actions/24/document-save-as.svg
@@ -1,321 +1,320 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
    height="24"
-   id="svg3828">
-  <defs
-     id="defs3830">
-    <linearGradient
-       id="linearGradient4110">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1"
-         id="stop4112" />
-      <stop
-         offset="0.25"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         id="stop4114" />
-      <stop
-         offset="0.62520313"
-         style="stop-color:#3689e6;stop-opacity:1"
-         id="stop4116" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         id="stop4118" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4046">
-      <stop
-         id="stop4048"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4050"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.33333334" />
-      <stop
-         id="stop4052"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop4054"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03626217" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
-         id="stop3602-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-6"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1"
-         id="stop3762" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6451">
-      <stop
-         id="stop6453"
-         style="stop-color:#eeeeec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6455"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4299-652-6">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3618-8" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3620-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4299-652-6"
-       id="linearGradient3198"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.06983294,-0.11624838)"
-       x1="11.703956"
-       y1="19.198923"
-       x2="11.703956"
-       y2="12.500629" />
-    <linearGradient
-       xlink:href="#linearGradient4110"
-       id="linearGradient3201"
-       gradientUnits="userSpaceOnUse"
-       x1="10"
-       y1="1"
-       x2="10"
-       y2="5" />
-    <linearGradient
-       xlink:href="#linearGradient6451"
-       id="linearGradient3206"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4764428,0,0,0.4057711,0.32715172,1.2682591)"
-       x1="21.478369"
-       y1="1.6845057"
-       x2="21.478369"
-       y2="6.5747066" />
-    <linearGradient
-       xlink:href="#linearGradient4046"
-       id="linearGradient3209"
-       gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="4"
-       x2="17"
-       y2="18" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient3211"
-       gradientUnits="userSpaceOnUse"
-       x1="7"
-       y1="18"
-       x2="7"
-       y2="7" />
-    <linearGradient
-       xlink:href="#linearGradient3977"
-       id="linearGradient3215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
-       x1="23.99999"
-       y1="5.5641499"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3218"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,0.3428289,0.3488617)"
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3224"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient5048"
-       id="linearGradient3227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-  </defs>
+   id="svg11300"
+   style="display:inline;enable-background:new"
+   version="1.0"
+   viewBox="0 0 24 24"
+   width="24"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
-     id="metadata3833">
+     id="metadata154">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>elementary Icon Template</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="g3999">
-    <rect
-       style="opacity:0.15;fill:url(#linearGradient3227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2879"
-       y="22"
-       x="3.5000007"
-       height="2"
-       width="16.999998" />
-    <path
-       style="opacity:0.15;fill:url(#radialGradient3224);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2881"
-       d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
-    <path
-       style="opacity:0.15;fill:url(#radialGradient3221);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2883"
-       d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
-    <path
-       style="fill:url(#linearGradient3218);fill-opacity:1;stroke:none;display:inline"
-       id="path4160-3"
-       d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-    <path
-       style="fill:none;stroke:url(#linearGradient3215);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-1"
-       d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-       id="path4160-3-1"
-       d="m 20.500019,6 2.1e-5,16.500033 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-9.500014 0,-16.500033" />
-    <path
-       style="color:#000000;fill:url(#linearGradient3209);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3211);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3288-2-2"
-       d="m 16.5,12.522385 -4.500001,5 -4.499999,-5 3,0 0,-5.0223848 3,0 0,5.0223848 z" />
-    <rect
-       style="fill:url(#linearGradient3206);fill-opacity:1;stroke:none;stroke-width:0.94228888000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-       id="rect3997"
-       y="1.4711444"
-       x="2.4711444"
-       ry="0.86372536"
-       rx="1.0141573"
-       height="4.0577111"
-       width="19.057711" />
-    <rect
-       width="19.057711"
-       height="4.0577111"
-       rx="1.0141573"
-       ry="0.86372536"
-       x="2.4711444"
-       y="1.4711444"
-       id="rect5480"
-       style="fill:none;fill-opacity:1;stroke:#000000;stroke-width:0.94228888000000000;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;opacity:0.3" />
-    <rect
-       width="6.0000014"
-       height="1"
-       x="3.9999988"
-       y="3.0000007"
-       id="rect6467"
-       style="fill:#c8cdc3;fill-opacity:1;stroke:none;display:inline" />
-    <rect
-       width="1"
-       height="2"
-       x="11.000001"
-       y="2.5000007"
-       id="rect6469"
-       style="fill:#6a6a6a;fill-opacity:1;stroke:none;display:inline" />
-    <rect
-       y="2"
-       x="3"
-       height="3"
-       width="9"
-       id="rect4100"
-       style="opacity:0.35;fill:url(#linearGradient3201);fill-opacity:1;stroke:none" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3198);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3524"
-       d="m 10.350708,6.3521966 c -0.5966541,0.112049 -0.9162261,0.736506 -0.8437501,1.30311 0,0.8989643 0,2.7982324 0,3.6971954 -0.578865,0.0367 -2.259239,-0.146354 -2.709023,0.328895 -0.466467,0.45279 -0.353856,1.232121 0.120358,1.631199 1.472113,1.632101 2.937205,3.270737 4.4137231,4.898738 0.474211,0.475926 1.303176,0.33271 1.665288,-0.205327 1.48182,-1.654007 2.97913,-3.295036 4.451232,-4.957186 0.514277,-0.661155 -0.04205,-1.734972 -0.878703,-1.696319 -0.3125,0 -1.62492,0 -1.93742,0 -0.0045,-1.014919 0.009,-3.0307161 -0.0069,-4.0452734 -0.05174,-0.634617 -0.69724,-1.035839 -1.29626,-0.955032 -1.659293,4.8e-5 -1.319779,-6.5e-5 -2.978595,0 z" />
-  </g>
+  <title
+     id="title4162">elementary Icon Template</title>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4712">
+      <stop
+         id="stop4708"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4710"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="34542">
+      <stop
+         id="stop3456-4-9-38-1-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop3458-39-80-3-5-5"
+         offset="0.002736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412" />
+      <stop
+         id="stop3460-7-0-2-4-2"
+         offset="0.99001008"
+         style="stop-color:#ffffff;stop-opacity:0.15686275" />
+      <stop
+         id="stop3462-0-9-8-7-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687" />
+    </linearGradient>
+    <linearGradient
+       id="50485">
+      <stop
+         id="stop2667-18"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0" />
+      <stop
+         id="stop2669-9"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         id="stop2671-33"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0" />
+    </linearGradient>
+    <linearGradient
+       id="46464">
+      <stop
+         id="stop4648-8-0-3-6"
+         offset="0"
+         style="stop-color:#f9f9f9;stop-opacity:1" />
+      <stop
+         id="stop4650-1-7-3-4"
+         offset="1"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.62762637,0,0,0.7245642,2.97306,4.62736)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#34542"
+       id="linearGradient4440-9"
+       x1="27.129089"
+       x2="27.129089"
+       y1="8.795126"
+       y2="22.596525" />
+    <linearGradient
+       gradientTransform="matrix(0.49096263,0,0,0.48984879,-24.70623,0.28723)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#46464"
+       id="linearGradient4414-2"
+       x1="62.542889"
+       x2="62.542889"
+       y1="13.703746"
+       y2="17.786638" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       gradientTransform="matrix(0.03279364,0,0,0.01512557,0.153892,13.78088)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient3030"
+       r="117.14286" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       gradientTransform="matrix(-0.03279364,0,0,0.01512557,23.846105,13.78088)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient3032"
+       r="117.14286" />
+    <linearGradient
+       gradientTransform="matrix(0.03279364,0,0,0.01512557,0.147438,13.78088)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#50485"
+       id="linearGradient3784"
+       x1="302.85715"
+       x2="302.85715"
+       y1="366.64789"
+       y2="609.50507" />
+    <linearGradient
+       id="linearGradient4632-0-6-4-4-4">
+      <stop
+         id="stop4634-4-4-7-4"
+         style="stop-color:#efdfc4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4636-3-1-5-9"
+         style="stop-color:#e7c591;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="110.26328"
+       x2="51.622452"
+       y1="84.425446"
+       x1="51.622452"
+       gradientTransform="matrix(0.50413225,0,0,0.49333391,-16.682193,-32.483135)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient964"
+       xlink:href="#linearGradient4632-0-6-4-4-4" />
+    <linearGradient
+       xlink:href="#linearGradient1140"
+       id="linearGradient1086"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3210282,0,0,1.2679796,-76.729885,-5.32619)"
+       x1="69.753395"
+       y1="9.7211266"
+       x2="69.771744"
+       y2="20.089539" />
+    <linearGradient
+       id="linearGradient1140">
+      <stop
+         id="stop1132"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1134"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop1136"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1138"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.28763665,0,0,-0.28763651,19.144067,21.977019)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient4132"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       xlink:href="#linearGradient1046"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,29.776674,43.245448)"
+       x1="-17.673822"
+       y1="40.745449"
+       x2="-17.673822"
+       y2="27.995216" />
+    <linearGradient
+       id="linearGradient1046">
+      <stop
+         id="stop1042"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" />
+      <stop
+         id="stop1044"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1356"
+       id="linearGradient4081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-11.519348,19.010508)"
+       x1="25.631071"
+       y1="57.037033"
+       x2="12.286115"
+       y2="57.037033" />
+    <linearGradient
+       id="linearGradient1356">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348" />
+      <stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient1597"
+       id="linearGradient4079"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-14.864986,26.525589)"
+       x1="36.618416"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" />
+    <linearGradient
+       id="linearGradient1597">
+      <stop
+         id="stop1589"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1591"
+         style="stop-color:#ffffff;stop-opacity:0.23999999;"
+         offset="0.0001" />
+      <stop
+         id="stop1593"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop1595"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <rect
+     y="19.326641"
+     x="4.0826759"
+     width="15.834642"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient3784);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.96237946;stroke-miterlimit:4;stroke-dasharray:none;marker:none"
+     id="rect4173-4"
+     height="3.6733527" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3030);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.96237946;stroke-miterlimit:4;stroke-dasharray:none;marker:none"
+     id="path5058-9"
+     d="m 19.917318,19.32676 c 0,0 0,3.67315 0,3.67315 1.688791,0.007 4.082675,-0.82296 4.082674,-1.83681 0,-1.01384 -1.884564,-1.83634 -4.082674,-1.83634 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3032);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.96237946;stroke-miterlimit:4;stroke-dasharray:none;marker:none"
+     id="path5018-53"
+     d="m 4.082675,19.32676 c 0,0 0,3.67315 0,3.67315 C 2.393883,23.00683 0,22.17695 0,21.1631 0,20.14926 1.884563,19.32676 4.082675,19.32676 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7e8087;stroke-width:0.99200022;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;fill-opacity:1"
+     id="rect3186"
+     d="m 3.03629,3.50437 c -0.277,0 -0.5,0.223 -0.5,0.5 v 1.49562 h -0.5 c -0.277,0 -0.5,0.223 -0.5,0.5 v 2.5074 h 21 v -2.5074 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 h -11.5 V 4.00437 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient4414-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect3409-5-2"
+     d="m 3.03629,3.99999 v 2 h -1 v 4 h 20 v -4 h -12 v -2 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient1086);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;fill-opacity:1"
+     id="rect3409-3"
+     d="m 3.53629,4.49999 v 2 h -1 v 3.33929 h 19 V 6.49999 h -12 v -2 z" />
+  <path
+     style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient964);fill-opacity:1;fill-rule:nonzero;stroke:#987124;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;marker:none"
+     id="rect4198"
+     d="m 1.499992,9.49999 v 0.5 8.00026 l 0.25,3.49974 h 20.5 l 0.25,-3.49974 V 9.49999 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient4440-9);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path3309-8"
+     d="m 2.499992,10.49999 -0.05376,7.50492 0.303763,2.49508 h 18.5 l 0.258854,-2.44427 -0.0089,-7.55573 z" />
+  <path
+     d="m 7.5,11.500969 a 4.5000001,4.5 0 1 1 9,0 4.5000001,4.5 0 0 1 -9,0 z"
+     id="path3501-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient4132);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;marker:none" />
+  <path
+     id="path873-5-5-4"
+     style="font-variation-settings:normal;fill:url(#linearGradient1556);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 17.999597,7.870809 c 0,0.129184 -0.10128,0.265019 -0.126255,0.321426 -0.0054,0.0048 -0.01065,0.01041 -0.01578,0.01553 l -5.60301,6.438003 c -0.06681,0.0657 -0.155041,0.104464 -0.254552,0.104464 -0.0988,0 -0.183919,-0.03876 -0.255001,-0.104464 L 6.1393805,8.207765 c -0.0051,-0.0051 -0.01037,-0.01072 -0.01577,-0.01553 -0.07606,-0.07024 -0.123358,-0.204059 -0.123358,-0.321428 0,-0.218072 0.158254,-0.370816 0.371495,-0.370816 h 3.7627765 c 0.199024,1.37e-4 0.365761,-0.18217 0.365761,-0.392893 V 0.861385 C 10.500285,0.654781 10.657553,0.5 10.867477,0.5 h 2.265766 c 0.209926,0 0.367194,0.154781 0.367194,0.361385 v 6.281009 c 0.01837,0.19344 0.177037,0.357729 0.364321,0.3576 h 3.767645 c 0.190944,0 0.367194,0.223285 0.367194,0.370815 z" />
+  <path
+     d="M 10.5,8.5 H 7.72 L 11.999998,13.41 16.28,8.5 h -2.779876"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4081);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4075" />
+  <path
+     d="m 13.499875,8.5 c -0.410995,0 -0.99965,-0.735733 -0.999752,-1.249998 0,0 -0.02402,-4.092125 -2.48e-4,-5.750002 h -0.999378 l -9.95e-4,5.750002 C 11.49944,7.715045 10.996991,8.5 10.499999,8.5"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4077" />
 </svg>

--- a/elementary-xfce/actions/24/document-save.svg
+++ b/elementary-xfce/actions/24/document-save.svg
@@ -1,235 +1,277 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
+   id="svg4157"
    height="24"
-   id="svg3828">
-  <defs
-     id="defs3830">
-    <linearGradient
-       id="linearGradient3251">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1"
-         id="stop3253" />
-      <stop
-         offset="0.33333334"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         id="stop3255" />
-      <stop
-         offset="0.66666669"
-         style="stop-color:#3689e6;stop-opacity:1"
-         id="stop3257" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         id="stop3259" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         id="stop3979"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3981"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03626217" />
-      <stop
-         id="stop3983"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3985"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
-         id="stop3602-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604-6"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1"
-         id="stop3760" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1"
-         id="stop3762" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4299-652-6">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3618-8" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3620-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4299-652-6"
-       id="linearGradient3200"
+   width="24"
+   version="1.1"
+   xml:space="preserve"
+   sodipodi:docname="document-save.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview62"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="11.828125"
+     inkscape:cy="4.625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="578"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157"
+     showguides="true" /><defs
+     id="defs4159"><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,0.97297429,0.97297586)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(0.06983298,-0.1162475)"
-       x1="11.703956"
-       y1="19.198923"
-       x2="11.703956"
-       y2="12.500629" />
-    <linearGradient
-       xlink:href="#linearGradient3251"
-       id="linearGradient3231"
-       gradientUnits="userSpaceOnUse"
-       x1="17"
-       y1="5.4035802"
-       x2="17"
-       y2="19" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
+       xlink:href="#linearGradient4095"
        id="linearGradient3233"
-       gradientUnits="userSpaceOnUse"
-       x1="7"
-       y1="18"
-       x2="7"
-       y2="7" />
-    <linearGradient
-       xlink:href="#linearGradient3977"
-       id="linearGradient3237"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40540511,0,0,0.51351351,2.2696871,-0.3243195)"
-       x1="23.99999"
-       y1="5.5641499"
+       y2="41.167725"
        x2="23.99999"
-       y2="43" />
-    <linearGradient
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3240"
+       y1="6.7566175"
+       x1="23.99999" /><linearGradient
+       id="linearGradient4095"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" /><stop
+         offset="0.03537823"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" /><stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48571543,0,0,0.45629666,0.3428289,0.3488617)"
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3243"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-166-749-9"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01204859,0,0,0.0082353,13.238793,18.980564)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3246"
+       xlink:href="#linearGradient3688-464-309-7-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-464-309-7-6"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-75" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4-9" /></linearGradient><linearGradient
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01204859,0,0,0.0082353,10.761206,18.980564)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient5048"
-       id="linearGradient3249"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-1"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.0352071,0,0,0.0082353,-0.724852,18.980547)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-  </defs>
-  <metadata
-     id="metadata3833">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="g3719">
-    <rect
-       style="opacity:0.15;fill:url(#linearGradient3249);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2879"
-       y="22"
-       x="3.5000007"
-       height="2"
-       width="16.999998" />
-    <path
-       style="opacity:0.15;fill:url(#radialGradient3246);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2881"
-       d="m 3.4999999,22.000085 c 0,0 0,1.999891 0,1.999891 C 2.8795275,24.003776 2,23.551901 2,22.999901 2,22.447902 2.6924,22.000085 3.4999999,22.000085 z" />
-    <path
-       style="opacity:0.15;fill:url(#radialGradient3243);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2883"
-       d="m 20.5,22.000085 c 0,0 0,1.999891 0,1.999891 0.620472,0.0038 1.5,-0.448075 1.5,-1.000075 0,-0.551999 -0.692402,-0.999816 -1.5,-0.999816 z" />
-    <path
-       style="fill:url(#linearGradient3240);fill-opacity:1;stroke:none;display:inline"
-       id="path4160-3"
-       d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-    <path
-       style="fill:none;stroke:url(#linearGradient3237);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741-1"
-       d="m 19.5,21.5 -15.0000004,0 0,-19 L 19.5,2.5 z" />
-    <path
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-       id="path4160-3-1"
-       d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
-    <path
-       style="color:#000000;fill:url(#linearGradient3231);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3288-2-2"
-       d="m 16.5,12.522385 -4.500001,5 -4.499999,-5 3,0 0,-5.0223848 3,0 0,5.0223848 z" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3200);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3524"
-       d="m 10.350708,6.3521977 c -0.5966541,0.112049 -0.9162261,0.736506 -0.8437501,1.30311 0,0.898964 0,2.7982323 0,3.6971953 -0.578865,0.0367 -2.259239,-0.146354 -2.709023,0.328895 -0.466467,0.45279 -0.353856,1.232121 0.120358,1.631199 1.472113,1.632101 2.937205,3.270736 4.4137231,4.898737 0.474211,0.475926 1.303176,0.33271 1.665288,-0.205327 1.48182,-1.654007 2.97913,-3.295035 4.451232,-4.957185 0.514277,-0.661155 -0.04205,-1.734972 -0.878703,-1.696319 -0.3125,0 -1.62492,0 -1.93742,0 -0.0045,-1.014919 0.009,-3.0307163 -0.0069,-4.0452733 -0.05174,-0.634617 -0.69724,-1.035839 -1.29626,-0.955032 -1.659293,4.8e-5 -1.319779,-6.5e-5 -2.978595,0 z" />
-  </g>
-</svg>
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-41.857271,-23.833435)"
+       x1="70.385941"
+       y1="51.425007"
+       x2="70.385941"
+       y2="29.002073" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46014931,0,0,0.44257234,-22.052748,0.86281849)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><linearGradient
+       id="linearGradient4213-9"><stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" /><stop
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" /></linearGradient><radialGradient
+       gradientTransform="matrix(-0.28763665,0,0,-0.28763651,19.144067,21.977019)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4213-9"
+       id="radialGradient4132"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1046"
+       id="linearGradient1556"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,-1,29.776674,43.245448)"
+       x1="-17.673822"
+       y1="40.745449"
+       x2="-17.673822"
+       y2="27.995216" /><linearGradient
+       id="linearGradient1046"><stop
+         id="stop1042"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" /><stop
+         id="stop1044"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1356"
+       id="linearGradient4081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.39056144,0.43562686,0,-11.519348,19.010508)"
+       x1="25.631071"
+       y1="57.037033"
+       x2="12.286115"
+       y2="57.037033" /><linearGradient
+       id="linearGradient1356"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1348" /><stop
+         offset="0.00000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1350" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1352" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1354" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1597"
+       id="linearGradient4079"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-0.66975928,0.49699178,0,-14.864986,26.525589)"
+       x1="36.618416"
+       y1="53.037033"
+       x2="27.66007"
+       y2="53.037033" /><linearGradient
+       id="linearGradient1597"><stop
+         id="stop1589"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop1591"
+         style="stop-color:#ffffff;stop-opacity:0.23999999;"
+         offset="0.0001" /><stop
+         id="stop1593"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" /><stop
+         id="stop1595"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><g
+     transform="matrix(0.5789476,0,0,0.42857134,-1.894738,2.8571464)"
+     id="g3712-8"
+     style="opacity:0.4"><rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801-6"
+       style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" /><rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3696-20"
+       style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" /><rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-5"
+       style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" /></g><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="3"
+     x="3"
+     ry="1.5"
+     rx="1.5"
+     height="18"
+     width="18" /><rect
+     width="19.000002"
+     height="19.000002"
+     rx="2"
+     ry="2"
+     x="2.4999981"
+     y="2.5000257"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1271);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" /><rect
+     width="17"
+     height="17"
+     x="3.4999995"
+     y="3.4999995"
+     id="rect6741-9"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" /><path
+     d="m 7.5,11.500969 a 4.5000001,4.5 0 1 1 9,0 4.5000001,4.5 0 0 1 -9,0 z"
+     id="path3501-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient4132);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;marker:none" /><path
+     id="path873-5-5-4"
+     style="font-variation-settings:normal;fill:url(#linearGradient1556);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     d="m 17.999597,7.870809 c 0,0.129184 -0.10128,0.265019 -0.126255,0.321426 -0.0054,0.0048 -0.01065,0.01041 -0.01578,0.01553 l -5.60301,6.438003 c -0.06681,0.0657 -0.155041,0.104464 -0.254552,0.104464 -0.0988,0 -0.183919,-0.03876 -0.255001,-0.104464 L 6.1393805,8.207765 c -0.0051,-0.0051 -0.01037,-0.01072 -0.01577,-0.01553 -0.07606,-0.07024 -0.123358,-0.204059 -0.123358,-0.321428 0,-0.218072 0.158254,-0.370816 0.371495,-0.370816 h 3.7627765 c 0.199024,1.37e-4 0.365761,-0.18217 0.365761,-0.392893 V 0.861385 C 10.500285,0.654781 10.657553,0.5 10.867477,0.5 h 2.265766 c 0.209926,0 0.367194,0.154781 0.367194,0.361385 v 6.281009 c 0.01837,0.19344 0.177037,0.357729 0.364321,0.3576 h 3.767645 c 0.190944,0 0.367194,0.223285 0.367194,0.370815 z"
+     sodipodi:nodetypes="scccscccsscsssssccss" /><path
+     d="M 10.5,8.5 H 7.72 L 11.999998,13.41 16.28,8.5 h -2.779876"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4081);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4075"
+     sodipodi:nodetypes="ccccc" /><path
+     d="m 13.499875,8.5 c -0.410995,0 -0.99965,-0.735733 -0.999752,-1.249998 0,0 -0.02402,-4.092125 -2.48e-4,-5.750002 h -0.999378 l -9.95e-4,5.750002 C 11.49944,7.715045 10.996991,8.5 10.499999,8.5"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient4079);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     id="path4077"
+     sodipodi:nodetypes="cccccc" /></svg>

--- a/elementary-xfce/actions/32/document-save-as.svg
+++ b/elementary-xfce/actions/32/document-save-as.svg
@@ -1,295 +1,325 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   id="svg3207"
    height="32"
-   width="32"
-   version="1.1"
-   sodipodi:docname="document-save-as.svg"
-   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   id="svg11300"
+   style="display:inline;enable-background:new"
+   version="1.0"
+   viewBox="0 0 32.000961 32"
+   width="32.000961"
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview16707"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:showpageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     inkscape:deskcolor="#d1d1d1"
-     showgrid="false"
-     inkscape:zoom="7.375"
-     inkscape:cx="7.9322034"
-     inkscape:cy="16"
-     inkscape:window-width="1322"
-     inkscape:window-height="411"
-     inkscape:window-x="596"
-     inkscape:window-y="169"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg3207" />
-  <defs
-     id="defs3209">
-    <linearGradient
-       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977"
-       id="linearGradient3013"
-       y2="41.814808"
-       x2="23.99999"
-       y1="5.5641499"
-       x1="23.99999" />
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979" />
-      <stop
-         offset="0.03626217"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981" />
-      <stop
-         offset="0.99999994"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.53479048)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3016"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <linearGradient
-       id="linearGradient3600-4">
-      <stop
-         offset="0"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
-      <stop
-         offset="1"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3021"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3024"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3205"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
-    <linearGradient
-       x1="21.478369"
-       y1="0.53711528"
-       x2="21.478369"
-       y2="6.5747066"
-       id="linearGradient3874"
-       xlink:href="#linearGradient6451"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60000005,0,0,0.40000002,1.2999979,0.80000025)" />
-    <linearGradient
-       id="linearGradient6451">
-      <stop
-         id="stop6453"
-         style="stop-color:#eeeeec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6455"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient4005"
-       x1="15.618644"
-       y1="8.0577536"
-       x2="15.618644"
-       y2="35.34322"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-26.440678,-7.2076133)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient4022"
-       x1="30.754238"
-       y1="34.733051"
-       x2="30.754238"
-       y2="13.375976"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-26.440678,-7.2076133)" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient17210"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-26.440678,-6.7075078)"
-       x1="15.618644"
-       y1="8.0577536"
-       x2="15.618644"
-       y2="35.34322" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient17212"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-26.440678,-6.7075078)"
-       x1="30.754238"
-       y1="34.733051"
-       x2="30.754238"
-       y2="13.375976" />
-  </defs>
   <metadata
-     id="metadata3212">
+     id="metadata154">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>elementary Icon Template</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <title
+     id="title4162">elementary Icon Template</title>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4712">
+      <stop
+         id="stop4708"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1;" />
+      <stop
+         id="stop4710"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.89186139,0,0,0.86792712,3.121219,9.57503)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#34542"
+       id="linearGradient8576"
+       x1="27.335257"
+       x2="27.335257"
+       y1="7.4026608"
+       y2="21.228706" />
+    <linearGradient
+       id="34542">
+      <stop
+         id="stop3456-4-9-38-1-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1" />
+      <stop
+         id="stop3458-39-80-3-5-5"
+         offset="0.002736"
+         style="stop-color:#ffffff;stop-opacity:0.23529412" />
+      <stop
+         id="stop3460-7-0-2-4-2"
+         offset="0.99001008"
+         style="stop-color:#ffffff;stop-opacity:0.15686275" />
+      <stop
+         id="stop3462-0-9-8-7-2"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.05114282,0,0,0.01591575,-2.489388,21.29927)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#50485"
+       id="linearGradient16107"
+       x1="302.85715"
+       x2="302.85715"
+       y1="366.64789"
+       y2="609.50507" />
+    <linearGradient
+       id="50485">
+      <stop
+         id="stop2667-18"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0" />
+      <stop
+         id="stop2669-9"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:1" />
+      <stop
+         id="stop2671-33"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0" />
+    </linearGradient>
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       gradientTransform="matrix(0.01983573,0,0,0.01591575,16.388219,21.29927)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient16109"
+       r="117.14286" />
+    <radialGradient
+       cx="605.71429"
+       cy="486.64789"
+       fx="605.71429"
+       fy="486.64789"
+       gradientTransform="matrix(-0.01983573,0,0,0.01591575,15.601959,21.29927)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient16111"
+       r="117.14286" />
+    <linearGradient
+       gradientTransform="matrix(0.61904762,0,0,0.61904762,-30.391421,1.42857)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#46464"
+       id="linearGradient8580"
+       x1="62.988873"
+       x2="62.988873"
+       y1="17.469706"
+       y2="20.469706" />
+    <linearGradient
+       id="46464">
+      <stop
+         id="stop4648-8-0-3-6"
+         offset="0"
+         style="stop-color:#f9f9f9;stop-opacity:1" />
+      <stop
+         id="stop4650-1-7-3-4"
+         offset="1"
+         style="stop-color:#d8d8d8;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4632-0-6-4-4-4">
+      <stop
+         offset="0"
+         style="stop-color:#efdfc4;stop-opacity:1"
+         id="stop4634-4-4-7-4" />
+      <stop
+         offset="1"
+         style="stop-color:#e7c591;stop-opacity:1"
+         id="stop4636-3-1-5-9" />
+    </linearGradient>
+    <linearGradient
+       y2="132.01555"
+       x2="21.599585"
+       y1="99.79232"
+       x1="21.599585"
+       gradientTransform="matrix(0.50413225,0,0,0.49333391,13.463176,-35.114264)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1048"
+       xlink:href="#linearGradient4632-0-6-4-4-4" />
+    <linearGradient
+       gradientTransform="matrix(0.54383556,0,0,0.61466406,3.2688794,5.091139)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4325"
+       id="linearGradient5903"
+       y2="34.016731"
+       x2="21.571081"
+       y1="7.9862504"
+       x1="21.571081" />
+    <linearGradient
+       id="linearGradient4325">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4327" />
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4329" />
+      <stop
+         offset="0.99001008"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4331" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4333" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,22.512547,21.835677)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient3862"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       y2="10.380685"
+       x2="20.866917"
+       y1="10.380685"
+       x1="6.0000367"
+       gradientTransform="matrix(0,1.333717,-1.3358905,0,30.698682,-5.0023508)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient72"
+       xlink:href="#linearGradient78" />
+    <linearGradient
+       id="linearGradient78">
+      <stop
+         id="stop74"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" />
+      <stop
+         id="stop76"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       y2="56.75816"
+       x2="19.873171"
+       y1="56.75816"
+       x1="26.914818"
+       gradientTransform="matrix(0,-1.004639,1,0,-37.960764,39.040337)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940-8"
+       xlink:href="#linearGradient1061" />
+    <linearGradient
+       id="linearGradient1061">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1053" />
+      <stop
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1055" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1057" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1059" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient24237"
+       id="linearGradient1014-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.004639,1,0,-59.960764,40.040337)"
+       x1="37.863892"
+       y1="75.964668"
+       x2="21.624302"
+       y2="75.964668" />
+    <linearGradient
+       id="linearGradient24237">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop24229" />
+      <stop
+         offset="0.0000001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop24231" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop24233" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop24235" />
+    </linearGradient>
+  </defs>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7e8087;stroke-width:0.99200022;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;fill-opacity:1"
+     id="use8307"
+     d="m 4.000569,6.50008 c -0.43342,0.005 -0.5,0.21723 -0.5,0.6349 V 8.5 c -1.24568,0 -1,-0.002 -1,0.54389 V 16.5 h 26.99991 l 9e-5,-7.45611 C 29.500579,8.62622 29.152579,8.49513 28.719159,8.5 H 14.500569 V 7.13498 c 0,-0.41767 -0.26424,-0.63977 -0.69767,-0.6349 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient8580);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="use8309"
+     d="m 4.000569,7 v 2 h -1 l -9e-5,7 h 26 l 9e-5,-7 h -15 V 7 Z" />
+  <path
+     d="m 4.5001794,7.499999 v 2 h -1 v 8 H 28.500179 v -8 h -15 v -2 z"
+     id="rect3409"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient5903);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <rect
-     width="22.100021"
-     height="2"
-     x="4.9499893"
-     y="29"
-     id="rect2879"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#linearGradient3205);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     y="27.13475"
+     x="3.6477492"
+     width="24.694677"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient16107);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="rect16101"
+     height="3.8652544" />
   <path
-     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z"
-     id="path2881"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient16109);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path16103"
+     d="m 28.342429,27.13488 c 0,0 0,3.86504 0,3.86504 1.02149,0.007 2.46947,-0.86596 2.46947,-1.93277 0,-1.06681 -1.13991,-1.93227 -2.46947,-1.93227 z" />
   <path
-     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z"
-     id="path2883"
-     style="display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient16111);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     id="path16105"
+     d="m 3.647751,27.13488 c 0,0 0,3.86504 0,3.86504 -1.021492,0.007 -2.469468,-0.86596 -2.469468,-1.93277 0,-1.06681 1.139907,-1.93227 2.469468,-1.93227 z" />
   <path
-     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 Z"
-     id="path4160-3"
-     style="display:inline;fill:url(#linearGradient3016);fill-opacity:1;stroke:none;stroke-width:1" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1048);fill-opacity:1;fill-rule:nonzero;stroke:#987124;stroke-width:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.49803922"
+     id="use8315"
+     d="m 0.500479,14.5 1.5,15 h 28 l 1.5,-15 z" />
   <path
-     d="m 26.5,28.5 h -21 v -27 h 21 z"
-     id="rect6741-1"
-     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient8576);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="use8572"
+     d="m 1.602042,15.5 1.265854,13 h 26.265163 l 1.26586,-13 z" />
+  <g
+     id="layer1"
+     transform="matrix(0.84428904,0,0,1.4482771,8.1058979,-1.0000178)"
+     style="stroke-width:0.904335">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.141;fill:url(#radialGradient3862);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.904335;marker:none"
+       id="path3501-0"
+       d="m 1.059,8.976195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z" />
+  </g>
   <path
-     id="rect5480-5"
-     style="display:inline;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     d="M 4.4999999,0.5 H 27.5 c 0.554,0 1,0.446 1,1 v 3 c 0,0.554 -0.446,1 -1,1 H 4.4999999 C 3.946,5.5 3.5,5.054 3.5,4.5 v -3 c 0,-0.554 0.446,-1 0.9999999,-1 z m -3.24e-5,-3.907e-5 c 5.270482,0 23.0000375,0.00185 23.0000375,0.00185 l 2.8e-5,28.99822807 c 0,0 -15.333376,0 -23.0000655,0 0,-9.666692 0,-19.333383 0,-29.00007387 z" />
-  <rect
-     style="display:inline;fill:url(#linearGradient3874);fill-opacity:1;stroke:none;stroke-width:1"
-     id="rect5480"
-     y="1"
-     x="4"
-     ry="0.5"
-     rx="0.49999997"
-     height="4"
-     width="24" />
-  <rect
-     style="display:inline;fill:#00aade;fill-opacity:1;stroke:none;stroke-width:1"
-     id="rect6467"
-     y="2"
-     x="5"
-     height="2"
-     width="7.9999995" />
-  <rect
-     style="display:inline;fill:#969696;fill-opacity:1;stroke:none;stroke-width:1"
-     id="rect6469"
-     y="1.5"
-     x="14"
-     height="3"
-     width="1" />
+     d="m 23.749973,11.207439 h -0.0052 c 0,0.216576 -0.08604,0.396568 -0.224388,0.526193 -0.0099,0.0089 -0.01939,0.01922 -0.02871,0.02866 l -7.028567,7.795328 c -0.121538,0.121233 -0.286021,0.192762 -0.467039,0.192762 -0.179725,0 -0.335132,-0.07153 -0.464432,-0.192764 L 8.5031967,11.762289 c -0.00932,-0.0095 -0.018866,-0.01977 -0.028695,-0.02866 -0.1383508,-0.129624 -0.2243885,-0.309616 -0.2243885,-0.526193 0,-0.402405 0.2878751,-0.706829 0.6757736,-0.706829 h 3.8904722 c 0.362037,2.52e-4 0.683538,-0.313586 0.683538,-0.702431 V 1.1628923 C 13.499897,0.78165064 13.767779,0.5 14.149642,0.5 h 3.681021 c 0.381863,0 0.669341,0.28165064 0.669341,0.6628923 v 8.7004094 c 0.03341,0.3569513 0.320648,0.6375443 0.661332,0.6373073 h 3.920691 c 0.387898,0 0.667946,0.304424 0.667946,0.70683 z"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient72);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     id="path873-5-5" />
   <path
-     id="path873-5-3-3-7-4"
-     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:url(#linearGradient17210);fill-opacity:1;stroke:url(#linearGradient17212);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
-     d="m 22.666772,17.389008 c 0,-0.492452 -0.189023,-0.76947 -0.666772,-0.888903 H 18 V 9.3889028 C 18,8.8964506 17.692475,8.5 17.200022,8.5 H 14.799978 C 14.307525,8.5 14.006154,8.896489 14,9.3889028 v 7.1112022 h -3.866665 c -0.4924528,0 -0.800107,0.396451 -0.800107,0.888903 0,0.265412 0.1153332,0.502339 0.2986191,0.664941 l 5.7587669,6.202991 c 0.1592,0.150298 0.373168,0.243059 0.609387,0.243059 0.236213,0 0.450186,-0.09276 0.609381,-0.243059 l 5.758773,-6.202991 c 0.183283,-0.162602 0.298617,-0.399529 0.298617,-0.664941 z" />
+     id="rect1007"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 13,11.500156 -3.385,-2e-6 L 16,18.575 22.375,11.500156 H 19" />
+  <path
+     id="rect1007-3"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1014-7);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 19,11.500661 c -0.875611,0 -1.499791,-0.908775 -1.5,-1.5620825 V 1.5 h -3 v 8.2318065 c 0,1.1487685 -0.870013,1.7688545 -1.5,1.7688545" />
 </svg>

--- a/elementary-xfce/actions/32/document-save.svg
+++ b/elementary-xfce/actions/32/document-save.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   id="svg3182"
+   id="svg4715"
    height="32"
    width="32"
    version="1.1"
@@ -15,202 +15,259 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview17465"
+     id="namedview22589"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
+     bordercolor="#000000"
+     borderopacity="0.25"
      inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="7.375"
-     inkscape:cx="-24.542373"
-     inkscape:cy="16"
-     inkscape:window-width="1322"
-     inkscape:window-height="411"
-     inkscape:window-x="34"
-     inkscape:window-y="217"
+     inkscape:zoom="16"
+     inkscape:cx="16.96875"
+     inkscape:cy="12.4375"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="608"
+     inkscape:window-y="3"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3182" />
+     inkscape:current-layer="svg4715" />
   <defs
-     id="defs3184">
+     id="defs4717">
     <linearGradient
-       id="linearGradient3977">
+       id="linearGradient24237">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3979" />
+         id="stop24229" />
       <stop
-         offset="0"
+         offset="0.0000001"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop3981" />
+         id="stop24231" />
       <stop
-         offset="0.99999994"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop3983" />
+         id="stop24233" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop3985" />
+         id="stop24235" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3600-4">
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.08071423"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3163"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3165"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3167"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.2162133,-0.21620907)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66466012,0,0,0.63927116,-33.187302,-0.08703975)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" />
+    <linearGradient
+       id="linearGradient3600-9-51">
       <stop
          offset="0"
          style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3602-7" />
+         id="stop3602-0-0" />
       <stop
          offset="1"
          style="stop-color:#dbdbdb;stop-opacity:1"
-         id="stop3604-6" />
+         id="stop3604-9-04" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5062" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5064" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5050" />
-      <stop
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop5056" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop5052" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.56756757,0,0,0.72972971,2.378382,-2.5135063)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3977"
-       id="linearGradient3013"
-       y2="41.814808"
-       x2="23.99999"
-       y1="6.1851754"
-       x1="23.99999" />
-    <linearGradient
-       gradientTransform="matrix(0.62856997,0,0,0.60839392,0.91431981,-0.5347905)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3600-4"
-       id="linearGradient3016"
-       y2="47.013336"
-       x2="25.132275"
-       y1="0.98520643"
-       x1="25.132275" />
-    <radialGradient
-       gradientTransform="matrix(0.01566318,0,0,0.00823529,17.610433,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3021"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <radialGradient
-       gradientTransform="matrix(-0.01566318,0,0,0.00823529,14.389566,25.980565)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5060"
-       id="radialGradient3024"
-       fy="486.64789"
-       fx="605.71429"
-       r="117.14286"
-       cy="486.64789"
-       cx="605.71429" />
-    <linearGradient
-       gradientTransform="matrix(0.04576928,0,0,0.00823529,-0.5423243,25.980548)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5048"
-       id="linearGradient3027"
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715" />
     <linearGradient
        id="linearGradient3104-6">
       <stop
-         id="stop3106-3"
+         offset="0"
          style="stop-color:#000000;stop-opacity:0.31782946"
-         offset="0" />
+         id="stop3106-3" />
       <stop
-         id="stop3108-9"
+         offset="1"
          style="stop-color:#000000;stop-opacity:0.24031007"
-         offset="1" />
+         id="stop3108-9" />
     </linearGradient>
     <linearGradient
-       y2="2.9062471"
-       x2="-51.786404"
-       y1="50.786446"
-       x1="-51.786404"
-       gradientTransform="matrix(0.53064141,0,0,0.58970049,39.269607,-1.791918)"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1572"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3148"
-       xlink:href="#linearGradient3104-6" />
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-45.635114,-9.2419267)"
+       x1="72.893349"
+       y1="43.73991"
+       x2="72.893349"
+       y2="12.523938" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient17210"
+       id="linearGradient4687">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop4689" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop4691" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,22.512547,21.835677)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-26.440678,-7.7075078)"
-       x1="15.618644"
-       y1="8.0577536"
-       x2="15.618644"
-       y2="35.34322" />
+       xlink:href="#linearGradient4687"
+       id="radialGradient3862"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
+       id="linearGradient78">
       <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
+         id="stop74"
+         offset="0"
+         style="stop-color:#9bdb4d;stop-opacity:1" />
       <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
+         id="stop76"
+         offset="1"
+         style="stop-color:#68b723;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient17212"
+       y2="10.380685"
+       x2="20.866917"
+       y1="10.380685"
+       x1="6.0000367"
+       gradientTransform="matrix(0,1.333717,-1.3358905,0,30.698682,-5.0023508)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-26.440678,-7.7075078)"
-       x1="30.754238"
-       y1="34.733051"
-       x2="30.754238"
-       y2="13.375976" />
+       id="linearGradient72"
+       xlink:href="#linearGradient78" />
     <linearGradient
-       id="linearGradient3707-319-631-407-324">
+       y2="56.75816"
+       x2="19.873171"
+       y1="56.75816"
+       x1="26.914818"
+       gradientTransform="matrix(0,-1.004639,1,0,-37.960764,39.040337)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940-8"
+       xlink:href="#linearGradient1061" />
+    <linearGradient
+       id="linearGradient1061">
       <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1053" />
       <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1055" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1057" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1059" />
     </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient24237"
+       id="linearGradient1014-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.004639,1,0,-59.960764,40.040337)"
+       x1="37.863892"
+       y1="75.964668"
+       x2="21.624302"
+       y2="75.964668" />
   </defs>
   <metadata
-     id="metadata3187">
+     id="metadata4720">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -220,35 +277,82 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <g
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(0.73684208,0,0,0.57142853,-1.6842105,4.1428584)">
+    <rect
+       style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
+  </g>
   <rect
-     style="opacity:0.15;fill:url(#linearGradient3027);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="29"
-     x="4.9499893"
-     height="2"
-     width="22.100021" />
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
+     y="3"
+     x="3"
+     ry="2.5"
+     rx="2.5"
+     height="26"
+     width="26" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient1572);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;fill-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="rect5505-6-6"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="27"
+     width="27" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.4999998"
+     x="3.5"
+     ry="1.9999999"
+     rx="2"
+     height="25.000002"
+     width="25" />
+  <g
+     id="layer1"
+     transform="matrix(0.84428904,0,0,1.4482771,8.1058979,-1.0000178)"
+     style="stroke-width:0.904335">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.141;fill:url(#radialGradient3862);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.904335;marker:none"
+       id="path3501-0"
+       d="m 1.059,8.976195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z" />
+  </g>
   <path
-     style="opacity:0.15;fill:url(#radialGradient3024);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2881"
-     d="m 4.9499887,29.000086 c 0,0 0,1.99989 0,1.99989 -0.806615,0.0038 -1.950002,-0.448074 -1.950002,-1.000074 0,-0.552 0.900121,-0.999816 1.950002,-0.999816 z" />
+     d="m 23.749973,11.207439 h -0.0052 c 0,0.216576 -0.08604,0.396568 -0.224388,0.526193 -0.0099,0.0089 -0.01939,0.01922 -0.02871,0.02866 l -7.028567,7.795328 c -0.121538,0.121233 -0.286021,0.192762 -0.467039,0.192762 -0.179725,0 -0.335132,-0.07153 -0.464432,-0.192764 L 8.5031967,11.762289 c -0.00932,-0.0095 -0.018866,-0.01977 -0.028695,-0.02866 -0.1383508,-0.129624 -0.2243885,-0.309616 -0.2243885,-0.526193 0,-0.402405 0.2878751,-0.706829 0.6757736,-0.706829 h 3.8904722 c 0.362037,2.52e-4 0.683538,-0.313586 0.683538,-0.702431 V 1.1628923 C 13.499897,0.78165064 13.767779,0.5 14.149642,0.5 h 3.681021 c 0.381863,0 0.669341,0.28165064 0.669341,0.6628923 v 8.7004094 c 0.03341,0.3569513 0.320648,0.6375443 0.661332,0.6373073 h 3.920691 c 0.387898,0 0.667946,0.304424 0.667946,0.70683 z"
+     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient72);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;stop-color:#000000"
+     id="path873-5-5"
+     sodipodi:nodetypes="cccccscccsscsssssccsc" />
   <path
-     style="opacity:0.15;fill:url(#radialGradient3021);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2883"
-     d="m 27.050011,29.000086 c 0,0 0,1.99989 0,1.99989 0.806614,0.0038 1.950002,-0.448074 1.950002,-1.000074 0,-0.552 -0.900122,-0.999816 -1.950002,-0.999816 z" />
+     id="rect1007"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 13,11.500156 -3.385,-2e-6 L 16,18.575 22.375,11.500156 H 19"
+     sodipodi:nodetypes="ccccc" />
   <path
-     style="fill:url(#linearGradient3016);fill-opacity:1;stroke:none;display:inline"
-     id="path4160-3"
-     d="m 5,1 c 5.041316,0 21.999973,0.00179 21.999973,0.00179 L 27,29 C 27,29 12.333334,29 5,29 5,19.666667 5,10.333336 5,1.0000041 z" />
-  <path
-     style="fill:none;stroke:url(#linearGradient3013);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect6741-1"
-     d="m 26.5,28.5 -21,0 0,-27 21,0 z" />
-  <path
-     d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z"
-     id="path4160-6-1"
-     style="fill:none;stroke:url(#linearGradient3148);stroke-width:0.9999218;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-  <path
-     id="path873-5-3-3-7-4"
-     style="font-variation-settings:normal;vector-effect:none;fill:url(#linearGradient17210);fill-opacity:1;stroke:url(#linearGradient17212);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
-     d="m 22.666772,16.389008 c 0,-0.492452 -0.189023,-0.76947 -0.666772,-0.888903 H 18 V 8.3889028 C 18,7.8964506 17.692475,7.5 17.200022,7.5 H 14.799978 C 14.307525,7.5 14.006154,7.896489 14,8.3889028 v 7.1112022 h -3.866665 c -0.492453,0 -0.800107,0.396451 -0.800107,0.888903 0,0.265412 0.115333,0.502339 0.298619,0.664941 l 5.758767,6.202991 c 0.1592,0.150298 0.373168,0.243059 0.609387,0.243059 0.236213,0 0.450186,-0.09276 0.609381,-0.243059 l 5.758773,-6.202991 c 0.183283,-0.162602 0.298617,-0.399529 0.298617,-0.664941 z" />
+     id="rect1007-3"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1014-7);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 19,11.500661 c -0.875611,0 -1.499791,-0.908775 -1.5,-1.5620825 V 1.5 h -3 v 8.2318065 c 0,1.1487685 -0.870013,1.7688545 -1.5,1.7688545"
+     sodipodi:nodetypes="ccccsc" />
 </svg>

--- a/elementary-xfce/actions/48/document-save-as.svg
+++ b/elementary-xfce/actions/48/document-save-as.svg
@@ -1,325 +1,325 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="48"
+   width="48.055344"
+   viewBox="0 0 48.055344 48"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   id="svg11300"
    height="48"
-   id="svg4000">
-  <defs
-     id="defs4002">
-    <linearGradient
-       id="linearGradient4299-652-5">
-      <stop
-         id="stop3618-8"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3620-9"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3029">
-      <stop
-         id="stop3031"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3033"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.01487851" />
-      <stop
-         id="stop3035"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98463625" />
-      <stop
-         id="stop3037"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3600">
-      <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
-      <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3707-319-631-407-324">
-      <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4299-652-5"
-       id="linearGradient3211"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(8.621297,13.834931)"
-       x1="11.703956"
-       y1="20.16507"
-       x2="11.703956"
-       y2="9.1650686" />
-    <linearGradient
-       xlink:href="#linearGradient3029"
-       id="linearGradient3216"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
-       x1="23.99999"
-       y1="5.5641499"
-       x2="23.99999"
-       y2="42.110645" />
-    <linearGradient
-       xlink:href="#linearGradient3600"
-       id="linearGradient3219"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-9.9999999e-8,-1.9149218)"
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3222"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3225"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient5048"
-       id="linearGradient3228"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient4005"
-       x1="15.618644"
-       y1="8.0577536"
-       x2="15.618644"
-       y2="35.34322"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient4022"
-       x1="30.754238"
-       y1="34.733051"
-       x2="30.754238"
-       y2="13.375976"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient4110-1">
-      <stop
-         id="stop4112-9"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4114-1"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.25" />
-      <stop
-         id="stop4116-2"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.62520313" />
-      <stop
-         id="stop4118-9"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6451-8">
-      <stop
-         offset="0"
-         style="stop-color:#eeeeec;stop-opacity:1"
-         id="stop6453-4" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop6455-2" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient6451-8"
-       id="linearGradient4861"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.9756098,0,0,0.9101061,0.08089799,-0.02725842)"
-       x1="21.478369"
-       y1="1.6845057"
-       x2="21.478369"
-       y2="6.5747066" />
-    <linearGradient
-       xlink:href="#linearGradient4110-1"
-       id="linearGradient4864"
-       gradientUnits="userSpaceOnUse"
-       x1="10"
-       y1="1"
-       x2="10"
-       y2="5"
-       gradientTransform="matrix(1.8888889,0,0,2.6666666,-0.6666678,-4.3333328)" />
-    <linearGradient
-       xlink:href="#linearGradient6451-8"
-       id="linearGradient4901"
-       x1="36.502308"
-       y1="2.2443838"
-       x2="36.502308"
-       y2="9.6696692"
-       gradientUnits="userSpaceOnUse" />
-  </defs>
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <metadata
-     id="metadata4005">
+     id="metadata154">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title>elementary Icon Template</dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <title
+     id="title4162">elementary Icon Template</title>
+  <defs
+     id="defs3">
+    <linearGradient
+       id="linearGradient4712">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop4708" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop4710" />
+    </linearGradient>
+    <linearGradient
+       id="34542">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         id="stop3456-4-9-38-1-8" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.002736"
+         id="stop3458-39-80-3-5-5" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99001008"
+         id="stop3460-7-0-2-4-2" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1"
+         id="stop3462-0-9-8-7-2" />
+    </linearGradient>
+    <linearGradient
+       id="50485">
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="0"
+         id="stop2667-18" />
+      <stop
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0.5"
+         id="stop2669-9" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1"
+         id="stop2671-33" />
+    </linearGradient>
+    <linearGradient
+       id="46464">
+      <stop
+         style="stop-color:#f9f9f9;stop-opacity:1"
+         offset="0"
+         id="stop4648-8-0-3-6" />
+      <stop
+         style="stop-color:#d8d8d8;stop-opacity:1"
+         offset="1"
+         id="stop4650-1-7-3-4" />
+    </linearGradient>
+    <linearGradient
+       y2="21.215551"
+       y1="18.215551"
+       x2="63.412205"
+       x1="63.412205"
+       id="linearGradient1359"
+       xlink:href="#46464"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-50.940791,-1e-5)" />
+    <linearGradient
+       y2="609.50507"
+       y1="366.64789"
+       x2="302.85715"
+       x1="302.85715"
+       id="linearGradient1361"
+       xlink:href="#50485"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.07938856,0,0,0.02470588,-4.69321,31.94163)" />
+    <radialGradient
+       r="117.14286"
+       id="radialGradient1363"
+       xlink:href="#linearGradient4712"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.03079083,0,0,0.02470588,24.61029,31.94163)"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429" />
+    <radialGradient
+       r="117.14286"
+       id="radialGradient1365"
+       xlink:href="#linearGradient4712"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.03079083,0,0,0.02470588,23.38989,31.94163)"
+       fy="486.64789"
+       fx="605.71429"
+       cy="486.64789"
+       cx="605.71429" />
+    <linearGradient
+       y2="21.228706"
+       y1="-1.8147031"
+       x2="27.335257"
+       x1="27.335257"
+       id="linearGradient1369"
+       xlink:href="#34542"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89186139,0,0,0.86792712,4.12081,24.57503)" />
+    <linearGradient
+       id="linearGradient4632-0-6-4-4-4">
+      <stop
+         id="stop4634-4-4-7-4"
+         style="stop-color:#efdfc4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4636-3-1-5-9"
+         style="stop-color:#e7c591;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4632-0-6-4-4-4"
+       id="linearGradient997-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.50413225,0,0,0.49333391,13.966446,-10.999227)"
+       x1="45.428802"
+       y1="64.793724"
+       x2="45.428802"
+       y2="113.49406" />
+    <linearGradient
+       x1="21.37039"
+       y1="7.2270284"
+       x2="21.37039"
+       y2="34.143417"
+       id="linearGradient12463"
+       xlink:href="#linearGradient4507-0-4-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.89189031,0,0,1.0580283,3.1206621,5.3536)" />
+    <linearGradient
+       id="linearGradient4507-0-4-7">
+      <stop
+         id="stop4509-35-6-1"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4511-46-3-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop4513-15-5-9"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.99001008" />
+      <stop
+         id="stop4515-1-1-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,22.512547,21.835677)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4712"
+       id="radialGradient3862-0-7"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
+    <linearGradient
+       xlink:href="#linearGradient899-9"
+       id="linearGradient12770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.0002228,-1.0014346,0,64.945034,52.010794)"
+       x1="22.005892"
+       y1="38.389961"
+       x2="47.00029"
+       y2="38.389961" />
+    <linearGradient
+       id="linearGradient899-9">
+      <stop
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0"
+         id="stop895-2" />
+      <stop
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="1"
+         id="stop897-2" />
+    </linearGradient>
+    <linearGradient
+       y2="57.037033"
+       x2="16.135088"
+       y1="57.037033"
+       x1="25.91967"
+       gradientTransform="matrix(0,-1.004639,1,0,-29.962042,44.040338)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940"
+       xlink:href="#linearGradient1061" />
+    <linearGradient
+       id="linearGradient1061">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1053" />
+      <stop
+         offset="0.00000005"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1055" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1057" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1059" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient32335"
+       id="linearGradient1014"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.004639,1,0,-51.962042,45.040338)"
+       x1="40.854595"
+       y1="75.964668"
+       x2="18.600533"
+       y2="75.964668" />
+    <linearGradient
+       id="linearGradient32335">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop32327" />
+      <stop
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop32329" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop32331" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop32333" />
+    </linearGradient>
+  </defs>
+  <path
+     d="m 5.50009,8.49999 c -0.554,0 -1,0.446 -1,1 v 2 h -1 c -0.554,0 -1,0.446 -1,1 v 12 h 43 v -12 c 0,-0.554 -0.446,-1 -1,-1 h -23 v -2 c 0,-0.554 -0.446,-1 -1,-1 z"
+     id="rect4251-0-0-9-7-3-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7e8087;stroke-width:0.99200022;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variant-east_asian:normal;vector-effect:none;fill-opacity:1" />
+  <path
+     d="m 5.50009,8.99999 c -0.277,0 -0.5,0.223 -0.5,0.5 v 2.5 h -1.5 c -0.277,0 -0.5,0.223 -0.5,0.5 L 3.00007,24 h 42 l 2e-5,-11.50001 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 h -23.5 v -2.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 z"
+     id="rect4251-4-8-2-72-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1359);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992168;marker:none;enable-background:accumulate" />
+  <rect
+     height="6.0000005"
+     id="rect4173-6-1-6-8-3"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient1361);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
+     width="38.333332"
+     x="4.8334594"
+     y="41" />
+  <path
+     d="m 43.16679,41.0002 c 0,0 0,5.99967 0,5.99967 1.5856,0.0113 3.8333,-1.34422 3.8333,-3.00022 0,-1.656 -1.7695,-2.99945 -3.8333,-2.99945 z"
+     id="path5058-7-5-8-1-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient1363);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     d="m 4.83339,41.0002 c 0,0 0,5.99967 0,5.99967 -1.5856,0.0113 -3.8333,-1.34422 -3.8333,-3.00022 0,-1.656 1.7695,-2.99945 3.8333,-2.99945 z"
+     id="path5018-8-7-1-0-4"
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient1365);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient12463);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect4251-9-21-7"
+     d="m 5.5000021,9.5 v 3 h -2 v 11 H 44.500002 v -11 h -24 v -3 z" />
+  <path
+     d="m 0.50007,22 2.5,22.5 H 45.36749 L 47.55311,21.99954 C 47.60163,21.5 47.00007,21.5 47.00007,21.5 h -46 c -0.5,0 -0.5,0.5 -0.5,0.5 z"
+     id="path3983"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient997-3);fill-opacity:1;fill-rule:nonzero;stroke:#987124;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.49803922;marker:none;enable-background:accumulate;font-variant-east_asian:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:round;stroke-dashoffset:0" />
+  <path
+     d="m 1.50007,22.5 2.36742,21 h 40.63258 l 2,-21 z"
+     id="path3985"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient1369);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <g
-     id="g5021">
-    <rect
-       width="32.508301"
-       height="3.5700529"
-       x="7.7378473"
-       y="42.429947"
-       id="rect2879"
-       style="opacity:0.3;fill:url(#linearGradient3228);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
+     id="layer1"
+     transform="matrix(0.96490176,0,0,2.0818984,14.978169,-0.18752584)"
+     style="stroke-width:0.705552">
     <path
-       d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z"
-       id="path2881"
-       style="opacity:0.3;fill:url(#radialGradient3225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z"
-       id="path2883"
-       style="opacity:0.3;fill:url(#radialGradient3222);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <path
-       d="M 6.4999609,0.497199 C 14.520256,0.497199 41.5,0.5 41.5,0.5 l 4.2e-5,44.002803 c 0,0 -23.333387,0 -35.0000811,0 0,-14.668535 0,-29.33707 0,-44.00560407 z"
-       id="path4160"
-       style="fill:url(#linearGradient3219);fill-opacity:1;stroke:none;display:inline" />
-    <path
-       d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z"
-       id="rect6741-1"
-       style="fill:none;stroke:url(#linearGradient3216);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <path
-       d="m 41.5,10 4.2e-5,34.5028 c 0,0 -23.333387,0 -35.0000811,0 0,-12.058365 0,-22.444439 0,-34.5028"
-       id="path4160-9"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-    <path
-       d="M 32,23.5 24.006769,33 16,23.5 l 5.5,0 0,-9 5,0 0,9 z"
-       id="path3288-2-2"
-       style="color:#000000;fill:url(#linearGradient4005);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4022);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       d="m 15.805769,22.55307 c -0.805587,0.138962 -1.024295,1.253585 -0.408339,1.746998 2.640884,3.131179 5.272364,6.270671 7.91912,9.396659 0.503249,0.522437 1.330582,0.237778 1.654595,-0.334342 2.610326,-3.106926 5.235188,-6.202465 7.83644,-9.3165 0.485346,-0.67243 -0.178868,-1.657218 -0.979245,-1.51464 z"
-       id="path3142"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3211);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="39.024391"
-       height="9.1010609"
-       rx="2.0766854"
-       ry="1.9372541"
-       x="4.4711447"
-       y="0.42779467"
-       id="rect5480-6"
-       style="opacity:0.3;fill:url(#linearGradient4861);fill-opacity:1;stroke:#000000;stroke-width:0.94228894;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
-    <path
-       d="m 6.9406544,1.3663415 c -0.8473229,0 -1.4634147,0.5747267 -1.4634147,1.3651592 l 0,4.4936489 c 0,0.7904325 0.6160918,1.3651591 1.4634147,1.3651591 l 34.0853676,0 c 0.847323,0 1.463415,-0.5747265 1.463415,-1.3651591 l 0,-4.4936489 c 0,-0.7904332 -0.61609,-1.3651592 -1.463415,-1.3651592 l -34.0853676,0 z"
-       id="path6463"
-       style="fill:url(#linearGradient4901);stroke:#ffffff;stroke-width:0.94228893999999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;fill-opacity:1" />
-    <rect
-       width="12"
-       height="3.9999995"
-       x="6.9833407"
-       y="3.0000002"
-       id="rect6467-2"
-       style="fill:#d3d7cf;fill-opacity:1;stroke:none;display:inline" />
-    <rect
-       width="0.99999732"
-       height="6"
-       x="20.983343"
-       y="2"
-       id="rect6469-0"
-       style="fill:#555753;fill-opacity:1;stroke:none;display:inline" />
-    <rect
-       style="opacity:0.35;fill:url(#linearGradient4864);fill-opacity:1;stroke:none"
-       id="rect4100"
-       width="17"
-       height="8"
-       x="5"
-       y="1" />
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient3862-0-7);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.705552;marker:none"
+       id="path3501-0"
+       d="m 1.059,8.976195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z" />
   </g>
+  <path
+     d="m 34,17.207601 h -0.0052 c 0,0.216562 -0.086,0.396542 -0.224278,0.526159 -0.0099,0.0089 -0.01938,0.01922 -0.02869,0.02866 l -9.275321,10.545256 c -0.12148,0.121227 -0.285884,0.192751 -0.466814,0.192751 -0.179638,0 -0.334971,-0.07153 -0.464208,-0.192751 L 14.252961,17.762417 c -0.0093,-0.0095 -0.01886,-0.01978 -0.02868,-0.02866 C 14.085995,17.604144 14,17.424164 14,17.207601 c 0,-0.402379 0.287736,-0.706782 0.675448,-0.706782 h 5.141232 c 0.361863,2.51e-4 0.683208,-0.313566 0.683208,-0.702387 V 3.16285 C 20.499888,2.781633 20.767641,2.5 21.149319,2.5 h 5.681172 c 0.381679,0 0.669017,0.281633 0.669017,0.66285 v 12.700703 c 0.0334,0.356929 0.329915,0.637504 0.670434,0.637266 h 5.162433 C 33.720086,16.500819 34,16.805222 34,17.207601 Z"
+     style="font-variation-settings:normal;fill:url(#linearGradient12770);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;stop-color:#000000"
+     id="path873-5-5" />
+  <path
+     id="rect1007"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 20,17.500427 -4.64,-2e-6 8.64,9.830001 8.64,-9.829999 H 28" />
+  <path
+     id="rect1007-3"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1014);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 28.002626,17.500427 c -0.875611,0 -1.502417,-0.908776 -1.502626,-1.562082 V 3.500001 h -5 v 12.231572 c 0,1.148768 -0.867413,1.768854 -1.4974,1.768854" />
 </svg>

--- a/elementary-xfce/actions/48/document-save.svg
+++ b/elementary-xfce/actions/48/document-save.svg
@@ -1,232 +1,344 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="48"
    height="48"
-   id="svg4000">
+   id="svg6649"
+   sodipodi:docname="document-save.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview31155"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.844039"
+     inkscape:cx="23.260646"
+     inkscape:cy="11.567"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="616"
+     inkscape:window-y="12"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6649" />
   <defs
-     id="defs4002">
+     id="defs6651">
     <linearGradient
-       id="linearGradient4299-652-5">
+       id="linearGradient32335">
       <stop
-         id="stop3618-8"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop32327" />
       <stop
-         id="stop3620-9"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         offset="0.0001"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop32329" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop32331" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop32333" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3029">
+       id="linearGradient1201">
       <stop
-         id="stop3031"
+         id="stop1193"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3033"
+         id="stop1195"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.01487851" />
+         offset="0.06781636" />
       <stop
-         id="stop3035"
+         id="stop1197"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98463625" />
+         offset="0.94694352" />
       <stop
-         id="stop3037"
+         id="stop1199"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3600">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop3602"
-         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3604"
-         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient5060">
+       id="linearGradient3702-501-757">
       <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop5052"
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="38.999996"
+       y1="5.9999938"
+       x2="38.999996"
+       y2="41.945408"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4e-6,1.0000062)" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient1191"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.1428571,0,0,0.6428571,-3.428569,16.035716)" />
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,10.835333,-0.132171)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,-47.889132,1.4881727)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" />
+    <linearGradient
+       id="linearGradient8662-7">
+      <stop
+         id="stop8664-0"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8666-1"
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6-5-76"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,0.89999994,29.98813,4.8500025)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-1-6-9"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,0.89999994,-18.01187,-83.149997)" />
+    <radialGradient
+       gradientTransform="matrix(-0.52995454,0,0,-0.35307735,22.512547,21.835677)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8662-7"
+       id="radialGradient3862-0-7"
+       fy="36.421127"
+       fx="24.837126"
+       r="15.644737"
+       cy="36.421127"
+       cx="24.837126" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177">
+       y2="57.037033"
+       x2="16.135088"
+       y1="57.037033"
+       x1="25.91967"
+       gradientTransform="matrix(0,-1.004639,1,0,-29.962042,44.040338)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient940"
+       xlink:href="#linearGradient1061" />
+    <linearGradient
+       id="linearGradient1061">
       <stop
-         id="stop3750"
-         style="stop-color:#90dbec;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1053" />
       <stop
-         id="stop3752"
-         style="stop-color:#55c1ec;stop-opacity:1"
-         offset="0.26238" />
+         offset="0.00000005"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1055" />
       <stop
-         id="stop3754"
-         style="stop-color:#3689e6;stop-opacity:1"
-         offset="0.704952" />
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1057" />
       <stop
-         id="stop3756"
-         style="stop-color:#2b63a0;stop-opacity:1"
-         offset="1" />
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1059" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3707-319-631-407-324">
+       inkscape:collect="always"
+       xlink:href="#linearGradient899-9"
+       id="linearGradient12770"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1.0002228,-1.0014346,0,64.945034,52.010794)"
+       x1="22.005892"
+       y1="38.389961"
+       x2="47.00029"
+       y2="38.389961" />
+    <linearGradient
+       id="linearGradient899-9">
       <stop
-         id="stop3760"
-         style="stop-color:#185f9a;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#68b723;stop-opacity:1"
+         offset="0"
+         id="stop895-2" />
       <stop
-         id="stop3762"
-         style="stop-color:#599ec9;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#9bdb4d;stop-opacity:1"
+         offset="1"
+         id="stop897-2" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4299-652-5"
-       id="linearGradient3211"
+       xlink:href="#linearGradient32335"
+       id="linearGradient1014"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(8.621297,13.834931)"
-       x1="11.703956"
-       y1="20.16507"
-       x2="11.703956"
-       y2="9.1650686" />
-    <linearGradient
-       xlink:href="#linearGradient3029"
-       id="linearGradient3216"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189189,0,0,1.1351351,2.5945999,-4.7432314)"
-       x1="23.99999"
-       y1="5.5641499"
-       x2="23.99999"
-       y2="42.110645" />
-    <linearGradient
-       xlink:href="#linearGradient3600"
-       id="linearGradient3219"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.9561695,-9.9999999e-8,-1.9149218)"
-       x1="25.132275"
-       y1="0.98520643"
-       x2="25.132275"
-       y2="47.013336" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3222"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02303995,0,0,0.01470022,26.360882,37.040176)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient3225"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.02303994,0,0,0.01470022,21.62311,37.040176)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient5048"
-       id="linearGradient3228"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06732488,0,0,0.01470022,-0.3411391,37.040146)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177"
-       id="linearGradient4005"
-       x1="15.618644"
-       y1="8.0577536"
-       x2="15.618644"
-       y2="35.34322"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324"
-       id="linearGradient4022"
-       x1="30.754238"
-       y1="34.733051"
-       x2="30.754238"
-       y2="13.375976"
-       gradientUnits="userSpaceOnUse" />
+       gradientTransform="matrix(0,-1.004639,1,0,-51.962042,45.040338)"
+       x1="40.854595"
+       y1="75.964668"
+       x2="18.600533"
+       y2="75.964668" />
   </defs>
   <metadata
-     id="metadata4005">
+     id="metadata6654">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <rect
-     style="opacity:0.3;fill:url(#linearGradient3228);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="rect2879"
-     y="42.429947"
-     x="7.7378473"
-     height="3.5700529"
-     width="32.508301" />
+     style="opacity:0.4;fill:url(#radialGradient3013-6-5-76);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect2801-3-7-7-2"
+     y="41.75"
+     x="40"
+     height="4.4999995"
+     width="5" />
+  <rect
+     style="opacity:0.4;fill:url(#radialGradient3015-1-6-9);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect3696-6-3-5-0"
+     transform="scale(-1)"
+     y="-46.25"
+     x="-8"
+     height="4.4999995"
+     width="5" />
+  <rect
+     style="opacity:0.4;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect3700-4-6-9-6"
+     y="41.75"
+     x="8"
+     height="4.5"
+     width="32" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-2-8"
+     y="5.4999952"
+     x="4.5000153"
+     ry="4"
+     rx="4"
+     height="39"
+     width="39" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
+     y="6"
+     x="5"
+     ry="3.5"
+     rx="3.5"
+     height="38"
+     width="38" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2-8-4"
+     y="6.4999952"
+     x="5.5000153"
+     ry="3"
+     rx="3"
+     height="37"
+     width="37" />
+  <g
+     id="layer1"
+     transform="matrix(0.96490176,0,0,2.0818984,14.978169,-0.18752584)"
+     style="stroke-width:0.705552">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.141176;fill:url(#radialGradient3862-0-7);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.705552;marker:none"
+       id="path3501-0"
+       d="m 1.059,8.976195 a 8.2909995,5.5238047 0 1 1 16.581999,0 8.2909995,5.5238047 0 0 1 -16.581999,0 z" />
+  </g>
   <path
-     style="opacity:0.3;fill:url(#radialGradient3225);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2881"
-     d="m 7.7378475,42.430102 c 0,0 0,3.569856 0,3.569856 -1.1865002,0.0067 -2.8683795,-0.799823 -2.8683795,-1.785158 0,-0.985333 1.3240446,-1.784697 2.8683795,-1.784698 z" />
+     d="m 34,17.207601 h -0.0052 c 0,0.216562 -0.086,0.396542 -0.224278,0.526159 -0.0099,0.0089 -0.01938,0.01922 -0.02869,0.02866 l -9.275321,10.545256 c -0.12148,0.121227 -0.285884,0.192751 -0.466814,0.192751 -0.179638,0 -0.334971,-0.07153 -0.464208,-0.192751 L 14.252961,17.762417 c -0.0093,-0.0095 -0.01886,-0.01978 -0.02868,-0.02866 C 14.085995,17.604144 14,17.424164 14,17.207601 c 0,-0.402379 0.287736,-0.706782 0.675448,-0.706782 h 5.141232 c 0.361863,2.51e-4 0.683208,-0.313566 0.683208,-0.702387 V 3.16285 C 20.499888,2.781633 20.767641,2.5 21.149319,2.5 h 5.681172 c 0.381679,0 0.669017,0.281633 0.669017,0.66285 v 12.700703 c 0.0334,0.356929 0.329915,0.637504 0.670434,0.637266 h 5.162433 C 33.720086,16.500819 34,16.805222 34,17.207601 Z"
+     style="font-variation-settings:normal;fill:url(#linearGradient12770);fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;stop-color:#000000"
+     id="path873-5-5"
+     sodipodi:nodetypes="cccccscccsscsssssccsc" />
   <path
-     style="opacity:0.3;fill:url(#radialGradient3222);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-     id="path2883"
-     d="m 40.246148,42.430102 c 0,0 0,3.569856 0,3.569856 1.1865,0.0067 2.86838,-0.799823 2.86838,-1.785158 0,-0.985333 -1.324045,-1.784697 -2.86838,-1.784698 z" />
+     id="rect1007"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient940);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 20,17.500427 -4.64,-2e-6 8.64,9.830001 8.64,-9.829999 H 28"
+     sodipodi:nodetypes="ccccc" />
   <path
-     style="fill:url(#linearGradient3219);fill-opacity:1;stroke:none;display:inline"
-     id="path4160"
-     d="M 6.4999609,0.497199 C 14.520256,0.497199 41.5,0.5 41.5,0.5 l 4.2e-5,44.002803 c 0,0 -23.333387,0 -35.0000811,0 0,-14.668535 0,-29.33707 0,-44.00560407 z" />
-  <path
-     style="fill:none;stroke:url(#linearGradient3216);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect6741-1"
-     d="m 40.5,43.5 -33,0 0,-41.9999998 33,0 z" />
-  <path
-     style="opacity:0.3;fill:none;stroke:#000000;stroke-width:0.99992186;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-     id="path4160-9"
-     d="M 6.4999609,0.497199 C 14.520256,0.497199 41.5,0.5 41.5,0.5 l 4.2e-5,44.002803 c 0,0 -23.333387,0 -35.0000811,0 0,-14.668535 0,-29.33707 0,-44.00560407 z" />
-  <path
-     style="color:#000000;fill:url(#linearGradient4005);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4022);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path3288-2-2"
-     d="M 32,23.5 24.006769,33 16,23.5 l 5.5,0 0,-9 5,0 0,9 z" />
-  <path
-     style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3211);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path3142"
-     d="m 15.805769,22.55307 c -0.805587,0.138962 -1.024295,1.253585 -0.408339,1.746998 2.640884,3.131179 5.272364,6.270671 7.91912,9.396659 0.503249,0.522437 1.330582,0.237778 1.654595,-0.334342 2.610326,-3.106926 5.235188,-6.202465 7.83644,-9.3165 0.485346,-0.67243 -0.178868,-1.657218 -0.979245,-1.51464 z" />
+     id="rect1007-3"
+     style="font-variation-settings:normal;opacity:0.6;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1014);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;stop-color:#000000"
+     d="m 28.002626,17.500427 c -0.875611,0 -1.502417,-0.908776 -1.502626,-1.562082 V 3.500001 h -5 v 12.231572 c 0,1.148768 -0.867413,1.768854 -1.4974,1.768854"
+     sodipodi:nodetypes="ccccsc" />
 </svg>

--- a/elementary-xfce/actions/symbolic/document-save-as-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/document-save-as-symbolic.svg
@@ -3,13 +3,47 @@
    height="16"
    width="16"
    version="1.1"
-   id="svg6"
+   id="svg8"
+   sodipodi:docname="document-save-as-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs10" />
+     id="defs12" />
+  <sodipodi:namedview
+     id="namedview10"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="53.125"
+     inkscape:cx="4.2823529"
+     inkscape:cy="6.0517647"
+     inkscape:window-width="1390"
+     inkscape:window-height="980"
+     inkscape:window-x="579"
+     inkscape:window-y="54"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg8" />
   <path
-     id="rect322"
-     style="opacity:1;fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;-inkscape-stroke:none;stop-color:#000000"
-     d="M 2 0 C 1.4460012 0 1 0.4460011 1 1 L 1 3 C 1 3.5539988 1.4460012 4 2 4 L 2 13 C 2 14.107996 2.8920044 15 4 15 L 12 15 C 13.107996 15 14 14.107996 14 13 L 14 4 C 14.553998 4 15 3.5539988 15 3 L 15 1 C 15 0.4460011 14.553998 0 14 0 L 2 0 z M 2.25 1 L 13.75 1 C 13.8885 1 14 1.1115001 14 1.25 L 14 2.75 C 14 2.8884999 13.8885 3 13.75 3 L 2.25 3 C 2.1115001 3 2 2.8884999 2 2.75 L 2 1.25 C 2 1.1115001 2.1115001 1 2.25 1 z M 3 4 L 13 4 L 13 13 C 13 13.553996 12.553996 14 12 14 L 4 14 C 3.4460024 14 3 13.553996 3 13 L 3 4 z M 7.40625 5 A 0.517 0.517 0 0 0 7 5.5 L 7 8 L 5.5 8 C 5.1310012 8.011 4.8940006 8.5235009 5.125 8.8125 L 7.625 11.8125 A 0.522 0.522 0 0 0 8.375 11.8125 L 10.875 8.8125 C 11.106 8.5235009 10.869 8.011 10.5 8 L 9 8 L 9 5.5 A 0.52 0.52 0 0 0 8.5 5 L 7.5 5 A 0.506 0.506 0 0 0 7.40625 5 z " />
+     id="path2"
+     style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#555761"
+     d="M 3,2 C 2.632629,2.0071412 2.2962906,2.2076077 2.1152344,2.5273438 1.9932346,2.7723432 2,3 2,3 2,3 1.7723432,2.9932346 1.5273438,3.1152344 1.2076077,3.2962906 1.0071412,3.632629 1,4 v 6 H 2 V 4 H 3 V 3 H 5 6 C 5.9932624,2.6330314 5.7935931,2.2967854 5.4746094,2.1152344 5.2296098,1.9932346 5,2 5,2 Z m 7,1 v 1 h 4 v 6 h 1 V 4 C 14.993262,3.6330313 14.793593,3.2967853 14.474609,3.1152344 14.229611,2.9932346 14,3 14,3 Z"
+     sodipodi:nodetypes="cccccccccccccccccccccccc" />
+  <path
+     id="path4"
+     style="line-height:normal;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;text-transform:none;text-orientation:mixed;shape-padding:0;isolation:auto;mix-blend-mode:normal;fill:#555761"
+     d="m 1,8 v 4.5 c 0,0 -0.0102653,0.352658 0.1777344,0.722656 C 1.361734,13.591656 1.8330014,14 2.5,14 h 11 c 0.666998,0 1.138266,-0.408344 1.322266,-0.777344 C 15.007264,12.852658 15,12.5 15,12.5 V 8 h -2.630859 l -2.8828129,3.353516 -0.033203,0.03516 c -0.7858012,0.805068 -2.1204488,0.805068 -2.90625,0 L 6.5136719,11.353516 3.6328125,8 Z"
+     sodipodi:nodetypes="cccsscccccccccc" />
+  <path
+     style="fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;-inkscape-stroke:none;stop-color:#000000"
+     d="m 11.499391,6.5664227 c -0.0026,0.09083 -0.03437,0.1774624 -0.09089,0.2489525 L 8.3796054,10.340547 c -0.207516,0.212604 -0.551225,0.212604 -0.758741,0 L 4.5920094,6.8153752 c -0.232681,-0.2890513 0.0061,-0.803422 0.37937,-0.8154657 h 2.028034 V 1.5018251 c 2.91e-4,-0.030223 0.0026,-0.059279 0.0079,-0.088212 C 7.0447334,1.2110906 7.2021084,1.0454111 7.4103954,1 h 1.083728 c 0.265054,0 0.505828,0.2398722 0.505828,0.501825 V 5.9999097 H 11.02913 c 0.280227,0.00803 0.483412,0.2985388 0.470261,0.566513 z"
+     id="path30069"
+     sodipodi:nodetypes="ccccccccscssccc" />
 </svg>

--- a/elementary-xfce/actions/symbolic/document-save-symbolic.svg
+++ b/elementary-xfce/actions/symbolic/document-save-symbolic.svg
@@ -3,13 +3,42 @@
    height="16"
    width="16"
    version="1.1"
-   id="svg6"
+   id="svg11"
+   sodipodi:docname="document-save-symbolic.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview29948"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="6.9140625"
+     inkscape:cy="5.515625"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="626"
+     inkscape:window-y="13"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg11" />
   <defs
-     id="defs10" />
+     id="defs15" />
   <path
+     style="fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;-inkscape-stroke:none;stop-color:#000000"
+     d="m 11.499722,6.5664229 c -0.0026,0.09083 -0.03437,0.1774624 -0.09089,0.2489525 L 8.379936,10.340547 c -0.2075165,0.212604 -0.5512247,0.212604 -0.7587412,0 L 4.5923397,6.8153754 C 4.3596584,6.5263241 4.5984092,6.0119534 4.9717099,5.9999097 H 6.9997438 V 1.5018253 c 2.908e-4,-0.030223 0.00256,-0.059279 0.0079,-0.088212 0.037422,-0.2025225 0.1947949,-0.368202 0.4030819,-0.4136131 h 1.0837286 c 0.2650533,0 0.5058274,0.2398722 0.5058274,0.501825 v 4.4980847 h 2.0291793 c 0.280227,0.00803 0.483412,0.2985388 0.470261,0.566513 z"
+     id="path30069"
+     sodipodi:nodetypes="ccccccccscssccc" />
+  <path
+     style="fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;-inkscape-stroke:none;stop-color:#000000"
+     d="m 14,12 c 0,1.10799 -0.89201,2 -2,2 H 4 C 2.892009,14 2,13.10799 2,12 V 4 C 2,2.892009 2.892009,2 4,2 H 6 V 3 H 4 C 3.446008,3 3,3.446009 3,4 v 8 c 0,0.553995 0.446008,1 1,1 h 8 c 0.553995,0 1,-0.446005 1,-1 V 4 C 13,3.446007 12.553993,3 12,3 H 10 V 2.000047 L 12,2 c 1.107991,-2.6e-5 2,0.89201 2,2 z"
      id="rect322"
-     style="opacity:1;fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;-inkscape-stroke:none;stop-color:#000000"
-     d="M 4 1 C 2.8920022 1 2 1.8920022 2 3 L 2 13 C 2 14.107998 2.8920022 15 4 15 L 12 15 C 13.107998 15 14 14.107998 14 13 L 14 3 C 14 1.8920022 13.107998 1 12 1 L 4 1 z M 4 2 L 12 2 C 12.553998 2 13 2.4460012 13 3 L 13 13 C 13 13.553998 12.553998 14 12 14 L 4 14 C 3.4460012 14 3 13.553998 3 13 L 3 3 C 3 2.4460012 3.4460012 2 4 2 z M 7.40625 5 A 0.517 0.517 0 0 0 7 5.5 L 7 8 L 5.5 8 C 5.1310004 8.011 4.8940002 8.5235003 5.125 8.8125 L 7.625 11.8125 A 0.522 0.522 0 0 0 8.375 11.8125 L 10.875 8.8125 C 11.106 8.5235003 10.869 8.011 10.5 8 L 9 8 L 9 5.5 A 0.52 0.52 0 0 0 8.5 5 L 7.5 5 A 0.506 0.506 0 0 0 7.40625 5 z " />
+     sodipodi:nodetypes="ssssssccssssssssccsss" />
 </svg>


### PR DESCRIPTION
New `document-save` and `document-save-as` icons from upstream.

"Save" uses new rounded-square "document action" (similar to the new import/export)
"Save as" uses the arrow into folder

Closes #341