### PR TITLE
Apps: New Settings Manager icon

### DIFF
--- a/elementary-xfce/apps/128/preferences-desktop.svg
+++ b/elementary-xfce/apps/128/preferences-desktop.svg
@@ -1,714 +1,371 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   id="svg4434"
+   height="128"
+   width="128"
+   version="1.1"
+   sodipodi:docname="preferences-desktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="128.00006"
-   height="128.00006"
-   id="svg4774"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview65"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="6.484375"
+     inkscape:cx="60.221687"
+     inkscape:cy="64"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4434" />
   <defs
-     id="defs4776">
+     id="defs4436">
     <linearGradient
-       xlink:href="#linearGradient4014"
-       id="linearGradient3266"
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135184,1.488321)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.1081086,0,0,2.5675673,-11.09865,-55.117495)"
-       x1="23.99999"
-       y1="5.5018549"
+       xlink:href="#linearGradient3924"
+       id="linearGradient4136"
+       y2="42.261559"
        x2="23.99999"
-       y2="43" />
+       y1="5.5907431"
+       x1="23.99999" />
     <linearGradient
-       id="linearGradient4014">
+       id="linearGradient3924">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4016" />
+         id="stop3926" />
       <stop
-         offset="0.0312818"
+         offset="0.03750312"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4018" />
+         id="stop3928" />
       <stop
-         offset="0.95292503"
+         offset="0.96667296"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4020" />
+         id="stop3930" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4022" />
+         id="stop3932" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3736-3"
-       id="linearGradient3402"
+       gradientTransform="matrix(2.0808079,0,0,2.3409091,-2.5858604,-7.907281)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2499999,0,0,2.2499971,-35.504102,-2304.5661)"
-       x1="14.666667"
-       y1="1041.3622"
-       x2="1.3333334"
-       y2="1041.3622" />
+       xlink:href="#linearGradient27416-1-2-0"
+       id="linearGradient3913-9"
+       y2="55.052982"
+       x2="30.271185"
+       y1="10.028973"
+       x1="30.271185" />
     <linearGradient
-       id="linearGradient3736-3">
+       id="linearGradient27416-1-2-0">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3738-2" />
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop27420-2-0-8" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3740-0" />
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop27422-3-5-3" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3690-8-5-0"
-       id="linearGradient3405"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3333334,0,0,2.3333301,-36.170775,-2391.3457)"
-       x1="14"
-       y1="1041.3621"
-       x2="2.0000002"
-       y2="1041.3621" />
-    <linearGradient
-       id="linearGradient3690-8-5-0">
+       id="linearGradient4632-92-3-0-8-1-9">
       <stop
          offset="0"
-         style="stop-color:#dcdcdc;stop-opacity:1"
-         id="stop3692-3-0-9" />
-      <stop
-         offset="1"
          style="stop-color:#fafafa;stop-opacity:1"
-         id="stop3694-1-7-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-4"
-       id="linearGradient3408"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2499999,0,0,2.249997,-34.504108,-2304.566)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-4">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3849-8" />
+         id="stop4634-68-8-0-2-9-4" />
       <stop
          offset="1"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         id="stop3851-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2"
-       id="linearGradient3411"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.8823531,0,0,3.0000002,2496.6781,-1244.5031)"
-       x1="-859.51093"
-       y1="425.3956"
-       x2="-860.8562"
-       y2="425.39563" />
-    <linearGradient
-       id="linearGradient7879-6-0-8-22-2">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7881-7-4-4-97-7" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop7883-6-5-2-5-4" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5"
-       id="linearGradient3413"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.8823531,0,0,3.0000002,2499.5603,-1247.503)"
-       x1="-860.51093"
-       y1="426.3956"
-       x2="-878.36401"
-       y2="426.3956" />
-    <linearGradient
-       id="linearGradient7863-2-2-4-4-5">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7865-4-0-2-6-2" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         id="stop7867-7-3-7-3-44" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3"
-       id="linearGradient3416"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.8836713,0,0,2.7377621,-1113.3095,-648.06176)"
-       x1="287.01065"
-       y1="245.27605"
-       x2="295.39691"
-       y2="245.27605" />
-    <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3">
-      <stop
-         offset="0"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         id="stop4753-7-6-9-9-0-7-3" />
-      <stop
-         offset="1"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         id="stop4755-7-7-1-0-5-0-1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3943"
-       id="linearGradient3418"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(3.8836713,0,0,2.7377621,-1113.3095,-648.06176)"
-       x1="281.59253"
-       y1="252.05637"
-       x2="295.22601"
-       y2="252.05637" />
-    <linearGradient
-       id="linearGradient3943">
-      <stop
-         id="stop3945"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3947"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3299-6-1"
-       id="linearGradient3437-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6000719,0,0,2.6217045,1.0942254,-61.660223)"
-       x1="29.772825"
-       y1="45.104366"
-       x2="29.772825"
-       y2="7.000001" />
-    <linearGradient
-       id="linearGradient3299-6-1">
-      <stop
-         offset="0"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         id="stop3301-7-1" />
-      <stop
-         offset="1"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3303-7-5" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3220-7-8"
-       id="linearGradient3439-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4894433,0,0,2.3686331,3.749354,-50.372128)"
-       x1="14.257096"
-       y1="2.982244"
-       x2="14.480406"
-       y2="45.042271" />
-    <linearGradient
-       id="linearGradient3220-7-8">
-      <stop
-         offset="0"
-         style="stop-color:#999999;stop-opacity:1"
-         id="stop3222-1-4" />
-      <stop
-         offset="1"
-         style="stop-color:#808080;stop-opacity:1"
-         id="stop3224-2-8" />
+         style="stop-color:#e1e1e1;stop-opacity:1"
+         id="stop4636-8-21-7-1-4-8" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5060-6-6-5"
-       id="radialGradient3682"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.17489954,0,0,0.06588237,126.67522,20.348436)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       id="linearGradient5060-6-6-5">
+       id="linearGradient3688-166-749-5">
       <stop
-         id="stop5062-3-0-3"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-0" />
       <stop
-         id="stop5064-1-4-9"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-5" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5060-6-6-5"
-       id="radialGradient3685"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.17489954,0,0,0.06588237,0.31667839,20.348436)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       id="linearGradient5048-7-7-5">
-      <stop
-         id="stop5050-5-6-4"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056-9-0-1"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052-6-9-5"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(0.17489954,0,0,0.06588237,0.28225063,20.348436)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4772"
-       xlink:href="#linearGradient5048-7-7-5" />
-    <linearGradient
-       xlink:href="#linearGradient3195-36-9-7"
-       id="linearGradient4375-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-3.7770114,2.1477126,0,-2201.6898,35.582823)"
-       x1="0.32473144"
-       y1="1009.4988"
-       x2="0.32473144"
-       y2="1011.5265" />
-    <linearGradient
-       id="linearGradient3195-36-9-7">
+       id="linearGradient3688-464-309-8">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3197-3-3-1" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-9" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3199-89-7-7" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3195-36-9-7-6"
-       id="linearGradient4375-8-0"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-3.7770114,2.1477126,0,-2201.6898,85.582822)"
-       x1="0.32473144"
-       y1="1009.4988"
-       x2="0.32473144"
-       y2="1011.5265" />
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <linearGradient
-       id="linearGradient3195-36-9-7-6">
+       id="linearGradient3702-501-757-0">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3197-3-3-1-0" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-0" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3199-89-7-7-2" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-6" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3736-3-84"
-       id="linearGradient3402-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2499999,0,0,2.2499971,-13.504102,-2254.5661)"
-       x1="14.666667"
-       y1="1041.3622"
-       x2="1.3333334"
-       y2="1041.3622" />
-    <linearGradient
-       id="linearGradient3736-3-84">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3738-2-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3740-0-1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3690-8-5-0-1"
-       id="linearGradient3405-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3333334,0,0,2.3333301,-14.170775,-2341.3457)"
-       x1="14"
-       y1="1041.3621"
-       x2="2.0000002"
-       y2="1041.3621" />
-    <linearGradient
-       id="linearGradient3690-8-5-0-1">
-      <stop
-         offset="0"
-         style="stop-color:#dcdcdc;stop-opacity:1"
-         id="stop3692-3-0-9-9" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop3694-1-7-8-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-4-0"
-       id="linearGradient3408-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.2499999,0,0,2.249997,70.4959,-2339.566)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-4-0">
+       id="linearGradient3811">
       <stop
          offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         id="stop3849-8-2" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         id="stop3851-4-5" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2-6"
-       id="linearGradient3411-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.8823531,0,0,3.0000002,2496.6781,-1194.5031)"
-       x1="-859.51093"
-       y1="425.3956"
-       x2="-862.56952"
-       y2="425.39526" />
-    <linearGradient
-       id="linearGradient7879-6-0-8-22-2-6">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7881-7-4-4-97-7-9" />
+         id="stop3813" />
       <stop
          offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         id="stop7883-6-5-2-5-4-1" />
+         id="stop3815" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5-7"
-       id="linearGradient3413-98"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.8823531,0,0,3.0000002,2499.5603,-1197.503)"
-       x1="-860.51093"
-       y1="426.3956"
-       x2="-878.36401"
-       y2="426.3956" />
-    <linearGradient
-       id="linearGradient7863-2-2-4-4-5-7">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7865-4-0-2-6-2-65" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         id="stop7867-7-3-7-3-44-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-7">
-      <stop
-         offset="0"
-         style="stop-color:#90dbec;stop-opacity:1;"
-         id="stop3750-1" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#55c1ec;stop-opacity:1;"
-         id="stop3752-0" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#3689e6;stop-opacity:1;"
-         id="stop3754-1" />
-      <stop
-         offset="1"
-         style="stop-color:#2b63a0;stop-opacity:1;"
-         id="stop3756-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3707-319-631-407-324-9"
-       id="linearGradient4228-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-60.450833,10.846159)"
-       x1="27.975796"
-       y1="65.494736"
-       x2="79.895973"
-       y2="65.494736" />
-    <linearGradient
-       id="linearGradient3707-319-631-407-324-9">
-      <stop
-         offset="0"
-         style="stop-color:#185f9a;stop-opacity:1;"
-         id="stop3760-0" />
-      <stop
-         offset="1"
-         style="stop-color:#599ec9;stop-opacity:1;"
-         id="stop3762-7" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3-0">
-      <stop
-         offset="0"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         id="stop4753-7-6-9-9-0-7-3-6" />
-      <stop
-         offset="1"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         id="stop4755-7-7-1-0-5-0-1-4" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3943-0">
-      <stop
-         id="stop3945-2"
-         style="stop-color:#828282;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3947-91"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="245.27605"
-       x2="295.39691"
-       y1="245.27605"
-       x1="287.01065"
-       gradientTransform="matrix(0,3.8836713,2.7377621,0,-597.55767,-1049.8135)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4304"
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3-0" />
-    <linearGradient
-       y2="252.05637"
-       x2="295.22601"
-       y1="252.05637"
-       x1="281.59253"
-       gradientTransform="matrix(0,3.8836713,2.7377621,0,-597.55767,-1049.8135)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4306"
-       xlink:href="#linearGradient3943-0" />
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-7"
-       id="radialGradient4342"
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270355,102.1321)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(6.3749523e-8,2.33699,-2.6211192,0,-14.523475,-1.5886408)"
-       cx="38.735065"
-       cy="-6.0674663"
-       fx="38.735065"
-       fy="-6.0674663"
-       r="19.99999" />
+       xlink:href="#linearGradient3811"
+       id="radialGradient4432"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" />
+    <radialGradient
+       r="27.5"
+       fy="4.3419166"
+       fx="31.999998"
+       cy="4.3419166"
+       cx="31.999998"
+       gradientTransform="matrix(1.8994991e-8,4.3639682,-4.363968,1.8994991e-8,82.947989,-123.94014)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3044"
+       xlink:href="#linearGradient4632-92-3-0-8-1-9" />
+    <linearGradient
+       id="linearGradient4011-9-9-70-61-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4013-5-4-3-8-3" />
+      <stop
+         id="stop4015-1-5-70-9-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.507761" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4017-7-0-13-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4019-1-12-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4215-8-4-07-7">
+      <stop
+         id="stop4217-1-2-1-2"
+         offset="0"
+         style="stop-color:#e9e9e9;stop-opacity:1;" />
+      <stop
+         id="stop4219-3-4-0-96"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(-0.94594587,0,0,0.94594587,149.85603,43.015232)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3882"
+       xlink:href="#linearGradient4011-9-9-70-61-7" />
+    <linearGradient
+       y2="8.0928917"
+       x2="38.976662"
+       y1="59.967686"
+       x1="38.976662"
+       gradientTransform="matrix(-0.70588238,0,0,0.70588238,104.58823,43.00181)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3885"
+       xlink:href="#linearGradient4215-8-4-07-7" />
   </defs>
   <metadata
-     id="metadata4779">
+     id="metadata4439">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4432);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="path3041"
+     d="m 119,118.00181 a 55,6 0 0 1 -109.9999982,0 55,6 0 1 1 109.9999982,0 z" />
   <g
-     id="layer1"
-     transform="translate(0.50409019,63.495964)">
-    <rect
-       style="opacity:0.40206185;fill:url(#linearGradient4772);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2512-9-5"
-       y="44.504089"
-       x="21.270224"
-       height="16.000008"
-       width="84.451477" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3685);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2514-7-4"
-       d="m 105.72168,44.504625 c 0,0 0,15.999123 0,15.999123 9.0069,0.0301 21.77428,-3.58459 21.77428,-8.000592 0,-4.415999 -10.05101,-7.998531 -21.77428,-7.998531 z" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3682);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2516-8-9"
-       d="m 21.27019,44.504625 c 0,0 0,15.999123 0,15.999123 -9.00689,0.03011 -21.77428018,-3.58459 -21.77428018,-8.000592 0,-4.415999 10.05101228,-7.998531 21.77428018,-7.998531 z" />
-    <rect
-       style="color:#000000;fill:url(#linearGradient3437-6);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3439-9);stroke-width:1.00213301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2551-5-8"
-       y="-41.994835"
-       x="4.9970083"
-       ry="3"
-       rx="3"
-       height="96.997864"
-       width="116.99786" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3"
-       d="m 15.495916,-32.494639 a 2.0000009,2.0000009 0 0 1 -4.000001,0 2.0000009,2.0000009 0 1 1 4.000001,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9"
-       d="m 15.495916,-33.495952 a 2.0000009,2.0000009 0 0 1 -4.000001,0 2.0000009,2.0000009 0 1 1 4.000001,0 z" />
-    <rect
-       style="opacity:0.98999999;color:#000000;fill:url(#linearGradient3416);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3418);stroke-width:0.99999964;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-1"
-       transform="matrix(0,1,1,0,0,0)"
-       y="23.995909"
-       x="-18.995903"
-       ry="3"
-       rx="3"
-       height="29"
-       width="51" />
-    <rect
-       style="opacity:0.15;color:#000000;fill:url(#linearGradient3411);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3413);stroke-width:0.99999981999999998;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2392-1"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="24.995911"
-       x="-31.004099"
-       height="27"
-       width="49.000004"
-       ry="2"
-       rx="2" />
-    <rect
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient3408);stroke-width:0.99999964;stroke-opacity:1"
-       id="rect7169-0-3-9-7"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="24.995909"
-       x="-30.004097"
-       ry="2.25"
-       rx="2.2499998"
-       height="27"
-       width="27" />
-    <rect
-       style="fill:url(#linearGradient3405);fill-opacity:1;stroke:none"
-       id="rect7169-0-1-8-9"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="24.495911"
-       x="-31.504097"
-       ry="2"
-       rx="2"
-       height="28"
-       width="28" />
-    <rect
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3402);stroke-width:0.9999997;stroke-opacity:1"
-       id="rect7169-0-3-8"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="24.995909"
-       x="-31.004097"
-       ry="2"
-       rx="2"
-       height="27"
-       width="27" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient3266);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="-40.995903"
-       x="5.9959364"
-       ry="2"
-       rx="2"
-       height="95"
-       width="115.00001" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3-8"
-       d="m 115.49596,-32.494115 a 2.0000008,2.0000008 0 0 1 -4,0 2.0000008,2.0000008 0 1 1 4,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-33"
-       d="m 115.49596,-33.495952 a 2.0000008,2.0000008 0 0 1 -4,0 2.0000008,2.0000008 0 1 1 4,0 z" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3-6"
-       d="m 15.495916,47.505361 a 2.0000009,2.0000009 0 0 1 -4.000001,0 2.0000009,2.0000009 0 1 1 4.000001,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-0"
-       d="m 15.495916,46.504082 a 2.0000009,2.0000009 0 0 1 -4.000001,0 2.0000009,2.0000009 0 1 1 4.000001,0 z" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3-4"
-       d="m 115.49596,47.505885 a 2.0000008,2.0000008 0 0 1 -4,0 2.0000008,2.0000008 0 1 1 4,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-6"
-       d="m 115.49596,46.504082 a 2.0000008,2.0000008 0 0 1 -4,0 2.0000008,2.0000008 0 1 1 4,0 z" />
-    <rect
-       style="opacity:0.59999999999999998;color:#000000;fill:none;stroke:url(#linearGradient4375-8);stroke-width:0.99999963999999997;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-1-7"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="22.995909"
-       x="-33.004097"
-       ry="4"
-       rx="4"
-       height="31"
-       width="53" />
-    <rect
-       style="opacity:0.98999999000000005;color:#000000;fill:url(#radialGradient4342);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4228-7);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-1-4"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="73.995911"
-       x="-32.004097"
-       ry="3"
-       rx="3"
-       height="29"
-       width="51" />
-    <path
-       style="opacity:0.98999999;color:#000000;fill:url(#linearGradient4304);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4306);stroke-width:0.99999964;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 77.5,44.5 c -1.662,0 -3,1.338 -3,3 l 0,24.46875 29,0 0,-24.46875 c 0,-1.662 -1.338,-3 -3,-3 z"
-       transform="translate(-0.50409019,-63.495964)"
-       id="rect7169-1-6" />
-    <rect
-       style="opacity:0.12000002;color:#000000;fill:url(#linearGradient3411-7);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3413-98);stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2392-1-3"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="74.995911"
-       x="-31.004097"
-       height="27"
-       width="49.000004"
-       ry="2"
-       rx="2" />
-    <rect
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient3408-0);stroke-width:0.99999964;stroke-opacity:1"
-       id="rect7169-0-3-9-7-6"
-       transform="scale(1,-1)"
-       y="-10.004097"
-       x="74.995911"
-       ry="2.25"
-       rx="2.2499998"
-       height="27"
-       width="27" />
-    <rect
-       style="fill:url(#linearGradient3405-1);fill-opacity:1;stroke:none"
-       id="rect7169-0-1-8-9-76"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="74.495911"
-       x="-9.504097"
-       ry="2"
-       rx="2"
-       height="28"
-       width="28" />
-    <rect
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3402-2);stroke-width:0.9999997;stroke-opacity:1"
-       id="rect7169-0-3-8-9"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="74.995911"
-       x="-9.004097"
-       ry="2"
-       rx="2"
-       height="27"
-       width="27" />
-    <rect
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4375-8-0);stroke-width:0.99999964;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-1-7-7"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="72.995911"
-       x="-33.004097"
-       ry="4"
-       rx="4"
-       height="31"
-       width="53" />
+     style="display:inline"
+     id="g2036"
+     transform="matrix(2.6999989,0,0,0.55555607,-0.80000812,94.890691)">
+    <g
+       style="opacity:0.4"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3044);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-3"
+     y="16"
+     x="13"
+     ry="9.5"
+     rx="9.5"
+     height="102"
+     width="102" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="rect3979-9"
+     y="49"
+     x="26.999987"
+     ry="19"
+     rx="19"
+     height="38"
+     width="74" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3913-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="rect3979"
+     y="48.001808"
+     x="26.999987"
+     ry="19"
+     rx="19"
+     height="38"
+     width="74" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient4136);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="16.501808"
+     x="13.499988"
+     ry="9"
+     rx="9"
+     height="101"
+     width="101" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.25;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-3-1"
+     y="15.501808"
+     x="12.499988"
+     ry="10"
+     rx="10"
+     height="103"
+     width="103" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:4.51065;marker:none;enable-background:accumulate"
+     id="rect3979-7-6"
+     d="m 46,48.000002 c -10.526,0 -19,8.474 -19,19 0,0.16989 0.02686,0.331206 0.03125,0.5 0.26748,-10.289295 8.61264,-18.5 18.96875,-18.5 h 36 c 10.35611,0 18.70127,8.210705 18.96875,18.5 0.004,-0.168794 0.0312,-0.33011 0.0312,-0.5 0,-10.526 -8.474,-19 -19,-19 h -36 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.07449;marker:none;enable-background:accumulate"
+     id="rect3979-8"
+     d="m 46,49.000002 c -10.35611,0 -18.70127,8.210705 -18.96875,18.5 0.26748,10.289295 8.61264,18.5 18.96875,18.5 h 1 c -10.526,0 -19,-8.028 -19,-18 0,-9.972 8.474,-18 19,-18 h 34 c 10.526,0 19,8.028 19,18 0,9.972 -8.474,18 -19,18 h 1 c 10.35611,0 18.70127,-8.210705 18.96875,-18.5 -0.26748,-10.289295 -8.61264,-18.5 -18.96875,-18.5 z" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;marker:none;enable-background:accumulate"
+     id="rect3979-5"
+     y="48.5"
+     x="27.5"
+     ry="18.5"
+     rx="18.743244"
+     height="37"
+     width="73" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4-9-1"
+     d="m 82,47.999998 c 11.03531,0 20,8.964687 20,20.000005 0,11.035313 -8.96469,19.999999 -20,19.999999 -11.03531,0 -20.00002,-8.964686 -20,-19.999999 0,-11.035318 8.96469,-20.000005 20,-20.000005 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4-9"
+     d="m 82,49 c 10.483546,0 19,8.516451 19,19.000002 C 101,78.483549 92.483546,87 82,87 71.516444,87 62.999979,78.483549 63,68.000002 63,57.516451 71.516444,49 82,49 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3885);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4"
+     d="m 82,49.00181 c 9.93178,0 18,8.068217 18,18.000002 0,9.931781 -8.06822,17.999998 -18,17.999998 -9.93179,0 -18.00002,-8.068217 -18,-17.999998 0,-9.931785 8.06821,-18.000002 18,-18.000002 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3882);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6-0-5-2"
+     d="m 64.5,67.001184 c 0,9.665309 7.8356,17.500627 17.49979,17.500627 C 91.66485,84.501811 99.5,76.666398 99.5,67.001184 99.5,57.336338 91.66485,49.50181 81.99979,49.50181 72.3356,49.50181 64.5,57.336338 64.5,67.001184 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#656565;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-9-41"
+     d="m 82,48.501811 c 10.20766,0 18.5,8.292334 18.5,18.500001 0,10.207663 -8.29234,18.499997 -18.5,18.499997 -10.20767,0 -18.50002,-8.292334 -18.5,-18.499997 0,-10.207667 8.29233,-18.500001 18.5,-18.500001 z" />
 </svg>

--- a/elementary-xfce/apps/16/preferences-desktop.svg
+++ b/elementary-xfce/apps/16/preferences-desktop.svg
@@ -1,317 +1,218 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.0"
-   width="16"
+   id="svg4715"
    height="16"
-   id="svg2">
+   width="16"
+   version="1.1"
+   sodipodi:docname="preferences-desktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview58"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="17.036854"
+     inkscape:cy="10.297242"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="581"
+     inkscape:window-y="22"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4715" />
+  <defs
+     id="defs4717">
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.04026115"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.95833331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.35135142,0,0,0.35135135,-0.43243132,-0.43242855)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="40.988411"
+       x2="23.999996"
+       y1="6.9856377"
+       x1="23.999996" />
+    <linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="32.022377"
+       x2="14.329722"
+       y2="-0.070297658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53846152,0,0,0.53846152,-0.61538459,-16.615385)" />
+    <linearGradient
+       id="linearGradient4011-2-96">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013-5-8" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-3-48" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-7-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4215-8-4-07-7">
+      <stop
+         id="stop4217-1-2-1-2"
+         offset="0"
+         style="stop-color:#e9e9e9;stop-opacity:1;" />
+      <stop
+         id="stop4219-3-4-0-96"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient27416-1-2">
+      <stop
+         id="stop27420-2-0"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop27422-3-5"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient27416-1-2"
+       id="linearGradient3884-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.31249724,0,0,0.37500001,-1.8748615,-4.0000005)"
+       x1="30.271185"
+       y1="10.028973"
+       x2="30.271185"
+       y2="55.052982" />
+    <linearGradient
+       xlink:href="#linearGradient4215-8-4-07-7"
+       id="linearGradient3869-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.10784313,0,0,0.10784315,14.20098,4.3333337)"
+       x1="38.976662"
+       y1="59.967686"
+       x2="38.976662"
+       y2="8.0928917" />
+    <linearGradient
+       xlink:href="#linearGradient4011-2-96"
+       id="linearGradient3866-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.09459464,0,0,0.0945947,17.535608,5.6013406)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+  </defs>
   <metadata
-     id="metadata28">
+     id="metadata4720">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <defs
-     id="defs4">
-    <linearGradient
-       id="linearGradient48779">
-      <stop
-         id="stop48781"
-         style="stop-color:#000000;stop-opacity:0.28627452;"
-         offset="0" />
-      <stop
-         id="stop48783"
-         style="stop-color:#000000;stop-opacity:0.34117648;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3299">
-      <stop
-         id="stop3301"
-         style="stop-color:#d2d2d2;stop-opacity:1;"
-         offset="0" />
-      <stop
-         id="stop3303"
-         style="stop-color:#f4f4f4;stop-opacity:1;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2238">
-      <stop
-         id="stop2240"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2242"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2238"
-       id="linearGradient3011"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46836271,0,0,0.41078564,-7.2887271,-2.9633161)"
-       x1="24.675762"
-       y1="8.5323372"
-       x2="24.675762"
-       y2="46.698467" />
-    <linearGradient
-       xlink:href="#linearGradient3299"
-       id="linearGradient3014"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48747042,0,0,0.4386755,-7.2149386,-4.0151248)"
-       x1="17.839369"
-       y1="43.790993"
-       x2="17.839369"
-       y2="13.142832" />
-    <linearGradient
-       xlink:href="#linearGradient48779"
-       id="linearGradient3016"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.48747042,0,0,0.4386755,-7.2149386,-4.0151248)"
-       x1="27.9825"
-       y1="9.6787424"
-       x2="27.9825"
-       y2="45.060455" />
-    <linearGradient
-       id="linearGradient3736-0-0-0-3">
-      <stop
-         id="stop3738-4-4-0-3"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3740-1-7-8-9"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4489-3-1-3-5-4-6-8-8-8">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4491-8-7-9-3-7-4-0-2-1" />
-      <stop
-         style="stop-color:#dadada;stop-opacity:1;"
-         offset="1"
-         id="stop4493-2-9-6-5-0-0-2-3-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4467-7-2-5-1-9-4-0-5-1">
-      <stop
-         style="stop-color:#aaaaaa;stop-opacity:1;"
-         offset="0"
-         id="stop4469-0-8-1-0-1-6-5-0-5" />
-      <stop
-         style="stop-color:#828282;stop-opacity:1;"
-         offset="1"
-         id="stop4471-8-9-8-0-6-2-1-5-8" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         offset="0"
-         style="stop-color:#66a7ee;stop-opacity:1"
-         id="stop4219" />
-      <stop
-         offset="1"
-         style="stop-color:#3da3e7;stop-opacity:1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3">
-      <stop
-         id="stop4753-7-6-9-9-0-7-3"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4755-7-7-1-0-5-0-1"
-         style="stop-color:#999999;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4021"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53304288,0,0,0.37760993,-161.69702,-89.739733)"
-       x1="284.21002"
-       y1="272.90118"
-       x2="284.21002"
-       y2="263.41644" />
-    <linearGradient
-       xlink:href="#linearGradient4489-3-1-3-5-4-6-8-8-8"
-       id="linearGradient4023"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02788949,0,0,0.17391811,-27.337518,-2.0062162)"
-       x1="344.09509"
-       y1="33.790791"
-       x2="344.09158"
-       y2="57.790791" />
-    <linearGradient
-       xlink:href="#linearGradient4467-7-2-5-1-9-4-0-5-1"
-       id="linearGradient4025"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02788949,0,0,0.17391811,-27.337518,-2.0062162)"
-       x1="251.21625"
-       y1="33.865498"
-       x2="251.21625"
-       y2="57.940205" />
-    <linearGradient
-       xlink:href="#linearGradient3736-0-0-0-3"
-       id="linearGradient4027"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.225,0,0,0.2249997,-7.7508472,-253.3419)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       xlink:href="#linearGradient4489-3-1-3-5-4-6-8-8-8"
-       id="linearGradient4051"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02788949,0,0,0.17391811,-27.337518,-2.0062162)"
-       x1="344.09509"
-       y1="33.790791"
-       x2="344.09158"
-       y2="57.790791" />
-    <linearGradient
-       xlink:href="#linearGradient4467-7-2-5-1-9-4-0-5-1"
-       id="linearGradient4053"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.02788949,0,0,0.17391811,-27.337518,-2.0062162)"
-       x1="251.21625"
-       y1="33.865498"
-       x2="251.21625"
-       y2="57.940205" />
-    <linearGradient
-       xlink:href="#linearGradient3736-0-0-0-3"
-       id="linearGradient4055"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.225,0,0,0.2249997,-7.7508472,-253.3419)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3"
-       id="linearGradient4082"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.53304288,0,0,0.37760993,-161.69703,-96.739732)"
-       x1="284.21002"
-       y1="272.90118"
-       x2="284.21002"
-       y2="263.41644" />
-  </defs>
   <rect
-     style="fill:url(#linearGradient3014);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3016);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect1316"
-     y="0.58842534"
-     x="0.49964085"
-     ry="0.69701332"
-     rx="0.73430365"
-     height="15.000168"
-     width="15.000168" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect5505"
+     y="-14.999999"
+     x="1"
+     ry="2"
+     rx="2"
+     height="14"
+     width="14"
+     transform="scale(1,-1)" />
   <rect
-     transform="matrix(0,-1,1,0,0,0)"
-     width="6.9998689"
-     height="3.9998689"
-     rx="0.55262113"
-     ry="0.5454365"
-     x="-11.499934"
-     y="2.5000656"
-     id="rect4080"
-     style="color:#000000;fill:url(#linearGradient4082);fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:1.00013125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#555761;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6-6"
+     y="0.49999952"
+     x="0.49999952"
+     ry="2.5"
+     rx="2.5"
+     height="15.000001"
+     width="15.000001" />
   <rect
-     style="opacity:0.4;fill:none;stroke:url(#linearGradient3011);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect2232"
-     y="1.5001154"
-     x="1.5001159"
-     ry="0"
-     rx="0"
-     height="12.999769"
-     width="12.999768" />
-  <rect
-     style="color:#000000;fill:url(#linearGradient4021);fill-opacity:1;fill-rule:nonzero;stroke:#3a7dc3;stroke-width:1.00013125;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect7169-9-6-9"
-     y="9.5000658"
-     x="-11.499934"
-     ry="0.5454365"
-     rx="0.55262113"
-     height="3.9998689"
-     width="6.9998689"
-     transform="matrix(0,-1,1,0,0,0)" />
-  <g
-     id="g3999"
-     transform="translate(-7.525424,0.54237294)">
-    <rect
-       transform="scale(-1,1)"
-       style="color:#000000;fill:url(#linearGradient4023);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4025);stroke-width:0.99988365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect6132-8-2-8-0-0-0-10-2-4"
-       width="4.0001163"
-       height="4.0001163"
-       x="-21.025482"
-       y="3.9575689"
-       rx="0.72729379"
-       ry="0.72729391" />
-    <rect
-       transform="matrix(0,-1,-1,0,0,0)"
-       width="2.7"
-       height="2.7"
-       rx="0.29999998"
-       ry="0.29999998"
-       x="-7.3008461"
-       y="-20.385733"
-       id="rect7169-0-3-3-3-8-4"
-       style="fill:none;stroke:url(#linearGradient4027);stroke-width:0.29999998;stroke-opacity:1" />
-  </g>
-  <g
-     transform="translate(-14.525424,3.5214479)"
-     id="g4045">
-    <rect
-       ry="0.72729391"
-       rx="0.72729379"
-       y="3.9575689"
-       x="-21.025482"
-       height="4.0001163"
-       width="4.0001163"
-       id="rect4047"
-       style="color:#000000;fill:url(#linearGradient4051);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4053);stroke-width:0.99988365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       transform="scale(-1,1)" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient4055);stroke-width:0.29999998;stroke-opacity:1"
-       id="rect4049"
-       y="-20.385733"
-       x="-7.3008461"
-       ry="0.29999998"
-       rx="0.29999998"
-       height="2.7"
-       width="2.7"
-       transform="matrix(0,-1,-1,0,0,0)" />
-  </g>
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="1.5"
+     x="1.5"
+     ry="1.5"
+     rx="1.5"
+     height="13"
+     width="13.000002" />
   <path
-     style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path4356-9"
-     d="m 3,13.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3884-3);fill-opacity:1;stroke:none;stroke-width:1.55555;marker:none;enable-background:accumulate"
+     id="rect13708-0"
+     d="M 5.3125745,5 C 3.7544637,5 2.5001001,6.338 2.5001001,7.9999998 2.5001001,9.6619994 3.7544637,11 5.3125745,11 H 10.937526 C 12.495638,11 13.75,9.6620003 13.75,7.9999998 13.75,6.338 12.495638,5 10.937526,5 Z" />
   <path
-     d="m 14,13.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z"
-     id="path4066"
-     style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:1.55555;marker:none;enable-background:accumulate"
+     d="M 5.312484,5 C 3.7543731,5 2.5000001,6.3380081 2.5000001,8.0000079 c 0,0.1468916 0.020296,0.2874437 0.039237,0.4285728 C 2.7345978,6.9729025 3.892083,5.8571454 5.3124846,5.8571454 h 5.6249664 c 1.420403,0 2.577887,1.1157571 2.773249,2.5714353 C 13.72963,8.2874516 13.74995,8.1468995 13.74995,8.0000079 13.749936,6.3380081 12.495565,5 10.937453,5 H 5.3124854 Z"
+     id="path5598" />
   <path
-     style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="path4068"
-     d="m 14,2.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z" />
+     d="m 10.75,5.25 c 1.793237,0 3.25,1.4567573 3.25,3.2499975 0,1.7932365 -1.456763,3.2499975 -3.25,3.2499975 -1.7932407,0 -3.2500028,-1.456761 -3.25,-3.2499975 C 7.5,6.7067572 8.9567593,5.25 10.75,5.25 Z"
+     id="path2555-7-1-9-4-9-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate" />
   <path
-     d="m 3,2.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z"
-     id="path4070"
-     style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+     d="m 10.75,5.25 c 1.517354,0 2.75,1.2326447 2.75,2.7499994 C 13.5,9.5173565 12.267354,10.75 10.75,10.75 9.2326435,10.75 7.9999974,9.5173565 8,7.9999994 8,6.4826447 9.2326435,5.25 10.75,5.25 Z"
+     id="path2555-7-1-9-4-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3869-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.777775;marker:none;enable-background:accumulate" />
+  <path
+     d="m 8.999999,7.9999382 c 0,0.9665323 0.7835617,1.7500656 1.749981,1.7500656 0.966506,0 1.750021,-0.7835431 1.750021,-1.7500656 0,-0.966485 -0.783515,-1.7499392 -1.750021,-1.7499392 -0.9664193,0 -1.749981,0.7834542 -1.749981,1.7499392 z"
+     id="path8655-6-0-5-2-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3866-6);stroke-width:0.999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="M 10.750001,5.25 C 12.267357,5.25 13.5,6.4826443 13.5,8.0000004 13.5,9.5173574 12.267357,10.75 10.750001,10.75 9.2326436,10.75 7.9999974,9.5173574 8,8.0000004 8,6.4826443 9.2326436,5.25 10.750001,5.25 Z"
+     id="path2555-7-1-9-9-41-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/apps/24/preferences-desktop.svg
+++ b/elementary-xfce/apps/24/preferences-desktop.svg
@@ -1,552 +1,315 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="24"
+   id="svg4157"
    height="24"
-   id="svg2"
-   version="1.0">
+   width="24"
+   version="1.1"
+   sodipodi:docname="preferences-desktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview57"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="256"
+     inkscape:cx="12.59375"
+     inkscape:cy="3.0917969"
+     inkscape:window-width="1275"
+     inkscape:window-height="948"
+     inkscape:window-x="404"
+     inkscape:window-y="5"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" />
   <defs
-     id="defs4">
+     id="defs4159">
     <linearGradient
-       id="linearGradient4031">
+       gradientTransform="matrix(0.51351354,0,0,0.51351354,-0.3230746,-0.32558956)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.501347"
+       x2="23.99999"
+       y1="6.5143332"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4033" />
+         id="stop4097" />
       <stop
-         offset="0.87921792"
+         offset="0.0001"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4035" />
+         id="stop4100" />
       <stop
-         offset="0.87921792"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4037" />
+         id="stop4102" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4039" />
+         id="stop4104" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient2646"
+       gradientTransform="matrix(2.003784,0,0,1.4,24.533118,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.969706,112.7623,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       id="linearGradient5060">
+       id="linearGradient3688-166-749-9">
       <stop
-         style="stop-color:black;stop-opacity:1;"
-         id="stop5062"
-         offset="0" />
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" />
       <stop
-         style="stop-color:black;stop-opacity:0;"
-         id="stop5064"
-         offset="1" />
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient5060"
-       id="radialGradient2644"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1891.633,-872.8854)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
+       xlink:href="#linearGradient3688-464-309-7-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
     <linearGradient
-       id="linearGradient5048">
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         id="stop5050"
-         offset="0" />
-      <stop
-         style="stop-color:black;stop-opacity:1;"
-         id="stop5056"
-         offset="0.5" />
-      <stop
-         style="stop-color:black;stop-opacity:0;"
-         id="stop5052"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient5048"
-       id="linearGradient2642"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.969706,-1892.179,-872.8854)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <linearGradient
-       xlink:href="#linearGradient3220-7-2"
-       id="linearGradient2436"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.489342,0,0,0.4394995,0.255801,1.9466225)"
-       x1="27.9825"
-       y1="2.5127616"
-       x2="27.9825"
-       y2="45.593712" />
-    <linearGradient
-       xlink:href="#linearGradient3299-6"
-       id="linearGradient2434"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.489342,0,0,0.4394995,0.255801,1.9466225)"
-       x1="17.839369"
-       y1="43.009785"
-       x2="17.839369"
-       y2="4.7218285" />
-    <linearGradient
-       id="linearGradient3220-7-2">
-      <stop
-         id="stop3222-1-8"
-         style="stop-color:#000000;stop-opacity:0.28682169;"
-         offset="0" />
-      <stop
-         id="stop3224-2-3"
-         style="stop-color:#000000;stop-opacity:0.34108528;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4467-7-2-5-1-9-4-0-5-1">
-      <stop
-         style="stop-color:#aaaaaa;stop-opacity:1;"
-         offset="0"
-         id="stop4469-0-8-1-0-1-6-5-0-5" />
-      <stop
-         style="stop-color:#828282;stop-opacity:1;"
-         offset="1"
-         id="stop4471-8-9-8-0-6-2-1-5-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-7-25-2-2"
-       id="linearGradient4677"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5347222,0,0,0.53472151,-20.777774,-545.8387)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-7-25-2-2">
-      <stop
-         id="stop3849-7-9-6-4"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3851-8-3-8-5"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3736-0-0-0"
-       id="linearGradient4680"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.525,0,0,0.5249993,-18.2,-554.21437)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       id="linearGradient3736-0-0-0">
-      <stop
-         id="stop3738-4-4-0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3740-1-7-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
+       id="linearGradient3688-464-309-7-6">
       <stop
          offset="0"
-         style="stop-color:#66a7ee;stop-opacity:1"
-         id="stop4219" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-75" />
       <stop
          offset="1"
-         style="stop-color:#3da3e7;stop-opacity:1"
-         id="stop4221" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4-9" />
     </linearGradient>
     <linearGradient
-       id="linearGradient7879-6-0-8-22-2-0-5">
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096"
+       gradientTransform="matrix(0.87665225,0,0,1,1.2334775,0)" />
+    <linearGradient
+       id="linearGradient3702-501-757-1">
       <stop
-         id="stop7881-7-4-4-97-7-5-7"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" />
       <stop
-         id="stop7883-6-5-2-5-4-7-0"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" />
     </linearGradient>
     <linearGradient
-       id="linearGradient7863-2-2-4-4-5-4-7">
+       id="linearGradient4011-2-96">
       <stop
-         id="stop7865-4-0-2-6-2-3-8"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7867-7-3-7-3-44-5-9"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3">
-      <stop
-         id="stop4753-7-6-9-9-0-7-3"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4755-7-7-1-0-5-0-1"
-         style="stop-color:#999999;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3195-36-9">
-      <stop
-         id="stop3197-3-3"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4013-5-8" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-3-48" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-7-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-6-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3199-89-7"
-         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3299-6">
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="32.022377"
+       x2="14.329722"
+       y2="-0.070297658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.76923076,0,0,0.76923076,-0.30769093,-24.307667)" />
+    <linearGradient
+       xlink:href="#linearGradient4011-2-96"
+       id="linearGradient3866"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.12612572,0,0,0.12612572,24.549488,9.2956328)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       xlink:href="#linearGradient4215-8-4-07-7"
+       id="linearGradient3869"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.12200399,0,0,0.12200399,19.406172,8.3456976)"
+       x1="38.976662"
+       y1="59.967686"
+       x2="38.976662"
+       y2="8.0928917" />
+    <linearGradient
+       id="linearGradient4215-8-4-07-7">
       <stop
-         id="stop3301-7"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="0" />
+         style="stop-color:#e9e9e9;stop-opacity:1;"
+         offset="0"
+         id="stop4217-1-2-1-2" />
       <stop
-         id="stop3303-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="1" />
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="1"
+         id="stop4219-3-4-0-96" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4031"
-       id="linearGradient4029"
+       xlink:href="#linearGradient27416-1-2"
+       id="linearGradient3884"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.46625799,0,0,0.40988166,0.80923981,3.0751707)"
-       x1="24.675762"
-       y1="4.1577182"
-       x2="24.675762"
-       y2="46.698467" />
+       gradientTransform="matrix(0.38888771,0,0,0.4374987,-0.4444278,-1.4999692)"
+       x1="30.271185"
+       y1="10.028973"
+       x2="30.271185"
+       y2="55.052982" />
     <linearGradient
-       xlink:href="#linearGradient4467-7-2-5-1-9-4-0-5-1"
-       id="linearGradient4048"
-       x1="4.9862275"
-       y1="8.5137711"
-       x2="4.9862275"
-       y2="12.725124"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5013531,0,0,1.5013296,8.2426056,-5.2639607)" />
-    <linearGradient
-       xlink:href="#linearGradient4467-7-2-5-1-9-4-0-5-1"
-       id="linearGradient4054"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5013531,0,0,1.5013296,-0.7573948,-1.2639609)"
-       x1="4.9862275"
-       y1="8.5137711"
-       x2="4.9862275"
-       y2="12.725124" />
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2-0-5"
-       id="linearGradient4061"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60852987,0,0,0.70500089,540.97831,-285.00512)"
-       x1="-862.41229"
-       y1="422.78278"
-       x2="-862.41229"
-       y2="425.51978" />
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5-4-7"
-       id="linearGradient4063"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60852987,0,0,0.70500089,541.58685,-285.71012)"
-       x1="-863.41229"
-       y1="423.78278"
-       x2="-863.41229"
-       y2="433.54517" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4074"
-       x1="5.2340794"
-       y1="39.250431"
-       x2="12.234172"
-       y2="39.250431"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95820191,0,0,1.625876,8.1309914,-51.316333)" />
-    <linearGradient
-       xlink:href="#linearGradient3195-36-9"
-       id="linearGradient4080"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60582653,0,0,0.81100567,539.73643,-331.1508)"
-       x1="-860.34033"
-       y1="428.25739"
-       x2="-868.03339"
-       y2="428.25739" />
-    <linearGradient
-       xlink:href="#linearGradient3195-36-9"
-       id="linearGradient4096"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60582653,0,0,0.81100567,539.73643,-340.1508)"
-       x1="-860.34033"
-       y1="428.25739"
-       x2="-868.03339"
-       y2="428.25739" />
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2-0-5"
-       id="linearGradient4100"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60852987,0,0,0.70500089,540.97831,-294.00512)"
-       x1="-862.41229"
-       y1="422.78278"
-       x2="-862.41229"
-       y2="425.51978" />
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5-4-7"
-       id="linearGradient4102"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.60852987,0,0,0.70500089,541.58685,-294.71012)"
-       x1="-863.41229"
-       y1="423.78278"
-       x2="-863.41229"
-       y2="433.54517" />
-    <linearGradient
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3"
-       id="linearGradient4106"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.95820191,0,0,1.625876,-0.8690091,-51.316332)"
-       x1="11.819606"
-       y1="40.831371"
-       x2="5.1620283"
-       y2="40.831371" />
-    <linearGradient
-       xlink:href="#linearGradient3847-7-25-2-2"
-       id="linearGradient4129"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5347222,0,0,0.53472151,-11.777772,-542.8387)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
+       id="linearGradient27416-1-2">
+      <stop
+         offset="0"
+         style="stop-color:#64baff;stop-opacity:1"
+         id="stop27420-2-0" />
+      <stop
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop27422-3-5" />
+    </linearGradient>
   </defs>
   <metadata
-     id="metadata7">
+     id="metadata4162">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <g
-       transform="matrix(1.1820155e-2,0,0,1.0012672e-2,22.513266,19.719245)"
-       id="g2544">
-      <rect
-         id="rect2546"
-         x="-1559.2523"
-         y="-150.69685"
-         width="1339.6335"
-         height="478.35718"
-         style="opacity:0.40206185;fill:url(#linearGradient2642);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
-      <path
-         d="M -219.61876,-150.68038 C -219.61876,-150.68038 -219.61876,327.65041 -219.61876,327.65041 C -76.744594,328.55086 125.78146,220.48075 125.78138,88.454235 C 125.78138,-43.572302 -33.655436,-150.68036 -219.61876,-150.68038 z"
-         id="path2548"
-         style="opacity:0.40206185;fill:url(#radialGradient2644);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
-      <path
-         id="path2550"
-         d="M -1559.2523,-150.68038 C -1559.2523,-150.68038 -1559.2523,327.65041 -1559.2523,327.65041 C -1702.1265,328.55086 -1904.6525,220.48075 -1904.6525,88.454235 C -1904.6525,-43.572302 -1745.2157,-150.68036 -1559.2523,-150.68038 z"
-         style="opacity:0.40206185;fill:url(#radialGradient2646);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;visibility:visible;display:inline;overflow:visible" />
-    </g>
+     transform="matrix(0.5789476,0,0,0.42857134,-0.894738,3.8571464)"
+     id="g3712-8"
+     style="opacity:0.3">
     <rect
-       id="rect1316"
-       x="0.50106728"
-       y="3.5010667"
-       width="22.997868"
-       height="17.997868"
-       ry="0.69832265"
-       rx="0.73712295"
-       style="fill:url(#linearGradient2434);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2436);stroke-width:1.00213301000000010;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+       width="5"
+       height="7"
+       x="34.544987"
+       y="40"
+       id="rect2801-6"
+       style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
     <rect
-       ry="0.40550283"
-       rx="0.30291328"
-       width="10.299052"
-       height="7.2990518"
-       x="7.8504734"
-       y="12.850474"
-       transform="matrix(0,1,1,0,0,0)"
-       id="rect4076"
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4080);stroke-width:0.70094848;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3696-20"
+       style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
     <rect
-       ry="0"
-       rx="0"
-       y="7.6297364"
-       x="13.629737"
-       height="9.7405272"
-       width="5.7406197"
-       id="rect4056"
-       style="fill:url(#linearGradient4074);fill-opacity:1;fill-rule:nonzero;stroke:#3a7dc3;stroke-width:1.25947297;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:6.4000001;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="opacity:0.12000002;color:#000000;fill:url(#linearGradient4061);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4063);stroke-width:0.65499169;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2392-1-3-2"
-       transform="matrix(0,1,1,0,0,0)"
-       y="13.327496"
-       x="7.3274951"
-       height="6.3450084"
-       width="10.345009"
-       rx="0.30426496"
-       ry="0.35250044" />
-    <rect
-       id="rect2232"
-       x="1.5000557"
-       y="4.5000558"
-       width="20.999889"
-       height="15.999888"
-       ry="0"
-       rx="0"
-       style="opacity:0.40000000000000002;fill:none;stroke:url(#linearGradient4029);stroke-width:1.00011133999999990;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <rect
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient4677);stroke-width:0.58333325;stroke-opacity:1"
-       id="rect7169-0-3-9-9-7-5-5"
-       y="7.791667"
-       x="-19.708334"
-       ry="0.875"
-       rx="0.875"
-       height="6.4166665"
-       width="6.4166665"
-       transform="scale(-1,1)" />
-    <rect
-       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4048);stroke-width:1.00905919;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:6.4000001;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect24246"
-       width="5.9910336"
-       height="5.990941"
-       x="13.50453"
-       y="7.5045295"
-       rx="0"
-       ry="0" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.00011444;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:6.4000001;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect24252"
-       width="3.999948"
-       height="3.9998856"
-       x="14.500057"
-       y="8.5000572"
-       rx="0"
-       ry="0" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33800000000000002;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.59"
-       id="path4356-7-9"
-       d="M 3,6 A 0.5,0.5 0 0 1 2,6 0.5,0.5 0 1 1 3,6 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9"
-       d="m 3,5.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z" />
-    <path
-       d="m 22,6 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z"
-       id="path4023"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.6" />
-    <path
-       d="m 22,5.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z"
-       id="path3249"
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.6"
-       id="path4025"
-       d="m 22,20 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path3251"
-       d="m 22,19.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z" />
-    <path
-       d="m 3,20 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z"
-       id="path4027"
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979000000000;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.6" />
-    <path
-       d="m 3,19.5 a 0.5,0.5 0 0 1 -1,0 0.5,0.5 0 1 1 1,0 z"
-       id="path3253"
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       style="opacity:0.6;fill:none;stroke:url(#linearGradient4680);stroke-width:0.69999993;stroke-opacity:1"
-       id="rect7169-0-3-3-3-8"
-       y="-10.650001"
-       x="-17.15"
-       ry="0.69999999"
-       rx="0.69999999"
-       height="6.3000002"
-       width="6.2999997"
-       transform="matrix(0,-1,-1,0,0,0)" />
-    <rect
-       style="fill:url(#linearGradient4106);fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:1.25947297;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:6.4000001;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect4104"
-       width="5.7406197"
-       height="9.7405272"
-       x="4.6297364"
-       y="7.6297364"
-       rx="0"
-       ry="0" />
-    <rect
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4096);stroke-width:0.70094848;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect4094"
-       transform="matrix(0,1,1,0,0,0)"
-       y="3.8504744"
-       x="7.8504734"
-       height="7.2990518"
-       width="10.299052"
-       rx="0.30291328"
-       ry="0.40550283" />
-    <rect
-       ry="0.35250044"
-       rx="0.30426496"
-       width="10.345009"
-       height="6.3450084"
-       x="7.3274951"
-       y="4.3274961"
-       transform="matrix(0,1,1,0,0,0)"
-       id="rect4098"
-       style="opacity:0.12000002;color:#000000;fill:url(#linearGradient4100);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4102);stroke-width:0.65499169;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       transform="scale(-1,1)"
-       width="6.4166665"
-       height="6.4166665"
-       rx="0.875"
-       ry="0.875"
-       x="-10.708333"
-       y="10.791667"
-       id="rect4127"
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient4129);stroke-width:0.58333325;stroke-opacity:1" />
-    <rect
-       ry="0"
-       rx="0"
-       y="11.504529"
-       x="4.5045295"
-       height="5.990941"
-       width="5.9910336"
-       id="rect4050"
-       style="fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4054);stroke-width:1.00905919;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:6.4000001;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       ry="0"
-       rx="0"
-       y="12.500056"
-       x="5.5000567"
-       height="3.9998856"
-       width="3.999948"
-       id="rect4052"
-       style="fill:none;stroke:#ffffff;stroke-width:1.00011444;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:6.4000001;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
+       width="24.546263"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-5"
+       style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none;stroke-width:1" />
   </g>
+  <rect
+     transform="scale(1,-1)"
+     width="20"
+     height="20"
+     rx="2.5"
+     ry="2.5"
+     x="2.0000021"
+     y="-21.999975"
+     id="rect5505"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="21"
+     height="21"
+     rx="3"
+     ry="3"
+     x="1.5"
+     y="1.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="19"
+     height="19"
+     x="2.5012479"
+     y="2.4987311"
+     id="rect6741-9"
+     style="opacity:1;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="2"
+     ry="2" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.55555081;marker:none;enable-background:accumulate"
+     id="rect13708-6"
+     d="m 8.5452698,8.9938381 c -1.9150596,0 -3.4567864,1.5417259 -3.4567864,3.4567849 0,1.91506 1.5417268,3.456788 3.4567864,3.456788 h 6.9135732 c 1.915061,0 3.456787,-1.541728 3.456787,-3.456788 0,-1.915059 -1.541726,-3.4567849 -3.456787,-3.4567849 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3884);fill-opacity:1;stroke:none;stroke-width:1.55555;marker:none;enable-background:accumulate"
+     id="rect13708"
+     d="M 8.4999886,9 C 6.560995,9 5,10.560995 5,12.499989 c 0,1.938993 1.560995,3.49999 3.4999886,3.49999 h 6.9999804 c 1.938994,0 3.499988,-1.560996 3.499988,-3.49999 C 18.999957,10.560995 17.438963,9 15.499969,9 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:1.55555;marker:none;enable-background:accumulate"
+     d="M 8.5,9 C 6.5610064,9 5,10.561005 5,12.499999 c 0,0.171373 0.025258,0.33535 0.048828,0.5 C 5.2919452,11.301713 6.7323789,10 8.5,10 h 7 c 1.767622,0 3.208055,1.301713 3.451172,2.999999 0.02357,-0.16465 0.04883,-0.328627 0.04883,-0.5 C 19.000002,10.561005 17.438996,9 15.500002,9 h -7 z"
+     id="path5598" />
+  <path
+     d="m 15.502045,9.9699662 c 1.931172,0 3.499989,1.5688108 3.499989,3.4999868 0,1.931173 -1.568817,3.499988 -3.499989,3.499988 -1.931177,0 -3.499993,-1.568815 -3.49999,-3.499988 0,-1.931176 1.568813,-3.4999868 3.49999,-3.4999868 z"
+     id="path2555-7-1-9-4-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.55555081;marker:none;enable-background:accumulate" />
+  <path
+     d="m 15.502045,9.3827312 c 1.716597,0 3.111102,1.3945028 3.111102,3.1111008 0,1.716601 -1.394505,3.111103 -3.111102,3.111103 -1.7166,0 -3.111105,-1.394502 -3.111102,-3.111103 0,-1.716598 1.394502,-3.1111008 3.111102,-3.1111008 z"
+     id="path2555-7-1-9-4"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.77777541;marker:none;enable-background:accumulate" />
+  <path
+     d="m 13.168718,12.493749 c 0,1.288704 1.044745,2.33341 2.333299,2.33341 1.28867,0 2.333354,-1.044719 2.333354,-2.33341 0,-1.288641 -1.044684,-2.333242 -2.333354,-2.333242 -1.288554,0 -2.333299,1.044601 -2.333299,2.333242 z"
+     id="path8655-6-0-5-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3866);stroke-width:0.77777541;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 15.502046,9.382732 c 1.716599,0 3.111101,1.394502 3.111101,3.111101 0,1.7166 -1.394502,3.111101 -3.111101,3.111101 -1.716601,0 -3.111106,-1.394501 -3.111103,-3.111101 0,-1.716599 1.394502,-3.111101 3.111103,-3.111101 z"
+     id="path2555-7-1-9-9-41"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:0.77777541;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/apps/32/preferences-desktop.svg
+++ b/elementary-xfce/apps/32/preferences-desktop.svg
@@ -1,610 +1,323 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="32"
+   id="svg4715"
    height="32"
-   id="svg4828"
-   version="1.1">
+   width="32"
+   version="1.1"
+   sodipodi:docname="preferences-desktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview58"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="25.9375"
+     inkscape:cx="15.055422"
+     inkscape:cy="16"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4715" />
   <defs
-     id="defs4830">
+     id="defs4717">
     <linearGradient
-       xlink:href="#linearGradient3736-0-0-0-3"
-       id="linearGradient4669"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.41666668,0,0,0.41666612,-32.333334,-455.90067)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       id="linearGradient3736-0-0-0-3">
+       id="linearGradient909">
       <stop
-         id="stop3738-4-4-0-3"
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop3926" />
       <stop
-         id="stop3740-1-7-8-9"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4489-3-1-3-5-4-6-8-8-8"
-       id="linearGradient4672"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04880515,0,0,0.30434786,-36.546093,15.063678)"
-       x1="344.09509"
-       y1="33.790791"
-       x2="344.09158"
-       y2="57.790791" />
-    <linearGradient
-       id="linearGradient4489-3-1-3-5-4-6-8-8-8">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4491-8-7-9-3-7-4-0-2-1" />
-      <stop
-         style="stop-color:#dadada;stop-opacity:1;"
-         offset="1"
-         id="stop4493-2-9-6-5-0-0-2-3-1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4467-7-2-5-1-9-4-0-5-1"
-       id="linearGradient4674"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04880515,0,0,0.30434786,-36.546093,15.063678)"
-       x1="251.21625"
-       y1="33.865498"
-       x2="251.21625"
-       y2="57.940205" />
-    <linearGradient
-       id="linearGradient4467-7-2-5-1-9-4-0-5-1">
-      <stop
-         style="stop-color:#aaaaaa;stop-opacity:1;"
-         offset="0"
-         id="stop4469-0-8-1-0-1-6-5-0-5" />
-      <stop
-         style="stop-color:#828282;stop-opacity:1;"
-         offset="1"
-         id="stop4471-8-9-8-0-6-2-1-5-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-7-25-2-2"
-       id="linearGradient4677"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.58333334,0,0,0.58333256,-26.666664,-578.46041)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-7-25-2-2">
-      <stop
-         id="stop3849-7-9-6-4"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3851-8-3-8-5"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3736-0-0-0"
-       id="linearGradient4680"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.41666668,0,0,0.41666612,-38.333333,-443.90067)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       id="linearGradient3736-0-0-0">
-      <stop
-         id="stop3738-4-4-0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3740-1-7-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4489-3-1-3-5-4-6-8-8"
-       id="linearGradient4683"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04880515,0,0,0.30434786,-24.546093,21.063678)"
-       x1="344.09509"
-       y1="33.790791"
-       x2="344.09158"
-       y2="57.790791" />
-    <linearGradient
-       id="linearGradient4489-3-1-3-5-4-6-8-8">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4491-8-7-9-3-7-4-0-2" />
-      <stop
-         style="stop-color:#dadada;stop-opacity:1;"
-         offset="1"
-         id="stop4493-2-9-6-5-0-0-2-3" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4696"
-       id="linearGradient4685"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04880515,0,0,0.30434786,-24.546093,21.063678)"
-       x1="251.21625"
-       y1="33.865498"
-       x2="251.21625"
-       y2="57.940205" />
-    <linearGradient
-       id="linearGradient4696">
-      <stop
-         id="stop4698"
-         offset="0"
-         style="stop-color:#999999;stop-opacity:1" />
-      <stop
-         id="stop4700"
-         offset="1"
-         style="stop-color:#828282;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         offset="0"
-         style="stop-color:#66a7ee;stop-opacity:1"
-         id="stop4219" />
-      <stop
-         offset="1"
-         style="stop-color:#3da3e7;stop-opacity:1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7879-6-0-8-22-2-0-5">
-      <stop
-         id="stop7881-7-4-4-97-7-5-7"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7883-6-5-2-5-4-7-0"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient7863-2-2-4-4-5-4-7">
-      <stop
-         id="stop7865-4-0-2-6-2-3-8"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7867-7-3-7-3-44-5-9"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4014"
-       id="linearGradient3097"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.72972974,0,0,0.56756759,-1.5135107,18.378385)"
-       x1="23.99999"
-       y1="5.5018549"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient4014">
-      <stop
-         id="stop4016"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4018"
+         offset="0.04026115"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0312818" />
+         id="stop3928" />
       <stop
-         id="stop4020"
+         offset="0.95833331"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95292503" />
+         id="stop3930" />
       <stop
-         id="stop4022"
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3163"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3165"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2"
-       id="linearGradient4575"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64705882,0,0,0.55555556,529.93883,-227.59239)"
-       x1="-859.51093"
-       y1="425.3956"
-       x2="-861.22693"
-       y2="425.3956" />
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3167"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
     <linearGradient
-       id="linearGradient7879-6-0-8-22-2">
+       id="linearGradient3702-501-757">
       <stop
-         id="stop7881-7-4-4-97-7"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
       <stop
-         id="stop7883-6-5-2-5-4"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5"
-       id="linearGradient4577"
+       gradientTransform="matrix(0.67567568,0,0,0.67567567,-0.2162133,-0.21620877)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64705882,0,0,0.55555556,530.58589,-228.14794)"
-       x1="-860.51093"
-       y1="426.3956"
-       x2="-878.36401"
-       y2="426.3956" />
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.759991"
+       x2="23.999996"
+       y1="6.2399888"
+       x1="23.999996" />
     <linearGradient
-       id="linearGradient7863-2-2-4-4-5">
-      <stop
-         id="stop7865-4-0-2-6-2"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7867-7-3-7-3-44"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3"
-       id="linearGradient3128"
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="32.022377"
+       x2="14.329722"
+       y2="-0.070297658"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.98995538,0,0,0.66083916,-317.44268,-155.72083)"
-       x1="290.13193"
-       y1="256.32428"
-       x2="290.13193"
-       y2="245.15491" />
+       gradientTransform="translate(0,-32)" />
     <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3">
+       id="linearGradient4011-2-96">
       <stop
-         id="stop4753-7-6-9-9-0-7-3"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4755-7-7-1-0-5-0-1"
-         style="stop-color:#999999;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3195-36-9"
-       id="linearGradient3146"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.4,0.86666666,0,-902.11384,41.2)"
-       x1="0.14285715"
-       y1="1044.3622"
-       x2="1.9707701"
-       y2="1044.3622" />
-    <linearGradient
-       id="linearGradient3195-36-9">
-      <stop
-         id="stop3197-3-3"
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
+         id="stop4013-5-8" />
       <stop
-         id="stop3199-89-7"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4015-3-48" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4017-7-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4019-6-4" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3299-6"
-       id="linearGradient3152"
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(-0.16216213,0,0,0.16216213,32.132461,12.388016)"
        gradientUnits="userSpaceOnUse"
-       x1="29.772825"
-       y1="45.104366"
-       x2="29.772825"
-       y2="7.000001"
-       gradientTransform="matrix(0.62225171,0,0,0.59462886,1.0659613,16.539648)" />
+       id="linearGradient3866"
+       xlink:href="#linearGradient4011-2-96" />
     <linearGradient
-       id="linearGradient3299-6">
+       y2="8.0928917"
+       x2="38.976662"
+       y1="59.967686"
+       x1="38.976662"
+       gradientTransform="matrix(-0.15686275,0,0,0.15686275,25.519607,11.166667)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3869"
+       xlink:href="#linearGradient4215-8-4-07-7" />
+    <linearGradient
+       id="linearGradient4215-8-4-07-7">
       <stop
-         id="stop3301-7"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="0" />
+         id="stop4217-1-2-1-2"
+         offset="0"
+         style="stop-color:#e9e9e9;stop-opacity:1;" />
       <stop
-         id="stop3303-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="1" />
+         id="stop4219-3-4-0-96"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
-       id="linearGradient5060-6">
+       y2="55.052982"
+       x2="30.271185"
+       y1="10.028973"
+       x1="30.271185"
+       gradientTransform="matrix(0.49999998,0,0,0.56250002,3e-7,-1.5000023)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3884"
+       xlink:href="#linearGradient27416-1-2" />
+    <linearGradient
+       id="linearGradient27416-1-2">
       <stop
-         id="stop5062-3"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop27420-2-0"
+         style="stop-color:#64baff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5064-1"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop27422-3-5"
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient5048-7">
-      <stop
-         id="stop5050-5"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056-9"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052-6"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3220-7-2">
-      <stop
-         id="stop3222-1-8"
-         style="stop-color:#000000;stop-opacity:0.28682169;"
-         offset="0" />
-      <stop
-         id="stop3224-2-3"
-         style="stop-color:#000000;stop-opacity:0.34108528;"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="45.042271"
-       x2="14.480406"
-       y1="2.982244"
-       x1="14.257096"
-       gradientTransform="matrix(0.61700828,0,0,0.5615972,1.1918142,18.514785)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3107"
-       xlink:href="#linearGradient3220-7-2" />
-    <linearGradient
-       xlink:href="#linearGradient5048-7"
-       id="linearGradient3094"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06553443,0,0,0.02470588,0.313987,31.94164)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <radialGradient
-       xlink:href="#linearGradient5060-6"
-       id="radialGradient3096"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06553443,0,0,0.02470588,0.326885,31.94164)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <radialGradient
-       xlink:href="#linearGradient5060-6"
-       id="radialGradient3098"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.06553443,0,0,0.02470588,47.673132,31.94164)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2-0-5"
-       id="linearGradient3101"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64705882,0,0,0.55555556,593.93883,-215.59239)"
-       x1="-862.41229"
-       y1="422.78278"
-       x2="-862.41229"
-       y2="425.51978" />
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5-4-7"
-       id="linearGradient3103"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64705882,0,0,0.55555556,594.58589,-216.14794)"
-       x1="-863.41229"
-       y1="423.78278"
-       x2="-863.41229"
-       y2="433.54517" />
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient3106"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.98995538,0,0,0.66083916,-317.44268,-155.17537)"
-       x1="284.21002"
-       y1="272.90118"
-       x2="284.21002"
-       y2="263.41644" />
   </defs>
   <metadata
-     id="metadata4833">
+     id="metadata4720">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-16)">
+     style="display:inline"
+     id="g2036"
+     transform="matrix(0.6999997,0,0,0.44444486,-0.8000003,10.111104)">
     <g
-       id="g3127">
-      <g
-         transform="matrix(0.66720454,0,0,1,-0.01290896,0)"
-         id="g3089">
-        <rect
-           style="opacity:0.3;fill:url(#linearGradient3094);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="rect2512"
-           y="41.000004"
-           x="8.1781178"
-           height="6.0000005"
-           width="31.643764" />
-        <path
-           style="opacity:0.3;fill:url(#radialGradient3096);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="path2514"
-           d="m 39.821884,41.000207 c 0,0 0,5.999669 0,5.999669 3.374861,0.01129 8.158768,-1.344221 8.158768,-3.000221 0,-1.655999 -3.766089,-2.999448 -8.158768,-2.999448 z" />
-        <path
-           style="opacity:0.3;fill:url(#radialGradient3098);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-           id="path2516"
-           d="m 8.178119,41.000207 c 0,0 0,5.999669 0,5.999669 -3.374861,0.01129 -8.158771,-1.344221 -8.158771,-3.000221 0,-1.655999 3.766091,-2.999448 8.158771,-2.999448 z" />
-      </g>
+       style="opacity:0.4"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
       <rect
-         width="28"
-         height="22"
-         rx="0.63636363"
-         ry="0.6111111"
-         x="2"
-         y="21"
-         id="rect2551"
-         style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none" />
-      <path
-         d="m 17.5,37.5 0,-11 c 0,-1.108 0.892,-2 2,-2 l 5,0 c 1.108,0 2,0.892 2,2 l 0,11 c 0,1.108 -0.892,2 -2,2 l -5,0 c -1.108,0 -2,-0.892 -2,-2 z m -12,0 0,-11 c 0,-1.108 0.892,-2 2,-2 l 5,0 c 1.108,0 2,0.892 2,2 l 0,11 c 0,1.108 -0.892,2 -2,2 l -5,0 c -1.108,0 -2,-0.892 -2,-2 z"
-         id="rect3180-4-2"
-         style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3146);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 5,24 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-7-9"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 5,23 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-9"
-         style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 29,24 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-7-6-7"
-         style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 29,23 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-8-9"
-         style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 5,42 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-7-62-7"
-         style="opacity:0.6;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 5,41 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-2-3"
-         style="opacity:0.4;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 29,42 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-7-62-4-5"
-         style="opacity:0.6;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         d="m 29,41 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z"
-         id="path4356-2-7-0"
-         style="opacity:0.4;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         width="13"
+         style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
+         id="rect2801"
+         y="40"
+         x="38"
          height="7"
-         rx="1.0263158"
-         ry="0.9545455"
-         x="-38.5"
-         y="6.5"
-         id="rect7169-1"
-         style="opacity:0.98999999;color:#000000;fill:url(#linearGradient3128);fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         width="5" />
       <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         rx="0.32352942"
-         ry="0.27777779"
-         width="11"
-         height="5"
-         x="-37.5"
-         y="7.5"
-         id="rect2392-1"
-         style="opacity:0.12000002;color:#000000;fill:url(#linearGradient4575);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4577);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         width="27"
-         height="21"
-         rx="0.31395349"
-         ry="0.29999998"
-         x="2.5"
-         y="21.5"
-         id="rect6741"
-         style="fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-      <rect
-         transform="matrix(0,-1,1,0,0,0)"
-         width="13"
+         style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
+         id="rect3696"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
          height="7"
-         rx="1.0263158"
-         ry="0.9545455"
-         x="-38.5"
-         y="18.5"
-         id="rect7169-9-6-9"
-         style="color:#000000;fill:url(#linearGradient3106);fill-opacity:1;fill-rule:nonzero;stroke:#3a7dc3;stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         width="5" />
       <rect
-         ry="0.27777779"
-         rx="0.32352942"
-         width="11"
-         height="5"
-         x="26.5"
-         y="19.5"
-         transform="matrix(0,1,1,0,0,0)"
-         id="rect2392-1-3-2"
-         style="opacity:0.12000002;color:#000000;fill:url(#linearGradient3101);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3103);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <rect
-         transform="scale(-1,1)"
-         style="color:#000000;fill:url(#linearGradient4683);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4685);stroke-width:0.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect6132-8-2-8-0-0-0-10-2"
-         width="7"
-         height="7"
-         x="-13.500351"
-         y="31.5"
-         rx="1.2727273"
-         ry="1.2727275" />
-      <rect
-         transform="matrix(0,-1,-1,0,0,0)"
-         width="5"
-         height="5"
-         rx="0.55555558"
-         ry="0.55555558"
-         x="-37.5"
-         y="-12.500351"
-         id="rect7169-0-3-3-3-8"
-         style="fill:none;stroke:url(#linearGradient4680);stroke-width:0.99999994;stroke-opacity:1" />
-      <rect
-         transform="scale(-1,1)"
-         width="7"
-         height="7"
-         rx="0.9545455"
-         ry="0.9545455"
-         x="-25.5"
-         y="25.5"
-         id="rect7169-0-3-9-9-7-5-5"
-         style="opacity:0.15;fill:none;stroke:url(#linearGradient4677);stroke-width:0.99999988;stroke-opacity:1" />
-      <rect
-         transform="scale(-1,1)"
-         style="color:#000000;fill:url(#linearGradient4672);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4674);stroke-width:0.99999976;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect6132-8-2-8-0-0-0-10-2-4"
-         width="7"
-         height="7"
-         x="-25.500351"
-         y="25.5"
-         rx="1.2727273"
-         ry="1.2727275" />
-      <rect
-         transform="matrix(0,-1,-1,0,0,0)"
-         width="5"
-         height="5"
-         rx="0.55555558"
-         ry="0.55555558"
-         x="-31.5"
-         y="-24.500351"
-         id="rect7169-0-3-3-3-8-4"
-         style="fill:none;stroke:url(#linearGradient4669);stroke-width:0.99999994;stroke-opacity:1" />
-      <rect
-         width="28.997868"
-         height="22.997868"
-         rx="0.96595365"
-         ry="0.93173623"
-         x="1.5010662"
-         y="20.501066"
-         id="rect2551-3"
-         style="fill:none;stroke:url(#linearGradient3107);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
+         style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
   </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect5505"
+     y="-29"
+     x="3"
+     ry="2.5"
+     rx="2.5"
+     height="26"
+     width="26"
+     transform="scale(1,-1)" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6-6"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="27"
+     width="27" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3027);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.4999998"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <path
+     d="m 11.555547,11.999993 c -2.462227,0 -4.444453,1.982226 -4.444453,4.444453 0,2.462227 1.982226,4.444454 4.444453,4.444454 h 8.888908 c 2.462228,0 4.444453,-1.982227 4.444453,-4.444454 0,-2.462227 -1.982225,-4.444453 -4.444453,-4.444453 z"
+     id="rect13708-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+  <path
+     d="M 11.499999,11.999999 C 9.0069997,11.999999 7,14.006999 7,16.499999 7,18.992998 9.0069997,21 11.499999,21 h 9.000002 C 22.993001,21 25,18.992999 25,16.499999 c 0,-2.493 -2.006999,-4.5 -4.499999,-4.5 z"
+     id="rect13708"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3884);fill-opacity:1;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+  <path
+     d="m 11.500002,11.999999 c -2.4930003,0 -4.5000007,2.007 -4.5000007,4.500002 0,0.07555 0.010419,0.150381 0.014064,0.224999 0.1166094,-2.387527 2.0684925,-4.275001 4.4859387,-4.275001 h 9.000004 c 2.417447,0 4.36933,1.887474 4.485941,4.275001 0.0036,-0.07462 0.01405,-0.149447 0.01405,-0.224999 0,-2.493002 -2.006999,-4.500002 -4.500001,-4.500002 h -9.000004 z"
+     id="rect13708-7"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.40860224;marker:none;enable-background:accumulate" />
+  <path
+     d="m 11.521127,11.999999 c -2.4350653,0 -4.403531,1.989304 -4.521127,4.505639 0.1167919,2.516336 2.0717286,4.505641 4.492957,4.505641 h 0.478873 c -2.5111694,0 -4.5352098,-1.903752 -4.5352098,-4.268501 0,-2.36475 2.0240404,-4.268501 4.5352098,-4.268501 h 8.056339 c 2.511168,0 4.53521,1.903751 4.53521,4.268501 0,2.364749 -2.024042,4.268501 -4.53521,4.268501 h 0.478872 c 2.421229,0 4.376166,-1.989305 4.492959,-4.505641 -0.117597,-2.516335 -2.086064,-4.505639 -4.521128,-4.505639 z"
+     id="rect3136"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.70967746;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4-9"
+     d="M 20.5,13 C 22.982943,13 25,15.017054 25,17.500002 25,19.982946 22.982943,22 20.5,22 18.017052,22 15.999996,19.982946 16,17.500002 16,15.017054 18.017052,13 20.5,13 Z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3869);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4"
+     d="m 20.5,12.5 c 2.207061,0 4,1.792938 4,4 0,2.207064 -1.792939,4.000001 -4,4.000001 -2.207064,0 -4.000004,-1.792937 -4,-4.000001 0,-2.207062 1.792936,-4 4,-4 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3866);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6-0-5-2"
+     d="M 17.5,16.499893 C 17.5,18.156804 18.843246,19.5 20.499963,19.5 22.156831,19.5 23.5,18.156787 23.5,16.499893 c 0,-1.656829 -1.343169,-2.999892 -3.000037,-2.999892 -1.656717,0 -2.999963,1.343063 -2.999963,2.999892 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#656565;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-9-41"
+     d="m 20.500001,12.500001 c 2.207063,0 3.999999,1.792937 3.999999,4 C 24.5,18.707064 22.707064,20.5 20.500001,20.5 18.292936,20.5 16.499996,18.707064 16.5,16.500001 c 0,-2.207063 1.792936,-4 4.000001,-4 z" />
 </svg>

--- a/elementary-xfce/apps/48/preferences-desktop.svg
+++ b/elementary-xfce/apps/48/preferences-desktop.svg
@@ -1,605 +1,515 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4117"
+   sodipodi:docname="preferences-desktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="48px"
-   height="48px"
-   id="svg4828"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview92"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="17.291667"
+     inkscape:cx="22.583133"
+     inkscape:cy="24"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4117" />
   <defs
-     id="defs4830">
+     id="defs4119">
     <linearGradient
-       xlink:href="#linearGradient3736-0-0-0-3"
-       id="linearGradient4669"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.75,0,0,0.749999,-28,-814.02089)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       id="linearGradient3736-0-0-0-3">
+       id="linearGradient3924">
       <stop
-         id="stop3738-4-4-0-3"
+         id="stop3926"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3740-1-7-8-9"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4489-3-1-3-5-4-6-8-8-8"
-       id="linearGradient4672"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.07669381,0,0,0.47826089,-55.857944,0.1000669)"
-       x1="344.09509"
-       y1="33.790791"
-       x2="344.09158"
-       y2="57.790791" />
-    <linearGradient
-       id="linearGradient4489-3-1-3-5-4-6-8-8-8">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4491-8-7-9-3-7-4-0-2-1" />
-      <stop
-         style="stop-color:#dadada;stop-opacity:1;"
-         offset="1"
-         id="stop4493-2-9-6-5-0-0-2-3-1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4467-7-2-5-1-9-4-0-5-1"
-       id="linearGradient4674"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.07669381,0,0,0.47826089,-55.857944,0.1000669)"
-       x1="251.21625"
-       y1="33.865498"
-       x2="251.21625"
-       y2="57.940205" />
-    <linearGradient
-       id="linearGradient4467-7-2-5-1-9-4-0-5-1">
-      <stop
-         style="stop-color:#aaaaaa;stop-opacity:1;"
-         offset="0"
-         id="stop4469-0-8-1-0-1-6-5-0-5" />
-      <stop
-         style="stop-color:#828282;stop-opacity:1;"
-         offset="1"
-         id="stop4471-8-9-8-0-6-2-1-5-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-7-25-2-2"
-       id="linearGradient4677"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.91666665,0,0,0.91666543,-40.33333,-931.58082)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-7-25-2-2">
-      <stop
-         id="stop3849-7-9-6-4"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3851-8-3-8-5"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3736-0-0-0"
-       id="linearGradient4680"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.75,0,0,0.749999,-36,-796.02089)"
-       x1="14.666667"
-       y1="1042.6954"
-       x2="1.3333334"
-       y2="1042.6954" />
-    <linearGradient
-       id="linearGradient3736-0-0-0">
-      <stop
-         id="stop3738-4-4-0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3740-1-7-8"
-         style="stop-color:#ffffff;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4489-3-1-3-5-4-6-8-8"
-       id="linearGradient4683"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.07669381,0,0,0.47826089,-37.857944,8.1000669)"
-       x1="344.09509"
-       y1="33.790791"
-       x2="344.09158"
-       y2="57.790791" />
-    <linearGradient
-       id="linearGradient4489-3-1-3-5-4-6-8-8">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop4491-8-7-9-3-7-4-0-2" />
-      <stop
-         style="stop-color:#dadada;stop-opacity:1;"
-         offset="1"
-         id="stop4493-2-9-6-5-0-0-2-3" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4696"
-       id="linearGradient4685"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.07669381,0,0,0.47826089,-37.857944,8.1000669)"
-       x1="251.21625"
-       y1="33.865498"
-       x2="251.21625"
-       y2="57.940205" />
-    <linearGradient
-       id="linearGradient4696">
-      <stop
-         id="stop4698"
-         offset="0"
-         style="stop-color:#999999;stop-opacity:1" />
-      <stop
-         id="stop4700"
-         offset="1"
-         style="stop-color:#828282;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4217"
-       id="linearGradient4583"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4468579,0,0,1.0384615,-353.5176,-260.41843)"
-       x1="284.21002"
-       y1="272.90118"
-       x2="284.21002"
-       y2="263.41644" />
-    <linearGradient
-       id="linearGradient4217">
-      <stop
-         offset="0"
-         style="stop-color:#66a7ee;stop-opacity:1"
-         id="stop4219" />
-      <stop
-         offset="1"
-         style="stop-color:#3da3e7;stop-opacity:1"
-         id="stop4221" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2-0-5"
-       id="linearGradient4585"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(804.78306,-409.66629)"
-       x1="-862.41229"
-       y1="422.78278"
-       x2="-862.41229"
-       y2="425.51978" />
-    <linearGradient
-       id="linearGradient7879-6-0-8-22-2-0-5">
-      <stop
-         id="stop7881-7-4-4-97-7-5-7"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7883-6-5-2-5-4-7-0"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5-4-7"
-       id="linearGradient4587"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(805.78306,-410.6663)"
-       x1="-863.41229"
-       y1="423.78278"
-       x2="-863.41229"
-       y2="433.54517" />
-    <linearGradient
-       id="linearGradient7863-2-2-4-4-5-4-7">
-      <stop
-         id="stop7865-4-0-2-6-2-3-8"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop7867-7-3-7-3-44-5-9"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4014"
-       id="linearGradient3097"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1621622,0,0,0.94594595,-3.8918875,3.2973068)"
-       x1="23.99999"
-       y1="5.5018549"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient4014">
-      <stop
-         id="stop4016"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4018"
+         id="stop3928"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0312818" />
+         offset="0.02705082" />
       <stop
-         id="stop4020"
+         id="stop3930"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95292503" />
+         offset="0.97222221" />
       <stop
-         id="stop4022"
+         id="stop3932"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2"
-       id="linearGradient4575"
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(842.45091,-412.66629)"
-       x1="-859.51093"
-       y1="425.3956"
-       x2="-861.22693"
-       y2="425.3956" />
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
     <linearGradient
-       id="linearGradient7879-6-0-8-22-2">
+       id="linearGradient3688-166-749">
       <stop
-         id="stop7881-7-4-4-97-7"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop7883-6-5-2-5-4"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5"
-       id="linearGradient4577"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(843.45091,-413.6663)"
-       x1="-860.51093"
-       y1="426.3956"
-       x2="-878.36401"
-       y2="426.3956" />
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient7863-2-2-4-4-5">
+       id="linearGradient3702-501-757">
       <stop
-         id="stop7865-4-0-2-6-2"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
          offset="0" />
       <stop
-         id="stop7867-7-3-7-3-44"
-         style="stop-color:#000000;stop-opacity:0.54471546"
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3831"
+       x="-0.076499999"
+       y="-0.067999999"
+       width="1.153"
+       height="1.136">
+      <feGaussianBlur
+         stdDeviation="0.6375"
+         id="feGaussianBlur3833" />
+    </filter>
+    <clipPath
+       id="clipPath3823">
+      <path
+         d="M 108.8125,58 C 107.25437,58 106,59.254375 106,60.8125 l 0,24.375 C 106,86.745625 107.25437,88 108.8125,88 l 24.375,0 C 134.74562,88 136,86.745625 136,85.1875 l 0,-24.375 C 136,59.254375 134.74562,58 133.1875,58 l -24.375,0 z m 7.1875,4.5 10,0 0,8.75 5,0 -10,13.75 -10,-13.75 5,0 0,-8.75 z"
+         id="path3825"
+         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+    </clipPath>
     <linearGradient
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3"
-       id="linearGradient3128"
+       x1="65.262688"
+       y1="64.205269"
+       x2="65.262688"
+       y2="50.068527"
+       id="linearGradient3812"
+       xlink:href="#linearGradient5010"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4468579,0,0,1.0384615,-443.18545,-245.41843)"
-       x1="290.13193"
-       y1="256.32428"
-       x2="290.13193"
-       y2="245.15491" />
+       gradientTransform="matrix(0.625,0,0,0.625,78.5,32.25)" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3806"
+       x="-0.096000004"
+       y="-0.096000004"
+       width="1.192"
+       height="1.192">
+      <feGaussianBlur
+         stdDeviation="1.2"
+         id="feGaussianBlur3808" />
+    </filter>
     <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3">
-      <stop
-         id="stop4753-7-6-9-9-0-7-3"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4755-7-7-1-0-5-0-1"
-         style="stop-color:#999999;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3195-36-9"
-       id="linearGradient3146"
+       x1="70"
+       y1="54"
+       x2="70"
+       y2="75.095024"
+       id="linearGradient3788"
+       xlink:href="#linearGradient3737"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.4,0.86666666,0,-890.11384,37.2)"
-       x1="0.14285715"
-       y1="1044.3622"
-       x2="1.9707701"
-       y2="1044.3622" />
+       gradientTransform="translate(0,4)" />
     <linearGradient
-       id="linearGradient3195-36-9">
+       x1="56"
+       y1="72"
+       x2="88"
+       y2="72"
+       id="linearGradient3773"
+       xlink:href="#linearGradient3778"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9375,0,0,0.9375,-140.5,3.5)" />
+    <linearGradient
+       x1="65.262688"
+       y1="64.205269"
+       x2="65.262688"
+       y2="50.068527"
+       id="linearGradient3832"
+       xlink:href="#linearGradient3737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.625,0,0,0.625,28.5,31.25)" />
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter3174"
+       x="-0.047720931"
+       y="-0.047172415"
+       width="1.0954419"
+       height="1.0943448">
+      <feGaussianBlur
+         stdDeviation="1.71"
+         id="feGaussianBlur3176" />
+    </filter>
+    <linearGradient
+       id="linearGradient3737">
       <stop
-         id="stop3197-3-3"
+         id="stop3739"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3199-89-7"
+         id="stop3741"
          style="stop-color:#ffffff;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3299-6"
-       id="linearGradient3152"
+       x1="45.447727"
+       y1="92.539597"
+       x2="45.447727"
+       y2="7.0165396"
+       id="ButtonShadow"
        gradientUnits="userSpaceOnUse"
-       x1="29.772825"
-       y1="45.104366"
-       x2="29.772825"
-       y2="7.000001"
-       gradientTransform="matrix(0.97782411,0,0,0.97302905,0.53222488,0.70124234)" />
-    <linearGradient
-       id="linearGradient3299-6">
+       gradientTransform="scale(1.0058652,0.994169)">
       <stop
-         id="stop3301-7"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3303-7"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5060-6"
-       id="radialGradient3157"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.06553443,0,0,0.02470588,47.673132,31.94164)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       id="linearGradient5060-6">
-      <stop
-         id="stop5062-3"
+         id="stop3750"
          style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop5064-1"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop3752"
+         style="stop-color:#000000;stop-opacity:0.58823532"
          offset="1" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5060-6"
-       id="radialGradient3160"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06553443,0,0,0.02470588,0.326885,31.94164)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
     <linearGradient
-       id="linearGradient5048-7">
+       id="linearGradient5010">
       <stop
-         id="stop5050-5"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056-9"
+         id="stop5012"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
+         offset="0" />
       <stop
-         id="stop5052-6"
+         id="stop5014"
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(0.06553443,0,0,0.02470588,0.313987,31.94164)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4826"
-       xlink:href="#linearGradient5048-7" />
-    <linearGradient
-       id="linearGradient3220-7-2">
+       id="linearGradient3778">
       <stop
-         id="stop3222-1-8"
-         style="stop-color:#000000;stop-opacity:0.28682169;"
+         id="stop3780"
+         style="stop-color:#499119;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3224-2-3"
-         style="stop-color:#000000;stop-opacity:0.34108528;"
+         id="stop3782"
+         style="stop-color:#8fd625;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       y2="45.042271"
-       x2="14.480406"
-       y1="2.982244"
-       x1="14.257096"
-       gradientTransform="matrix(0.9574517,0,0,0.9034707,1.0211799,4.305632)"
+       x1="23.999998"
+       y1="6.0325513"
+       x2="23.999998"
+       y2="42.032551"
+       id="linearGradient3084"
+       xlink:href="#linearGradient3924"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient3107"
-       xlink:href="#linearGradient3220-7-2" />
+       gradientTransform="translate(2.4e-6,0.9674489)" />
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop905"
+         style="stop-color:#fafafa;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop907"
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient903"
+       x1="14.329722"
+       y1="32.022377"
+       x2="14.329722"
+       y2="-0.070297658"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4615385,0,0,1.4615385,0.61538514,-48.352052)" />
+    <linearGradient
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(-0.29729724,0,0,0.29729724,52.326181,17.461356)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3590"
+       xlink:href="#linearGradient4011-9-9-70-61-7" />
+    <linearGradient
+       id="linearGradient4011-9-9-70-61-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4013-5-4-3-8-3" />
+      <stop
+         id="stop4015-1-5-70-9-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.507761" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4017-7-0-13-0-1" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4019-1-12-7-0-7" />
+    </linearGradient>
+    <linearGradient
+       y2="8.0928917"
+       x2="38.976662"
+       y1="59.967686"
+       x1="38.976662"
+       gradientTransform="matrix(-0.25490196,0,0,0.25490196,39.156863,16.333328)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3593"
+       xlink:href="#linearGradient4215-8-4-07-7" />
+    <linearGradient
+       id="linearGradient4215-8-4-07-7">
+      <stop
+         id="stop4217-1-2-1-2"
+         offset="0"
+         style="stop-color:#e9e9e9;stop-opacity:1;" />
+      <stop
+         id="stop4219-3-4-0-96"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       y2="55.052982"
+       x2="30.271185"
+       y1="10.028973"
+       x1="30.271185"
+       gradientTransform="matrix(0.78787871,0,0,0.88636364,-1.212111,-3.3636418)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3853"
+       xlink:href="#linearGradient27416-1-2-2" />
+    <linearGradient
+       id="linearGradient27416-1-2-2">
+      <stop
+         offset="0"
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop27420-2-0-2" />
+      <stop
+         offset="1"
+         style="stop-color:#3689e6;stop-opacity:1"
+         id="stop27422-3-5-1" />
+    </linearGradient>
   </defs>
   <metadata
-     id="metadata4833">
+     id="metadata4122">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
-    <rect
-       style="opacity:0.3;fill:url(#linearGradient4826);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2512"
-       y="41.000004"
-       x="8.1781178"
-       height="6.0000005"
-       width="31.643764" />
-    <path
-       style="opacity:0.3;fill:url(#radialGradient3160);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2514"
-       d="m 39.821884,41.000207 c 0,0 0,5.999669 0,5.999669 3.374861,0.01129 8.158768,-1.344221 8.158768,-3.000221 0,-1.655999 -3.766089,-2.999448 -8.158768,-2.999448 z" />
-    <path
-       style="opacity:0.3;fill:url(#radialGradient3157);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2516"
-       d="m 8.178119,41.000207 c 0,0 0,5.999669 0,5.999669 -3.374861,0.01129 -8.158771,-1.344221 -8.158771,-3.000221 0,-1.655999 3.766091,-2.999448 8.158771,-2.999448 z" />
-    <rect
-       style="fill:url(#linearGradient3152);fill-opacity:1;fill-rule:evenodd;stroke:none"
-       id="rect2551"
-       y="8"
-       x="2"
-       ry="1"
-       rx="1"
-       height="36"
-       width="44" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient3146);stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect3180-4-2"
-       d="m 26.5,34.5 0,-17 c 0,-1.108 0.892,-2 2,-2 l 9,0 c 1.108,0 2,0.892 2,2 l 0,17 c 0,1.108 -0.892,2 -2,2 l -9,0 c -1.108,0 -2,-0.892 -2,-2 z m -18,0 0,-17 c 0,-1.108 0.892,-2 2,-2 l 9,0 c 1.108,0 2,0.892 2,2 l 0,17 c 0,1.108 -0.892,2 -2,2 l -9,0 c -1.108,0 -2,-0.892 -2,-2 z" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-7-9"
-       d="m 6,12 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9"
-       d="m 6,11 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-7-6-7"
-       d="m 44,12 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-8-9"
-       d="m 44,11 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.6;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-7-62-7"
-       d="m 6,42 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.4;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-2-3"
-       d="m 6,41 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.6;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-7-62-4-5"
-       d="m 44,42 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.4;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-2-7-0"
-       d="m 44,41 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <rect
-       style="opacity:0.98999999;color:#000000;fill:url(#linearGradient3128);fill-opacity:1;fill-rule:nonzero;stroke:#808080;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-1"
-       y="9.5"
-       x="-35.5"
-       ry="1.5"
-       rx="1.5"
-       height="11"
-       width="19"
-       transform="matrix(0,-1,1,0,0,0)" />
-    <rect
-       style="opacity:0.12000002;color:#000000;fill:url(#linearGradient4575);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4577);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2392-1"
-       y="10.5"
-       x="-34.5"
-       height="9"
-       width="17"
-       ry="0.5"
-       rx="0.5"
-       transform="matrix(0,-1,1,0,0,0)" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="8.5"
-       x="2.5"
-       ry="0.5"
-       rx="0.5"
-       height="35"
-       width="43" />
+     transform="matrix(1.1,0,0,0.4444449,-2.4000022,25.11107)"
+     id="g2036"
+     style="display:inline">
     <g
-       id="g4579"
-       transform="matrix(0,-1,1,0,15,89.667854)">
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
       <rect
-         width="19"
-         height="11"
-         rx="1.5"
-         ry="1.5"
-         x="54.167854"
-         y="12.5"
-         id="rect7169-9-6-9"
-         style="color:#000000;fill:url(#linearGradient4583);fill-opacity:1;fill-rule:nonzero;stroke:#3a7dc3;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient2873-966-168);fill-opacity:1;stroke:none" />
       <rect
-         ry="0.5"
-         rx="0.5"
-         width="17"
-         height="9"
-         x="-72.167854"
-         y="13.5"
-         transform="scale(-1,1)"
-         id="rect2392-1-3-2"
-         style="opacity:0.12000002;color:#000000;fill:url(#linearGradient4585);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4587);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2875-742-326);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2877-634-617);fill-opacity:1;stroke:none" />
     </g>
-    <rect
-       ry="2.0000002"
-       rx="1.9999999"
-       y="24.5"
-       x="-20.500351"
-       height="11"
-       width="11"
-       id="rect6132-8-2-8-0-0-0-10-2"
-       style="color:#000000;fill:url(#linearGradient4683);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4685);stroke-width:0.9999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       transform="scale(-1,1)" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient4680);stroke-width:0.99999988;stroke-opacity:1"
-       id="rect7169-0-3-3-3-8"
-       y="-19.500351"
-       x="-34.5"
-       ry="1"
-       rx="1"
-       height="9"
-       width="9"
-       transform="matrix(0,-1,-1,0,0,0)" />
-    <rect
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient4677);stroke-width:0.99999988;stroke-opacity:1"
-       id="rect7169-0-3-9-9-7-5-5"
-       y="17.499802"
-       x="-38.5"
-       ry="1.5"
-       rx="1.5"
-       height="11"
-       width="11"
-       transform="scale(-1,1)" />
-    <rect
-       ry="2.0000002"
-       rx="1.9999999"
-       y="16.5"
-       x="-38.500351"
-       height="11"
-       width="11"
-       id="rect6132-8-2-8-0-0-0-10-2-4"
-       style="color:#000000;fill:url(#linearGradient4672);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4674);stroke-width:0.9999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       transform="scale(-1,1)" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient4669);stroke-width:0.99999988;stroke-opacity:1"
-       id="rect7169-0-3-3-3-8-4"
-       y="-37.500351"
-       x="-26.5"
-       ry="1"
-       rx="1"
-       height="9"
-       width="9"
-       transform="matrix(0,-1,-1,0,0,0)" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient3107);stroke-width:1.00213289;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect2551-3"
-       y="7.5010686"
-       x="1.5010662"
-       ry="1.4989328"
-       rx="1.4989328"
-       height="36.997868"
-       width="44.997868" />
   </g>
+  <rect
+     transform="scale(1,-1)"
+     width="38"
+     height="38"
+     rx="3.5"
+     ry="3.5"
+     x="5"
+     y="-43.967438"
+     id="rect5505-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient903);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="39"
+     height="39"
+     rx="4"
+     ry="4"
+     x="4.5"
+     y="5.4674392"
+     id="rect5505-21"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#555761;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="37"
+     height="37"
+     rx="3"
+     ry="3"
+     x="5.5"
+     y="6.4674392"
+     id="rect6741-2"
+     style="fill:none;stroke:url(#linearGradient3084);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     transform="translate(-135.85714,-31.05041)"
+     id="layer2"
+     style="display:none">
+    <path
+       d="M 11,7 48,5 85,7 c 3.324,0 6,2.676 6,6 l 0,73 c 0,3.324 -2.676,6 -6,6 L 11,92 C 7.676,92 5,89.324 5,86 L 5,13 C 5,9.676 7.676,7 11,7 z"
+       id="rect3745"
+       style="opacity:0.9;fill:url(#ButtonShadow);fill-opacity:1;fill-rule:nonzero;stroke:none;filter:url(#filter3174)" />
+  </g>
+  <g
+     transform="translate(-135.85714,-31.05041)"
+     id="layer4"
+     style="display:none">
+    <rect
+       width="30"
+       height="30"
+       rx="2.8125"
+       ry="2.8125"
+       x="-86"
+       y="56"
+       transform="matrix(0,-1,1,0,0,4)"
+       id="rect3790"
+       style="opacity:0.6;fill:#000000;fill-opacity:1;stroke:none;filter:url(#filter3806)" />
+    <rect
+       width="30"
+       height="30"
+       rx="2.8125"
+       ry="2.8125"
+       x="-88"
+       y="56"
+       transform="matrix(0,-1,1,0,0,0)"
+       id="rect2993"
+       style="fill:url(#linearGradient3773);fill-opacity:1;stroke:none" />
+    <path
+       d="M 58.8125,58 C 57.254375,58 56,59.254375 56,60.8125 l 0,24.375 c 0,0.873066 0.410816,1.641163 1.03125,2.15625 C 57.02841,87.289908 57,87.242129 57,87.1875 l 0,-24.375 C 57,61.254375 58.17075,60 59.625,60 l 22.75,0 C 83.82925,60 85,61.254375 85,62.8125 l 0,24.375 c 0,0.05463 -0.02841,0.102408 -0.03125,0.15625 C 85.589184,86.828663 86,86.060566 86,85.1875 l 0,-24.375 C 86,59.254375 84.745625,58 83.1875,58 l -24.375,0 z"
+       id="rect3775"
+       style="opacity:0.5;fill:url(#linearGradient3788);fill-opacity:1;stroke:none" />
+    <path
+       d="m 116,63.5 0,8.75 -5,0 10,13.75 10,-13.75 -5,0 0,-8.75 -10,0 z"
+       transform="translate(-50,0)"
+       clip-path="url(#clipPath3823)"
+       id="path3810"
+       style="opacity:0.6;fill:url(#linearGradient3812);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline;filter:url(#filter3831)" />
+    <path
+       d="m 66,62.5 0,8.75 -5,0 10,13.75 10,-13.75 -5,0 0,-8.75 -10,0 z"
+       id="path4278"
+       style="fill:url(#linearGradient3832);fill-opacity:1;fill-rule:nonzero;stroke:none;display:inline" />
+  </g>
+  <rect
+     width="28"
+     height="14"
+     rx="7"
+     ry="7"
+     x="10.00001"
+     y="19"
+     id="rect3990-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+  <rect
+     width="28"
+     height="14"
+     rx="7"
+     ry="7"
+     x="10.00001"
+     y="17.999994"
+     id="rect3990"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3853);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+  <path
+     d="m 17,18 c -3.878,0 -7,3.122 -7,7 0,0.168748 0.01962,0.33431 0.03125,0.5 C 10.286844,21.857963 13.290748,19 17,19 h 14 c 3.709252,0 6.713156,2.857963 6.96875,6.5 C 37.98038,25.33431 38,25.168748 38,25 38,21.122 34.878,18 31,18 Z"
+     id="rect3990-5"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.40860224;marker:none;enable-background:accumulate" />
+  <path
+     d="m 17,19 c -3.709252,0 -6.713156,2.857963 -6.96875,6.5 0.226734,3.230802 2.621542,5.826238 5.75,6.375 C 13.042227,31.317352 11,28.9085 11,26 c 0,-3.324 2.676,-6 6,-6 h 14 c 3.324,0 6,2.676 6,6 0,2.9085 -2.042227,5.317352 -4.78125,5.875 3.128458,-0.548762 5.523266,-3.144198 5.75,-6.375 C 37.713156,21.857963 34.709252,19 31,19 Z"
+     id="rect3990-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.70967746;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.07000002;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4-9-1"
+     d="m 31.000002,18.500001 c 4.138242,0 7.499999,3.361757 7.499999,7.500001 0,4.138241 -3.361757,7.499998 -7.499999,7.499998 -4.138244,0 -7.500009,-3.361757 -7.500001,-7.499998 0,-4.138244 3.361757,-7.500001 7.500001,-7.500001 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4-9"
+     d="m 31.000001,19.500001 c 3.586477,0 6.5,2.913523 6.5,6.5 0,3.586476 -2.913523,6.499999 -6.5,6.499999 -3.586477,0 -6.500006,-2.913523 -6.5,-6.499999 0,-3.586477 2.913523,-6.5 6.5,-6.5 z" />
+  <path
+     d="M 37.000001,26 A 6.0000005,6.0000005 0 0 1 25,26 6.0000005,6.0000005 0 1 1 37.000001,26 Z"
+     id="path13859-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.15;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.12727261;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3593);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-4"
+     d="m 31.000001,18.499995 c 3.586477,0 6.5,2.913522 6.5,6.5 0,3.586476 -2.913523,6.499999 -6.5,6.499999 -3.586477,0 -6.500006,-2.913522 -6.5,-6.499999 0,-3.586478 2.913523,-6.5 6.5,-6.5 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3590);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655-6-0-5-2"
+     d="m 25.500001,24.999798 c 0,3.037668 2.462616,5.500196 5.49993,5.500196 3.037592,0 5.50007,-2.462559 5.50007,-5.500196 0,-3.037523 -2.462478,-5.499803 -5.50007,-5.499803 -3.037314,0 -5.499929,2.46228 -5.49993,5.499803 z" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#656565;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path2555-7-1-9-9-41"
+     d="m 31.000001,18.499995 c 3.586477,0 6.5,2.913523 6.5,6.5 0,3.586477 -2.913523,6.499999 -6.5,6.499999 -3.586477,0 -6.500006,-2.913522 -6.5,-6.499999 0,-3.586477 2.913523,-6.5 6.5,-6.5 z" />
 </svg>

--- a/elementary-xfce/apps/64/preferences-desktop.svg
+++ b/elementary-xfce/apps/64/preferences-desktop.svg
@@ -1,647 +1,319 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   id="svg13986"
+   height="64"
+   width="64"
+   version="1.1"
+   sodipodi:docname="preferences-desktop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
-   id="svg4774"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview58"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="12.96875"
+     inkscape:cx="30.110843"
+     inkscape:cy="32"
+     inkscape:window-width="1920"
+     inkscape:window-height="1029"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg13986" />
   <defs
-     id="defs4776">
+     id="defs13988">
     <linearGradient
-       xlink:href="#linearGradient3736-3-8"
-       id="linearGradient3402-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99999997,0,0,0.99999873,21.499998,-997.8609)"
-       x1="14.666667"
-       y1="1041.3622"
-       x2="1.3333334"
-       y2="1041.3622" />
-    <linearGradient
-       id="linearGradient3736-3-8">
+       id="linearGradient27416-1-2">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3738-2-5" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3740-0-6" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3690-8-5-0-5"
-       id="linearGradient3405-2"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0833334,0,0,1.0833319,20.833328,-1084.6408)"
-       x1="14"
-       y1="1041.3621"
-       x2="2.0000002"
-       y2="1041.3621" />
-    <linearGradient
-       id="linearGradient3690-8-5-0-5">
-      <stop
-         offset="0"
-         style="stop-color:#dcdcdc;stop-opacity:1"
-         id="stop3692-3-0-9-2" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop3694-1-7-8-6" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-4-1"
-       id="linearGradient3408-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99999997,0,0,0.99999873,22.499999,-997.8609)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-4-1">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3849-8-3" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         id="stop3851-4-3" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2-5"
-       id="linearGradient3411-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3529412,0,0,1.3333334,1139.963,-526.72178)"
-       x1="-859.51093"
-       y1="425.3956"
-       x2="-862.56952"
-       y2="425.39526" />
-    <linearGradient
-       id="linearGradient7879-6-0-8-22-2-5">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7881-7-4-4-97-7-2" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop7883-6-5-2-5-4-6" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5-44"
-       id="linearGradient3413-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3529412,0,0,1.3333334,1141.3159,-528.05512)"
-       x1="-860.51093"
-       y1="426.3956"
-       x2="-878.36401"
-       y2="426.3956" />
-    <linearGradient
-       id="linearGradient7863-2-2-4-4-5-44">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7865-4-0-2-6-2-6" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         id="stop7867-7-3-7-3-44-0" />
-    </linearGradient>
-    <linearGradient
-       y2="1044.3622"
-       x2="1.9707701"
-       y1="1044.3622"
-       x1="0.14285715"
-       gradientTransform="matrix(0,-1.8,1.0666667,0,-1070.4863,49.400001)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient4558"
-       xlink:href="#linearGradient3195-36-9-6" />
-    <linearGradient
-       id="linearGradient3195-36-9-6">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3197-3-3-9" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3199-89-7-0" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-0"
-       id="linearGradient3429-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9037604,0,0,1.3216783,-583.92823,-310.85074)"
-       x1="281.89017"
-       y1="272.66611"
-       x2="289.25864"
-       y2="265.06918" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-0">
-      <stop
-         offset="0"
-         style="stop-color:#66c7ee;stop-opacity:1"
-         id="stop3752-9" />
+         style="stop-color:#55c1ec;stop-opacity:1"
+         id="stop27420-2-0" />
       <stop
          offset="1"
          style="stop-color:#3689e6;stop-opacity:1"
-         id="stop3754-2" />
+         id="stop27422-3-5" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3937-1"
-       id="linearGradient3431-3"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9037604,0,0,1.3216783,-583.92823,-310.85074)"
-       x1="281.59253"
-       y1="252.05637"
-       x2="295.22601"
-       y2="252.05637" />
-    <linearGradient
-       id="linearGradient3937-1">
-      <stop
-         id="stop3939-8"
-         style="stop-color:#666666;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3941-7"
-         style="stop-color:#929292;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4014"
-       id="linearGradient3266"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5405406,0,0,1.2702702,-4.972968,4.5135262)"
-       x1="23.99999"
-       y1="5.5018549"
-       x2="23.99999"
-       y2="43" />
-    <linearGradient
-       id="linearGradient4014">
+       id="linearGradient3924-2-2-5-8">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4016" />
+         id="stop3926-9-4-9-6" />
       <stop
-         offset="0.0312818"
+         offset="0.06316455"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4018" />
+         id="stop3928-9-8-6-5" />
       <stop
-         offset="0.95292503"
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4020" />
+         id="stop3930-3-5-1-7" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4022" />
+         id="stop3932-8-0-4-8" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3736-3"
-       id="linearGradient3402"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99999997,0,0,0.99999873,-48.500002,-1021.8609)"
-       x1="14.666667"
-       y1="1041.3622"
-       x2="1.3333334"
-       y2="1041.3622" />
-    <linearGradient
-       id="linearGradient3736-3">
+       id="linearGradient3688-166-749-4-0-3-8">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3738-2" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-4-0-1-8" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3740-0" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-9-2-9-6" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3690-8-5-0"
-       id="linearGradient3405"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0833334,0,0,1.0833319,-49.166672,-1108.6408)"
-       x1="14"
-       y1="1041.3621"
-       x2="2.0000002"
-       y2="1041.3621" />
-    <linearGradient
-       id="linearGradient3690-8-5-0">
+       id="linearGradient3702-501-757-8-4-1-1">
       <stop
          offset="0"
-         style="stop-color:#dcdcdc;stop-opacity:1"
-         id="stop3692-3-0-9" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-8-9-9-1" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-7-8-7-7" />
       <stop
          offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-4-5-1-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4632-92-3-0-8-1">
+      <stop
+         offset="0"
          style="stop-color:#fafafa;stop-opacity:1"
-         id="stop3694-1-7-8" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3847-4"
-       id="linearGradient3408"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.99999997,0,0,0.99999873,-47.500001,-1021.8609)"
-       x1="8.9350796"
-       y1="1034.8622"
-       x2="8.9350796"
-       y2="1047.8633" />
-    <linearGradient
-       id="linearGradient3847-4">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop3849-8" />
+         id="stop4634-68-8-0-2-9" />
       <stop
          offset="1"
-         style="stop-color:#000000;stop-opacity:0.23529412"
-         id="stop3851-4" />
+         style="stop-color:#e1e1e1;stop-opacity:1"
+         id="stop4636-8-21-7-1-4" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient7879-6-0-8-22-2"
-       id="linearGradient3411"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3529412,0,0,1.3333334,1139.963,-550.72178)"
-       x1="-859.51093"
-       y1="425.3956"
-       x2="-862.56952"
-       y2="425.39526" />
-    <linearGradient
-       id="linearGradient7879-6-0-8-22-2">
+       id="linearGradient4215-8-4-07-7">
       <stop
+         style="stop-color:#e9e9e9;stop-opacity:1;"
          offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7881-7-4-4-97-7" />
+         id="stop4217-1-2-1-2" />
       <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop7883-6-5-2-5-4" />
+         id="stop4219-3-4-0-96" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient7863-2-2-4-4-5"
-       id="linearGradient3413"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3529412,0,0,1.3333334,1141.3159,-552.05512)"
-       x1="-860.51093"
-       y1="426.3956"
-       x2="-878.36401"
-       y2="426.3956" />
-    <linearGradient
-       id="linearGradient7863-2-2-4-4-5">
+       id="linearGradient4011-9-9-70-61-7">
       <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop7865-4-0-2-6-2" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.54471546"
-         id="stop7867-7-3-7-3-44" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4751-5-4-1-2-9-1-3"
-       id="linearGradient3416"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9037604,0,0,1.3216783,-583.92823,-311.94165)"
-       x1="287.01065"
-       y1="245.27605"
-       x2="295.39691"
-       y2="245.27605" />
-    <linearGradient
-       id="linearGradient4751-5-4-1-2-9-1-3">
-      <stop
-         offset="0"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         id="stop4753-7-6-9-9-0-7-3" />
-      <stop
-         offset="1"
-         style="stop-color:#8c8c8c;stop-opacity:1"
-         id="stop4755-7-7-1-0-5-0-1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3943"
-       id="linearGradient3418"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9037604,0,0,1.3216783,-583.92823,-311.94165)"
-       x1="281.59253"
-       y1="252.05637"
-       x2="295.22601"
-       y2="252.05637" />
-    <linearGradient
-       id="linearGradient3943">
-      <stop
-         id="stop3945"
-         style="stop-color:#828282;stop-opacity:1"
+         id="stop4013-5-4-3-8-3"
+         style="stop-color:#ffffff;stop-opacity:1;"
          offset="0" />
       <stop
-         id="stop3947"
-         style="stop-color:#666666;stop-opacity:1"
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop4015-1-5-70-9-5" />
+      <stop
+         id="stop4017-7-0-13-0-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.83456558" />
+      <stop
+         id="stop4019-1-12-7-0-7"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient3195-36-9"
-       id="linearGradient4375"
+       y2="55.052982"
+       x2="30.271185"
+       y1="10.028973"
+       x1="30.271185"
+       gradientTransform="matrix(1.111111,0,0,1.25,-3.5555565,-7.9999992)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1.8,1.0666667,0,-1094.4863,49.400001)"
-       x1="0.14285715"
-       y1="1044.3622"
-       x2="1.9707701"
-       y2="1044.3622" />
+       id="linearGradient3643"
+       xlink:href="#linearGradient27416-1-2" />
     <linearGradient
-       id="linearGradient3195-36-9">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop3197-3-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0"
-         id="stop3199-89-7" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3299-6-1"
-       id="linearGradient3437-6"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999"
+       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,-2.4707781)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3111239,0,0,1.3243376,0.53303161,0.5672184)"
-       x1="29.772825"
-       y1="45.104366"
-       x2="29.772825"
-       y2="7.000001" />
-    <linearGradient
-       id="linearGradient3299-6-1">
-      <stop
-         offset="0"
-         style="stop-color:#d2d2d2;stop-opacity:1"
-         id="stop3301-7-1" />
-      <stop
-         offset="1"
-         style="stop-color:#f4f4f4;stop-opacity:1"
-         id="stop3303-7-5" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3220-7-8"
-       id="linearGradient3439-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2553378,0,0,1.1965002,1.8719186,6.2693287)"
-       x1="14.257096"
-       y1="2.982244"
-       x2="14.480406"
-       y2="45.042271" />
-    <linearGradient
-       id="linearGradient3220-7-8">
-      <stop
-         offset="0"
-         style="stop-color:#999999;stop-opacity:1"
-         id="stop3222-1-4" />
-      <stop
-         offset="1"
-         style="stop-color:#808080;stop-opacity:1"
-         id="stop3224-2-8" />
-    </linearGradient>
+       id="linearGradient3647"
+       xlink:href="#linearGradient3924-2-2-5-8" />
     <radialGradient
-       xlink:href="#linearGradient5060-6-6-5"
-       id="radialGradient3682"
+       r="27.5"
+       fy="4.3419166"
+       fx="31.999998"
+       cy="4.3419166"
+       cx="31.999998"
+       gradientTransform="matrix(1.0056172e-8,2.3103361,-2.310336,1.0056172e-8,42.031285,-69.085963)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.08744973,0,0,0.03294117,63.589628,42.588843)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
+       id="radialGradient3651"
+       xlink:href="#linearGradient4632-92-3-0-8-1" />
     <linearGradient
-       id="linearGradient5060-6-6-5">
-      <stop
-         id="stop5062-3-0-3"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064-1-4-9"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       y2="44.340794"
+       x2="71.204407"
+       y1="6.2375584"
+       x1="71.204407"
+       gradientTransform="matrix(-0.45945942,0,0,0.45945942,74.958504,20.349516)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3659"
+       xlink:href="#linearGradient4011-9-9-70-61-7" />
+    <linearGradient
+       y2="8.0928917"
+       x2="38.976662"
+       y1="59.967686"
+       x1="38.976662"
+       gradientTransform="matrix(-0.37254354,0,0,0.37254354,53.921253,19.33366)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3662"
+       xlink:href="#linearGradient4215-8-4-07-7" />
     <radialGradient
-       xlink:href="#linearGradient5060-6-6-5"
-       id="radialGradient3685"
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2-3"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.08744973,0,0,0.03294117,0.41038411,42.588843)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       id="linearGradient5048-7-7-5">
-      <stop
-         id="stop5050-5-6-4"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056-9-0-1"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052-6-9-5"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       y2="609.50507"
-       x2="302.85715"
-       y1="366.64789"
-       x1="302.85715"
-       gradientTransform="matrix(0.08744973,0,0,0.03294117,0.39317023,42.588843)"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,41.985755,15.500001)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4-5"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
        gradientUnits="userSpaceOnUse"
-       id="linearGradient4772"
-       xlink:href="#linearGradient5048-7-7-5" />
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,-22.014244,-102.5)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient6394"
+       xlink:href="#linearGradient3702-501-757-8-4-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5714286,0,0,0.7142857,-5.7142853,27.928572)" />
   </defs>
   <metadata
-     id="metadata4779">
+     id="metadata13991">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     id="g866">
     <rect
-       style="opacity:0.40206185;fill:url(#linearGradient4772);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect2512-9-5"
-       y="54.666664"
-       x="10.887152"
-       height="8"
-       width="42.225719" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3685);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2514-7-4"
-       d="m 53.112863,54.666932 c 0,0 0,7.999558 0,7.999558 4.503444,0.01505 10.887135,-1.792294 10.887135,-4.000294 0,-2.207999 -5.025503,-3.999264 -10.887135,-3.999264 z" />
-    <path
-       style="opacity:0.40206185;fill:url(#radialGradient3682);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="path2516-8-9"
-       d="m 10.887135,54.666932 c 0,0 0,7.999558 0,7.999558 C 6.383692,62.681544 0,60.874196 0,58.666196 0,56.458197 5.025504,54.666932 10.887135,54.666932 z" />
+       style="opacity:0.6;fill:url(#radialGradient3337-2-2-3);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect2801-5-5-7-9"
+       y="56.5"
+       x="54"
+       height="5"
+       width="6" />
     <rect
-       style="color:#000000;fill:url(#linearGradient3437-6);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3439-9);stroke-width:1.00213301;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2551-5-8"
-       y="10.501066"
-       x="2.5010664"
-       ry="1.4989328"
-       rx="1.4989328"
-       height="48.997868"
-       width="58.997868" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4375);stroke-width:0.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 11.5,45.928572 0,-21.857144 C 11.5,22.646857 12.597846,21.5 13.961539,21.5 l 11.076923,0 C 26.402154,21.5 27.5,22.646857 27.5,24.071428 l 0,21.857144 C 27.5,47.353143 26.402154,48.5 25.038462,48.5 l -11.076923,0 C 12.597846,48.5 11.5,47.353143 11.5,45.928572 z"
-       id="rect3180-4-2" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3"
-       d="m 8,16 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9"
-       d="m 8,15 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
+       style="opacity:0.6;fill:url(#radialGradient3339-1-4-5);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-61.5"
+       x="-10"
+       height="5"
+       width="6" />
     <rect
-       style="opacity:0.98999999;color:#000000;fill:url(#linearGradient3416);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3418);stroke-width:0.9999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-1"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="12.5"
-       x="-47.5"
-       ry="1.4999999"
-       rx="1.4999998"
-       height="14"
-       width="25" />
-    <rect
-       style="opacity:0.12000002;color:#000000;fill:url(#linearGradient3411);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3413);stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2392-1"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="13.5"
-       x="-46.5"
-       height="12"
-       width="23"
-       ry="0.49999994"
-       rx="0.49999988" />
-    <rect
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient3408);stroke-width:0.99999976;stroke-opacity:1"
-       id="rect7169-0-3-9-7"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="13.5"
-       x="-45.5"
-       ry="0.99999994"
-       rx="0.99999982"
-       height="12"
-       width="12" />
-    <rect
-       style="fill:url(#linearGradient3405);fill-opacity:1;stroke:none"
-       id="rect7169-0-1-8-9"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="13"
-       x="-47"
-       ry="0.99999994"
-       rx="0.99999976"
-       height="13"
-       width="13" />
-    <rect
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3402);stroke-width:0.99999976;stroke-opacity:1"
-       id="rect7169-0-3-8"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="13.5"
-       x="-46.5"
-       ry="0.99999994"
-       rx="0.99999982"
-       height="12"
-       width="12" />
-    <rect
-       style="fill:none;stroke:url(#linearGradient3266);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-       id="rect6741"
-       y="11.5"
-       x="3.5000002"
-       ry="0.49999997"
-       rx="0.5"
-       height="47"
-       width="57" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3-8"
-       d="m 58,16 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-33"
-       d="m 58,15 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3-6"
-       d="m 8,56 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-0"
-       d="m 8,55 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-3-4"
-       d="m 58,56 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <path
-       style="opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.33830979;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4356-9-6"
-       d="m 58,55 a 1,1 0 0 1 -2,0 1,1 0 1 1 2,0 z" />
-    <rect
-       style="color:#000000;fill:url(#linearGradient3429-8);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3431-3);stroke-width:0.9999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect7169-9-6"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="36.5"
-       x="-47.5"
-       ry="1.4999999"
-       rx="1.4999998"
-       height="14"
-       width="25" />
-    <path
-       style="opacity:0.6;color:#000000;fill:none;stroke:url(#linearGradient4558);stroke-width:0.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 35.5,45.928572 0,-21.857144 C 35.5,22.646857 36.597846,21.5 37.961539,21.5 l 11.076923,0 C 50.402154,21.5 51.5,22.646857 51.5,24.071428 l 0,21.857144 C 51.5,47.353143 50.402154,48.5 49.038462,48.5 l -11.076923,0 C 36.597846,48.5 35.5,47.353143 35.5,45.928572 z"
-       id="rect3180-4-2-3" />
-    <rect
-       style="opacity:0.12000002;color:#000000;fill:url(#linearGradient3411-1);fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3413-9);stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="rect2392-1-5"
-       transform="matrix(0,-1,1,0,0,0)"
-       y="37.5"
-       x="-46.5"
-       height="12"
-       width="23"
-       ry="0.49999994"
-       rx="0.49999988" />
-    <rect
-       style="opacity:0.15;fill:none;stroke:url(#linearGradient3408-9);stroke-width:0.99999976;stroke-opacity:1"
-       id="rect7169-0-3-9-7-8"
-       transform="matrix(0,1,1,0,0,0)"
-       y="37.5"
-       x="24.5"
-       ry="0.99999994"
-       rx="0.99999982"
-       height="12"
-       width="12" />
-    <rect
-       style="fill:url(#linearGradient3405-2);fill-opacity:1;stroke:none"
-       id="rect7169-0-1-8-9-7"
-       transform="matrix(0,1,1,0,0,0)"
-       y="37"
-       x="23"
-       ry="0.99999994"
-       rx="0.99999976"
-       height="13"
-       width="13" />
-    <rect
-       style="opacity:0.4;fill:none;stroke:url(#linearGradient3402-4);stroke-width:0.99999976;stroke-opacity:1"
-       id="rect7169-0-3-8-1"
-       transform="matrix(0,1,1,0,0,0)"
-       y="37.5"
-       x="23.5"
-       ry="0.99999994"
-       rx="0.99999982"
-       height="12"
-       width="12" />
+       style="opacity:0.6;fill:url(#linearGradient6394);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3700-5-6-8-4"
+       y="56.5"
+       x="10"
+       height="5.0000005"
+       width="44" />
   </g>
+  <rect
+     width="54"
+     height="54"
+     rx="5.5"
+     ry="5.5"
+     x="5"
+     y="5"
+     id="rect5505-21-3-8-5-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3651);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 21.999999,23 c -5.54,0 -10,4.46 -10,10 0,5.54 4.46,10 10,10 l 20,0 c 5.54,0 10,-4.46 10,-10 0,-5.54 -4.46,-10 -10,-10 z"
+     id="rect13708-6"
+     style="opacity:0.2;color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <rect
+     width="53"
+     height="53.142479"
+     rx="5"
+     ry="5"
+     x="5.4999986"
+     y="5.4287739"
+     id="rect6741-5-0-2-3"
+     style="fill:none;stroke:url(#linearGradient3647);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="55"
+     height="55"
+     rx="6"
+     ry="6"
+     x="4.4999986"
+     y="4.5000019"
+     id="rect5505-21-3-8-9-1-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     d="m 21.999999,22.000002 c -5.54,0 -10,4.46 -10,10 0,5.54 4.46,10 10,10 l 20,0 c 5.54,0 10,-4.46 10,-10 0,-5.54 -4.46,-10 -10,-10 z"
+     id="rect13708"
+     style="color:#000000;fill:url(#linearGradient3643);fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 21.999999,22.000002 c -5.54,0 -10,4.46 -10,10 0,0.167898 0.02315,0.33418 0.03125,0.5 0.259131,-5.305614 4.596648,-9.5 9.96875,-9.5 l 20,0 c 5.372102,0 9.709619,4.194386 9.96875,9.5 0.0081,-0.16582 0.03125,-0.332102 0.03125,-0.5 0,-5.54 -4.46,-10 -10,-10 l -20,0 z"
+     id="rect13708-7"
+     style="opacity:0.3;color:#000000;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.40860224;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <path
+     d="m 22.062499,23.000002 c -5.4028,0 -9.770333,4.194386 -10.03125,9.5 0.259131,5.305614 4.596648,9.5 9.96875,9.5 l 1.0625,0 c -5.571657,0 -10.0625,-4.014 -10.0625,-9 0,-4.986 4.490843,-9 10.0625,-9 l 17.875,0 c 5.571657,0 10.0625,4.014 10.0625,9 0,4.986 -4.490843,9 -10.0625,9 l 1.0625,0 c 5.372102,0 9.709619,-4.194386 9.96875,-9.5 -0.260917,-5.305614 -4.62845,-9.5 -10.03125,-9.5 l -19.875,0 z"
+     id="rect3136"
+     style="opacity:0.15;color:#000000;fill:#0e4774;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.70967746;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  <g
+     id="layer4-0"
+     transform="matrix(0.9047486,0,0,0.9047486,-570.51497,-675.56047)" />
+  <g
+     id="layer4-0-7"
+     transform="matrix(0.9047486,0,0,0.9047486,-570.51497,-668.32248)" />
+  <g
+     id="layer1-3"
+     transform="matrix(0.9047486,0,0,0.9047486,-73.807987,0.49666306)" />
+  <path
+     style="opacity:0.07;color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path2555-7-1-9-4-9-1"
+     d="m 41.999862,22.500001 c 5.793539,0 10.499999,4.70646 10.499999,10.500001 0,5.793538 -4.70646,10.499998 -10.499999,10.499998 -5.793541,0 -10.500011,-4.70646 -10.500001,-10.499998 0,-5.793541 4.70646,-10.500001 10.500001,-10.500001 z" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;opacity:0.15"
+     id="path2555-7-1-9-4-9"
+     d="m 41.999861,23.50028 c 5.241697,0 9.49986,4.258163 9.49986,9.499861 0,5.241696 -4.258163,9.499859 -9.49986,9.499859 -5.241698,0 -9.49987,-4.258163 -9.499861,-9.499859 0,-5.241698 4.258163,-9.499861 9.499861,-9.499861 z" />
+  <path
+     style="color:#000000;fill:url(#linearGradient3662);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path2555-7-1-9-4"
+     d="m 41.999861,22.50028 c 5.241697,0 9.49986,4.258163 9.49986,9.499861 0,5.241696 -4.258163,9.499859 -9.49986,9.499859 -5.241698,0 -9.49987,-4.258163 -9.499861,-9.499859 0,-5.241698 4.258163,-9.499861 9.499861,-9.499861 z" />
+  <path
+     style="color:#000000;fill:none;stroke:url(#linearGradient3659);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path8655-6-0-5-2"
+     d="m 33.49986,31.999836 c 0,4.694578 3.805862,8.500304 8.499893,8.500304 4.694461,0 8.500107,-3.805772 8.500107,-8.500304 0,-4.694354 -3.805646,-8.499696 -8.500107,-8.499696 -4.694031,0 -8.499893,3.805342 -8.499893,8.499696 l 0,0 z" />
+  <path
+     style="opacity:0.5;color:#000000;fill:none;stroke:#656565;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+     id="path2555-7-1-9-9-41"
+     d="m 41.999861,22.50028 c 5.241697,0 9.49986,4.258163 9.49986,9.499861 0,5.241696 -4.258163,9.499859 -9.49986,9.499859 -5.241698,0 -9.49987,-4.258163 -9.499861,-9.499859 0,-5.241698 4.258163,-9.499861 9.499861,-9.499861 z" />
 </svg>


### PR DESCRIPTION
Use newer style from upstream for `preferences-system`. A more simplified version of the previous style, and maybe goes a little better with the new session icons and newer rounded-square app icons.

This one was [deleted from upstream](https://github.com/elementary/icons/commit/bc2afafaa0d4a3f05306440c4368944bcf3a9d92) a little bit back, but still fits this theme well I think.

Current:
![current](https://github.com/shimmerproject/elementary-xfce/assets/1984060/bbe8404b-c401-4125-84fb-5039a41f1741)


Proposed:
![proposed](https://github.com/shimmerproject/elementary-xfce/assets/1984060/d5d73e7b-8bb8-41b0-8ac7-a1a0643db73c)
