### PR TITLE
Remove inherited themes from index.theme

### DIFF
--- a/elementary-xfce/index.theme
+++ b/elementary-xfce/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=elementary Xfce
 Comment=Smooth modern theme for Xfce
-Inherits=elementary,Adwaita,gnome,hicolor
+Inherits=hicolor
 
 Example=directory-x-normal
 


### PR DESCRIPTION
The FreeDesktop.org Icon Theme Spec has been updated stating that inherited themes should be present on the system (considered dependencies).

The currently listed themes in elementary-xfce's `Inherits` line are either no longer developed and missing modern icons (gnome), or have reduced the scope of their theme to focus on their OS (Adwaita, elementary).

elementary-xfce should currently be robust enough that it should already include the icons found in these themes. So it no longer seems very necessary to keep these, and removing them will prevent unnecessary themes from being forced as dependencies for users who may not want them.

Fixes #458