### PR TITLE
Apps: Remove unused terminal symlinks

### DIFF
--- a/elementary-xfce/apps/128/Terminal.svg
+++ b/elementary-xfce/apps/128/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/128/bash.svg
+++ b/elementary-xfce/apps/128/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/128/gksu-debian.svg
+++ b/elementary-xfce/apps/128/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/128/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/128/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/16/Terminal.svg
+++ b/elementary-xfce/apps/16/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/16/bash.svg
+++ b/elementary-xfce/apps/16/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/16/gksu-debian.svg
+++ b/elementary-xfce/apps/16/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/16/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/16/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/22/Terminal.svg
+++ b/elementary-xfce/apps/22/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/22/bash.svg
+++ b/elementary-xfce/apps/22/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/22/gksu-debian.svg
+++ b/elementary-xfce/apps/22/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/22/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/22/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/24/Terminal.svg
+++ b/elementary-xfce/apps/24/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/24/bash.svg
+++ b/elementary-xfce/apps/24/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/24/gksu-debian.svg
+++ b/elementary-xfce/apps/24/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/24/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/24/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/32/Terminal.svg
+++ b/elementary-xfce/apps/32/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/32/bash.svg
+++ b/elementary-xfce/apps/32/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/32/gksu-debian.svg
+++ b/elementary-xfce/apps/32/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/32/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/32/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/48/Terminal.svg
+++ b/elementary-xfce/apps/48/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/48/bash.svg
+++ b/elementary-xfce/apps/48/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/48/gksu-debian.svg
+++ b/elementary-xfce/apps/48/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/48/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/48/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/64/Terminal.svg
+++ b/elementary-xfce/apps/64/Terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/64/bash.svg
+++ b/elementary-xfce/apps/64/bash.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/64/gksu-debian.svg
+++ b/elementary-xfce/apps/64/gksu-debian.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg

--- a/elementary-xfce/apps/64/gksu-root-terminal.svg
+++ b/elementary-xfce/apps/64/gksu-root-terminal.svg
@@ -1,1 +1,0 @@
-utilities-terminal.svg


### PR DESCRIPTION
gksu has been deprecated/discontinued, replaced with PolicyKit/pkexec, so these icons are no longer needed.

`Terminal` and `bash` names don't seem to be used anywhere and, if so, apps should be using the FD.o spec name `utilities-terminal` anyway.