### PR TITLE
Apps: New Xfburn icon

### DIFF
--- a/elementary-xfce/apps/128/stock_xfburn.svg
+++ b/elementary-xfce/apps/128/stock_xfburn.svg
@@ -1,0 +1,493 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="128"
+   height="128"
+   id="svg4201"
+   version="1.1"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview76"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="29.344931"
+     inkscape:cy="80.256619"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     inkscape:window-x="610"
+     inkscape:window-y="268"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4203">
+    <linearGradient
+       id="linearGradient31977">
+      <stop
+         id="stop31973"
+         style="stop-color:#000000;stop-opacity:0.28;"
+         offset="0" />
+      <stop
+         id="stop31975"
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="15.786877"
+       y1="31.299713"
+       x2="17.218966"
+       y2="30.558231"
+       id="linearGradient2651"
+       xlink:href="#linearGradient31977"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0859888,0,0,-1.0859883,37.559432,27.149712)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#000000;stop-opacity:0.28;"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#000000;stop-opacity:0.23999999;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient4064"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.9459458,0,0,2.9459459,-147.32304,-74.701047)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop4015" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2682"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2684"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2686"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2688"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2690"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2672"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2674"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2676"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2678"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2680"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient2658"
+       xlink:href="#linearGradient3263-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,3.1714559,-3.1714559,0,137.26064,-76.11495)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263-6"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265-8"
+         style="stop-color:#dedcde;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3267-9"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="0.5" />
+      <stop
+         id="stop3269-2"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627417"
+       fy="41.63604"
+       fx="23.334524"
+       cy="41.63604"
+       cx="23.334524"
+       gradientTransform="matrix(2.2097086,0,0,0.7954211,12.437497,8.881818)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4199"
+       xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="40.887032"
+       y1="-14.630476"
+       x2="43.546879"
+       y2="-13.299444"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,10.883559,-12.068949,0,209.06849,-112.51881)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7103894,0,0,2.7060766,-1.0779784,-64.929716)" />
+    <linearGradient
+       id="linearGradient6036-7">
+      <stop
+         id="stop6038-5"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040-9"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7103894,0,0,2.7060766,-1.0779784,-64.929716)" />
+  </defs>
+  <metadata
+     id="metadata4206">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,64)">
+    <path
+       d="M 114,41.999991 C 114.0025,51.94084 91.616059,60 64,60 36.383939,60 13.997424,51.94084 13.999999,41.999991 13.997419,32.05915 36.383939,24.000001 64,24.000001 c 27.616059,0 50.00257,8.059149 50,17.99999 z"
+       id="path23417"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4199);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+    <path
+       id="path2781"
+       style="fill:url(#linearGradient2658);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 64 -55.5 C 33.236897 -55.5 8.5 -30.763099 8.5 0 C 8.4999946 30.763099 33.2369 55.5 64 55.5 C 94.763093 55.49999 119.5 30.763101 119.5 0 C 119.5 -30.763101 94.763096 -55.5 64 -55.5 z M 64 -21 A 21 20.99999 0 0 1 85 0 A 21 20.99999 0 0 1 64 21 A 21 20.99999 0 0 1 43 0 A 21 20.99999 0 0 1 64 -21 z " />
+    <g
+       transform="matrix(2.7320403,0,0,2.7320403,-1.0900842,-65.074256)"
+       id="g3527">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient2672);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient2674);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient2676);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient2678);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient2680);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       transform="matrix(-2.7073165,0,0,-2.7073165,128.97558,64.95078)"
+       id="g3297">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3299"
+         style="opacity:0.8;fill:url(#linearGradient2682);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3301"
+         style="opacity:0.8;fill:url(#linearGradient2684);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         id="path3303"
+         style="opacity:0.8;fill:url(#linearGradient2686);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         id="path3305"
+         style="opacity:0.8;fill:url(#linearGradient2688);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         id="path3307"
+         style="opacity:0.8;fill:url(#linearGradient2690);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <path
+       id="path2559"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2477);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       d="m 65.501953,-55.478516 c -1.176802,-0.03434 -1.831415,-0.02609 -3.001953,0.02148 2.83e-4,11.252608 2.1e-5,22.778948 0,34.054687 0.665234,-0.0621 0.818626,-0.09766 1.5,-0.09766 11.867987,0 21.5,9.632012 21.5,21.5 0,11.867989 -9.632013,21.5 -21.5,21.5 -7.544549,0 -14.18031,-3.896304 -18.017578,-9.78125 L 18.554688,31.966797 c 5.58933,8.338813 16.159273,16.979192 27.40039,20.560547 20.431586,7.177131 44.695193,1.042911 59.115232,-15.125 16.47375,-17.538033 19.22799,-46.2465157 6.20899,-66.541016 -10.05011,-16.181034 -28.125311,-25.824696 -45.777347,-26.339844 z"
+       sodipodi:nodetypes="sccssscccccs" />
+    <path
+       style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient4064);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path8655"
+       d="m 118.49999,-0.001923 c 0,30.100492 -24.402273,54.501933 -54.499313,54.501933 -30.099783,0 -54.500684,-24.401718 -54.500684,-54.501933 0,-30.099098 24.400901,-54.498065 54.500684,-54.498065 30.09704,0 54.499313,24.398967 54.499313,54.498065 l 0,0 z" />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:0.999998;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="63.999989"
+       cy="9.9999997e-06"
+       r="9.5" />
+    <circle
+       style="opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="64"
+       cy="0"
+       r="55.5" />
+    <path
+       d="m 64,-21 c -11.592,0 -21,9.408 -21,21 0,11.592001 9.408,21 21,21 11.592,0 21,-9.407999 21,-21 0,-11.592 -9.408,-21 -21,-21 z m 0,10.500001 C 69.796001,-10.499999 74.5,-5.796 74.5,0 74.5,5.7960003 69.796001,10.5 64,10.5 58.204,10.5 53.5,5.7960003 53.5,0 c 0,-5.796 4.704,-10.499999 10.5,-10.499999 z"
+       id="path2474"
+       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+    <path
+       d="M 63.999999,22.500002 C 51.52857,22.500002 41.5,12.471432 41.5,2e-7 41.5,-12.471432 51.52857,-22.500002 63.999999,-22.500002 76.471435,-22.500002 86.5,-12.471432 86.5,2e-7 86.5,12.471432 76.471435,22.500002 63.999999,22.500002 Z"
+       id="path7063"
+       style="opacity:1;fill:none;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.5" />
+    <path
+       d="M 63.999999,21.5 C 52.082857,21.5 42.500001,11.917145 42.500001,1.5e-7 42.500001,-11.917145 52.082857,-21.5 63.999999,-21.5 c 11.91715,0 21.5,9.582855 21.5,21.50000015 C 85.499999,11.917145 75.917149,21.5 63.999999,21.5 Z"
+       id="path3281"
+       style="opacity:1;fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="M 46.146064,12.844273 19.54984,32.491164"
+       id="path2528"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 63.5,-55 v 33"
+       id="path2526"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/16/stock_xfburn.svg
+++ b/elementary-xfce/apps/16/stock_xfburn.svg
@@ -1,0 +1,462 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg4087"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview23023"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="41.7193"
+     inkscape:cx="7.3347347"
+     inkscape:cy="8.4613117"
+     inkscape:window-width="1326"
+     inkscape:window-height="823"
+     inkscape:window-x="187"
+     inkscape:window-y="118"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4089">
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient3194"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135135,0,0,0.35135138,-17.203666,-0.9093005)" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient3054"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.1767888,0,0,-0.1767887,3.6957217,12.41972)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient3301"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient3303"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient3305"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient3307"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient3309"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient3312"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient3314"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient3316"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient3318"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient3320"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dedbde;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3269"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient4083"
+       xlink:href="#linearGradient3263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.4285752,-0.4285752,0,17.900088,-2.2858061)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="40.99971"
+       y1="-21.614748"
+       x2="47.893272"
+       y2="-17.992374"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13513514,0,0,0.13513514,-0.64864946,7.9999993)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-9"
+       id="linearGradient4698"
+       x1="57.735619"
+       y1="-4.892344"
+       x2="61.89027"
+       y2="-2.1521533"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2631579,0,0,0.2631579,-8.8421021,7.9999987)" />
+    <linearGradient
+       id="linearGradient6036-9">
+      <stop
+         id="stop6038-1"
+         style="stop-color:#000000;stop-opacity:0.33000001;"
+         offset="0" />
+      <stop
+         id="stop6040-2"
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477-3"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.5143897,-1.6937278,0,28.574618,-7.6053473)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35941103,0,0,0.36528796,-0.49313571,-0.77208069)" />
+    <linearGradient
+       id="linearGradient6036-6">
+      <stop
+         id="stop6038-18"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040-7"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35941103,0,0,0.36528796,-0.49313571,-0.77208069)" />
+  </defs>
+  <metadata
+     id="metadata4092">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       id="path2781"
+       style="fill:url(#linearGradient4083);fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 8 0.5 C 3.8428233 0.5 0.5 3.842824 0.5 8 C 0.4999992 12.157175 3.8428236 15.5 8 15.5 C 12.157176 15.499999 15.5 12.157175 15.5 8 C 15.5 3.8428237 12.157177 0.5 8 0.5 z M 8 5 A 3 3 0 0 1 11 8 A 3 3 0 0 1 8 11 A 3 3 0 0 1 5 8 A 3 3 0 0 1 8 5 z " />
+    <g
+       transform="matrix(0.3357395,0,0,0.3357395,-0.1714995,-0.39196467)"
+       id="g3527">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 l 10e-7,0 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient3312);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 l 0,0 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient3314);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient3316);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient3318);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient3320);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       transform="matrix(-0.34797631,0,0,-0.34797631,16.395856,16.437447)"
+       id="g3297"
+       style="stroke-width:1.0081">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z"
+         transform="rotate(1.618417,24.093743,24.175959)"
+         id="path3299"
+         style="opacity:0.8;fill:url(#linearGradient3301);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3301"
+         style="opacity:0.8;fill:url(#linearGradient3303);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path3303"
+         style="opacity:0.8;fill:url(#linearGradient3305);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path3305"
+         style="opacity:0.8;fill:url(#linearGradient3307);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z"
+         id="path3307"
+         style="opacity:0.8;fill:url(#linearGradient3309);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0081" />
+    </g>
+    <path
+       d="M 7.9999996,11.5 C 6.0599997,11.5 4.5,9.9400008 4.5,8.000001 4.5,6.0600013 6.0599997,4.5000015 7.9999996,4.5000015 9.9399998,4.5000015 11.5,6.0600013 11.5,8.000001 11.5,9.9400008 9.9399998,11.5 7.9999996,11.5 l 0,0 0,0 0,0 z"
+       id="path3281"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3054);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       id="path2559"
+       style="font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#radialGradient2477-3);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate;stop-color:#000000"
+       d="M 8.4199219,0.50390625 C 8.26449,0.49925625 7.6552188,0.49946938 7.5,0.50585938 7.5000326,1.8571884 7.5000083,4.0510746 7.5,5.5507812 7.6618242,5.5176041 7.8286905,5.5 8,5.5 9.375774,5.5 10.5,6.6242261 10.5,8 10.5,9.3757739 9.375774,10.5 8,10.5 7.0723972,10.5 6.2595347,9.989037 5.828125,9.234375 l -3.8971664,3.158839 c 0.741171,1.12563 2.2756833,2.246394 3.766307,2.729833 2.5644305,0.917013 5.9472144,0.09458 7.8593754,-2.087891 2.232577,-2.419529 2.581641,-6.1846922 0.822265,-8.9765622 C 13.073658,1.9193305 10.666924,0.57092571 8.4199219,0.50390625 Z"
+       sodipodi:nodetypes="cccssscccccc" />
+    <path
+       d="M 14.5,7.9997706 C 14.5,11.589738 11.589638,14.5 8.0000825,14.5 4.4102002,14.5 1.5,11.589704 1.5,7.9997706 c 0,-3.5898007 2.9102002,-6.49977 6.5000825,-6.49977 3.5895555,0 6.4999175,2.9099693 6.4999175,6.49977 l 0,0 z"
+       id="path8655"
+       style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3194);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="8"
+       cy="8"
+       r="2.5" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999998;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="8"
+       cy="8"
+       r="7.5000005" />
+    <path
+       d="M 6.0330217,10.375579 2.9941909,12.844904"
+       id="path2528"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="M 8.5,1 V 5"
+       id="path2526"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/22/stock_xfburn.svg
+++ b/elementary-xfce/apps/22/stock_xfburn.svg
@@ -1,0 +1,501 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="22"
+   height="22"
+   id="svg4250"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20733"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="1.2374369"
+     inkscape:cy="15.556349"
+     inkscape:window-width="1326"
+     inkscape:window-height="791"
+     inkscape:window-x="208"
+     inkscape:window-y="236"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4252">
+    <linearGradient
+       id="linearGradient23205">
+      <stop
+         id="stop23201"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop23203"
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient3065"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,-0.2272999,5.4659271,24.682537)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient4112"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945944,0,0,0.45945944,-21.958749,7.3494157)" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2492"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2494"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2496"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2498"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2500"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2480"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2482"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2484"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2486"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2488"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.54286194,-0.54286195,0,23.540113,5.9713495)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dedbde;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3269"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.334524"
+       cy="41.63604"
+       r="22.627417"
+       fx="23.334524"
+       fy="41.63604"
+       id="radialGradient4248"
+       xlink:href="#linearGradient23419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48613589,0,0,0.1546652,-0.34375034,20.060392)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="37.747486"
+       y1="-17.190691"
+       x2="48.305836"
+       y2="-13.042283"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17117118,0,0,0.17117118,0.04504405,19.000039)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="9.3959713"
+       y1="35.451885"
+       x2="18.351213"
+       y2="28.840721"
+       id="linearGradient2651"
+       xlink:href="#linearGradient23205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17678888,0,0,-0.1767888,6.6957213,23.419761)" />
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5804"
+       id="linearGradient21339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08839444,0,0,-0.0883944,8.847861,21.209898)"
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591" />
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45630868,0,0,0.4631407,0.19461215,7.8859676)" />
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45630868,0,0,0.4631407,0.19461215,7.8859676)" />
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477-3"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9200619,-2.1503589,0,37.099068,-0.77778292)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4255">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-8)"
+     id="layer1">
+    <path
+       d="m 22,26.500038 c 5.65e-4,1.932944 -4.924467,3.500001 -11,3.500001 C 4.9244668,30.000039 -5.6640114e-4,28.432982 4.8857551e-8,26.500038 -5.6640114e-4,24.567095 4.9244668,23.000039 11,23.000039 c 6.075533,0 11.000565,1.567056 11,3.499999 z"
+       id="path23417"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4248);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+    <path
+       d="m 20.5,19.00004 c 0,-5.265763 -4.234239,-9.5000012 -9.5,-9.5000012 -5.265763,0 -9.5000002,4.2342392 -9.5000002,9.5000012 -1.1e-6,5.265761 4.2342377,9.499999 9.5000002,9.499999 5.265761,-1e-6 9.5,-4.234238 9.5,-9.499999 z m -6.016667,0 c 0,1.783341 -1.737124,3.483333 -3.483333,3.483333 -1.783582,0 -3.4833334,-1.814067 -3.4833334,-3.483333 0,-1.706641 1.6410484,-3.483334 3.4833334,-3.483334 1.87965,0 3.483333,1.662649 3.483333,3.483334 z"
+       id="path2781"
+       style="fill:url(#linearGradient3072);fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999999;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="11"
+       cy="19.000038"
+       r="9.5" />
+    <path
+       id="path2474"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="m 11,16.000039 c -1.655998,0 -3,1.344002 -3,3 0,1.655998 1.344002,3 3,3 1.655997,0 3,-1.344002 3,-3 0,-1.655998 -1.344003,-3 -3,-3 z m 0,1.125 a 1.875,1.875 0 0 1 1.875,1.875 1.875,1.875 0 0 1 -1.875,1.875 1.875,1.875 0 0 1 -1.875,-1.875 1.875,1.875 0 0 1 1.875,-1.875 z" />
+    <g
+       transform="matrix(0.444875,0,0,0.444875,0.32300005,8.3230387)"
+       id="g3527">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z"
+         transform="rotate(1.618417,24.093743,24.175959)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient2480);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient2482);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient2484);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient2486);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient2488);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       transform="matrix(-0.444875,0,0,-0.444875,21.677,29.672961)"
+       id="g3297">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z"
+         transform="rotate(1.618417,24.093743,24.175959)"
+         id="path3299"
+         style="opacity:0.8;fill:url(#linearGradient2492);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3301"
+         style="opacity:0.8;fill:url(#linearGradient2494);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path3303"
+         style="opacity:0.8;fill:url(#linearGradient2496);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path3305"
+         style="opacity:0.8;fill:url(#linearGradient2498);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z"
+         id="path3307"
+         style="opacity:0.8;fill:url(#linearGradient2500);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <path
+       id="path2559"
+       style="font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#radialGradient2477-3);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate;stop-color:#000000"
+       d="m 11.509766,9.5039448 c -0.197337,-0.0059 -0.8127,-0.0061 -1.009766,0.002 4.2e-5,1.7318952 10e-6,4.1288892 0,6.0312502 0.16331,-0.02344 0.330253,-0.03716 0.5,-0.03716 1.932033,0 3.5,1.567968 3.5,3.5 0,1.932033 -1.567967,3.5 -3.5,3.5 -1.292187,0 -2.4210513,-0.701547 -3.0273438,-1.744141 l -4.6582031,3.806641 c 0.9409927,1.427162 2.8457814,2.86362 4.7382813,3.476562 3.2558076,1.162662 7.5527836,0.118671 9.9804686,-2.648437 2.834486,-3.067673 3.276678,-7.839151 1.042969,-11.378906 -1.691989,-2.769355 -4.606361,-4.4196462 -7.566406,-4.5078132 z" />
+    <path
+       d="m 19.499893,18.999738 c 0,4.694572 -3.80586,8.500301 -8.499893,8.500301 -4.6944621,0 -8.5001081,-3.805772 -8.5001081,-8.500301 0,-4.694354 3.805646,-8.499698 8.5001081,-8.499698 4.694033,0 8.499893,3.805344 8.499893,8.499698 z"
+       id="path8655"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.55;fill:none;stroke:url(#linearGradient4112);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 11,23.500039 c -2.4942862,0 -4.5000005,-2.005714 -4.5000005,-4.500001 0,-2.494285 2.0057142,-4.5 4.5000005,-4.5 2.494287,0 4.5,2.005715 4.5,4.5 0,2.494287 -2.005713,4.500001 -4.5,4.500001 z"
+       id="path3281"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3065);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="m 11,20.750039 c -0.97,0 -1.75,-0.78 -1.75,-1.75 0,-0.970001 0.78,-1.75 1.75,-1.75 0.970001,0 1.75,0.779999 1.75,1.75 0,0.97 -0.779999,1.75 -1.75,1.75 z"
+       id="path21337"
+       style="fill:none;stroke:url(#linearGradient21339);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="m 11,22.50004 c -1.94,0 -3.5,-1.559999 -3.5,-3.5 0,-1.94 1.56,-3.5 3.5,-3.5 1.940001,0 3.5,1.56 3.5,3.5 0,1.940001 -1.559999,3.5 -3.5,3.5 z"
+       id="path3281-7"
+       style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="M 8.2572457,22.027658 4.3459545,25.05822"
+       id="path2528"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 11.5,10.000039 v 5"
+       id="path2526"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/24/stock_xfburn.svg
+++ b/elementary-xfce/apps/24/stock_xfburn.svg
@@ -1,0 +1,501 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg4250"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20733"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="10.234375"
+     inkscape:cy="9.5625"
+     inkscape:window-width="1326"
+     inkscape:window-height="791"
+     inkscape:window-x="208"
+     inkscape:window-y="277"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs4252">
+    <linearGradient
+       id="linearGradient23205">
+      <stop
+         id="stop23201"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop23203"
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient3065"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2272999,0,0,-0.2272999,6.4659271,25.682498)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794"
+       id="linearGradient4112"
+       xlink:href="#linearGradient4011"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45945944,0,0,0.45945944,-20.958749,8.3493769)" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.507761" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2492"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2494"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2496"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2498"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2500"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2480"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2482"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2484"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2486"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2488"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3072"
+       xlink:href="#linearGradient3263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.54286194,-0.54286195,0,24.540113,6.9713107)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dedbde;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3269"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.334524"
+       cy="41.63604"
+       r="22.627417"
+       fx="23.334524"
+       fy="41.63604"
+       id="radialGradient4248"
+       xlink:href="#linearGradient23419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.48613589,0,0,0.1546652,0.65624961,21.060353)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="37.747486"
+       y1="-17.190691"
+       x2="48.305836"
+       y2="-13.042283"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17117118,0,0,0.17117118,1.045044,20)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="9.3959713"
+       y1="35.451885"
+       x2="18.351213"
+       y2="28.840721"
+       id="linearGradient2651"
+       xlink:href="#linearGradient23205"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.17678888,0,0,-0.1767888,7.6957213,24.419722)" />
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5804"
+       id="linearGradient21339"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.08839444,0,0,-0.0883944,9.847861,22.209859)"
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591" />
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45630868,0,0,0.4631407,1.1946121,8.8859288)" />
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45630868,0,0,0.4631407,1.1946121,8.8859288)" />
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477-3"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.9200619,-2.1503589,0,38.099068,0.22217827)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4255">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-8)"
+     id="layer1">
+    <path
+       d="M 23,27.499999 C 23.000565,29.432943 18.075533,31 12,31 5.9244668,31 0.99943355,29.432943 1,27.499999 0.99943355,25.567056 5.9244668,24 12,24 c 6.075533,0 11.000565,1.567056 11,3.499999 z"
+       id="path23417"
+       style="opacity:0.3;fill:url(#radialGradient4248);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
+    <path
+       d="M 21.5,20.000001 C 21.5,14.734238 17.265761,10.5 12,10.5 6.734237,10.5 2.4999998,14.734239 2.4999998,20.000001 2.4999987,25.265762 6.7342375,29.5 12,29.5 c 5.265761,-1e-6 9.5,-4.234238 9.5,-9.499999 z m -6.016667,0 c 0,1.783341 -1.737124,3.483333 -3.483333,3.483333 -1.783582,0 -3.4833334,-1.814067 -3.4833334,-3.483333 0,-1.706641 1.6410484,-3.483334 3.4833334,-3.483334 1.87965,0 3.483333,1.662649 3.483333,3.483334 z"
+       id="path2781"
+       style="fill:url(#linearGradient3072);fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999999;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="12"
+       cy="20"
+       r="9.5" />
+    <path
+       id="path2474"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="M 12 17 C 10.344002 17 9 18.344002 9 20 C 9 21.655998 10.344002 23 12 23 C 13.655997 23 15 21.655998 15 20 C 15 18.344002 13.655997 17 12 17 z M 12 18.125 A 1.875 1.875 0 0 1 13.875 20 A 1.875 1.875 0 0 1 12 21.875 A 1.875 1.875 0 0 1 10.125 20 A 1.875 1.875 0 0 1 12 18.125 z " />
+    <g
+       transform="matrix(0.444875,0,0,0.444875,1.323,9.3229999)"
+       id="g3527">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient2480);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient2482);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient2484);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient2486);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient2488);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       transform="matrix(-0.444875,0,0,-0.444875,22.677,30.672922)"
+       id="g3297">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251083,1.7260236 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3299"
+         style="opacity:0.8;fill:url(#linearGradient2492);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3301"
+         style="opacity:0.8;fill:url(#linearGradient2494);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         id="path3303"
+         style="opacity:0.8;fill:url(#linearGradient2496);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         id="path3305"
+         style="opacity:0.8;fill:url(#linearGradient2498);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         id="path3307"
+         style="opacity:0.8;fill:url(#linearGradient2500);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <path
+       id="path2559"
+       style="font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#radialGradient2477-3);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate;stop-color:#000000"
+       d="M 12.509766 10.503906 C 12.312429 10.498006 11.697066 10.497759 11.5 10.505859 C 11.500042 12.237754 11.50001 14.634748 11.5 16.537109 C 11.66331 16.513719 11.830253 16.5 12 16.5 C 13.932033 16.5 15.5 18.067968 15.5 20 C 15.5 21.932033 13.932033 23.5 12 23.5 C 10.707813 23.5 9.5789487 22.798453 8.9726562 21.755859 L 4.3144531 25.5625 C 5.2554458 26.989662 7.1602345 28.42612 9.0527344 29.039062 C 12.308542 30.201724 16.605518 29.157733 19.033203 26.390625 C 21.867689 23.322952 22.309881 18.551474 20.076172 15.011719 C 18.384183 12.242364 15.469811 10.592073 12.509766 10.503906 z " />
+    <path
+       d="M 20.499893,19.999699 C 20.499893,24.694271 16.694033,28.5 12,28.5 c -4.6944621,0 -8.5001081,-3.805772 -8.5001081,-8.500301 0,-4.694354 3.805646,-8.499698 8.5001081,-8.499698 4.694033,0 8.499893,3.805344 8.499893,8.499698 l 0,0 z"
+       id="path8655"
+       style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient4112);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="m 12,24.5 c -2.4942862,0 -4.5000005,-2.005714 -4.5000005,-4.500001 0,-2.494285 2.0057142,-4.5 4.5000005,-4.5 2.494287,0 4.5,2.005715 4.5,4.5 C 16.5,22.494286 14.494287,24.5 12,24.5 l 0,0 0,0 z"
+       id="path3281"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3065);stroke-width:0.99999976;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="m 12,21.75 c -0.97,0 -1.75,-0.78 -1.75,-1.75 0,-0.970001 0.78,-1.75 1.75,-1.75 0.970001,0 1.75,0.779999 1.75,1.75 0,0.97 -0.779999,1.75 -1.75,1.75 z"
+       id="path21337"
+       style="fill:none;stroke:url(#linearGradient21339);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="m 12,23.500001 c -1.94,0 -3.5,-1.559999 -3.5,-3.5 0,-1.94 1.56,-3.5 3.5,-3.5 1.940001,0 3.5,1.56 3.5,3.5 0,1.940001 -1.559999,3.5 -3.5,3.5 z"
+       id="path3281-7"
+       style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="M 9.2572457,23.027619 5.3459545,26.058181"
+       id="path2528"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 12.5,11 v 5"
+       id="path2526"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/32/stock_xfburn.svg
+++ b/elementary-xfce/apps/32/stock_xfburn.svg
@@ -1,0 +1,501 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="32px"
+   height="32px"
+   id="svg4106"
+   version="1.1"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview15024"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="20.815456"
+     inkscape:cy="31.156892"
+     inkscape:window-width="1326"
+     inkscape:window-height="990"
+     inkscape:window-x="556"
+     inkscape:window-y="77"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4106" />
+  <defs
+     id="defs4108">
+    <linearGradient
+       id="linearGradient15992">
+      <stop
+         id="stop15988"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop15990"
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient3406"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.3283222,0,0,-0.3283221,8.0063395,24.208052)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3199"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567564,0,0,0.67567564,-32.468594,-1.1332689)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4013" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.507761" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4017" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4019" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient3436"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient3438"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient3440"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient3442"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient3444"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient3446"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient3448"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient3450"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient3452"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient3454"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3431"
+       xlink:href="#linearGradient3263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,0.7714354,-0.7714354,0,33.82016,-2.5144531)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dedbde;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3269"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627417"
+       fy="41.63604"
+       fx="23.334524"
+       cy="41.63604"
+       cx="23.334524"
+       gradientTransform="matrix(0.61871843,0,0,0.19951815,1.5624994,18.177856)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4104"
+       xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="40.31485"
+       y1="-15.497827"
+       x2="45.617664"
+       y2="-13.217505"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.24324325,0,0,0.24324325,0.43243062,16.000001)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="16.129335"
+       y1="45.258049"
+       x2="16.129335"
+       y2="4.7419591"
+       id="linearGradient2651"
+       xlink:href="#linearGradient5804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.13890557,0,0,-0.1389055,12.618067,19.472637)" />
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.2;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="9.1064291"
+       y1="34.554546"
+       x2="24.682758"
+       y2="24.449186"
+       id="linearGradient2651-6"
+       xlink:href="#linearGradient15992"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2778111,0,0,-0.27781097,9.236133,22.945276)" />
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.65731016,0,0,0.65817542,0.23861408,0.2062241)" />
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.65731016,0,0,0.65817542,0.23861408,0.2062241)" />
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477-3"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.8813381,-3.0975802,0,53.399281,-13.487623)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4111">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1">
+    <path
+       d="M 30,26.484999 C 30.000722,28.978497 23.732497,31 16,31 8.2675033,31 1.999279,28.978497 2.0000001,26.484999 1.999279,23.991503 8.2675033,21.97 16,21.97 c 7.732497,0 14.000722,2.021503 14,4.514999 z"
+       id="path23417"
+       style="opacity:0.3;fill:url(#radialGradient4104);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible" />
+    <path
+       d="M 29.5,16 C 29.5,8.5170745 23.482924,2.5 16,2.5 8.5170738,2.5 2.5,8.5170751 2.5,16 c -1.3e-6,7.482925 6.0170745,13.5 13.5,13.5 7.482924,-1e-6 13.5,-6.017074 13.5,-13.5 z m -8.231707,0 c 0,3.044415 -2.223878,5.268293 -5.268293,5.268293 -3.044414,0 -5.268293,-2.223878 -5.268293,-5.268293 0,-3.044414 2.223879,-5.268293 5.268293,-5.268293 3.044415,0 5.268293,2.223879 5.268293,5.268293 z"
+       id="path2781"
+       style="fill:url(#linearGradient3431);fill-rule:nonzero;stroke:none" />
+    <path
+       id="path2474"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="M 16 11 C 13.240007 11 11 13.240007 11 16 C 11 18.759994 13.240007 21 16 21 C 18.759994 21 21 18.759994 21 16 C 21 13.240007 18.759994 11 16 11 z M 16 12.75 A 3.25 3.25 0 0 1 19.25 16 A 3.25 3.25 0 0 1 16 19.25 A 3.25 3.25 0 0 1 12.75 16 A 3.25 3.25 0 0 1 16 12.75 z " />
+    <g
+       transform="matrix(0.6585366,0,0,0.6585366,0.195122,0.195122)"
+       id="g3527">
+      <path
+         d="m 24,3.5 c -2.975804,0 -5.797406,0.6208152 -8.34375,1.75 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 l 0,-12.125 C 24.06248,3.4998614 24.0313,3.5 24,3.5 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient3446);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 19.597283,3.9975155 c -2.9067,0.6375811 -5.529765,1.8485223 -7.775043,3.4970525 l 7.230257,9.771547 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.688856,3.9774292 c -0.03058,0.00656 -0.061,0.013379 -0.09157,0.020086 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient3448);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 14.558173,5.8448691 C 11.915535,7.2130345 9.6952631,9.061613 7.9531621,11.235092 l 9.5129549,7.567261 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.641427,5.8017664 c -0.02783,0.014254 -0.05545,0.02871 -0.08325,0.043103 z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient3450);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 10.168897,8.9334932 C 7.970412,10.939005 6.3042413,13.299243 5.1840387,15.849551 L 16.331399,20.69683 c 0.455898,-1.036579 1.119019,-1.993675 2.009011,-2.805547 0.02369,-0.02161 0.0454,-0.0419 0.06926,-0.06318 L 10.238158,8.8703115 c -0.0232,0.020972 -0.04613,0.042084 -0.06926,0.063182 z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient3452);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 6.78125,12.96875 c -0.016978,0.02626 -0.045621,0.06739 -0.0625,0.09375 -1.1482224,1.793482 -1.9616625,3.681269 -2.5,5.625 l 11.75,3.125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 6.78125,12.96875 z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient3454);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <g
+       transform="matrix(-0.6585366,0,0,-0.6585366,31.804879,31.804879)"
+       id="g3642"
+       style="opacity:0.8">
+      <path
+         d="m 24,3.5 c -2.975804,0 -5.797406,0.6208152 -8.34375,1.75 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 l 0,-12.125 C 24.06248,3.4998614 24.0313,3.5 24,3.5 z"
+         transform="matrix(0.9996011,0.02824295,-0.02824295,0.9996011,0.6924114,-0.6708346)"
+         id="path3644"
+         style="opacity:0.8;fill:url(#linearGradient3436);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 19.597283,3.9975155 c -2.9067,0.6375811 -5.529765,1.8485223 -7.775043,3.4970525 l 7.230257,9.771547 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.688856,3.9774292 c -0.03058,0.00656 -0.061,0.013379 -0.09157,0.020086 z"
+         id="path3646"
+         style="opacity:0.8;fill:url(#linearGradient3438);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 14.558173,5.8448691 C 11.915535,7.2130345 9.6952631,9.061613 7.9531621,11.235092 l 9.5129549,7.567261 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.641427,5.8017664 c -0.02783,0.014254 -0.05545,0.02871 -0.08325,0.043103 z"
+         id="path3648"
+         style="opacity:0.8;fill:url(#linearGradient3440);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 10.168897,8.9334932 C 7.970412,10.939005 6.3042413,13.299243 5.1840387,15.849551 L 16.331399,20.69683 c 0.455898,-1.036579 1.119019,-1.993675 2.009011,-2.805547 0.02369,-0.02161 0.0454,-0.0419 0.06926,-0.06318 L 10.238158,8.8703115 c -0.0232,0.020972 -0.04613,0.042084 -0.06926,0.063182 z"
+         id="path3650"
+         style="opacity:0.8;fill:url(#linearGradient3442);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="m 6.78125,12.96875 c -0.016978,0.02626 -0.045621,0.06739 -0.0625,0.09375 -1.1482224,1.793482 -1.9616625,3.681269 -2.5,5.625 l 11.75,3.125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 L 6.78125,12.96875 z"
+         id="path3652"
+         style="opacity:0.8;fill:url(#linearGradient3444);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <path
+       d="m 16,18.75 c -1.524286,0 -2.75,-1.225715 -2.75,-2.750001 C 13.25,14.475713 14.475714,13.25 16,13.25 c 1.524286,0 2.75,1.225714 2.75,2.749999 C 18.75,17.524285 17.524286,18.75 16,18.75 Z"
+       id="path3281-7"
+       style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       style="opacity:0.55;color:#000000;fill:none;stroke:url(#linearGradient3199);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
+       id="path8655"
+       d="M 28.5,15.999557 C 28.5,22.903339 22.903147,28.5 16.000158,28.5 9.096537,28.5 3.5,22.903276 3.5,15.999557 3.5,9.0960941 9.096537,3.5000011 16.000158,3.5000011 22.903147,3.5000011 28.5,9.0960941 28.5,15.999557 l 0,0 z" />
+    <path
+       d="m 16,22.5 c -3.602857,0 -6.4999998,-2.897142 -6.4999998,-6.499999 0,-3.602858 2.8971428,-6.5000015 6.4999998,-6.5000015 3.602859,0 6.5,2.8971435 6.5,6.5000015 C 22.5,19.602858 19.602859,22.5 16,22.5 Z"
+       id="path3281"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient3406);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999997;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="16"
+       cy="16"
+       r="13.500001" />
+    <path
+       d="m 16,21.5 c -3.048572,0 -5.5,-2.451428 -5.5,-5.5 0,-3.048572 2.451428,-5.5 5.5,-5.5 3.048573,0 5.5,2.451428 5.5,5.5 0,3.048572 -2.451427,5.5 -5.5,5.5 z"
+       id="path3281-7-1"
+       style="fill:none;stroke:url(#linearGradient2651-6);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+  </g>
+  <path
+     id="path2559"
+     style="font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#radialGradient2477-3);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate;stop-color:#000000"
+     d="m 16.537998,2.5055507 c -0.284262,-0.00835 -0.754125,-0.00773 -1.037998,0.00383 7e-5,2.7824237 4e-6,5.208169 0,7.9906193 0.111711,-0.0073 0.409665,0 0.523199,0 3.1884,0 5.493169,2.653886 5.493169,5.499023 0,2.845136 -2.291652,5.430973 -5.493169,5.4847 -2.13171,0.03577 -3.815905,-1.149839 -4.690828,-2.565138 l -6.3323891,4.854962 c 1.3554961,2.028161 3.820484,4.098497 6.6445501,5.000849 4.954968,1.745631 10.802855,0.295201 14.33688,-3.678731 C 30.018043,20.785732 30.659693,13.872709 27.486579,8.9119346 25.049276,4.9763586 20.801931,2.6308461 16.537998,2.5055507 Z"
+     sodipodi:nodetypes="sccssscccccs" />
+  <path
+     d="M 11.523681,20.041577 6.0035187,24.280232"
+     id="path2528"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cc" />
+  <path
+     d="M 16.5,2.7452385 V 10.599334"
+     id="path2526"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cc" />
+</svg>

--- a/elementary-xfce/apps/48/stock_xfburn.svg
+++ b/elementary-xfce/apps/48/stock_xfburn.svg
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.0"
+   width="48"
+   height="48"
+   id="svg2536"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview76"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16.75"
+     inkscape:cx="27.313433"
+     inkscape:cy="28.895522"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="531"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1" />
+  <metadata
+     id="metadata57951">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs2538">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient36558">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop36554" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1"
+         id="stop36556" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="23.334524"
+       cy="41.63604"
+       r="22.627417"
+       fx="23.334524"
+       fy="41.63604"
+       id="radialGradient2464"
+       xlink:href="#linearGradient23419"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.92807763,0,0,0.2872354,2.3437492,27.540524)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265"
+         style="stop-color:#dedbde;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3267"
+         style="stop-color:#e6e6e6;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop3269"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient2459"
+       xlink:href="#linearGradient3263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.1714389,-1.1714389,0,51.060244,-4.11454)" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient3354"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient3352"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient3350"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient3348"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient3346"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient2445"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4293444,0,0,0.4293442,13.546752,13.266392)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,4.0218963,-4.4528468,0,77.533666,-17.586016)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient2443"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4293444,0,0,-0.4293442,13.546752,34.733607)" />
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient3210"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient3210"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3210">
+      <stop
+         id="stop3212"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3214"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="-0.28915662"
+       x2="17.301205"
+       y2="48.156349"
+       id="linearGradient3216"
+       xlink:href="#linearGradient3210"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient36558"
+       id="linearGradient36560"
+       x1="17.088123"
+       y1="17.39418"
+       x2="18.357628"
+       y2="18.058981"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="layer1">
+    <path
+       d="m 45,39.499867 c 10e-4,3.589753 -9.401255,6.500001 -21,6.500001 -11.598745,0 -21.0010816,-2.910248 -21,-6.500001 -0.00108,-3.589751 9.401255,-6.499999 21,-6.499999 11.598745,0 21.001082,2.910248 21,6.499999 z"
+       id="path23417"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient2464);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+    <path
+       d="M 44.5,24 C 44.5,12.637039 35.362959,3.5 24,3.5 12.637038,3.5 3.5000001,12.63704 3.5000001,24 3.4999981,35.36296 12.637039,44.5 24,44.5 35.362958,44.499998 44.5,35.362961 44.5,24 Z m -13,0 c 0,4.12813 -3.28927,7.5 -7.5,7.5 -4.29333,0 -7.5,-3.455313 -7.5,-7.5 0,-4.127303 3.041467,-7.5 7.5,-7.5 4.458533,0 7.5,3.45447 7.5,7.5 z"
+       id="path2781"
+       style="fill:url(#linearGradient2459);fill-rule:nonzero;stroke:url(#linearGradient36560);stroke-width:1;stroke-miterlimit:4;stroke-opacity:0.3" />
+    <path
+       d="M 24,16 C 19.584,16 16,19.584 16,24 C 16,28.416 19.584,32 24,32 C 28.416,32 32,28.416 32,24 C 32,19.584 28.416,16 24,16 z M 24,20 C 26.208,20 28,21.792 28,24 C 28,26.208 26.208,28 24,28 C 21.792,28 20,26.208 20,24 C 20,21.792 21.792,20 24,20 z"
+       id="path2474"
+       style="opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 24,16.5 C 19.86,16.5 16.5,19.86 16.5,24 C 16.5,28.14 19.86,31.5 24,31.5 C 28.14,31.5 31.5,28.14 31.5,24 C 31.5,19.86 28.14,16.5 24,16.5 z M 24,20.25 C 26.07,20.25 27.75,21.93 27.75,24 C 27.75,26.07 26.07,27.75 24,27.75 C 21.93,27.75 20.25,26.07 20.25,24 C 20.25,21.93 21.93,20.25 24,20.25 z"
+       id="path3418"
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;marker:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.30000001;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <g
+       id="g3527">
+      <path
+         d="M 15.856928,5.7307748 L 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 C 24.03206,15.625 24.06178,15.62464 24.09375,15.625 L 24.10801,4.0047512 C 21.16586,3.9340642 18.564969,4.6620377 15.856927,5.7307748 L 15.856928,5.7307748 z"
+         transform="matrix(0.9996011,2.824295e-2,-2.824295e-2,0.9996011,0.6924114,-0.6708346)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient3346);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 12.121471,7.9060109 L 19.052497,17.266115 C 19.965606,16.59636 21.018435,16.099051 22.195126,15.840946 C 22.226446,15.834046 22.255386,15.827356 22.286696,15.820856 L 19.857174,4.426276 C 16.968201,4.9876004 14.537644,6.2818798 12.121471,7.9060109 L 12.121471,7.9060109 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient3348);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 8.2523933,11.646535 L 17.466117,18.802353 C 18.174767,17.919089 19.063008,17.166234 20.132802,16.612373 C 20.161272,16.597633 20.187492,16.583653 20.216052,16.569273 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient3350);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 5.6328855,16.073974 C 12.807692,18.316222 13.483148,23.105437 18.409671,17.828101 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient3352);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 C 16.95479,19.56675 16.98246,19.52673 17,19.5 L 7.155289,13.193173 z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient3354);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+    <path
+       d="M 24,15.499999 C 19.288571,15.499999 15.5,19.28857 15.5,23.999999 C 15.5,28.711428 19.288571,32.5 24,32.5 C 28.711431,32.5 32.5,28.711428 32.5,23.999999 C 32.5,19.28857 28.711431,15.499999 24,15.499999 L 24,15.499999 L 24,15.499999 L 24,15.499999 z"
+       id="path2443"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient2445);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="M 23.5,3.5 C 23.500109,7.8333333 23.5,12.166667 23.5,16.5 C 28.495859,16.5 32.591413,20.608167 31.251697,25.790596 C 30.274467,29.952566 25.62769,32.687818 21.262252,30.974247 C 19.898605,30.36365 18.498786,29.343412 17.672999,28.103718 C 17.672999,28.103718 7.2437019,35.807275 7.2437019,35.807275 C 9.3058927,38.888773 13.205287,42.081562 17.352713,43.405013 C 24.890976,46.057246 33.843296,43.790629 39.163583,37.815949 C 45.241595,31.334954 46.257756,20.725927 41.454372,13.226309 C 37.499169,6.8481443 30.409949,3.2187718 23.5,3.5 z"
+       id="path2559"
+       style="fill:url(#radialGradient2477);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;marker:none;marker-start:none;marker-mid:none;marker-end:none;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+    <path
+       d="M 24,32.5 C 19.288571,32.5 15.5,28.711429 15.5,24 C 15.5,19.288571 19.288571,15.499999 24,15.499999 C 28.711431,15.499999 32.5,19.288571 32.5,24 C 32.5,28.711429 28.711431,32.5 24,32.5 L 24,32.5 L 24,32.5 L 24,32.5 z"
+       id="path3281"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient2443);stroke-width:0.99999982;stroke-miterlimit:4;stroke-opacity:1" />
+    <path
+       d="M 17.046209,29.756641 L 8.9865803,35.718872"
+       id="path2528"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="M 24.5,5 L 24.5,15.5"
+       id="path2526"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="M 24.000001,4.5000009 C 13.191429,4.5000009 4.4999995,13.191431 4.4999995,24.000001 C 4.4999995,34.808572 13.191429,43.499999 24.000001,43.499999 C 34.808573,43.499999 43.5,34.808572 43.5,24.000001 C 43.5,13.191431 34.808573,4.5000009 24.000001,4.5000009 L 24.000001,4.5000009 L 24.000001,4.5000009 z"
+       id="path2561"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3216);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/64/stock_xfburn.svg
+++ b/elementary-xfce/apps/64/stock_xfburn.svg
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="64px"
+   height="64px"
+   id="svg4132"
+   version="1.1"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview4604"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4"
+     inkscape:cx="1.625"
+     inkscape:cy="35.75"
+     inkscape:window-width="1326"
+     inkscape:window-height="895"
+     inkscape:window-x="592"
+     inkscape:window-y="92"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4132" />
+  <defs
+     id="defs4134">
+    <linearGradient
+       id="linearGradient5804">
+      <stop
+         id="stop5800"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0" />
+      <stop
+         id="stop5802"
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient6036"
+       id="linearGradient3064"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5808777,0,0,-0.5808775,17.85737,46.52194)"
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient3227"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.4324324,-70.753407,-4.322531)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         id="stop4013" />
+      <stop
+         id="stop4015"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         offset="0.507761" />
+      <stop
+         offset="0.83456558"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         id="stop4017" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         id="stop4019" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2489"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2491"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2493"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2495"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2497"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2477"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2479"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2481"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2483"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2485"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       xlink:href="#linearGradient3263-6"
+       id="linearGradient3070"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1.5714424,-1.5714424,0,68.300327,-5.7146267)"
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3263-6"
+       y2="14.2033"
+       x2="35.391201"
+       y1="32.4165"
+       x1="12.2744">
+      <stop
+         offset="0"
+         style="stop-color:#dedcde;stop-opacity:1;"
+         id="stop3265-8" />
+      <stop
+         offset="0.5"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         id="stop3267-9" />
+      <stop
+         offset="1"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         id="stop3269-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627417"
+       fy="41.63604"
+       fx="23.334524"
+       cy="41.63604"
+       cx="23.334524"
+       gradientTransform="matrix(1.1048543,0,0,0.3756156,6.218749,37.860857)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4130"
+       xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="39.026234"
+       y1="-11.909745"
+       x2="43.978451"
+       y2="-9.344243"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.4954955,0,0,0.4954955,0.2882874,32)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="12.332931"
+       y1="35.300495"
+       x2="20.067657"
+       y2="30.882797"
+       id="linearGradient2651"
+       xlink:href="#linearGradient5804"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.53036665,0,0,-0.53036641,19.087164,45.259163)" />
+    <linearGradient
+       id="linearGradient6036-9">
+      <stop
+         id="stop6038-1"
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="0" />
+      <stop
+         id="stop6040-2"
+         style="stop-color:#000000;stop-opacity:0.25999999;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-9"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55263156,0,0,0.55263156,-3.3684128,31.999996)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3416663,0,0,1.3408046,-0.21864914,-0.17236267)" />
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3416663,0,0,1.3408046,-0.21864914,-0.17236267)" />
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477-3"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.5586302,-6.3226148,0,108.29006,-25.25415)" />
+  </defs>
+  <metadata
+     id="metadata4137">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4130);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none"
+     id="path23417"
+     d="M 57,53.499999 C 57.001249,58.194291 45.808029,62 32,62 18.191971,62 6.9987125,58.194291 7.0000001,53.499999 6.9987125,48.805709 18.191971,45 32,45 c 13.808029,0 25.001287,3.805709 25,8.499999 z" />
+  <path
+     id="path2781"
+     style="fill:url(#linearGradient3070);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+     d="M 32,4.5 C 16.757017,4.5 4.5,16.757021 4.5,32 4.4999974,47.24298 16.757019,59.5 32,59.5 47.242977,59.499997 59.5,47.242982 59.5,32 59.5,16.75702 47.242979,4.5 32,4.5 Z M 32,22 A 10,10 0 0 1 42,32 10,10 0 0 1 32,42 10,10 0 0 1 22,32 10,10 0 0 1 32,22 Z" />
+  <g
+     id="g3527"
+     transform="matrix(1.3333334,0,0,1.3333334,-1.6000002e-6,0.0588927)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2477);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3296"
+       transform="rotate(1.618417,24.093743,24.175959)"
+       d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2479);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3308"
+       d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2481);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3310"
+       d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2483);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3312"
+       d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2485);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3314"
+       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z" />
+  </g>
+  <g
+     id="g3297"
+     transform="matrix(-1.3333334,0,0,-1.3333334,64,64.046673)">
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2489);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3299"
+       transform="rotate(1.618417,24.093743,24.175959)"
+       d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2491);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3301"
+       d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2493);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3303"
+       d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2495);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3305"
+       d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z" />
+    <path
+       style="opacity:0.8;fill:url(#linearGradient2497);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="path3307"
+       d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z" />
+  </g>
+  <path
+     id="path2559"
+     style="font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#radialGradient2477-3);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate;stop-color:#000000"
+     d="m 33.050781,4.5117188 c -0.58022,-0.017016 -0.971355,-0.015754 -1.550781,0.00781 1.42e-4,5.6682252 7e-6,11.3375802 0,17.0058602 C 31.728017,21.510582 31.768261,21.5 32,21.5 c 5.79598,0 10.5,4.704019 10.5,10.5 0,5.79598 -4.70402,10.5 -10.5,10.5 -3.68415,0 -6.92472,-1.901854 -8.798828,-4.775391 L 9.5,47.837891 c 2.766766,4.131677 7.998052,8.413013 13.5625,10.1875 C 33.176315,61.58151 45.188136,58.542112 52.326172,50.53125 60.480816,41.84152 61.842954,27.618003 55.398438,17.5625 50.423546,9.5451351 41.754093,4.7669645 33.050781,4.5117188 Z"
+     sodipodi:nodetypes="sccssscccccs" />
+  <path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.55;fill:none;stroke:url(#linearGradient3227);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="path8655"
+     d="M 58.500001,31.999061 C 58.500001,46.63508 46.634673,58.5 32.000336,58.5 17.364659,58.5 5.5000001,46.634945 5.5000001,31.999061 c 0,-14.635341 11.8646589,-26.4990586 26.5003359,-26.4990586 14.634337,0 26.499665,11.8637176 26.499665,26.4990586 z" />
+  <path
+     style="opacity:0.4;fill:none;stroke:url(#linearGradient3064);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+     id="path3281"
+     d="m 31.999999,43.500001 c -6.374286,0 -11.5,-5.125713 -11.5,-11.5 0,-6.374285 5.125714,-11.500001 11.5,-11.500001 6.374289,0 11.5,5.125716 11.5,11.500001 0,6.374287 -5.125711,11.5 -11.5,11.5 v 0 z" />
+  <path
+     id="path3418"
+     style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.498039;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     d="m 32,22 c -5.519987,0 -10,4.480012 -10,10 0,5.519987 4.480013,10 10,10 5.519987,0 10,-4.480013 10,-10 0,-5.519988 -4.480013,-10 -10,-10 z m 0,4 a 6,6 0 0 1 6,6 6,6 0 0 1 -6,6 6,6 0 0 1 -6,-6 6,6 0 0 1 6,-6 z" />
+  <path
+     d="m 32,42.5 c -5.82,0 -10.5,-4.679998 -10.5,-10.5 0,-5.820001 4.68,-10.5 10.5,-10.5 5.820003,0 10.5,4.679999 10.5,10.5 0,5.820002 -4.679997,10.5 -10.5,10.5 z"
+     id="path3281-7"
+     style="fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+  <circle
+     style="fill:none;fill-rule:evenodd;stroke:#ffffff;stroke-width:1;stroke-linecap:round;stroke-opacity:0.5;stop-color:#000000"
+     id="circle10638"
+     cx="32"
+     cy="32"
+     r="6.25" />
+  <circle
+     style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path3498"
+     cx="32"
+     cy="32"
+     r="5.25" />
+  <path
+     d="M 23.358431,38.871037 10.51434,48.34249"
+     id="path2528"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cc" />
+  <path
+     d="M 32.5,5 V 21"
+     id="path2526"
+     style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="cc" />
+  <circle
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:0.999999;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+     id="path3554"
+     cx="32"
+     cy="32"
+     r="27.5" />
+</svg>

--- a/elementary-xfce/apps/96/stock_xfburn.svg
+++ b/elementary-xfce/apps/96/stock_xfburn.svg
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="96"
+   height="96"
+   id="svg4201"
+   version="1.1"
+   sodipodi:docname="stock_xfburn.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview76"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="4.5078058"
+     inkscape:cx="36.825012"
+     inkscape:cy="48.360558"
+     inkscape:window-width="1281"
+     inkscape:window-height="1005"
+     inkscape:window-x="462"
+     inkscape:window-y="22"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="layer1"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
+  <defs
+     id="defs4203">
+    <linearGradient
+       id="linearGradient30333">
+      <stop
+         id="stop30329"
+         style="stop-color:#000000;stop-opacity:0.28;"
+         offset="0" />
+      <stop
+         id="stop30331"
+         style="stop-color:#000000;stop-opacity:0.1;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="18.775953"
+       y1="4.0378027"
+       x2="18.203465"
+       y2="45.962208"
+       id="linearGradient2651"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80817772,0,0,-0.80817734,28.323288,4.2044439)" />
+    <linearGradient
+       id="linearGradient6036">
+      <stop
+         id="stop6038"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop6040"
+         style="stop-color:#ffffff;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4011"
+       id="linearGradient4064"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1891893,0,0,2.1891893,-109.03824,-71.511797)"
+       x1="71.204407"
+       y1="6.2375584"
+       x2="71.204407"
+       y2="44.340794" />
+    <linearGradient
+       id="linearGradient4011">
+      <stop
+         id="stop4013"
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0" />
+      <stop
+         offset="0.507761"
+         style="stop-color:#ffffff;stop-opacity:0.23529412;"
+         id="stop4015" />
+      <stop
+         id="stop4017"
+         style="stop-color:#ffffff;stop-opacity:0.15686275;"
+         offset="0.83456558" />
+      <stop
+         id="stop4019"
+         style="stop-color:#ffffff;stop-opacity:0.39215687;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2682"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3487">
+      <stop
+         id="stop3489"
+         style="stop-color:#e6cde2;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3491"
+         style="stop-color:#e6cde2;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2684"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3495">
+      <stop
+         id="stop3497"
+         style="stop-color:#c1cbe4;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3499"
+         style="stop-color:#c1cbe4;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2686"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3503">
+      <stop
+         id="stop3505"
+         style="stop-color:#c4ebdd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3507"
+         style="stop-color:#c4ebdd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2688"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3511">
+      <stop
+         id="stop3513"
+         style="stop-color:#ebeec7;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3515"
+         style="stop-color:#ebeec7;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2690"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       id="linearGradient3519">
+      <stop
+         id="stop3521"
+         style="stop-color:#fcd9cd;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3523"
+         style="stop-color:#fcd9cd;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="20.580074"
+       y1="10.774516"
+       x2="24.27351"
+       y2="9.8622112"
+       id="linearGradient2672"
+       xlink:href="#linearGradient3487"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="17.494959"
+       y1="11.200086"
+       x2="21.047453"
+       y2="9.7956104"
+       id="linearGradient2674"
+       xlink:href="#linearGradient3495"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="14.084608"
+       y1="13.045606"
+       x2="16.994024"
+       y2="10.732353"
+       id="linearGradient2676"
+       xlink:href="#linearGradient3503"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.371647"
+       y1="16.188046"
+       x2="14.609327"
+       y2="13.461712"
+       id="linearGradient2678"
+       xlink:href="#linearGradient3511"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="10.609375"
+       y1="17.886322"
+       x2="9.7297754"
+       y2="20.612656"
+       id="linearGradient2680"
+       xlink:href="#linearGradient3519"
+       gradientUnits="userSpaceOnUse"
+       spreadMethod="reflect" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient2658"
+       xlink:href="#linearGradient3263-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.371449,-2.371449,0,102.78049,-72.91479)" />
+    <linearGradient
+       x1="12.2744"
+       y1="32.4165"
+       x2="35.391201"
+       y2="14.2033"
+       id="linearGradient3263-6"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         id="stop3265-8"
+         style="stop-color:#dedcde;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop3267-9"
+         style="stop-color:#f0f0f0;stop-opacity:1;"
+         offset="0.5" />
+      <stop
+         id="stop3269-2"
+         style="stop-color:#d2d2d2;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient23419">
+      <stop
+         id="stop23421"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop23423"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       r="22.627417"
+       fy="41.63604"
+       fx="23.334524"
+       cy="41.63604"
+       cx="23.334524"
+       gradientTransform="matrix(1.5909902,0,0,0.59656582,10.874999,-9.338637)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4199"
+       xlink:href="#linearGradient23419" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3560"
+       id="linearGradient3562"
+       x1="40.473587"
+       y1="-12.766847"
+       x2="46.090122"
+       y2="-9.7346897"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.74774775,0,0,0.74774775,0.14414456,-16.000002)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3560">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.30000001;"
+         offset="0"
+         id="stop3556" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.05;"
+         offset="1"
+         id="stop3558" />
+    </linearGradient>
+    <linearGradient
+       x1="13.963497"
+       y1="33.571308"
+       x2="20.868813"
+       y2="30.389938"
+       id="linearGradient2651-3"
+       xlink:href="#linearGradient30333"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75766665,0,0,-0.7576663,29.553091,2.9416607)" />
+    <linearGradient
+       id="linearGradient6036-6">
+      <stop
+         id="stop6038-7"
+         style="stop-color:#000000;stop-opacity:0.28;"
+         offset="0" />
+      <stop
+         id="stop6040-5"
+         style="stop-color:#000000;stop-opacity:0.23999999;"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6036-6"
+       id="linearGradient4698"
+       x1="62.497486"
+       y1="-9.9999886"
+       x2="62.497486"
+       y2="10.000009"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.73684212,0,0,0.73684212,0.84211142,-16.000007)" />
+    <radialGradient
+       cx="9.0475655"
+       cy="12.872128"
+       r="11"
+       fx="9.0475655"
+       fy="12.872128"
+       id="radialGradient2477"
+       xlink:href="#linearGradient3839"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,8.1380469,-9.0215691,0,156.44907,-100.13534)" />
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         id="stop3841"
+         style="stop-color:#fff394;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3843"
+         style="stop-color:#ffa154;stop-opacity:1"
+         offset="0.52875197" />
+      <stop
+         id="stop3845"
+         style="stop-color:#f37329;stop-opacity:1"
+         offset="0.66093999" />
+    </linearGradient>
+    <linearGradient
+       x1="17.301205"
+       y1="23.514465"
+       x2="17.301205"
+       y2="42.501011"
+       id="linearGradient2530"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0260228,0,0,2.0234353,-0.63592621,-64.55118)" />
+    <linearGradient
+       x1="17.301205"
+       y1="4.4996829"
+       x2="17.301205"
+       y2="16.042885"
+       id="linearGradient2532"
+       xlink:href="#linearGradient6036"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0260228,0,0,2.0234353,-0.63592621,-64.55118)" />
+  </defs>
+  <metadata
+     id="metadata4206">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     transform="translate(0,64)">
+    <path
+       d="M 83.999999,15.499992 C 84.001848,22.955629 67.883564,28.999999 48.000001,28.999999 28.116437,28.999999 11.998146,22.955629 12,15.499992 11.998146,8.044362 28.116437,2 48.000001,2 67.883564,2 84.001854,8.044362 83.999999,15.499992 Z"
+       id="path23417"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient4199);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;marker:none" />
+    <path
+       id="path2781"
+       style="fill:url(#linearGradient2658);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 48 -57.5 C 24.996959 -57.5 6.5 -39.003038 6.5 -16 C 6.4999959 7.0030382 24.996961 25.5 48 25.5 C 71.003034 25.499992 89.5 7.0030397 89.5 -16 C 89.5 -39.003039 71.003036 -57.5 48 -57.5 z M 48 -30.5 A 14.5 14.5 0 0 1 62.5 -16 A 14.5 14.5 0 0 1 48 -1.5 A 14.5 14.5 0 0 1 33.5 -16 A 14.5 14.5 0 0 1 48 -30.5 z " />
+    <path
+       id="path2474"
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999994;marker:none;enable-background:accumulate"
+       d="M 48 -30.5 C 39.996008 -30.5 33.5 -24.003992 33.5 -16 C 33.5 -7.9960075 39.996008 -1.5 48 -1.5 C 56.003992 -1.5 62.5 -7.9960075 62.5 -16 C 62.5 -24.003992 56.003992 -30.5 48 -30.5 z M 48 -24 A 7.9999995 7.9999995 0 0 1 56 -16 A 7.9999995 7.9999995 0 0 1 48 -8 A 7.9999995 7.9999995 0 0 1 40 -16 A 7.9999995 7.9999995 0 0 1 48 -24 z " />
+    <circle
+       style="fill:none;fill-rule:evenodd;stroke:url(#linearGradient4698);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3498"
+       cx="48"
+       cy="-16"
+       r="7" />
+    <path
+       d="M 47.999999,-0.99999915 C 39.685714,-0.99999915 33,-7.6857123 33,-16 33,-24.314288 39.685714,-31.000001 47.999999,-31.000001 56.314291,-31.000001 63,-24.314288 63,-16 63,-7.6857123 56.314291,-0.99999915 47.999999,-0.99999915 Z"
+       id="path3281-3"
+       style="fill:none;stroke:url(#linearGradient2651-3);stroke-width:0.999997;stroke-miterlimit:4;stroke-opacity:1" />
+    <g
+       transform="matrix(2.0490302,0,0,2.0490302,-0.8175631,-64.805692)"
+       id="g3527"
+       style="stroke-width:1.33333">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z"
+         transform="rotate(1.618417,24.093743,24.175959)"
+         id="path3296"
+         style="opacity:0.8;fill:url(#linearGradient2672);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3308"
+         style="opacity:0.8;fill:url(#linearGradient2674);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path3310"
+         style="opacity:0.8;fill:url(#linearGradient2676);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path3312"
+         style="opacity:0.8;fill:url(#linearGradient2678);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z"
+         id="path3314"
+         style="opacity:0.8;fill:url(#linearGradient2680);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+    </g>
+    <g
+       transform="matrix(-2.0304874,0,0,-2.0304874,96.731685,32.713085)"
+       id="g3297"
+       style="stroke-width:1.33333">
+      <path
+         d="M 15.856928,5.7307748 20.625,16.34375 C 21.660403,15.885186 22.795334,15.625 24,15.625 c 0.03206,0 0.06178,-3.6e-4 0.09375,0 L 24.10801,4.0047512 c -2.94215,-0.070687 -5.543041,0.6572865 -8.251082,1.7260236 z"
+         transform="rotate(1.618417,24.093743,24.175959)"
+         id="path3299"
+         style="opacity:0.8;fill:url(#linearGradient2682);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="m 12.121471,7.9060109 6.931026,9.3601041 c 0.913109,-0.669755 1.965938,-1.167064 3.142629,-1.425169 0.03132,-0.0069 0.06026,-0.01359 0.09157,-0.02009 L 19.857174,4.426276 c -2.888973,0.5613244 -5.31953,1.8556038 -7.735703,3.4797349 z"
+         id="path3301"
+         style="opacity:0.8;fill:url(#linearGradient2684);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="m 8.2523933,11.646535 9.2137237,7.155818 c 0.70865,-0.883264 1.596891,-1.636119 2.666685,-2.18998 0.02847,-0.01474 0.05469,-0.02872 0.08325,-0.0431 L 14.86585,6.2506132 C 12.220599,7.5405321 10.165881,9.452393 8.2523933,11.646535 Z"
+         id="path3303"
+         style="opacity:0.8;fill:url(#linearGradient2686);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="m 5.6328855,16.073974 c 7.1748065,2.242248 7.8502625,7.031463 12.7767855,1.754127 L 10.499985,9.1321388 C 8.2787249,11.062747 6.9132871,13.459349 5.6328855,16.073974 Z"
+         id="path3305"
+         style="opacity:0.8;fill:url(#linearGradient2688);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+      <path
+         d="M 7.155289,13.193173 C 5.9722117,14.945185 5.2475768,16.829547 4.6301929,18.837116 L 15.96875,21.8125 C 16.184264,21.049497 16.486796,20.297733 16.9375,19.59375 16.95479,19.56675 16.98246,19.52673 17,19.5 Z"
+         id="path3307"
+         style="opacity:0.8;fill:url(#linearGradient2690);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333" />
+    </g>
+    <path
+       id="path2559"
+       style="display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient2477);fill-opacity:1;fill-rule:nonzero;stroke:#f3600c;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
+       d="M 49.132812 -57.484375 C 48.253149 -57.510055 47.374981 -57.504315 46.5 -57.46875 C 46.500221 -48.70054 46.5 -39.699851 46.5 -30.931641 L 46.496094 -30.923828 C 46.990737 -30.973141 47.492445 -31 48 -31 C 56.279984 -31 63 -24.279984 63 -16 C 63 -7.7200156 56.279984 -1 48 -1 C 42.716359 -1 38.070833 -3.7391221 35.398438 -7.8710938 L 35.396484 -7.8691406 L 14.039062 7.9023438 C 18.217104 14.137548 26.118713 20.597475 34.521484 23.275391 C 49.794161 28.642007 67.931922 24.056164 78.710938 11.966797 C 91.025115 -1.1470626 93.083313 -22.614086 83.351562 -37.789062 C 75.839073 -49.888242 62.327765 -57.099179 49.132812 -57.484375 z " />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.55;fill:none;stroke:url(#linearGradient4064);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path8655"
+       d="m 88.500001,-16.001438 c 0,22.3682567 -18.133799,40.50144 -40.499491,40.50144 -22.36773,0 -40.5005115,-18.1333892 -40.5005115,-40.50144 0,-22.367219 18.1327815,-40.498563 40.5005115,-40.498563 22.365692,0 40.499491,18.131344 40.499491,40.498563 z" />
+    <path
+       d="M 47.999992,7.0593023e-6 C 39.131418,7.0593023e-6 31.99999,-7.1314201 31.99999,-15.999993 c 0,-8.868573 7.131428,-16 16.000002,-16 8.868573,0 16,7.131427 16,16 0,8.8685729 -7.131427,16.0000000593023 -16,16.0000000593023 z"
+       id="path3281"
+       style="opacity:0.4;fill:none;stroke:url(#linearGradient2651);stroke-width:1;stroke-miterlimit:4;stroke-opacity:1" />
+    <circle
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3562);stroke-width:1;stroke-linecap:round;stroke-opacity:1;stop-color:#000000"
+       id="path3554"
+       cx="48"
+       cy="-16"
+       r="41.5" />
+    <path
+       d="M 35.568093,-6.7311839 15.076117,8.3993296"
+       id="path2528"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2530);stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+    <path
+       d="m 47.5,-57 v 26"
+       id="path2526"
+       style="opacity:0.4;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient2532);stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       sodipodi:nodetypes="cc" />
+  </g>
+</svg>


### PR DESCRIPTION
Uses `animations/48/brasero-disc-60` animation step as base, updated with newer borders and palette.

Fixes #207

--- 

Wasn't sure if using an animation as an app icon was a great choice, I tried this one and Disc + Fire (from the Firewall icon), and I liked this one better.