### PR TITLE
Remove -darker and -darkest themes

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -13,29 +13,21 @@ install:
 	install -d $(DESTDIR)/$(PREFIX)/share/icons
 	cp -rf build/elementary-xfce $(DESTDIR)/$(PREFIX)/share/icons
 	cp -rf build/elementary-xfce-dark $(DESTDIR)/$(PREFIX)/share/icons
-	cp -rf build/elementary-xfce-darker $(DESTDIR)/$(PREFIX)/share/icons
-	cp -rf build/elementary-xfce-darkest $(DESTDIR)/$(PREFIX)/share/icons
 	@echo
 	@echo The icon-theme cache has not yet been regenerated, which means your changes may not be visible yet. Please run 'make icon-caches' next.
 
 uninstall:
 	rm -rf $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce
 	rm -rf $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce-dark
-	rm -rf $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce-darker
-	rm -rf $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce-darkest
 
 icon-caches:
 	gtk-update-icon-cache -f $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce
 	gtk-update-icon-cache -f $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce-dark
-	gtk-update-icon-cache -f $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce-darker
-	gtk-update-icon-cache -f $(DESTDIR)/$(PREFIX)/share/icons/elementary-xfce-darkest
 
 test: builddir $(SUBDIRS)
 	chmod +x ./svgtopng/pngtheme.sh
 	@./svgtopng/pngtheme.sh build/elementary-xfce
 	@./svgtopng/pngtheme.sh build/elementary-xfce-dark
-	@./svgtopng/pngtheme.sh build/elementary-xfce-darker
-	@./svgtopng/pngtheme.sh build/elementary-xfce-darkest
 
 build: test
 	@echo == Optimizing all icon pngs
@@ -45,8 +37,6 @@ builddir:
 	mkdir -p build
 	mkdir -p build/elementary-xfce && cp -R elementary-xfce/. build/elementary-xfce
 	mkdir -p build/elementary-xfce-dark && cp -R elementary-xfce-dark/. build/elementary-xfce-dark
-	mkdir -p build/elementary-xfce-darker && cp -R elementary-xfce-darker/. build/elementary-xfce-darker
-	mkdir -p build/elementary-xfce-darkest && cp -R elementary-xfce-darkest/. build/elementary-xfce-darkest
 	rm build/elementary-xfce/AUTHORS && cp AUTHORS build/elementary-xfce
 	rm build/elementary-xfce/CONTRIBUTORS && cp CONTRIBUTORS build/elementary-xfce
 	rm build/elementary-xfce/LICENSE && cp LICENSE build/elementary-xfce

--- a/elementary-xfce-darker/AUTHORS
+++ b/elementary-xfce-darker/AUTHORS
@@ -1,1 +1,0 @@
-../elementary-xfce/AUTHORS

--- a/elementary-xfce-darker/CONTRIBUTORS
+++ b/elementary-xfce-darker/CONTRIBUTORS
@@ -1,1 +1,0 @@
-../elementary-xfce/CONTRIBUTORS

--- a/elementary-xfce-darker/LICENSE
+++ b/elementary-xfce-darker/LICENSE
@@ -1,1 +1,0 @@
-../elementary-xfce/LICENSE

--- a/elementary-xfce-darker/README.md
+++ b/elementary-xfce-darker/README.md
@@ -1,1 +1,0 @@
-../elementary-xfce/README.md

--- a/elementary-xfce-darker/index.theme
+++ b/elementary-xfce-darker/index.theme
@@ -1,9 +1,0 @@
-[Icon Theme]
-Name=elementary Xfce darker
-Comment=Deprecated, please use elementary Xfce dark
-Inherits=elementary-xfce-dark
-
-Example=directory-x-normal
-
-#Directory list
-Directories=

--- a/elementary-xfce-darkest/AUTHORS
+++ b/elementary-xfce-darkest/AUTHORS
@@ -1,1 +1,0 @@
-../elementary-xfce/AUTHORS

--- a/elementary-xfce-darkest/CONTRIBUTORS
+++ b/elementary-xfce-darkest/CONTRIBUTORS
@@ -1,1 +1,0 @@
-../elementary-xfce/CONTRIBUTORS

--- a/elementary-xfce-darkest/LICENSE
+++ b/elementary-xfce-darkest/LICENSE
@@ -1,1 +1,0 @@
-../elementary-xfce/LICENSE

--- a/elementary-xfce-darkest/README.md
+++ b/elementary-xfce-darkest/README.md
@@ -1,1 +1,0 @@
-../elementary-xfce/README.md

--- a/elementary-xfce-darkest/index.theme
+++ b/elementary-xfce-darkest/index.theme
@@ -1,9 +1,0 @@
-[Icon Theme]
-Name=elementary Xfce darkest
-Comment=Deprecated, please use elementary Xfce
-Inherits=elementary-xfce
-
-Example=directory-x-normal
-
-#Directory list
-Directories=


### PR DESCRIPTION
These have been deprecated for a while. The folders only contain symlinks to the regular and -dark theme, no actual content.

I wanted to wait until after the Xubuntu 24.04 LTS release for this to avoid any possible issues when upgrading from the previous LTS release. Xubuntu 24.04 defaults to -dark now, so I think we've done all we can to reduce any disruptions.