### PR TITLE
Categories: Use "Theme" color swatch from upstream

### DIFF
--- a/elementary-xfce/apps/128/preferences-desktop-theme.svg
+++ b/elementary-xfce/apps/128/preferences-desktop-theme.svg
@@ -1,373 +1,658 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="128"
    height="128"
-   id="svg4211"
-   version="1.1"
-   sodipodi:docname="preferences-desktop-theme.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview60"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="7.5351066"
-     inkscape:cx="23.954538"
-     inkscape:cy="24.883523"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="430"
-     inkscape:window-y="67"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="layer1" />
+   id="svg4379">
   <defs
-     id="defs4213">
+     id="defs4381">
     <linearGradient
-       spreadMethod="pad"
-       gradientTransform="matrix(0.87539065,-0.87968181,0.97932539,0.97445279,-3.0169552,27.152318)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient1039"
-       id="linearGradient3176"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972" />
-    <linearGradient
-       id="linearGradient1039">
+       id="linearGradient1054">
       <stop
-         id="stop1023"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop1050"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop1052"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient896">
+      <stop
+         id="stop892"
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+      <stop
+         id="stop894"
+         offset="1"
+         style="stop-color:#7e8087;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2455-1"
+       xlink:href="#linearGradient3688-166-749-5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-5">
+      <stop
+         id="stop2883-0"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop1025"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.13482948" />
+         id="stop2885-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2457-5"
+       xlink:href="#linearGradient3688-464-309-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-8">
       <stop
-         id="stop1027"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.20224422" />
+         id="stop2889-9"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         id="stop1029"
-         style="stop-color:#fff394;stop-opacity:1"
-         offset="0.26965895" />
-      <stop
-         id="stop1031"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.44650277" />
-      <stop
-         id="stop1033"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.57114136" />
-      <stop
-         id="stop1035"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.72038066" />
-      <stop
-         id="stop1037"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop2891-4"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       spreadMethod="pad"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972"
-       gradientTransform="matrix(0.87539065,-0.87968181,0.97932539,0.97445279,-3.0169552,27.152318)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient1018"
-       xlink:href="#linearGradient3155-40" />
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2459-7"
+       xlink:href="#linearGradient3702-501-757-0"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3155-40">
+       id="linearGradient3702-501-757-0">
       <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2541" />
+         id="stop2895-0"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
       <stop
-         offset="0.13482948"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2543" />
+         id="stop2897-2"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
       <stop
-         offset="0.20224422"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2545" />
-      <stop
-         offset="0.26965895"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2547" />
-      <stop
-         offset="0.44650277"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2549" />
-      <stop
-         offset="0.57114136"
-         style="stop-color:#7e8087;stop-opacity:1"
-         id="stop2551" />
-      <stop
-         offset="0.72038066"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2553" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2555" />
+         id="stop2899-6"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-6.2249016,22.651052)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient3171"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       id="linearGradient3240-279">
+       id="linearGradient3811">
       <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2559" />
+         id="stop3813"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
       <stop
-         offset="0.5"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2561" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2563" />
+         id="stop3815"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-6.4685146,22.89586)"
+    <radialGradient
+       cx="-4.0287771"
+       cy="93.467628"
+       r="35.338131"
+       fx="-4.0287771"
+       fy="93.467628"
+       id="radialGradient4377"
+       xlink:href="#linearGradient3811"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient3168"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270358,102.13029)" />
     <linearGradient
-       id="linearGradient3223-789">
-      <stop
-         offset="0"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2567" />
-      <stop
-         offset="0.5"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2569" />
-      <stop
-         offset="1"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2571" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-5.3783496,21.800349)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient3165"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="108.5"
+       x2="26.5"
+       y1="100.5"
+       x1="26.5"
+       id="linearGradient898"
+       xlink:href="#linearGradient896" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-5.6219636,22.045155)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient3162"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="108"
+       x2="26.5"
+       y1="101"
+       x1="26.5"
+       id="linearGradient1056"
+       xlink:href="#linearGradient1054" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-4.5277046,20.945534)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient3159"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="117.5"
+       x2="26"
+       y1="16.5"
+       x1="26"
+       id="linearGradient1066"
+       xlink:href="#linearGradient1054" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-4.7713176,21.190343)"
+       gradientTransform="translate(48.700334,-27.250522)"
+       y2="101.17357"
+       x2="63.261192"
+       y1="18.035131"
+       x1="15.26119"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient3156"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient1070"
+       xlink:href="#linearGradient1054" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.1461221,1.1404197,-6.5479896,22.97572)"
+       y2="51.927921"
+       x2="72.440201"
+       y1="18.927921"
+       x1="15.282522"
+       gradientTransform="translate(77.250799,-75.200334)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3290-678"
-       id="linearGradient3151"
-       y2="26.02973"
-       x2="9"
-       y1="29.056757"
-       x1="9" />
+       id="linearGradient1074"
+       xlink:href="#linearGradient1054" />
     <linearGradient
-       id="linearGradient3290-678">
-      <stop
-         offset="0"
-         style="stop-color:#fff394;stop-opacity:1"
-         id="stop2607" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2609" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.74712277,0.03224699,0.03220731,0.74620134,24.394615,18.140574)"
+       y2="39.00132"
+       x2="38.99868"
+       y1="39.00132"
+       x1="13.998679"
+       gradientTransform="translate(78.001321,-131.00132)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3191-577"
-       id="linearGradient3153"
-       y2="41.391716"
-       x2="9.5220556"
-       y1="37.371799"
-       x1="5.5178981" />
-    <linearGradient
-       id="linearGradient3191-577">
-      <stop
-         offset="0"
-         style="stop-color:#d48e15;stop-opacity:1"
-         id="stop2613" />
-      <stop
-         offset="1"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         id="stop2615" />
-    </linearGradient>
+       id="linearGradient1078"
+       xlink:href="#linearGradient1054" />
   </defs>
   <metadata
-     id="metadata4216">
+     id="metadata4384">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,16)">
+     id="g1030">
+    <path
+       d="M 119,118 A 55,6 0 0 1 9.0000016,118 55,6 0 1 1 119,118 Z"
+       id="path3041"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4377);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
     <g
-       id="g4127"
-       transform="matrix(2.6751592,0,0,2.6855496,128.96815,-15.874509)"
-       style="stroke-width:0.499032">
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path2964"
-         style="display:inline;overflow:visible;visibility:visible;fill:#ed5353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-1.3076923)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4113"
-         style="display:inline;overflow:visible;visibility:visible;fill:#de3e80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-11.307692)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4115"
-         style="display:inline;overflow:visible;visibility:visible;fill:#924ab4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,-4.78022,-20.021977)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4117"
-         style="display:inline;overflow:visible;visibility:visible;fill:#a56de2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,-13.208791,-25.021976)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4119"
-         style="display:inline;overflow:visible;visibility:visible;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,-23.208791,-25.021976)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4121"
-         style="display:inline;overflow:visible;visibility:visible;fill:#28bca3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,-31.637363,-20.164834)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4123"
-         style="display:inline;overflow:visible;visibility:visible;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,-36.637363,-11.593405)" />
-      <path
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4125"
-         style="display:inline;overflow:visible;visibility:visible;fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.499032;marker:none;enable-background:accumulate"
-         transform="matrix(1.0384615,0,0,1.0384615,-36.923077,-1.7362627)" />
+       transform="matrix(2.6999989,0,0,0.55555607,-0.8000019,94.888882)"
+       id="g2036"
+       style="display:inline;opacity:0.4">
+      <g
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g3712"
+         style="opacity:0.4">
+        <rect
+           width="5"
+           height="7"
+           x="38"
+           y="40"
+           id="rect2801"
+           style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none" />
+        <rect
+           width="5"
+           height="7"
+           x="-10"
+           y="-47"
+           transform="scale(-1)"
+           id="rect3696"
+           style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none" />
+        <rect
+           width="28"
+           height="7.0000005"
+           x="10"
+           y="40"
+           id="rect3700"
+           style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" />
+      </g>
     </g>
     <g
-       id="g963"
-       transform="matrix(3.1401476,0,0,3.1523142,-71.412462,-63.643205)"
-       style="stroke-width:0.317841">
-      <path
-         id="path2422"
-         d="m 51.633192,45.795819 c -0.232549,-0.0028 -0.419086,0.02249 -0.544782,0.0494 l -16.737955,3.573485 -3.080835,0.658706 -0.09393,0.01647 -3.907402,1.860847 8.772866,-0.823384 0.07514,-0.01647 3.099623,-0.658708 16.737954,-3.589952 c 0.502781,-0.10769 -0.175705,-0.422676 -1.521633,-0.708111 -1.009444,-0.214076 -2.101405,-0.353866 -2.799053,-0.362289 z"
-         style="opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.253048" />
-      <path
-         style="fill:url(#linearGradient3176);fill-opacity:1;stroke:none;stroke-width:0.158921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect2383-6"
-         d="m 31.57772,42.038752 c 0.594537,-0.446137 2.262714,0.39074 3.795697,1.916096 1.529317,1.521706 2.335133,3.150009 1.899097,3.750366 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 L 58.654191,26.29035 c 0.541954,-0.544611 -0.300099,-2.265649 -1.88175,-3.839428 -1.581645,-1.57378 -3.306905,-2.407285 -3.848863,-1.862671 z" />
-      <path
-         style="opacity:0.6;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3208-7"
-         d="m 31.57772,42.038749 c 0.594537,-0.446136 2.262715,0.390742 3.795696,1.916096 1.529317,1.521707 2.335134,3.150009 1.899097,3.750366 -0.0016,0.0023 0.03752,0.03339 0.03583,0.03564 l 14.700196,-14.772261 0.05317,-0.05343 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436028,-0.600361 -0.369789,-2.228662 -1.899105,-3.750369 -1.532982,-1.525354 -3.201161,-2.362232 -3.795698,-1.916094 l -0.05317,0.05342 -14.700191,14.772262 h -7e-6 z" />
-      <path
-         d="m 31.57772,42.038752 c 0.594537,-0.446137 2.262714,0.39074 3.795697,1.916096 1.529317,1.521706 2.335133,3.150009 1.899097,3.750366 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 L 58.654191,26.29035 c 0.541954,-0.544611 -0.300099,-2.265649 -1.88175,-3.839428 -1.581645,-1.57378 -3.306905,-2.407285 -3.848863,-1.862671 z"
-         id="path1021"
-         style="fill:none;fill-opacity:1;stroke:#ad5f00;stroke-width:0.158921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         id="path934"
-         d="m 53.53125,20.427734 c -0.262669,-0.02614 -0.471932,0.024 -0.607422,0.160157 l -6.591797,6.625 c 0.594537,-0.446138 2.26194,0.390661 3.794922,1.916015 1.529316,1.521707 2.334466,3.149639 1.898438,3.75 -0.0017,0.0023 0.03881,0.03481 0.03711,0.03711 l 6.591797,-6.625 C 59.196251,25.746405 58.353135,24.024951 56.771484,22.451172 55.585251,21.270837 54.319258,20.50617 53.53125,20.427734 Z"
-         style="fill:url(#linearGradient1018);fill-opacity:1;stroke:#555761;stroke-width:0.158921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="opacity:0.9;fill:#fe9ab8;fill-opacity:1;stroke:#de3e80;stroke-width:0.158921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect3175-5"
-         d="m 50.318482,23.20612 c 0.594537,-0.446136 2.262715,0.390742 3.795697,1.916096 1.529316,1.521706 2.335133,3.150009 1.899096,3.750365 -0.0016,0.0023 0.03752,0.03338 0.03581,0.03564 l 2.605098,-2.61787 0.05317,-0.05342 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.43603,-0.600356 -0.369788,-2.228658 -1.899104,-3.750363 -1.53298,-1.525355 -3.201157,-2.362234 -3.795696,-1.916096 l -0.05317,0.05342 -2.605096,2.617869 h 4e-6 z" />
-      <path
-         style="fill:url(#linearGradient3171);fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3233-3"
-         d="m 47.398481,26.140433 c 0.594536,-0.446138 2.262717,0.390741 3.795698,1.916096 1.529315,1.521705 2.335133,3.150007 1.899095,3.750365 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 L 53.394912,31.5754 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436038,-0.600357 -0.36978,-2.22866 -1.899097,-3.750363 -1.532981,-1.525356 -3.20116,-2.362234 -3.795696,-1.916097 l -0.265827,0.26713 v 2e-6 z" />
-      <path
-         style="fill:url(#linearGradient3168);fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3216-5"
-         d="m 47.154867,26.38524 c 0.594539,-0.446138 2.262718,0.39074 3.795697,1.916095 1.529319,1.521706 2.335136,3.150007 1.899097,3.750364 -0.0016,0.0023 0.03751,0.03339 0.03581,0.03564 l 0.265825,-0.267132 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436041,-0.600355 -0.369777,-2.228658 -1.899095,-3.750363 C 49.68341,26.50885 48.015232,25.67197 47.420692,26.118108 l -0.265825,0.267131 z" />
-      <path
-         style="fill:url(#linearGradient3165);fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3248-6"
-         d="m 48.245034,25.28973 c 0.594537,-0.446138 2.262715,0.39074 3.795697,1.916096 1.529316,1.521705 2.335134,3.150006 1.899097,3.750364 -0.0016,0.0023 0.03751,0.03338 0.03581,0.03564 l 0.265826,-0.26713 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 C 54.641691,30.088704 53.835875,28.4604 52.306556,26.938696 50.773576,25.413341 49.1054,24.576462 48.510859,25.0226 Z" />
-      <path
-         style="fill:url(#linearGradient3162);fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3250-2"
-         d="m 48.00142,25.534537 c 0.59454,-0.446138 2.262718,0.39074 3.795697,1.916095 1.529318,1.521706 2.335135,3.150007 1.899098,3.750364 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 l 0.265825,-0.267131 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436039,-0.600357 -0.369778,-2.228661 -1.899095,-3.750364 -1.53298,-1.525355 -3.201159,-2.362235 -3.795699,-1.916096 l -0.265826,0.267131 z" />
-      <path
-         style="fill:url(#linearGradient3159);fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3256-9"
-         d="m 49.095679,24.434915 c 0.594536,-0.446137 2.262714,0.390741 3.795696,1.916096 1.529316,1.521705 2.335134,3.150007 1.899097,3.750364 -0.0016,0.0023 0.0375,0.03339 0.03581,0.03564 l 0.265824,-0.267131 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436038,-0.600356 -0.36978,-2.22866 -1.899097,-3.750365 -1.532978,-1.525354 -3.201157,-2.362234 -3.795696,-1.916094 l -0.265825,0.267129 z" />
-      <path
-         style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none;stroke-width:0.317841"
-         id="path3258-1"
-         d="m 48.852067,24.679722 c 0.594534,-0.446138 2.262715,0.39074 3.795696,1.916097 1.529315,1.521704 2.335135,3.150007 1.899095,3.750362 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 l 0.265826,-0.267128 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436038,-0.600359 -0.36978,-2.228661 -1.899096,-3.750365 -1.532981,-1.525356 -3.20116,-2.362235 -3.795697,-1.916096 l -0.265825,0.267129 v 0 z" />
-      <path
-         style="fill:url(#linearGradient3151);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3153);stroke-width:0.158921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3270-2"
-         d="m 27.487084,51.747568 9.711253,-3.960957 0.08274,-0.08273 c 0.436037,-0.600362 -0.380288,-2.22879 -1.909605,-3.7505 -1.532982,-1.525354 -3.199188,-2.357607 -3.793726,-1.911469 l -4.090658,9.705656 h -7e-6 z" />
-      <path
-         style="fill:#333333;fill-opacity:1;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:0.158921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3281-7"
-         d="m 28.595131,49.118873 -1.108643,2.618307 2.648745,-1.085868 C 29.92294,50.397024 29.726959,50.138742 29.472072,49.885124 29.178629,49.59314 28.890001,49.35623 28.595131,49.118873 Z" />
+       id="g982"
+       transform="rotate(90,26.501408,104.50044)">
+      <rect
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect962"
+         width="27"
+         height="102"
+         x="13"
+         y="16"
+         rx="5.5"
+         ry="5.5" />
+      <rect
+         style="opacity:1;fill:#ff8c82;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect964"
+         width="14"
+         height="14"
+         x="19.5"
+         y="22.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="41.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect966"
+         style="opacity:1;fill:#ed5353;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#c6262e;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect968"
+         width="14"
+         height="14"
+         x="19.5"
+         y="60.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="79.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect970"
+         style="opacity:1;fill:#a10705;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="22.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect972"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-opacity:1"
+         id="rect974"
+         width="14"
+         height="14"
+         x="19.5"
+         y="41.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="60.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect976"
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:0.7;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-opacity:1"
+         id="rect978"
+         width="14"
+         height="14"
+         x="19.5"
+         y="79.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="6"
+         rx="6"
+         y="15.5"
+         x="12.502815"
+         height="103"
+         width="27.997185"
+         id="rect980"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1078);stroke-width:1;stroke-opacity:1"
+       id="rect1076"
+       width="26"
+       height="101"
+       x="91.50132"
+       y="-114.50132"
+       rx="5"
+       ry="5"
+       transform="rotate(90)" />
+    <g
+       transform="rotate(60,26.501408,104.50044)"
+       id="g960">
+      <rect
+         ry="5.5"
+         rx="5.5"
+         y="16"
+         x="13"
+         height="102"
+         width="27"
+         id="rect940"
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="22.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect942"
+         style="opacity:1;fill:#ffc27d;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect944"
+         width="14"
+         height="14"
+         x="19.5"
+         y="41.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="60.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect946"
+         style="opacity:1;fill:#f37329;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#cc3b02;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect948"
+         width="14"
+         height="14"
+         x="19.5"
+         y="79.5"
+         rx="1"
+         ry="1" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-opacity:1"
+         id="rect950"
+         width="14"
+         height="14"
+         x="19.5"
+         y="22.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="41.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect952"
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-opacity:1"
+         id="rect954"
+         width="14"
+         height="14"
+         x="19.5"
+         y="60.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="79.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect956"
+         style="opacity:0.7;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-opacity:1"
+         id="rect958"
+         width="27.997185"
+         height="103"
+         x="12.502815"
+         y="15.5"
+         rx="6"
+         ry="6" />
+    </g>
+    <rect
+       transform="rotate(60)"
+       ry="5"
+       rx="5"
+       y="-58.700333"
+       x="90.750801"
+       height="101"
+       width="26"
+       id="rect1072"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1074);stroke-width:1;stroke-opacity:1" />
+    <g
+       id="g938"
+       transform="rotate(30,26.501408,104.50044)">
+      <rect
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect918"
+         width="27"
+         height="102"
+         x="13"
+         y="16"
+         rx="5.5"
+         ry="5.5" />
+      <rect
+         style="opacity:1;fill:#8cd5ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect920"
+         width="14"
+         height="14"
+         x="19.5"
+         y="22.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="41.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect922"
+         style="opacity:1;fill:#64baff;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+         id="rect924"
+         width="14"
+         height="14"
+         x="19.5"
+         y="60.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="79.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect926"
+         style="opacity:1;fill:#0d52bf;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="22.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect928"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-opacity:1"
+         id="rect930"
+         width="14"
+         height="14"
+         x="19.5"
+         y="41.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="1"
+         rx="1"
+         y="60.5"
+         x="19.5"
+         height="14"
+         width="14"
+         id="rect932"
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-opacity:1" />
+      <rect
+         style="opacity:0.7;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-opacity:1"
+         id="rect934"
+         width="14"
+         height="14"
+         x="19.5"
+         y="79.5"
+         rx="1"
+         ry="1" />
+      <rect
+         ry="6"
+         rx="6"
+         y="15.5"
+         x="12.502815"
+         height="103"
+         width="27.997185"
+         id="rect936"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1070);stroke-width:1;stroke-opacity:1"
+       id="rect1068"
+       width="26"
+       height="101"
+       x="62.200333"
+       y="-10.750523"
+       rx="5"
+       ry="5"
+       transform="rotate(30)" />
+    <rect
+       style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect856"
+       width="27"
+       height="102"
+       x="13"
+       y="16"
+       rx="5.5"
+       ry="5.5" />
+    <rect
+       style="opacity:1;fill:#d1ff82;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect858"
+       width="14"
+       height="14"
+       x="19.5"
+       y="22.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="41.5"
+       x="19.5"
+       height="14"
+       width="14"
+       id="rect866"
+       style="opacity:1;fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+    <rect
+       style="opacity:1;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect868"
+       width="14"
+       height="14"
+       x="19.5"
+       y="60.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="79.5"
+       x="19.5"
+       height="14"
+       width="14"
+       id="rect870"
+       style="opacity:1;fill:#3a9104;fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="22.5"
+       x="19.5"
+       height="14"
+       width="14"
+       id="rect882"
+       style="opacity:0.4;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-opacity:1" />
+    <rect
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-opacity:1"
+       id="rect884"
+       width="14"
+       height="14"
+       x="19.5"
+       y="41.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="60.5"
+       x="19.5"
+       height="14"
+       width="14"
+       id="rect886"
+       style="opacity:0.6;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-opacity:1" />
+    <rect
+       style="opacity:0.7;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-opacity:1"
+       id="rect888"
+       width="14"
+       height="14"
+       x="19.5"
+       y="79.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="6"
+       rx="6"
+       y="15.5"
+       x="12.502815"
+       height="103"
+       width="27.997185"
+       id="rect900"
+       style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-opacity:1" />
+    <rect
+       ry="5"
+       rx="5"
+       y="16.5"
+       x="13.5"
+       height="101"
+       width="26"
+       id="rect1058"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1066);stroke-width:1;stroke-opacity:1" />
+    <g
+       id="g916">
+      <circle
+         r="4"
+         cy="104.5"
+         cx="26.5"
+         id="path874"
+         style="opacity:1;fill:url(#linearGradient898);fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+      <circle
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-opacity:1"
+         id="circle890"
+         cx="26.5"
+         cy="104.5"
+         r="4" />
+      <circle
+         r="3"
+         cy="104.5"
+         cx="26.5"
+         id="circle1048"
+         style="opacity:0.2;fill:none;fill-opacity:1;stroke:url(#linearGradient1056);stroke-width:1;stroke-opacity:1" />
     </g>
   </g>
 </svg>

--- a/elementary-xfce/apps/16/preferences-desktop-theme.svg
+++ b/elementary-xfce/apps/16/preferences-desktop-theme.svg
@@ -1,348 +1,264 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="16px"
-   height="16px"
-   id="svg8657"
-   version="1.1"
-   sodipodi:docname="preferences-desktop-theme.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview71"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="21.3125"
-     inkscape:cx="6.3108504"
-     inkscape:cy="10.064516"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="629"
-     inkscape:window-y="96"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="layer1" />
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg4372"
+   height="16"
+   width="16"
+   version="1.1">
   <defs
-     id="defs8659">
-    <linearGradient
-       spreadMethod="pad"
-       gradientTransform="matrix(0.415777,-0.4174938,0.518983,0.5146192,-15.747227,2.6503673)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient942"
-       id="linearGradient3140"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972" />
-    <linearGradient
-       id="linearGradient942">
-      <stop
-         id="stop926"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop928"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.13482948" />
-      <stop
-         id="stop930"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.20224422" />
-      <stop
-         id="stop932"
-         style="stop-color:#fff394;stop-opacity:1"
-         offset="0.26965895" />
-      <stop
-         id="stop934"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.44650277" />
-      <stop
-         id="stop936"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.57114136" />
-      <stop
-         id="stop938"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.72038066" />
-      <stop
-         id="stop940"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.602268,-17.636692,0.462492)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3290-678-3"
-       id="linearGradient3154"
-       y2="26.02973"
-       x2="9"
-       y1="29.056757"
-       x1="9" />
-    <linearGradient
-       id="linearGradient3290-678-3">
-      <stop
-         offset="0"
-         style="stop-color:#fff394;stop-opacity:1"
-         id="stop2607-6" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2609-7" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.3763801,0.03615261,0.03669995,0.374874,-2.2182805,-1.1331002)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3191-577-5"
-       id="linearGradient3156"
-       y2="41.391716"
-       x2="9.5220556"
-       y1="37.371799"
-       x1="5.5178981" />
-    <linearGradient
-       id="linearGradient3191-577-5">
-      <stop
-         offset="0"
-         style="stop-color:#d48e15;stop-opacity:1"
-         id="stop2613-3" />
-      <stop
-         offset="1"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         id="stop2615-5" />
-    </linearGradient>
-    <linearGradient
-       spreadMethod="pad"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972"
-       gradientTransform="matrix(0.29211546,-0.29402456,0.36462565,0.36242618,-6.0319343,3.5294879)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient923"
-       xlink:href="#linearGradient3155-40-6" />
-    <linearGradient
-       id="linearGradient3155-40-6">
-      <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2541-2" />
-      <stop
-         offset="0.13482948"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2543-9" />
-      <stop
-         offset="0.20224422"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2545-1" />
-      <stop
-         offset="0.26965895"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2547-2" />
-      <stop
-         offset="0.44650277"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2549-7" />
-      <stop
-         offset="0.57114136"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2551-0" />
-      <stop
-         offset="0.72038066"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2553-9" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2555-3" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.465684,0.2892868)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-686-6"
-       id="linearGradient3146"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       id="linearGradient3240-686-6">
-      <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2575-0" />
-      <stop
-         offset="0.5"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2577-6" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2579-2" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.867764,0.6930272)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-686-6"
-       id="linearGradient3142"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.983472,0.8092126)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3144"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       id="linearGradient3223-789-9">
-      <stop
-         offset="0"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2567-2" />
-      <stop
-         offset="0.5"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2569-0" />
-      <stop
-         offset="1"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2571-2" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.581392,0.4054707)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3148"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.061661,-0.1164056)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-686-6"
-       id="linearGradient3150"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.177369,-2.1969969e-4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3152"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-  </defs>
+     id="defs4374" />
   <metadata
-     id="metadata8662">
+     id="metadata4377">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1">
+     transform="translate(0.001518)"
+     id="g995">
+    <g
+       id="g1039"
+       transform="rotate(90,4.5,11.498482)">
+      <g
+         id="g1029">
+        <rect
+           ry="0.5"
+           rx="0.5"
+           y="2"
+           x="2"
+           height="12"
+           width="5"
+           id="rect1025"
+           style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+        <rect
+           ry="1"
+           rx="1"
+           y="1.5"
+           x="1.5"
+           height="13"
+           width="6"
+           id="rect1027"
+           style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <rect
+         style="opacity:1;fill:#ff8c82;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect1031"
+         width="2"
+         height="2"
+         x="3.5"
+         y="3.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="7.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect1033"
+         style="opacity:1;fill:#ed5353;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="3.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect1035"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect1037"
+         width="2"
+         height="2"
+         x="3.5"
+         y="7.5"
+         rx="0"
+         ry="0" />
+    </g>
     <path
-       id="path2422"
-       d="M 13.219868,12.085402 C 13.084273,12.064287 12.980411,12.07315 12.912182,12.08838 L 3.8246893,14.105582 L 2.1521901,14.477776 L 2.100557,14.485736 L 0.1618417,15.918399 L 5.1116758,15.844379 L 5.1523982,15.834924 L 6.8358105,15.464226 L 15.920372,13.431596 C 16.193283,13.370679 15.743073,13.021669 14.910389,12.647286 C 14.285874,12.366498 13.626647,12.148745 13.219868,12.085402 z"
-       style="opacity:0.14999999999999999;fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+       style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+       d="m 11.230469,4.7714844 c -0.06446,0.00808 -0.127528,0.027875 -0.1875,0.0625 L 2,10.054688 v 2.115234 L 3.0566406,14 H 5.1679688 L 13.542969,9.1640625 c 0.239889,-0.1385 0.322094,-0.4437047 0.183593,-0.6835937 l -2,-3.4628907 C 11.622687,4.8376613 11.42384,4.7472561 11.230469,4.7714844 Z"
+       id="rect863" />
+    <g
+       transform="rotate(60,4.5,11.498482)"
+       id="g1023">
+      <g
+         id="g1013">
+        <path
+           id="rect1011"
+           transform="rotate(-60,4.5,11.498482)"
+           d="m 11.169922,4.2734375 c -0.128914,0.016152 -0.257009,0.057703 -0.376953,0.1269531 L 2.5,9.1894531 V 13 c 0,0.277 0.223,0.5 0.5,0.5 H 7.0351562 L 13.792969,9.5976562 c 0.479778,-0.2769999 0.642234,-0.8874094 0.365234,-1.3671874 l -2,-3.4628907 C 11.950453,4.4077446 11.556663,4.224981 11.169922,4.2734375 Z"
+           style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <rect
+         ry="0"
+         rx="0"
+         y="3.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect1015"
+         style="opacity:1;fill:#ffc27d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect1017"
+         width="2"
+         height="2"
+         x="3.5"
+         y="7.5"
+         rx="0"
+         ry="0" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect1019"
+         width="2"
+         height="2"
+         x="3.5"
+         y="3.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="7.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect1021"
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
     <path
-       style="fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4123"
-       d="m -2.0000002,34 a 3.7142856,3.7142856 0 1 1 -7.4285713,0 3.7142856,3.7142856 0 1 1 7.4285713,0 z"
-       transform="matrix(0.40723282,-0.35226828,0.35226828,0.40723282,-7.6500768,-7.8588775)" />
-    <path
-       style="fill:#ed5353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path2964"
-       d="m -2.0000002,34 a 3.7142856,3.7142856 0 1 1 -7.4285713,0 3.7142856,3.7142856 0 1 1 7.4285713,0 z"
-       transform="matrix(0.40723282,-0.35226828,0.35226828,0.40723282,4.3499232,-7.8588775)" />
-    <path
-       style="fill:#a56de2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4115"
-       d="m -2.0000002,34 a 3.7142856,3.7142856 0 1 1 -7.4285713,0 3.7142856,3.7142856 0 1 1 7.4285713,0 z"
-       transform="matrix(0.40723282,-0.35226828,0.35226828,0.40723282,-0.65007675,-13.358878)" />
-    <path
-       style="fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path4119"
-       d="m -2.0000002,34 a 3.7142856,3.7142856 0 1 1 -7.4285713,0 3.7142856,3.7142856 0 1 1 7.4285713,0 z"
-       transform="matrix(0.40723282,-0.35226828,0.35226828,0.40723282,-5.1500768,-11.858878)" />
-  </g>
-  <g
-     id="g8626-9"
-     transform="matrix(1.0248073,0,0,1.0272555,0.0988185,-0.58865612)"
-     style="stroke-width:0.685572">
-    <path
-       style="fill:url(#linearGradient3140);fill-opacity:1;stroke:none;stroke-width:0.416814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3041"
-       d="m 2.0488085,11.037368 c 0.2865424,-0.207707 1.1479509,0.256388 1.9603385,1.061945 0.8104458,0.803629 1.2601996,1.641331 1.0575577,1.930575 -7.708e-4,0.0011 0.01977,0.01774 0.01898,0.01882 L 15.224149,3.8683779 C 15.481557,3.6099071 15.011041,2.7247557 14.172862,1.893626 13.334685,1.0624962 12.444681,0.59856571 12.187272,0.85703737 Z" />
-    <path
-       style="opacity:0.6;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3045"
-       d="m 2.0488079,11.037368 c 0.286543,-0.207708 1.1479512,0.256388 1.960339,1.061943 0.8104449,0.80363 1.2601992,1.641332 1.0575579,1.930577 -7.714e-4,0.0011 0.01977,0.01774 0.01898,0.01882 l 6.9820302,-7.0108637 0.02525,-0.025356 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.276628,6.7044221 11.826873,5.8667226 11.01643,5.0630931 10.204041,4.2575368 9.3426319,3.7934425 9.0560897,4.0011493 l -0.025251,0.025355 z" />
-    <path
-       style="fill:url(#linearGradient3154);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3156);stroke-width:0.416814;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3059"
-       d="m 0.25980529,15.79419 4.77185621,-1.725488 0.039308,-0.03926 C 5.2736124,13.740202 4.8185731,12.902156 4.0081274,12.098526 3.1957395,11.29297 2.335449,10.831246 2.0489062,11.038953 Z" />
-    <path
-       style="fill:#333333;fill-opacity:1;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:0.416814;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3061"
-       d="M 0.7444326,14.506276 0.25922075,15.788967 1.560593,15.315574 C 1.446907,15.182439 1.3413094,15.047739 1.2062351,14.913801 1.0507282,14.759602 0.89915498,14.633134 0.7444326,14.506276 Z" />
-    <path
-       d="m 2.0488085,11.037368 c 0.2865424,-0.207707 1.1479509,0.256388 1.9603385,1.061945 0.8104458,0.803629 1.2601996,1.641331 1.0575577,1.930575 -7.708e-4,0.0011 0.01977,0.01774 0.01898,0.01882 L 15.224149,3.8683779 C 15.481557,3.6099071 15.011041,2.7247557 14.172862,1.893626 13.334685,1.0624962 12.444681,0.59856571 12.187272,0.85703737 Z"
-       id="path909"
-       style="fill:none;fill-opacity:1;stroke:#ad5f00;stroke-width:0.416814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       id="path911"
-       transform="matrix(1.423331,0,0,1.4199283,-7.1617877,-2.3612525)"
-       d="m 13.681641,2.2207031 c -0.03556,0.00734 -0.06529,0.022168 -0.08789,0.044922 l -2.199219,2.2148438 c 0.201318,-0.1462798 0.806187,0.180725 1.376953,0.7480468 0.569399,0.5659649 0.88456,1.1556702 0.742188,1.359375 -5.41e-4,7.747e-4 0.01423,0.012911 0.01367,0.013672 L 15.728516,4.3867188 C 15.909365,4.2046879 15.577167,3.5814259 14.988281,2.9960938 14.473008,2.4839281 13.930533,2.1692966 13.681641,2.2207031 Z"
-       style="fill:url(#linearGradient923);fill-opacity:1;stroke:#555761;stroke-width:0.293194;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       style="fill:url(#linearGradient3146);fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3051"
-       d="m 9.5806143,3.4729643 c 0.2865426,-0.2077069 1.1479517,0.2563872 1.9603387,1.0619442 0.810446,0.803629 1.2602,1.6413292 1.057558,1.9305747 -7.73e-4,0.0011 0.01977,0.017737 0.01898,0.01882 l 0.126258,-0.1267784 c 7.91e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.01882 C 12.927411,6.0494594 12.477656,5.2117588 11.66721,4.4081298 10.854824,3.6025731 9.9934151,3.1384786 9.7068717,3.3461854 Z" />
-    <path
-       style="opacity:0.9;fill:#fe9ab8;fill-opacity:1;stroke:#de3e80;stroke-width:0.416814;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3043"
-       d="m 10.565423,2.4840909 c 0.286542,-0.2077065 1.147951,0.2563879 1.960338,1.0619443 0.810445,0.8036291 1.260199,1.6413295 1.057557,1.9305744 -7.69e-4,0.0011 0.01977,0.017738 0.01898,0.018821 L 15.154234,3.9383089 C 15.562715,3.5297289 15.124956,2.8454879 14.172862,1.893626 13.360476,1.0880699 12.499066,0.6239749 12.212525,0.83168148 l -0.02525,0.0253559 -1.621849,1.62705352 z" />
-    <path
-       style="fill:url(#linearGradient3142);fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3047"
-       d="m 9.1785348,3.8767048 c 0.2865413,-0.2077068 1.1479522,0.2563879 1.9603392,1.0619443 0.810445,0.8036291 1.2602,1.6413294 1.057556,1.9305753 -7.71e-4,0.0011 0.01977,0.017736 0.01898,0.01882 l 0.126256,-0.1267795 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.525331,6.4531992 12.075576,5.6154986 11.26513,4.8118704 10.452743,4.0063135 9.5913335,3.542219 9.3047918,3.7499256 Z" />
-    <path
-       style="fill:url(#linearGradient3144);fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3049"
-       d="m 9.0628273,3.9928895 c 0.2865436,-0.2077068 1.1479527,0.2563878 1.9603397,1.061944 0.810444,0.8036294 1.2602,1.6413292 1.057556,1.9305742 -7.71e-4,0.0011 0.01977,0.017738 0.01898,0.018822 L 12.22596,6.8774498 c 7.9e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.018821 C 12.409623,6.569384 11.95987,5.7316836 11.149423,4.9280545 10.337036,4.1224982 9.4756273,3.6584033 9.1890844,3.8661101 Z" />
-    <path
-       style="fill:url(#linearGradient3148);fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3053"
-       d="m 9.4649071,3.5891488 c 0.2865435,-0.207707 1.1479529,0.2563877 1.9603379,1.061944 0.810447,0.8036298 1.260201,1.6413294 1.057558,1.9305748 -7.69e-4,0.0011 0.01977,0.017737 0.01898,0.018821 l 0.126257,-0.12678 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.811705,6.1656438 12.361949,5.3279425 11.551504,4.5243147 10.739118,3.718758 9.877708,3.254663 9.5911645,3.46237 Z" />
-    <path
-       style="fill:url(#linearGradient3150);fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3055"
-       d="M 9.9846388,3.0672723 C 10.27118,2.8595657 11.13259,3.3236601 11.944976,4.1292168 c 0.810446,0.8036288 1.260201,1.641329 1.057558,1.9305741 -7.7e-4,0.0011 0.01977,0.017738 0.01898,0.018821 L 13.14777,5.9518328 c 7.92e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.018821 C 13.331434,5.6437674 12.881679,4.8060668 12.071233,4.0024374 11.258848,3.1968815 10.397438,2.7327869 10.110895,2.9404937 Z" />
-    <path
-       style="fill:url(#linearGradient3152);fill-opacity:1;stroke:none;stroke-width:0.685572"
-       id="path3057"
-       d="m 9.8689318,3.1834569 c 0.2865412,-0.2077072 1.1479512,0.2563879 1.9603392,1.0619447 0.810444,0.8036283 1.260198,1.6413291 1.057556,1.9305739 -7.71e-4,0.0011 0.01977,0.017737 0.01898,0.018821 l 0.126258,-0.1267782 c 7.89e-4,-0.00108 -0.01975,-0.017722 -0.01898,-0.018821 C 13.215727,5.7599515 12.765972,4.9222512 11.955527,4.1186224 11.143141,3.313066 10.281731,2.848971 9.9951884,3.0566783 Z" />
+       style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+       d="M 7.328125,2.2089844 C 7.1347542,2.1847561 6.9378594,2.2751613 6.8339844,2.4550781 L 2,10.828125 v 2.115234 L 3.8300781,14 H 5.9433594 L 11.164062,4.9550781 c 0.1385,-0.239889 0.0563,-0.5431406 -0.183593,-0.6816406 l -3.4628909,-2 C 7.4576059,2.2388125 7.3925819,2.2170605 7.328125,2.2089844 Z"
+       id="rect896" />
+    <g
+       id="g1007"
+       transform="rotate(30,4.5,11.498482)">
+      <g
+         id="g997">
+        <path
+           id="rect995"
+           transform="rotate(-30,4.5,11.498482)"
+           d="M 7.390625,1.7128906 C 7.0038834,1.6644342 6.6081406,1.8452446 6.4003906,2.2050781 L 2.5,8.9609375 V 13 c 0,0.277 0.223,0.5 0.5,0.5 H 6.8085938 L 11.597656,5.2050781 c 0.277,-0.479778 0.112591,-1.0882344 -0.367187,-1.3652343 l -3.4628909,-2 C 7.6476336,1.7705937 7.5195389,1.7290428 7.390625,1.7128906 Z"
+           style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      </g>
+      <rect
+         style="opacity:1;fill:#8cd5ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect999"
+         width="2"
+         height="2"
+         x="3.5"
+         y="3.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="7.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect1001"
+         style="opacity:1;fill:#64baff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="3.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect1003"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect1005"
+         width="2"
+         height="2"
+         x="3.5"
+         y="7.5"
+         rx="0"
+         ry="0" />
+    </g>
+    <g
+       id="g912">
+      <g
+         id="g866">
+        <rect
+           style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+           id="rect862"
+           width="6"
+           height="13"
+           x="1.5"
+           y="1.5"
+           rx="1"
+           ry="1" />
+        <rect
+           style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+           id="rect829"
+           width="5"
+           height="12"
+           x="2"
+           y="2"
+           rx="0.5"
+           ry="0.5" />
+      </g>
+      <rect
+         ry="0"
+         rx="0"
+         y="3.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect831"
+         style="opacity:1;fill:#d1ff82;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect833"
+         width="2"
+         height="2"
+         x="3.5"
+         y="7.5"
+         rx="0"
+         ry="0" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect874"
+         width="2"
+         height="2"
+         x="3.5"
+         y="3.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="7.5"
+         x="3.5"
+         height="2"
+         width="2"
+         id="rect876"
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <rect
+       style="opacity:1;fill:#7e8087;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+       id="rect836"
+       width="2"
+       height="2"
+       x="3"
+       y="11"
+       rx="1"
+       ry="1" />
   </g>
 </svg>

--- a/elementary-xfce/apps/24/preferences-desktop-theme.svg
+++ b/elementary-xfce/apps/24/preferences-desktop-theme.svg
@@ -1,370 +1,525 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="24"
    height="24"
-   id="svg2"
-   version="1.0"
-   sodipodi:docname="preferences-desktop-theme.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview77"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="14.208333"
-     inkscape:cx="11.788857"
-     inkscape:cy="8.5513198"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="488"
-     inkscape:window-y="74"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg2"
-     inkscape:snap-global="false" />
+   id="svg4157">
   <defs
-     id="defs4">
+     id="defs4159">
     <linearGradient
-       spreadMethod="pad"
-       gradientTransform="matrix(0.415777,-0.4174938,0.518983,0.5146192,-15.747227,2.6503673)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient985"
-       id="linearGradient3841"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972" />
-    <linearGradient
-       id="linearGradient985">
+       id="linearGradient899">
       <stop
-         id="stop969"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop895"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop897"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.6" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3082-6"
+       xlink:href="#linearGradient3688-166-749-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-9">
+      <stop
+         id="stop2883-2"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop971"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.13482948" />
+         id="stop2885-2"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3084-4"
+       xlink:href="#linearGradient3688-464-309-7-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-7-6">
       <stop
-         id="stop973"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.20224422" />
+         id="stop2889-75"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         id="stop975"
-         style="stop-color:#fff394;stop-opacity:1"
-         offset="0.26965895" />
-      <stop
-         id="stop977"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.44650277" />
-      <stop
-         id="stop979"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.57114136" />
-      <stop
-         id="stop981"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.72038066" />
-      <stop
-         id="stop983"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop2891-4-9"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       spreadMethod="pad"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972"
-       gradientTransform="matrix(0.34152048,-0.34376139,0.42629419,0.42373374,-1.9585025,8.453782)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient964"
-       xlink:href="#linearGradient3155-40-3" />
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3086-8"
+       xlink:href="#linearGradient3702-501-757-1"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3155-40-3">
+       id="linearGradient3702-501-757-1">
       <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2541-6" />
+         id="stop2895-2"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
       <stop
-         offset="0.13482948"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2543-7" />
+         id="stop2897-89"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
       <stop
-         offset="0.20224422"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2545-5" />
-      <stop
-         offset="0.26965895"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2547-3" />
-      <stop
-         offset="0.44650277"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2549-5" />
-      <stop
-         offset="0.57114136"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2551-6" />
-      <stop
-         offset="0.72038066"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2553-2" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2555-9" />
+         id="stop2899-36"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.867764,0.6930272)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279-1"
-       id="linearGradient3843"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="20"
+       x2="5.5"
+       y1="4"
+       x1="5.5"
+       id="linearGradient901"
+       xlink:href="#linearGradient899" />
     <linearGradient
-       id="linearGradient3240-279-1">
-      <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2559-2" />
-      <stop
-         offset="0.5"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2561-7" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2563-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.983472,0.8092126)"
+       y2="17.665064"
+       x2="11.946153"
+       y1="4.2416697"
+       x1="4.1961522"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3845"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient956"
+       xlink:href="#linearGradient899" />
     <linearGradient
-       id="linearGradient3223-789-9">
-      <stop
-         offset="0"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2567-3" />
-      <stop
-         offset="0.5"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2569-6" />
-      <stop
-         offset="1"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2571-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.465684,0.2892868)"
+       y2="9.3264456"
+       x2="13.610937"
+       y1="3.8576951"
+       x1="4.1387839"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279-1"
-       id="linearGradient3847"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient978"
+       xlink:href="#linearGradient899" />
     <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.581392,0.4054707)"
+       y2="7.5"
+       x2="7"
+       y1="7.5"
+       x1="4"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3849"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.061661,-0.1164056)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279-1"
-       id="linearGradient3851"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.177369,-2.1969969e-4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3853"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.602268,-17.636692,0.462492)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3290-678-8"
-       id="linearGradient3855"
-       y2="26.02973"
-       x2="9"
-       y1="29.056757"
-       x1="9" />
-    <linearGradient
-       id="linearGradient3290-678-8">
-      <stop
-         offset="0"
-         style="stop-color:#fff394;stop-opacity:1"
-         id="stop2607-9" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2609-7" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.3763801,0.03615261,0.03669995,0.374874,-2.2182805,-1.1331002)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3191-577-3"
-       id="linearGradient3857"
-       y2="41.391716"
-       x2="9.5220556"
-       y1="37.371799"
-       x1="5.5178981" />
-    <linearGradient
-       id="linearGradient3191-577-3">
-      <stop
-         offset="0"
-         style="stop-color:#d48e15;stop-opacity:1"
-         id="stop2613-6" />
-      <stop
-         offset="1"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         id="stop2615-1" />
-    </linearGradient>
+       id="linearGradient1000"
+       xlink:href="#linearGradient899" />
   </defs>
   <metadata
-     id="metadata7">
+     id="metadata4162">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(0.5116664,0,0,0.5116664,24.42613,-0.35596062)"
-     id="g4127-3">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ed5353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path2964-6"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-1.3076923)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#de3e80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4113-7"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-11.307692)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#924ab4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4115-5"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-4.78022,-20.021977)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#a56de2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4117-3"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-13.208791,-25.021976)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4119-5"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-23.208791,-25.021976)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#28bca3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4121-6"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-31.637363,-20.164834)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4123-2"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-36.637363,-11.593405)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4125-9"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-36.923077,-1.7362627)" />
-  </g>
-  <path
-     style="opacity:0.15;fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999"
-     id="path2422-2"
-     d="m 19.270405,18.638644 c -0.173627,-0.0321 -0.307989,-0.02375 -0.396746,-0.0059 l -11.8218649,2.364496 -2.1757918,0.436406 -0.066992,0.0088 -2.5760096,1.823259 6.3840491,0.0604 0.05301,-0.01114 2.1897802,-0.434093 11.81892,-2.384887 c 0.355034,-0.07145 -0.206481,-0.545026 -1.259611,-1.064175 -0.789851,-0.38936 -1.62784,-0.696888 -2.148748,-0.793202 z" />
-  <g
-     id="g8626"
-     transform="matrix(1.3830672,0,0,1.3863941,2.579483,0.67376581)"
-     style="stroke-width:0.593904">
-    <path
-       style="fill:url(#linearGradient3841);fill-opacity:1;stroke:none;stroke-width:0.361081;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3041"
-       d="m 2.0488085,11.037368 c 0.2865424,-0.207707 1.1479509,0.256388 1.9603385,1.061945 0.8104458,0.803629 1.2601996,1.641331 1.0575577,1.930575 -7.708e-4,0.0011 0.01977,0.01774 0.01898,0.01882 L 15.224149,3.8683779 C 15.481557,3.6099071 15.011041,2.7247557 14.172862,1.893626 13.334685,1.0624962 12.444681,0.59856571 12.187272,0.85703737 Z" />
-    <path
-       style="opacity:0.6;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3045"
-       d="m 2.0488079,11.037368 c 0.286543,-0.207708 1.1479512,0.256388 1.960339,1.061943 0.8104449,0.80363 1.2601992,1.641332 1.0575579,1.930577 -7.714e-4,0.0011 0.01977,0.01774 0.01898,0.01882 l 6.9820302,-7.0108637 0.02525,-0.025356 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.276628,6.7044221 11.826873,5.8667226 11.01643,5.0630931 10.204041,4.2575368 9.3426319,3.7934425 9.0560897,4.0011493 l -0.025251,0.025355 z" />
-    <path
-       d="m 2.0488085,11.037368 c 0.2865424,-0.207707 1.1479509,0.256388 1.9603385,1.061945 0.8104458,0.803629 1.2601996,1.641331 1.0575577,1.930575 -7.708e-4,0.0011 0.01977,0.01774 0.01898,0.01882 L 15.224149,3.8683779 C 15.481557,3.6099071 15.011041,2.7247557 14.172862,1.893626 13.334685,1.0624962 12.444681,0.59856571 12.187272,0.85703737 Z"
-       id="path967"
-       style="fill:none;fill-opacity:1;stroke:#ad5f00;stroke-width:0.361081;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       id="path960"
-       transform="matrix(1.2174292,0,0,1.2144872,-13.362889,-7.6166425)"
-       d="m 21.089844,6.9238281 c -0.04157,0.00859 -0.07709,0.026131 -0.103516,0.052734 l -2.572266,2.5898437 c 0.235367,-0.1710242 0.94403,0.2097577 1.611329,0.8730472 0.6657,0.661703 1.035592,1.351681 0.86914,1.589844 -6.32e-4,9.06e-4 0.01627,0.01474 0.01563,0.01563 L 23.482422,9.4570312 C 23.693858,9.2442083 23.30567,8.5144243 22.617188,7.8300781 22.014767,7.2312751 21.38083,6.8637258 21.089844,6.9238281 Z"
-       style="fill:url(#linearGradient964);fill-opacity:1;stroke:#555761;stroke-width:0.296953;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       style="opacity:0.9;fill:#fe9ab8;fill-opacity:1;stroke:#de3e80;stroke-width:0.361081;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3043"
-       d="m 10.565423,2.4840909 c 0.286542,-0.2077065 1.147951,0.2563879 1.960338,1.0619443 0.810445,0.8036291 1.260199,1.6413295 1.057557,1.9305744 -7.69e-4,0.0011 0.01977,0.017738 0.01898,0.018821 L 15.154234,3.9383089 C 15.562715,3.5297289 15.124956,2.8454879 14.172862,1.893626 13.360476,1.0880699 12.499066,0.6239749 12.212525,0.83168148 l -0.02525,0.0253559 -1.621849,1.62705352 z" />
-    <path
-       style="fill:url(#linearGradient3843);fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3047"
-       d="m 9.1785348,3.8767048 c 0.2865413,-0.2077068 1.1479522,0.2563879 1.9603392,1.0619443 0.810445,0.8036291 1.2602,1.6413294 1.057556,1.9305753 -7.71e-4,0.0011 0.01977,0.017736 0.01898,0.01882 l 0.126256,-0.1267795 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.525331,6.4531992 12.075576,5.6154986 11.26513,4.8118704 10.452743,4.0063135 9.5913335,3.542219 9.3047918,3.7499256 Z" />
-    <path
-       style="fill:url(#linearGradient3845);fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3049"
-       d="m 9.0628273,3.9928895 c 0.2865436,-0.2077068 1.1479527,0.2563878 1.9603397,1.061944 0.810444,0.8036294 1.2602,1.6413292 1.057556,1.9305742 -7.71e-4,0.0011 0.01977,0.017738 0.01898,0.018822 L 12.22596,6.8774498 c 7.9e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.018821 C 12.409623,6.569384 11.95987,5.7316836 11.149423,4.9280545 10.337036,4.1224982 9.4756273,3.6584033 9.1890844,3.8661101 Z" />
-    <path
-       style="fill:url(#linearGradient3847);fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3051"
-       d="m 9.5806143,3.4729643 c 0.2865426,-0.2077069 1.1479517,0.2563872 1.9603387,1.0619442 0.810446,0.803629 1.2602,1.6413292 1.057558,1.9305747 -7.73e-4,0.0011 0.01977,0.017737 0.01898,0.01882 l 0.126258,-0.1267784 c 7.91e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.01882 C 12.927411,6.0494594 12.477656,5.2117588 11.66721,4.4081298 10.854824,3.6025731 9.9934151,3.1384786 9.7068717,3.3461854 Z" />
-    <path
-       style="fill:url(#linearGradient3849);fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3053"
-       d="m 9.4649071,3.5891488 c 0.2865435,-0.207707 1.1479529,0.2563877 1.9603379,1.061944 0.810447,0.8036298 1.260201,1.6413294 1.057558,1.9305748 -7.69e-4,0.0011 0.01977,0.017737 0.01898,0.018821 l 0.126257,-0.12678 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.811705,6.1656438 12.361949,5.3279425 11.551504,4.5243147 10.739118,3.718758 9.877708,3.254663 9.5911645,3.46237 Z" />
-    <path
-       style="fill:url(#linearGradient3851);fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3055"
-       d="M 9.9846388,3.0672723 C 10.27118,2.8595657 11.13259,3.3236601 11.944976,4.1292168 c 0.810446,0.8036288 1.260201,1.641329 1.057558,1.9305741 -7.7e-4,0.0011 0.01977,0.017738 0.01898,0.018821 L 13.14777,5.9518328 c 7.92e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.018821 C 13.331434,5.6437674 12.881679,4.8060668 12.071233,4.0024374 11.258848,3.1968815 10.397438,2.7327869 10.110895,2.9404937 Z" />
-    <path
-       style="fill:url(#linearGradient3853);fill-opacity:1;stroke:none;stroke-width:0.593904"
-       id="path3057"
-       d="m 9.8689318,3.1834569 c 0.2865412,-0.2077072 1.1479512,0.2563879 1.9603392,1.0619447 0.810444,0.8036283 1.260198,1.6413291 1.057556,1.9305739 -7.71e-4,0.0011 0.01977,0.017737 0.01898,0.018821 l 0.126258,-0.1267782 c 7.89e-4,-0.00108 -0.01975,-0.017722 -0.01898,-0.018821 C 13.215727,5.7599515 12.765972,4.9222512 11.955527,4.1186224 11.143141,3.313066 10.281731,2.848971 9.9951884,3.0566783 Z" />
-    <path
-       style="fill:url(#linearGradient3855);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3857);stroke-width:0.361081;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3059"
-       d="m 0.25980529,15.79419 4.77185621,-1.725488 0.039308,-0.03926 C 5.2736124,13.740202 4.8185731,12.902156 4.0081274,12.098526 3.1957395,11.29297 2.335449,10.831246 2.0489062,11.038953 Z" />
-    <path
-       style="fill:#333333;fill-opacity:1;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:0.361081;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3061"
-       d="M 0.7444326,14.506276 0.25922075,15.788967 1.560593,15.315574 C 1.446907,15.182439 1.3413094,15.047739 1.2062351,14.913801 1.0507282,14.759602 0.89915498,14.633134 0.7444326,14.506276 Z" />
+     id="g1062">
+    <g
+       transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33333)"
+       id="g2036-4"
+       style="display:inline">
+      <g
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g3712-8"
+         style="opacity:0.4">
+        <rect
+           width="5"
+           height="7"
+           x="38"
+           y="40"
+           id="rect2801-6"
+           style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+        <rect
+           width="5"
+           height="7"
+           x="-10"
+           y="-47"
+           transform="scale(-1)"
+           id="rect3696-20"
+           style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+        <rect
+           width="28"
+           height="7.0000005"
+           x="10"
+           y="40"
+           id="rect3700-5"
+           style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <g
+       id="g998"
+       transform="rotate(90,5.5,18.5)">
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="3"
+         x="3"
+         height="18"
+         width="5"
+         id="rect980"
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient1000);stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect982"
+         width="4"
+         height="17"
+         x="3.5"
+         y="3.5"
+         rx="0"
+         ry="0" />
+      <rect
+         style="opacity:1;fill:#ff8c82;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect984"
+         width="2"
+         height="2"
+         x="4.5"
+         y="4.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="8.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect986"
+         style="opacity:1;fill:#ed5353;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#c6262e;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect988"
+         width="2"
+         height="2"
+         x="4.5"
+         y="12.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="4.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect990"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect992"
+         width="2"
+         height="2"
+         x="4.5"
+         y="8.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="12.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect994"
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#7a0000;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect996"
+         width="6"
+         height="19"
+         x="2.5"
+         y="2.5"
+         rx="1"
+         ry="1" />
+    </g>
+    <g
+       transform="rotate(60,5.5,18.5)"
+       id="g976">
+      <rect
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect958"
+         width="5"
+         height="18"
+         x="3"
+         y="3"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0"
+         rx="0"
+         y="3.5"
+         x="3.5"
+         height="17"
+         width="4"
+         id="rect960"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient978);stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="4.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect962"
+         style="opacity:1;fill:#ffc27d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#ffa154;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect964"
+         width="2"
+         height="2"
+         x="4.5"
+         y="8.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="12.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect966"
+         style="opacity:1;fill:#f37329;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect968"
+         width="2"
+         height="2"
+         x="4.5"
+         y="4.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="8.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect970"
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#a62100;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect972"
+         width="2"
+         height="2"
+         x="4.5"
+         y="12.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="1"
+         rx="1"
+         y="2.5"
+         x="2.5"
+         height="19"
+         width="6"
+         id="rect974"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <g
+       id="g954"
+       transform="rotate(30,5.5,18.5)">
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="3"
+         x="3"
+         height="18"
+         width="5"
+         id="rect936"
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient956);stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect938"
+         width="4"
+         height="17"
+         x="3.5"
+         y="3.5"
+         rx="0"
+         ry="0" />
+      <rect
+         style="opacity:1;fill:#8cd5ff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect940"
+         width="2"
+         height="2"
+         x="4.5"
+         y="4.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="8.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect942"
+         style="opacity:1;fill:#64baff;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#3689e6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect944"
+         width="2"
+         height="2"
+         x="4.5"
+         y="12.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="4.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect946"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect948"
+         width="2"
+         height="2"
+         x="4.5"
+         y="8.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="12.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect950"
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#002e99;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect952"
+         width="6"
+         height="19"
+         x="2.5"
+         y="2.5"
+         rx="1"
+         ry="1" />
+    </g>
+    <g
+       id="g912">
+      <rect
+         style="opacity:1;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect853"
+         width="5"
+         height="18"
+         x="3"
+         y="3"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0"
+         rx="0"
+         y="3.5"
+         x="3.5"
+         height="17"
+         width="4"
+         id="rect851"
+         style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient901);stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         ry="0"
+         rx="0"
+         y="4.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect855"
+         style="opacity:1;fill:#d1ff82;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#9bdb4d;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect857"
+         width="2"
+         height="2"
+         x="4.5"
+         y="8.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="12.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect859"
+         style="opacity:1;fill:#68b723;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect885"
+         width="2"
+         height="2"
+         x="4.5"
+         y="4.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="0"
+         rx="0"
+         y="8.5"
+         x="4.5"
+         height="2"
+         width="2"
+         id="rect887"
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;fill-opacity:1;stroke:#206b00;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="rect889"
+         width="2"
+         height="2"
+         x="4.5"
+         y="12.5"
+         rx="0"
+         ry="0" />
+      <rect
+         ry="1"
+         rx="1"
+         y="2.5"
+         x="2.5"
+         height="19"
+         width="6"
+         id="rect893"
+         style="opacity:0.4;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <g
+       id="g1004">
+      <circle
+         r="1"
+         cy="18.5"
+         cx="5.5"
+         id="path883"
+         style="opacity:1;fill:#abacae;fill-opacity:1;stroke:none;stroke-width:1;stroke-linejoin:round;stroke-opacity:1" />
+      <circle
+         style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-linejoin:round;stroke-opacity:1"
+         id="circle891"
+         cx="5.5"
+         cy="18.5"
+         r="1" />
+    </g>
   </g>
 </svg>

--- a/elementary-xfce/apps/32/preferences-desktop-theme.svg
+++ b/elementary-xfce/apps/32/preferences-desktop-theme.svg
@@ -1,371 +1,572 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="32"
    height="32"
-   id="svg2"
-   version="1.0"
-   sodipodi:docname="preferences-desktop-theme.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview77"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="10.046809"
-     inkscape:cx="19.160313"
-     inkscape:cy="12.790131"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="398"
-     inkscape:window-y="38"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg2"
-     inkscape:snap-global="false" />
+   id="svg4588">
   <defs
-     id="defs4">
+     id="defs4590">
     <linearGradient
-       spreadMethod="pad"
-       gradientTransform="matrix(0.415777,-0.4174938,0.518983,0.5146192,-15.747227,2.6503673)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient985"
-       id="linearGradient3841"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972" />
-    <linearGradient
-       id="linearGradient985">
+       id="linearGradient904">
       <stop
-         id="stop969"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop900"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop902"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop905"
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+      <stop
+         id="stop907"
+         offset="1"
+         style="stop-color:#7e8087;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient893">
+      <stop
+         id="stop889"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop891"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.6" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3493"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop971"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.13482948" />
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3495"
+       xlink:href="#linearGradient3688-464-309-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-7">
       <stop
-         id="stop973"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.20224422" />
+         id="stop2889-0"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         id="stop975"
-         style="stop-color:#fff394;stop-opacity:1"
-         offset="0.26965895" />
-      <stop
-         id="stop977"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.44650277" />
-      <stop
-         id="stop979"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.57114136" />
-      <stop
-         id="stop981"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.72038066" />
-      <stop
-         id="stop983"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop2891-66"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       spreadMethod="pad"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972"
-       gradientTransform="matrix(0.34152048,-0.34376139,0.42629419,0.42373374,-1.9585025,8.453782)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient964"
-       xlink:href="#linearGradient3155-40-3" />
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3497"
+       xlink:href="#linearGradient3702-501-757-3"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3155-40-3">
+       id="linearGradient3702-501-757-3">
       <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2541-6" />
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
       <stop
-         offset="0.13482948"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2543-7" />
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
       <stop
-         offset="0.20224422"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2545-5" />
-      <stop
-         offset="0.26965895"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2547-3" />
-      <stop
-         offset="0.44650277"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2549-5" />
-      <stop
-         offset="0.57114136"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2551-6" />
-      <stop
-         offset="0.72038066"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2553-2" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2555-9" />
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.867764,0.6930272)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279-1"
-       id="linearGradient3843"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="27"
+       x2="6.5"
+       y1="24"
+       x1="6.5"
+       id="linearGradient895"
+       xlink:href="#linearGradient893" />
     <linearGradient
-       id="linearGradient3240-279-1">
-      <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2559-2" />
-      <stop
-         offset="0.5"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2561-7" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2563-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.983472,0.8092126)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3845"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="27.5"
+       x2="6.5"
+       y1="23.5"
+       x1="6.5"
+       id="linearGradient911"
+       xlink:href="#linearGradient909" />
     <linearGradient
-       id="linearGradient3223-789-9">
-      <stop
-         offset="0"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2567-3" />
-      <stop
-         offset="0.5"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2569-6" />
-      <stop
-         offset="1"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2571-0" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.465684,0.2892868)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279-1"
-       id="linearGradient3847"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="28"
+       x2="6.5"
+       y1="4"
+       x1="6.5"
+       id="linearGradient906"
+       xlink:href="#linearGradient904" />
     <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.581392,0.4054707)"
+       gradientTransform="translate(11.879165,-6.6663522)"
+       y2="24.03109"
+       x2="16.044228"
+       y1="4.5455174"
+       x1="4.7942286"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3849"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient910"
+       xlink:href="#linearGradient904" />
     <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.061661,-0.1164056)"
+       y2="12.527568"
+       x2="18.031088"
+       y1="4.5275679"
+       x1="4.1746821"
+       gradientTransform="translate(18.833648,-18.379165)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279-1"
-       id="linearGradient3851"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient914"
+       xlink:href="#linearGradient904" />
     <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.6022679,-17.177369,-2.1969969e-4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789-9"
-       id="linearGradient3853"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.4040235,-0.4056919,0.6073752,0.602268,-17.636692,0.462492)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3290-678-8"
-       id="linearGradient3855"
-       y2="26.02973"
+       y2="7.5"
        x2="9"
-       y1="29.056757"
-       x1="9" />
-    <linearGradient
-       id="linearGradient3290-678-8">
-      <stop
-         offset="0"
-         style="stop-color:#fff394;stop-opacity:1"
-         id="stop2607-9" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2609-7" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.3763801,0.03615261,0.03669995,0.374874,-2.2182805,-1.1331002)"
+       y1="7.5"
+       x1="4"
+       gradientTransform="translate(19,-32)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3191-577-3"
-       id="linearGradient3857"
-       y2="41.391716"
-       x2="9.5220556"
-       y1="37.371799"
-       x1="5.5178981" />
-    <linearGradient
-       id="linearGradient3191-577-3">
-      <stop
-         offset="0"
-         style="stop-color:#d48e15;stop-opacity:1"
-         id="stop2613-6" />
-      <stop
-         offset="1"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         id="stop2615-1" />
-    </linearGradient>
+       id="linearGradient918"
+       xlink:href="#linearGradient904" />
   </defs>
   <metadata
-     id="metadata7">
+     id="metadata4593">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(0.68656604,0,0,0.68670939,32.364808,-1.1850053)"
-     id="g4127-3"
-     style="stroke-width:0.745177">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ed5353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path2964-6"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-1.3076923)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#de3e80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4113-7"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-11.307692)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#924ab4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4115-5"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-4.78022,-20.021977)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#a56de2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4117-3"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-13.208791,-25.021976)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4119-5"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-23.208791,-25.021976)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#28bca3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4121-6"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-31.637363,-20.164834)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4123-2"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-36.637363,-11.593405)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.745177;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4125-9"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-36.923077,-1.7362627)" />
-  </g>
-  <path
-     style="opacity:0.15;fill:#0c0c0c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999"
-     id="path2422-2"
-     d="m 25.446735,24.307724 c -0.232977,-0.04308 -0.413267,-0.03188 -0.532363,-0.0079 l -15.8628579,3.173398 -2.9195288,0.585702 -0.089892,0.01181 -3.4565504,2.447003 8.5662691,0.08106 0.07113,-0.01495 2.938297,-0.582598 15.858906,-3.200766 c 0.476393,-0.09589 -0.277061,-0.731481 -1.690176,-1.428233 -1.05984,-0.522562 -2.184274,-0.935296 -2.88324,-1.064559 z" />
-  <g
-     id="g8626"
-     transform="matrix(1.8558322,0,0,1.8606847,3.0504615,0.19699434)"
-     style="stroke-width:0.442563">
-    <path
-       style="fill:url(#linearGradient3841);fill-opacity:1;stroke:none;stroke-width:0.269069;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3041"
-       d="m 2.0488085,11.037368 c 0.2865424,-0.207707 1.1479509,0.256388 1.9603385,1.061945 0.8104458,0.803629 1.2601996,1.641331 1.0575577,1.930575 -7.708e-4,0.0011 0.01977,0.01774 0.01898,0.01882 L 15.224149,3.8683779 C 15.481557,3.6099071 15.011041,2.7247557 14.172862,1.893626 13.334685,1.0624962 12.444681,0.59856571 12.187272,0.85703737 Z" />
-    <path
-       style="opacity:0.6;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3045"
-       d="m 2.0488079,11.037368 c 0.286543,-0.207708 1.1479512,0.256388 1.960339,1.061943 0.8104449,0.80363 1.2601992,1.641332 1.0575579,1.930577 -7.714e-4,0.0011 0.01977,0.01774 0.01898,0.01882 l 6.9820302,-7.0108637 0.02525,-0.025356 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.276628,6.7044221 11.826873,5.8667226 11.01643,5.0630931 10.204041,4.2575368 9.3426319,3.7934425 9.0560897,4.0011493 l -0.025251,0.025355 z" />
-    <path
-       d="m 2.0488085,11.037368 c 0.2865424,-0.207707 1.1479509,0.256388 1.9603385,1.061945 0.8104458,0.803629 1.2601996,1.641331 1.0575577,1.930575 -7.708e-4,0.0011 0.01977,0.01774 0.01898,0.01882 L 15.224149,3.8683779 C 15.481557,3.6099071 15.011041,2.7247557 14.172862,1.893626 13.334685,1.0624962 12.444681,0.59856571 12.187272,0.85703737 Z"
-       id="path967"
-       style="fill:none;fill-opacity:1;stroke:#ad5f00;stroke-width:0.269069;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       id="path960"
-       transform="matrix(1.2174292,0,0,1.2144872,-13.362889,-7.6166425)"
-       d="m 21.089844,6.9238281 c -0.04157,0.00859 -0.07709,0.026131 -0.103516,0.052734 l -2.572266,2.5898437 c 0.235367,-0.1710242 0.94403,0.2097577 1.611329,0.8730472 0.6657,0.661703 1.035592,1.351681 0.86914,1.589844 -6.32e-4,9.06e-4 0.01627,0.01474 0.01563,0.01563 L 23.482422,9.4570312 C 23.693858,9.2442083 23.30567,8.5144243 22.617188,7.8300781 22.014767,7.2312751 21.38083,6.8637258 21.089844,6.9238281 Z"
-       style="fill:url(#linearGradient964);fill-opacity:1;stroke:#555761;stroke-width:0.221282;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-    <path
-       style="opacity:0.9;fill:#fe9ab8;fill-opacity:1;stroke:#de3e80;stroke-width:0.269069;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-       id="path3043"
-       d="m 10.565423,2.4840909 c 0.286542,-0.2077065 1.147951,0.2563879 1.960338,1.0619443 0.810445,0.8036291 1.260199,1.6413295 1.057557,1.9305744 -7.69e-4,0.0011 0.01977,0.017738 0.01898,0.018821 L 15.154234,3.9383089 C 15.562715,3.5297289 15.124956,2.8454879 14.172862,1.893626 13.360476,1.0880699 12.499066,0.6239749 12.212525,0.83168148 l -0.02525,0.0253559 -1.621849,1.62705352 z" />
-    <path
-       style="fill:url(#linearGradient3843);fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3047"
-       d="m 9.1785348,3.8767048 c 0.2865413,-0.2077068 1.1479522,0.2563879 1.9603392,1.0619443 0.810445,0.8036291 1.2602,1.6413294 1.057556,1.9305753 -7.71e-4,0.0011 0.01977,0.017736 0.01898,0.01882 l 0.126256,-0.1267795 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.525331,6.4531992 12.075576,5.6154986 11.26513,4.8118704 10.452743,4.0063135 9.5913335,3.542219 9.3047918,3.7499256 Z" />
-    <path
-       style="fill:url(#linearGradient3845);fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3049"
-       d="m 9.0628273,3.9928895 c 0.2865436,-0.2077068 1.1479527,0.2563878 1.9603397,1.061944 0.810444,0.8036294 1.2602,1.6413292 1.057556,1.9305742 -7.71e-4,0.0011 0.01977,0.017738 0.01898,0.018822 L 12.22596,6.8774498 c 7.9e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.018821 C 12.409623,6.569384 11.95987,5.7316836 11.149423,4.9280545 10.337036,4.1224982 9.4756273,3.6584033 9.1890844,3.8661101 Z" />
-    <path
-       style="fill:url(#linearGradient3847);fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3051"
-       d="m 9.5806143,3.4729643 c 0.2865426,-0.2077069 1.1479517,0.2563872 1.9603387,1.0619442 0.810446,0.803629 1.2602,1.6413292 1.057558,1.9305747 -7.73e-4,0.0011 0.01977,0.017737 0.01898,0.01882 l 0.126258,-0.1267784 c 7.91e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.01882 C 12.927411,6.0494594 12.477656,5.2117588 11.66721,4.4081298 10.854824,3.6025731 9.9934151,3.1384786 9.7068717,3.3461854 Z" />
-    <path
-       style="fill:url(#linearGradient3849);fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3053"
-       d="m 9.4649071,3.5891488 c 0.2865435,-0.207707 1.1479529,0.2563877 1.9603379,1.061944 0.810447,0.8036298 1.260201,1.6413294 1.057558,1.9305748 -7.69e-4,0.0011 0.01977,0.017737 0.01898,0.018821 l 0.126257,-0.12678 c 7.9e-4,-0.00108 -0.01975,-0.01772 -0.01898,-0.01882 C 12.811705,6.1656438 12.361949,5.3279425 11.551504,4.5243147 10.739118,3.718758 9.877708,3.254663 9.5911645,3.46237 Z" />
-    <path
-       style="fill:url(#linearGradient3851);fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3055"
-       d="M 9.9846388,3.0672723 C 10.27118,2.8595657 11.13259,3.3236601 11.944976,4.1292168 c 0.810446,0.8036288 1.260201,1.641329 1.057558,1.9305741 -7.7e-4,0.0011 0.01977,0.017738 0.01898,0.018821 L 13.14777,5.9518328 c 7.92e-4,-0.00108 -0.01975,-0.017721 -0.01898,-0.018821 C 13.331434,5.6437674 12.881679,4.8060668 12.071233,4.0024374 11.258848,3.1968815 10.397438,2.7327869 10.110895,2.9404937 Z" />
-    <path
-       style="fill:url(#linearGradient3853);fill-opacity:1;stroke:none;stroke-width:0.442563"
-       id="path3057"
-       d="m 9.8689318,3.1834569 c 0.2865412,-0.2077072 1.1479512,0.2563879 1.9603392,1.0619447 0.810444,0.8036283 1.260198,1.6413291 1.057556,1.9305739 -7.71e-4,0.0011 0.01977,0.017737 0.01898,0.018821 l 0.126258,-0.1267782 c 7.89e-4,-0.00108 -0.01975,-0.017722 -0.01898,-0.018821 C 13.215727,5.7599515 12.765972,4.9222512 11.955527,4.1186224 11.143141,3.313066 10.281731,2.848971 9.9951884,3.0566783 Z" />
-    <path
-       style="fill:url(#linearGradient3855);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3857);stroke-width:0.269069;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3059"
-       d="m 0.25980529,15.79419 4.77185621,-1.725488 0.039308,-0.03926 C 5.2736124,13.740202 4.8185731,12.902156 4.0081274,12.098526 3.1957395,11.29297 2.335449,10.831246 2.0489062,11.038953 Z" />
-    <path
-       style="fill:#333333;fill-opacity:1;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:0.269069;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       id="path3061"
-       d="M 0.7444326,14.506276 0.25922075,15.788967 1.560593,15.315574 C 1.446907,15.182439 1.3413094,15.047739 1.2062351,14.913801 1.0507282,14.759602 0.89915498,14.633134 0.7444326,14.506276 Z" />
+     id="g1012">
+    <g
+       transform="matrix(0.6999997,0,0,0.3333336,-0.8000002,15.33333)"
+       id="g2036-2"
+       style="display:inline">
+      <g
+         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+         id="g3712-3"
+         style="opacity:0.4">
+        <rect
+           width="5"
+           height="7"
+           x="38"
+           y="40"
+           id="rect2801-0"
+           style="fill:url(#radialGradient3493);fill-opacity:1;stroke:none" />
+        <rect
+           width="5"
+           height="7"
+           x="-10"
+           y="-47"
+           transform="scale(-1)"
+           id="rect3696-2"
+           style="fill:url(#radialGradient3495);fill-opacity:1;stroke:none" />
+        <rect
+           width="28"
+           height="7.0000005"
+           x="10"
+           y="40"
+           id="rect3700-1"
+           style="fill:url(#linearGradient3497);fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <g
+       id="g969"
+       transform="rotate(90,6.5,25.496094)">
+      <rect
+         style="opacity:1;fill:#fafafa;stroke:none;stroke-opacity:1"
+         id="rect959"
+         width="7"
+         height="26"
+         x="3"
+         y="3"
+         rx="1.5"
+         ry="1.5" />
+      <rect
+         ry="2"
+         rx="2"
+         y="2.5"
+         x="2.5"
+         height="26.992188"
+         width="8"
+         id="rect967"
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="4.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect979"
+         style="opacity:1;fill:#ff8c82;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#7a0000;stroke-opacity:1"
+         id="rect961"
+         width="4"
+         height="4"
+         x="4.5"
+         y="4.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="opacity:1;fill:#ed5353;stroke:none;stroke-opacity:1"
+         id="rect981"
+         width="4"
+         height="4"
+         x="4.5"
+         y="10.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="10.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect963"
+         style="opacity:0.5;fill:none;stroke:#7a0000;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="16.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect983"
+         style="opacity:1;fill:#c6262e;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;stroke:#7a0000;stroke-opacity:1"
+         id="rect965"
+         width="4"
+         height="4"
+         x="4.5"
+         y="16.5"
+         rx="0.5"
+         ry="0.5" />
+    </g>
+    <rect
+       ry="1"
+       rx="1"
+       y="-28.5"
+       x="22.499998"
+       height="25"
+       width="6"
+       id="rect916"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient918);stroke-width:1;stroke-opacity:1"
+       transform="rotate(90)" />
+    <g
+       transform="rotate(60,6.5,25.496094)"
+       id="g957">
+      <rect
+         ry="1.5"
+         rx="1.5"
+         y="3"
+         x="3"
+         height="26"
+         width="7"
+         id="rect947"
+         style="opacity:1;fill:#fafafa;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+         id="rect955"
+         width="8"
+         height="26.992188"
+         x="2.5"
+         y="2.5"
+         rx="2"
+         ry="2" />
+      <rect
+         style="opacity:1;fill:#ffc27d;stroke:none;stroke-opacity:1"
+         id="rect985"
+         width="4"
+         height="4"
+         x="4.5"
+         y="4.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="4.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect949"
+         style="opacity:0.4;fill:none;stroke:#a62100;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="10.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect987"
+         style="opacity:1;fill:#ffa154;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;stroke:#a62100;stroke-opacity:1"
+         id="rect951"
+         width="4"
+         height="4"
+         x="4.5"
+         y="10.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="opacity:1;fill:#f37329;stroke:none;stroke-opacity:1"
+         id="rect989"
+         width="4"
+         height="4"
+         x="4.5"
+         y="16.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="16.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect953"
+         style="opacity:0.6;fill:none;stroke:#a62100;stroke-opacity:1" />
+    </g>
+    <rect
+       transform="rotate(60)"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient914);stroke-width:1;stroke-opacity:1"
+       id="rect912"
+       width="6"
+       height="25"
+       x="22.333647"
+       y="-14.879166"
+       rx="1"
+       ry="1" />
+    <g
+       id="g945"
+       transform="rotate(30,6.5,25.496094)">
+      <rect
+         style="opacity:1;fill:#fafafa;stroke:none;stroke-opacity:1"
+         id="rect935"
+         width="7"
+         height="26"
+         x="3"
+         y="3"
+         rx="1.5"
+         ry="1.5" />
+      <rect
+         ry="2"
+         rx="2"
+         y="2.5"
+         x="2.5"
+         height="26.992188"
+         width="8"
+         id="rect943"
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="4.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect991"
+         style="opacity:1;fill:#8cd5ff;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#64baff;stroke:none;stroke-opacity:1"
+         id="rect993"
+         width="4"
+         height="4"
+         x="4.5"
+         y="10.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="10.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect939"
+         style="opacity:0.5;fill:none;stroke:#002e99;stroke-opacity:1" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="16.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect995"
+         style="opacity:1;fill:#3689e6;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;stroke:#002e99;stroke-opacity:1"
+         id="rect941"
+         width="4"
+         height="4"
+         x="4.5"
+         y="16.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#002e99;stroke-opacity:1"
+         id="rect937"
+         width="4"
+         height="4"
+         x="4.5"
+         y="4.5"
+         rx="0.5"
+         ry="0.5" />
+    </g>
+    <rect
+       ry="1"
+       rx="1"
+       y="-3.1663523"
+       x="15.379165"
+       height="25"
+       width="6"
+       id="rect908"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient910);stroke-width:1;stroke-opacity:1"
+       transform="rotate(30)" />
+    <g
+       id="g885">
+      <rect
+         ry="1.5"
+         rx="1.5"
+         y="3"
+         x="3"
+         height="26"
+         width="7"
+         id="rect851"
+         style="opacity:1;fill:#fafafa;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+         id="rect878"
+         width="8"
+         height="26.992188"
+         x="2.5"
+         y="2.5"
+         rx="2"
+         ry="2" />
+      <rect
+         style="opacity:1;fill:#d1ff82;stroke:none;stroke-opacity:1"
+         id="rect997"
+         width="4"
+         height="4"
+         x="4.5"
+         y="4.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="10.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect999"
+         style="opacity:1;fill:#9bdb4d;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:1;fill:#68b723;stroke:none;stroke-opacity:1"
+         id="rect1001"
+         width="4"
+         height="4"
+         x="4.5"
+         y="16.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="4.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect853"
+         style="opacity:0.4;fill:none;stroke:#206b00;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;stroke:#206b00;stroke-opacity:1"
+         id="rect870"
+         width="4"
+         height="4"
+         x="4.5"
+         y="10.5"
+         rx="0.5"
+         ry="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="16.5"
+         x="4.5"
+         height="4"
+         width="4"
+         id="rect872"
+         style="opacity:0.6;fill:none;stroke:#206b00;stroke-opacity:1" />
+    </g>
+    <circle
+       style="opacity:1;fill:url(#linearGradient911);fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="path876"
+       cx="6.5"
+       cy="25.5"
+       r="2" />
+    <circle
+       r="2"
+       cy="25.5"
+       cx="6.5"
+       id="circle885"
+       style="opacity:0.5;fill:none;stroke:#555761;stroke-width:1;stroke-opacity:1" />
+    <circle
+       style="opacity:0.2;fill:none;stroke:url(#linearGradient895);stroke-width:1;stroke-opacity:1"
+       id="circle887"
+       cx="6.5"
+       cy="25.5"
+       r="1" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient906);stroke-width:1;stroke-opacity:1"
+       id="rect898"
+       width="6"
+       height="25"
+       x="3.5"
+       y="3.5"
+       rx="1"
+       ry="1" />
   </g>
 </svg>

--- a/elementary-xfce/apps/48/preferences-desktop-theme.svg
+++ b/elementary-xfce/apps/48/preferences-desktop-theme.svg
@@ -1,383 +1,548 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="48px"
-   height="48px"
-   id="svg4211"
-   version="1.1"
-   sodipodi:docname="preferences-desktop-theme.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview61"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="8"
-     inkscape:cx="26.9375"
-     inkscape:cy="13.8125"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="0"
-     inkscape:window-y="105"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg4211" />
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4405">
   <defs
-     id="defs4213">
+     id="defs4407">
     <linearGradient
-       id="linearGradient954">
+       id="linearGradient898">
       <stop
-         id="stop938"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop894"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop896"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1057">
+      <stop
+         id="stop1053"
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+      <stop
+         id="stop1055"
+         offset="1"
+         style="stop-color:#7e8087;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-896"
+       xlink:href="#linearGradient3688-166-749-2-324"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-2-324">
+      <stop
+         id="stop3216"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop940"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.13482948" />
+         id="stop3218"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-826"
+       xlink:href="#linearGradient3688-464-309-8-331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-8-331">
       <stop
-         id="stop942"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.20224422" />
+         id="stop3222"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         id="stop944"
-         style="stop-color:#fff394;stop-opacity:1"
-         offset="0.26965895" />
-      <stop
-         id="stop946"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.44650277" />
-      <stop
-         id="stop948"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.57114136" />
-      <stop
-         id="stop950"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.72038066" />
-      <stop
-         id="stop952"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop3224"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3155-40">
+       id="linearGradient3702-501-757-6-946">
       <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2541" />
+         id="stop3228"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
       <stop
-         offset="0.13482948"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2543" />
+         id="stop3230"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
       <stop
-         offset="0.20224422"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2545" />
-      <stop
-         offset="0.26965895"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2547" />
-      <stop
-         offset="0.44650277"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2549" />
-      <stop
-         offset="0.57114136"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2551" />
-      <stop
-         offset="0.72038066"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2553" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2555" />
+         id="stop3232"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3240-279">
-      <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2559" />
-      <stop
-         offset="0.5"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2561" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2563" />
-    </linearGradient>
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient4395"
+       xlink:href="#linearGradient3702-501-757-6-946"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3223-789">
-      <stop
-         offset="0"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2567" />
-      <stop
-         offset="0.5"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2569" />
-      <stop
-         offset="1"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2571" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3290-678">
-      <stop
-         offset="0"
-         style="stop-color:#fff394;stop-opacity:1"
-         id="stop2607" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2609" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3191-577">
-      <stop
-         offset="0"
-         style="stop-color:#d48e15;stop-opacity:1"
-         id="stop2613" />
-      <stop
-         offset="1"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         id="stop2615" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient954"
-       id="linearGradient1733"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6565695,-0.659788,0.7345237,0.7308691,-1.012959,19.863185)"
-       x1="23.575972"
-       y1="25.356892"
-       x2="23.575972"
-       y2="31.210939"
-       spreadMethod="pad" />
+       y2="41.5"
+       x2="10"
+       y1="36.5"
+       x1="10"
+       id="linearGradient1059"
+       xlink:href="#linearGradient1057" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3155-40"
-       id="linearGradient1735"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6565695,-0.659788,0.7345237,0.7308691,-1.012959,19.863185)"
-       x1="23.575972"
-       y1="25.356892"
-       x2="23.575972"
-       y2="31.210939"
-       spreadMethod="pad" />
+       y2="43"
+       x2="10"
+       y1="7"
+       x1="10"
+       id="linearGradient900"
+       xlink:href="#linearGradient898" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient1737"
+       gradientTransform="translate(18.160254,-10.225009)"
+       y2="37.080128"
+       x2="23.325317"
+       y1="7.635263"
+       x1="6.3253174"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596262,0.8553492,-3.419016,16.487099)"
-       x1="30.037716"
-       y1="24.989594"
-       x2="30.037716"
-       y2="30.000141" />
+       id="linearGradient904"
+       xlink:href="#linearGradient898" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient1739"
+       y2="19.916351"
+       x2="27.946152"
+       y1="7.6663523"
+       x1="6.7285299"
+       gradientTransform="translate(28.774991,-28.160254)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596262,0.8553492,-3.601733,16.670712)"
-       x1="30.037716"
-       y1="24.989594"
-       x2="30.037716"
-       y2="30.000141" />
+       id="linearGradient908"
+       xlink:href="#linearGradient898" />
     <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient1741"
+       y2="15"
+       x2="14"
+       y1="15"
+       x1="6"
+       gradientTransform="translate(29,-49)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596262,0.8553492,-2.784076,15.849046)"
-       x1="30.037716"
-       y1="24.989594"
-       x2="30.037716"
-       y2="30.000141" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient1743"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596262,0.8553492,-2.966794,16.032658)"
-       x1="30.037716"
-       y1="24.989594"
-       x2="30.037716"
-       y2="30.000141" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient1745"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596262,0.8553492,-2.146067,15.207909)"
-       x1="30.037716"
-       y1="24.989594"
-       x2="30.037716"
-       y2="30.000141" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient1747"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596262,0.8553492,-2.328784,15.391523)"
-       x1="30.037716"
-       y1="24.989594"
-       x2="30.037716"
-       y2="30.000141" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3290-678"
-       id="linearGradient1749"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.6380091,-0.6411367,0.8596263,0.8553493,-3.661342,16.73061)"
-       x1="9"
-       y1="29.056757"
-       x2="9"
-       y2="26.02973" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3191-577"
-       id="linearGradient1751"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.5603647,0.02418622,0.02415646,0.5596736,19.546549,13.104104)"
-       x1="5.5178981"
-       y1="37.371799"
-       x2="9.5220556"
-       y2="41.391716" />
+       id="linearGradient912"
+       xlink:href="#linearGradient898" />
   </defs>
   <metadata
-     id="metadata4216">
+     id="metadata4410">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(0.99999682,0,0,1.0002056,48.28559,-3.007261)"
-     id="g4127-3"
-     style="stroke-width:0.511615">
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ed5353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path2964-6"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-1.3076923)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#de3e80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4113-7"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-11.307692)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#924ab4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4115-5"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-4.78022,-20.021977)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#a56de2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4117-3"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-13.208791,-25.021976)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4119-5"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-23.208791,-25.021976)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#28bca3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4121-6"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-31.637363,-20.164834)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4123-2"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-36.637363,-11.593405)" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.511615;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;enable-background:accumulate"
-       id="path4125-9"
-       d="m -2.0000002,34 a 3.7142857,3.7142857 0 1 1 -7.4285713,0 3.7142857,3.7142857 0 1 1 7.4285713,0 z"
-       transform="matrix(1.0384615,0,0,1.0384615,-36.923077,-1.7362627)" />
-  </g>
-  <g
-     id="g4169-1"
-     transform="translate(3.2919804e-8,-3)">
+     id="g1004">
     <g
-       id="g963-0"
-       transform="matrix(1.6845893,0,0,1.6845697,-28.66607,-16.698399)"
-       style="stroke-width:0.59362">
-      <path
-         style="opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.59362px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         d="m 41.782795,33.430317 c -0.190571,-0.0023 -0.343436,0.01798 -0.446443,0.03951 l -13.716561,2.857899 -2.524709,0.526801 -0.07697,0.01317 -3.202071,1.488214 7.189263,-0.658502 0.06158,-0.01317 2.540105,-0.526803 13.716561,-2.871069 c 0.412023,-0.08612 -0.143989,-0.338034 -1.246961,-0.566312 -0.827228,-0.171208 -1.722077,-0.283005 -2.293791,-0.289741 z"
-         id="path2422-6" />
-      <path
-         style="fill:url(#linearGradient1733);fill-opacity:1;stroke:none;stroke-width:0.29681;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect2383-9-3"
-         d="m 24.934095,31.028461 c 0.445921,-0.334616 1.697104,0.293067 2.846888,1.43713 1.147034,1.141326 1.75142,2.362602 1.42438,2.812888 -0.0012,0.0017 0.02814,0.02504 0.02686,0.02673 L 45.242268,19.216683 C 45.64875,18.808208 45.017185,17.517377 43.830899,16.336995 42.644617,15.156613 41.35062,14.531459 40.944135,14.939936 Z" />
-      <path
-         style="opacity:0.6;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3208-3-2"
-         d="m 24.934095,31.028459 c 0.445921,-0.334616 1.697105,0.293068 2.846887,1.43713 1.147034,1.141326 1.751421,2.362602 1.42438,2.812888 -0.0012,0.0017 0.02814,0.02504 0.02687,0.02673 l 11.025592,-11.079643 0.03988,-0.04007 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327034,-0.450289 -0.277353,-1.671564 -1.424386,-2.81289 -1.149783,-1.144062 -2.400968,-1.771746 -2.846889,-1.437129 l -0.03988,0.04007 L 24.9341,31.028459 Z" />
-      <path
-         d="m 24.934095,31.028461 c 0.445921,-0.334616 1.697104,0.293067 2.846888,1.43713 1.147034,1.141326 1.75142,2.362602 1.42438,2.812888 -0.0012,0.0017 0.02814,0.02504 0.02686,0.02673 L 45.242268,19.216683 C 45.64875,18.808208 45.017185,17.517377 43.830899,16.336995 42.644617,15.156613 41.35062,14.531459 40.944135,14.939936 Z"
-         id="path936-0"
-         style="fill:none;fill-opacity:1;stroke:#ad5f00;stroke-width:0.29681;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         id="path929-6"
-         d="m 41.400391,14.820312 c -0.19701,-0.01961 -0.35541,0.01702 -0.457032,0.119141 L 36,19.908203 c 0.445921,-0.334617 1.69592,0.293438 2.845703,1.4375 1.147033,1.141326 1.752815,2.362211 1.425781,2.8125 -0.0012,0.0017 0.02669,0.02564 0.02539,0.02734 l 4.945313,-4.96875 c 0.406481,-0.408475 -0.225824,-1.698524 -1.41211,-2.878906 -0.889711,-0.885287 -1.838658,-1.45875 -2.429687,-1.517579 z"
-         style="fill:url(#linearGradient1735);fill-opacity:1;stroke:#555761;stroke-width:0.29681;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="opacity:0.9;fill:#fe9ab8;fill-opacity:1;stroke:#de3e80;stroke-width:0.29681;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect3175-6-1"
-         d="m 38.990234,16.903417 c 0.445921,-0.334616 1.697105,0.293068 2.846888,1.43713 1.147033,1.141325 1.75142,2.362602 1.424379,2.812887 -0.0012,0.0017 0.02814,0.02504 0.02686,0.02673 l 1.953903,-1.963482 0.03988,-0.04007 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327036,-0.450285 -0.277352,-1.671561 -1.424385,-2.812886 -1.149782,-1.144062 -2.400965,-1.771747 -2.846887,-1.43713 l -0.03988,0.04007 -1.953901,1.963481 z" />
-      <path
-         style="fill:url(#linearGradient1737);fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3233-0-5"
-         d="m 36.800145,19.10424 c 0.44592,-0.334617 1.697106,0.293068 2.846888,1.43713 1.147033,1.141325 1.751421,2.362601 1.424379,2.812888 -0.0012,0.0017 0.02814,0.02504 0.02686,0.02673 L 41.29765,23.18063 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327042,-0.450286 -0.277346,-1.671563 -1.42438,-2.812886 -1.149782,-1.144063 -2.400967,-1.771747 -2.846887,-1.437131 l -0.199378,0.200356 z" />
-      <path
-         style="fill:url(#linearGradient1739);fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3216-6-5"
-         d="m 36.617427,19.287853 c 0.445922,-0.334617 1.697107,0.293067 2.846888,1.437129 1.147035,1.141326 1.751422,2.362601 1.42438,2.812887 -0.0012,0.0017 0.02813,0.02504 0.02686,0.02673 l 0.199377,-0.200357 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327044,-0.450285 -0.277344,-1.671561 -1.424379,-2.812886 -1.149782,-1.144062 -2.400966,-1.771747 -2.846889,-1.43713 l -0.199377,0.200356 z" />
-      <path
-         style="fill:url(#linearGradient1741);fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3248-2-4"
-         d="m 37.435085,18.466187 c 0.445921,-0.334617 1.697105,0.293067 2.846888,1.43713 1.147033,1.141325 1.751421,2.3626 1.42438,2.812887 -0.0012,0.0017 0.02813,0.02504 0.02686,0.02673 l 0.199378,-0.200355 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327041,-0.450286 -0.277346,-1.671563 -1.424381,-2.812887 -1.149782,-1.144063 -2.400964,-1.771747 -2.846888,-1.43713 z" />
-      <path
-         style="fill:url(#linearGradient1743);fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3250-6-7"
-         d="m 37.252367,18.6498 c 0.445923,-0.334617 1.697107,0.293067 2.846888,1.437129 1.147035,1.141326 1.751422,2.362601 1.424381,2.812887 -0.0012,0.0017 0.02814,0.02504 0.02686,0.02673 l 0.199377,-0.200356 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327042,-0.450286 -0.277345,-1.671563 -1.424379,-2.812886 -1.149781,-1.144063 -2.400966,-1.771748 -2.846889,-1.43713 z" />
-      <path
-         style="fill:url(#linearGradient1745);fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3256-1-6"
-         d="m 38.073095,17.82505 c 0.44592,-0.334616 1.697104,0.293068 2.846887,1.43713 1.147033,1.141325 1.751421,2.362601 1.42438,2.812887 -0.0012,0.0017 0.02813,0.02504 0.02686,0.02673 l 0.199376,-0.200356 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327042,-0.450285 -0.277346,-1.671562 -1.42438,-2.812887 -1.14978,-1.144062 -2.400965,-1.771747 -2.846887,-1.437129 z" />
-      <path
-         style="fill:url(#linearGradient1747);fill-opacity:1;stroke:none;stroke-width:0.59362"
-         id="path3258-8-5"
-         d="m 37.890378,18.008663 c 0.445919,-0.334617 1.697105,0.293067 2.846887,1.437131 1.147033,1.141324 1.751422,2.3626 1.424379,2.812885 -0.0012,0.0017 0.02814,0.02504 0.02686,0.02673 l 0.199378,-0.200354 c 0.0013,-0.0017 -0.02811,-0.02502 -0.02686,-0.02673 0.327042,-0.450287 -0.277346,-1.671563 -1.424379,-2.812887 -1.149782,-1.144063 -2.400967,-1.771748 -2.846888,-1.43713 z" />
-      <path
-         style="fill:url(#linearGradient1749);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient1751);stroke-width:0.29681;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3270-7-6"
-         d="m 21.865994,38.310367 7.283734,-2.970838 0.06206,-0.06205 c 0.327041,-0.450289 -0.285228,-1.67166 -1.432262,-2.812988 -1.149783,-1.144062 -2.399488,-1.768277 -2.845409,-1.43366 l -3.068118,7.279536 z" />
-      <path
-         style="fill:#333333;fill-opacity:1;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:0.29681;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3281-9-9"
-         d="m 22.697063,36.338766 -0.831516,1.96381 1.986639,-0.814434 C 23.69296,37.297418 23.545968,37.103699 23.354795,36.913478 23.134704,36.694481 22.918224,36.516791 22.697063,36.338766 Z" />
+       style="opacity:0.4"
+       id="g3712-0"
+       transform="matrix(1.1578952,0,0,0.57142859,-3.789476,19.142856)">
+      <rect
+         style="fill:url(#radialGradient3013-896);fill-opacity:1;stroke:none"
+         id="rect2801-4"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3015-826);fill-opacity:1;stroke:none"
+         id="rect3696-8"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient4395);fill-opacity:1;stroke:none"
+         id="rect3700-7"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
     </g>
+    <g
+       id="g219"
+       transform="rotate(90,10,38.998505)">
+      <rect
+         id="rect203"
+         width="10"
+         height="38"
+         x="5"
+         y="6"
+         rx="1.5"
+         ry="1.5"
+         style="fill:#f9f9f9" />
+      <rect
+         style="fill:#c6262e;stroke:none;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="26.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect205" />
+      <rect
+         id="rect207"
+         width="5"
+         height="5"
+         x="7.5"
+         y="26.5"
+         rx="1"
+         ry="1"
+         style="opacity:0.6;fill:none;stroke:#7a0000;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+         ry="2"
+         rx="2"
+         y="5.5"
+         x="4.5"
+         height="39"
+         width="11"
+         id="rect209" />
+      <rect
+         id="rect211"
+         width="5"
+         height="5"
+         x="7.5"
+         y="17.5"
+         rx="1"
+         ry="1"
+         style="fill:#ed5353;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;stroke:#7a0000;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="17.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect213" />
+      <rect
+         style="fill:#ff8c82;stroke:none;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="8.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect215" />
+      <rect
+         id="rect217"
+         width="5"
+         height="5"
+         x="7.5"
+         y="8.5"
+         rx="1"
+         ry="1"
+         style="opacity:0.4;fill:none;stroke:#7a0000;stroke-opacity:1" />
+    </g>
+    <rect
+       ry="1"
+       rx="1"
+       y="-42.5"
+       x="34.5"
+       height="37"
+       width="9"
+       id="rect910"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient912);stroke-width:1;stroke-opacity:1"
+       transform="rotate(90)" />
+    <g
+       transform="rotate(60,10,38.998505)"
+       id="g201">
+      <rect
+         style="fill:#f9f9f9"
+         ry="1.5"
+         rx="1.5"
+         y="6"
+         x="5"
+         height="38"
+         width="10"
+         id="rect185" />
+      <rect
+         id="rect187"
+         width="5"
+         height="5"
+         x="7.5"
+         y="26.5"
+         rx="1"
+         ry="1"
+         style="fill:#f37329;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;stroke:#a62100;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="26.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect189" />
+      <rect
+         id="rect191"
+         width="11"
+         height="39"
+         x="4.5"
+         y="5.5"
+         rx="2"
+         ry="2"
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1" />
+      <rect
+         style="fill:#ffa154;stroke:none;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="17.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect193" />
+      <rect
+         id="rect195"
+         width="5"
+         height="5"
+         x="7.5"
+         y="17.5"
+         rx="1"
+         ry="1"
+         style="opacity:0.5;fill:none;stroke:#a62100;stroke-opacity:1" />
+      <rect
+         id="rect197"
+         width="5"
+         height="5"
+         x="7.5"
+         y="8.5"
+         rx="1"
+         ry="1"
+         style="fill:#ffc27d;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#a62100;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="8.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect199" />
+    </g>
+    <rect
+       transform="rotate(60)"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient908);stroke-width:1;stroke-opacity:1"
+       id="rect906"
+       width="9"
+       height="37"
+       x="34.27499"
+       y="-21.660254"
+       rx="1"
+       ry="1" />
+    <g
+       id="g183"
+       transform="rotate(30,10,38.998505)">
+      <rect
+         id="rect167"
+         width="10"
+         height="38"
+         x="5"
+         y="6"
+         rx="1.5"
+         ry="1.5"
+         style="fill:#f9f9f9" />
+      <rect
+         style="fill:#3689e6;stroke:none;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="26.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect169" />
+      <rect
+         id="rect171"
+         width="5"
+         height="5"
+         x="7.5"
+         y="26.5"
+         rx="1"
+         ry="1"
+         style="opacity:0.6;fill:none;stroke:#002e99;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+         ry="2"
+         rx="2"
+         y="5.5"
+         x="4.5"
+         height="39"
+         width="11"
+         id="rect173" />
+      <rect
+         id="rect175"
+         width="5"
+         height="5"
+         x="7.5"
+         y="17.5"
+         rx="1"
+         ry="1"
+         style="fill:#64baff;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.5;fill:none;stroke:#002e99;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="17.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect177" />
+      <rect
+         style="fill:#8cd5ff;stroke:none;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="8.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect179" />
+      <rect
+         id="rect181"
+         width="5"
+         height="5"
+         x="7.5"
+         y="8.5"
+         rx="1"
+         ry="1"
+         style="opacity:0.4;fill:none;stroke:#002e99;stroke-opacity:1" />
+    </g>
+    <rect
+       ry="1"
+       rx="1"
+       y="-3.7250092"
+       x="23.660254"
+       height="37"
+       width="9"
+       id="rect902"
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient904);stroke-width:1;stroke-opacity:1"
+       transform="rotate(30)" />
+    <g
+       id="g165">
+      <rect
+         style="fill:#f9f9f9"
+         ry="1.5"
+         rx="1.5"
+         y="6"
+         x="5"
+         height="38"
+         width="10"
+         id="rect45" />
+      <rect
+         id="rect145"
+         width="5"
+         height="5"
+         x="7.5"
+         y="26.5"
+         rx="1"
+         ry="1"
+         style="fill:#68b723;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.6;fill:none;stroke:#206b00;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="26.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect55" />
+      <rect
+         id="rect85"
+         width="11"
+         height="39"
+         x="4.5"
+         y="5.5"
+         rx="2"
+         ry="2"
+         style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1" />
+      <rect
+         style="fill:#9bdb4d;stroke:none;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="17.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect147" />
+      <rect
+         id="rect141"
+         width="5"
+         height="5"
+         x="7.5"
+         y="17.5"
+         rx="1"
+         ry="1"
+         style="opacity:0.5;fill:none;stroke:#206b00;stroke-opacity:1" />
+      <rect
+         id="rect149"
+         width="5"
+         height="5"
+         x="7.5"
+         y="8.5"
+         rx="1"
+         ry="1"
+         style="fill:#d1ff82;stroke:none;stroke-opacity:1" />
+      <rect
+         style="opacity:0.4;fill:none;stroke:#206b00;stroke-opacity:1"
+         ry="1"
+         rx="1"
+         y="8.5"
+         x="7.5"
+         height="5"
+         width="5"
+         id="rect143" />
+    </g>
+    <circle
+       style="fill:url(#linearGradient1059);fill-opacity:1"
+       id="path71"
+       cx="10"
+       cy="39"
+       r="2.5" />
+    <circle
+       r="2.5"
+       cy="39"
+       cx="10"
+       id="circle228"
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761" />
+    <circle
+       style="opacity:0.3;fill:none;fill-opacity:1;stroke:#ffffff;stroke-opacity:1"
+       id="circle230"
+       cx="10"
+       cy="39"
+       r="1.5" />
+    <rect
+       style="opacity:1;fill:none;fill-opacity:1;stroke:url(#linearGradient900);stroke-width:1;stroke-opacity:1"
+       id="rect892"
+       width="9"
+       height="37"
+       x="5.5"
+       y="6.5"
+       rx="1"
+       ry="1" />
   </g>
 </svg>

--- a/elementary-xfce/apps/64/preferences-desktop-theme.svg
+++ b/elementary-xfce/apps/64/preferences-desktop-theme.svg
@@ -1,372 +1,643 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   width="64"
-   height="64"
-   id="svg4211"
-   version="1.1"
-   sodipodi:docname="preferences-desktop-theme.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview60"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
-     inkscape:pageopacity="0.0"
-     inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="7.5351066"
-     inkscape:cx="24.219963"
-     inkscape:cy="24.883523"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="430"
-     inkscape:window-y="67"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="g4127" />
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="64px"
+   height="64px"
+   id="svg4332"
+   version="1.1">
   <defs
-     id="defs4213">
+     id="defs4334">
     <linearGradient
-       spreadMethod="pad"
-       gradientTransform="matrix(0.87539065,-0.87968181,0.97932539,0.97445279,-3.0169552,27.152318)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient1039"
-       id="linearGradient3176"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972" />
-    <linearGradient
-       id="linearGradient1039">
+       id="linearGradient4729">
       <stop
-         id="stop1023"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop4725"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop4727"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4687">
+      <stop
+         id="stop4683"
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1" />
+      <stop
+         id="stop4685"
+         offset="1"
+         style="stop-color:#7e8087;stop-opacity:1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2873-966-168-714"
+       xlink:href="#linearGradient3688-166-749-654"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1638751,0,0,0.99999998,38.297112,16.000003)" />
+    <linearGradient
+       id="linearGradient3688-166-749-654">
+      <stop
+         id="stop3088"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop1025"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.13482948" />
+         id="stop3090"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2875-742-326-419"
+       xlink:href="#linearGradient3688-464-309-604"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.1638751,0,0,0.99999998,-25.702995,-103)" />
+    <linearGradient
+       id="linearGradient3688-464-309-604">
       <stop
-         id="stop1027"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.20224422" />
+         id="stop3094"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
       <stop
-         id="stop1029"
-         style="stop-color:#fff394;stop-opacity:1"
-         offset="0.26965895" />
-      <stop
-         id="stop1031"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.44650277" />
-      <stop
-         id="stop1033"
-         style="stop-color:#f9c440;stop-opacity:1"
-         offset="0.57114136" />
-      <stop
-         id="stop1035"
-         style="stop-color:#ffe16b;stop-opacity:1"
-         offset="0.72038066" />
-      <stop
-         id="stop1037"
-         style="stop-color:#ad5f00;stop-opacity:1"
+         id="stop3096"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       spreadMethod="pad"
-       y2="31.210939"
-       x2="23.575972"
-       y1="25.356892"
-       x1="23.575972"
-       gradientTransform="matrix(0.87539065,-0.87968181,0.97932539,0.97445279,-3.0169552,27.152318)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient1018"
-       xlink:href="#linearGradient3155-40" />
+       gradientTransform="matrix(1.5789502,0,0,0.7142857,-5.8947511,28.428574)"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2877-634-617-908"
+       xlink:href="#linearGradient3702-501-757-795"
+       gradientUnits="userSpaceOnUse" />
     <linearGradient
-       id="linearGradient3155-40">
+       id="linearGradient3702-501-757-795">
       <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2541" />
+         id="stop3100"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
       <stop
-         offset="0.13482948"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2543" />
+         id="stop3102"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
       <stop
-         offset="0.20224422"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2545" />
-      <stop
-         offset="0.26965895"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2547" />
-      <stop
-         offset="0.44650277"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2549" />
-      <stop
-         offset="0.57114136"
-         style="stop-color:#7e8087;stop-opacity:1"
-         id="stop2551" />
-      <stop
-         offset="0.72038066"
-         style="stop-color:#d4d4d4;stop-opacity:1"
-         id="stop2553" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2555" />
+         id="stop3104"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-6.2249016,22.651052)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient3171"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="54.5"
+       x2="12"
+       y1="49.5"
+       x1="12"
+       id="linearGradient4689"
+       xlink:href="#linearGradient4687" />
     <linearGradient
-       id="linearGradient3240-279">
-      <stop
-         offset="0"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2559" />
-      <stop
-         offset="0.5"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2561" />
-      <stop
-         offset="1"
-         style="stop-color:#555761;stop-opacity:1"
-         id="stop2563" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-6.4685146,22.89586)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient3168"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="54"
+       x2="12"
+       y1="50"
+       x1="12"
+       id="linearGradient4731"
+       xlink:href="#linearGradient4729" />
     <linearGradient
-       id="linearGradient3223-789">
-      <stop
-         offset="0"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2567" />
-      <stop
-         offset="0.5"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2569" />
-      <stop
-         offset="1"
-         style="stop-color:#abacae;stop-opacity:1"
-         id="stop2571" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-5.3783496,21.800349)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient3165"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       y2="58"
+       x2="12"
+       y1="6"
+       x1="12"
+       id="linearGradient910"
+       xlink:href="#linearGradient4729" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-5.6219636,22.045155)"
+       gradientTransform="translate(24.391907,-12.966572)"
+       y2="49.428097"
+       x2="32.45488"
+       y1="7.8588767"
+       x1="8.4548807"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient3162"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient918"
+       xlink:href="#linearGradient4729" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-4.5277046,20.945534)"
+       y2="24.822687"
+       x2="36.928894"
+       y1="7.3226876"
+       x1="6.6180029"
+       gradientTransform="translate(39.032632,-36.391907)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3240-279"
-       id="linearGradient3159"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
+       id="linearGradient922"
+       xlink:href="#linearGradient4729" />
     <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.146122,1.1404196,-4.7713176,21.190343)"
+       y2="15.999205"
+       x2="18.000795"
+       y1="15.999205"
+       x1="6.0007958"
+       gradientTransform="translate(39.999204,-63.999205)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3223-789"
-       id="linearGradient3156"
-       y2="30.000141"
-       x2="30.037716"
-       y1="24.989594"
-       x1="30.037716" />
-    <linearGradient
-       gradientTransform="matrix(0.85064445,-0.85481442,1.1461221,1.1404197,-6.5479896,22.97572)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3290-678"
-       id="linearGradient3151"
-       y2="26.02973"
-       x2="9"
-       y1="29.056757"
-       x1="9" />
-    <linearGradient
-       id="linearGradient3290-678">
-      <stop
-         offset="0"
-         style="stop-color:#fff394;stop-opacity:1"
-         id="stop2607" />
-      <stop
-         offset="1"
-         style="stop-color:#fafafa;stop-opacity:1"
-         id="stop2609" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="matrix(0.74712277,0.03224699,0.03220731,0.74620134,24.394615,18.140574)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3191-577"
-       id="linearGradient3153"
-       y2="41.391716"
-       x2="9.5220556"
-       y1="37.371799"
-       x1="5.5178981" />
-    <linearGradient
-       id="linearGradient3191-577">
-      <stop
-         offset="0"
-         style="stop-color:#d48e15;stop-opacity:1"
-         id="stop2613" />
-      <stop
-         offset="1"
-         style="stop-color:#ad5f00;stop-opacity:1"
-         id="stop2615" />
-    </linearGradient>
+       id="linearGradient926"
+       xlink:href="#linearGradient4729" />
   </defs>
   <metadata
-     id="metadata4216">
+     id="metadata4337">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,16)">
+     id="g1086">
     <g
-       id="g4127"
-       transform="matrix(1.3375796,0,0,1.3375796,64.484076,-15.7798)">
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-1.3076923)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path2964"
-         style="fill:#ed5353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,0.2197802,-11.307692)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4113"
-         style="fill:#de3e80;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,-4.78022,-20.021977)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4115"
-         style="fill:#924ab4;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,-13.208791,-25.021976)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4117"
-         style="fill:#a56de2;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,-23.208791,-25.021976)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4119"
-         style="fill:#3689e6;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,-31.637363,-20.164834)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4121"
-         style="fill:#28bca3;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,-36.637363,-11.593405)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4123"
-         style="fill:#68b723;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         transform="matrix(1.0384615,0,0,1.0384615,-36.923077,-1.7362627)"
-         d="m -2.0000002,34 c 0,2.051343 -1.6629424,3.714286 -3.7142857,3.714286 -2.0513433,0 -3.7142856,-1.662943 -3.7142856,-3.714286 0,-2.051343 1.6629423,-3.714286 3.7142856,-3.714286 2.0513433,0 3.7142857,1.662943 3.7142857,3.714286 z"
-         id="path4125"
-         style="fill:#9bdb4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+       id="g1033"
+       style="opacity:0.4">
+      <rect
+         width="7.8947511"
+         height="5"
+         x="54.105358"
+         y="57.000004"
+         id="rect2801"
+         style="fill:url(#radialGradient2873-966-168-714);fill-opacity:1;stroke:none;stroke-width:1.06198943" />
+      <rect
+         width="7.8947511"
+         height="5"
+         x="-9.8947506"
+         y="-62"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2875-742-326-419);fill-opacity:1;stroke:none;stroke-width:1.06198943" />
+      <rect
+         width="44.210606"
+         height="5.0000005"
+         x="9.8947506"
+         y="57.000004"
+         id="rect3700"
+         style="fill:url(#linearGradient2877-634-617-908);fill-opacity:1;stroke:none;stroke-width:1.06198943" />
     </g>
-    <g
-       id="g963"
-       transform="matrix(1.5700738,0,0,1.5700589,-35.70623,-39.571739)"
-       style="stroke-width:0.636916">
-      <path
-         id="path2422"
-         d="m 51.633192,45.795819 c -0.232549,-0.0028 -0.419086,0.02249 -0.544782,0.0494 l -16.737955,3.573485 -3.080835,0.658706 -0.09393,0.01647 -3.907402,1.860847 8.772866,-0.823384 0.07514,-0.01647 3.099623,-0.658708 16.737954,-3.589952 c 0.502781,-0.10769 -0.175705,-0.422676 -1.521633,-0.708111 -1.009444,-0.214076 -2.101405,-0.353866 -2.799053,-0.362289 z"
-         style="opacity:0.15;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.507077" />
-      <path
-         style="fill:url(#linearGradient3176);fill-opacity:1;stroke:none;stroke-width:0.318458;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect2383-6"
-         d="m 31.57772,42.038752 c 0.594537,-0.446137 2.262714,0.39074 3.795697,1.916096 1.529317,1.521706 2.335133,3.150009 1.899097,3.750366 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 L 58.654191,26.29035 c 0.541954,-0.544611 -0.300099,-2.265649 -1.88175,-3.839428 -1.581645,-1.57378 -3.306905,-2.407285 -3.848863,-1.862671 z" />
-      <path
-         style="opacity:0.6;fill:#f9c440;fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3208-7"
-         d="m 31.57772,42.038749 c 0.594537,-0.446136 2.262715,0.390742 3.795696,1.916096 1.529317,1.521707 2.335134,3.150009 1.899097,3.750366 -0.0016,0.0023 0.03752,0.03339 0.03583,0.03564 l 14.700196,-14.772261 0.05317,-0.05343 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436028,-0.600361 -0.369789,-2.228662 -1.899105,-3.750369 -1.532982,-1.525354 -3.201161,-2.362232 -3.795698,-1.916094 l -0.05317,0.05342 -14.700191,14.772262 h -7e-6 z" />
-      <path
-         d="m 31.57772,42.038752 c 0.594537,-0.446137 2.262714,0.39074 3.795697,1.916096 1.529317,1.521706 2.335133,3.150009 1.899097,3.750366 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 L 58.654191,26.29035 c 0.541954,-0.544611 -0.300099,-2.265649 -1.88175,-3.839428 -1.581645,-1.57378 -3.306905,-2.407285 -3.848863,-1.862671 z"
-         id="path1021"
-         style="fill:none;fill-opacity:1;stroke:#ad5f00;stroke-width:0.318458;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         id="path934"
-         d="m 53.53125,20.427734 c -0.262669,-0.02614 -0.471932,0.024 -0.607422,0.160157 l -6.591797,6.625 c 0.594537,-0.446138 2.26194,0.390661 3.794922,1.916015 1.529316,1.521707 2.334466,3.149639 1.898438,3.75 -0.0017,0.0023 0.03881,0.03481 0.03711,0.03711 l 6.591797,-6.625 C 59.196251,25.746405 58.353135,24.024951 56.771484,22.451172 55.585251,21.270837 54.319258,20.50617 53.53125,20.427734 Z"
-         style="fill:url(#linearGradient1018);fill-opacity:1;stroke:#555761;stroke-width:0.318458;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
-      <path
-         style="opacity:0.9;fill:#fe9ab8;fill-opacity:1;stroke:#de3e80;stroke-width:0.318458;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-         id="rect3175-5"
-         d="m 50.318482,23.20612 c 0.594537,-0.446136 2.262715,0.390742 3.795697,1.916096 1.529316,1.521706 2.335133,3.150009 1.899096,3.750365 -0.0016,0.0023 0.03752,0.03338 0.03581,0.03564 l 2.605098,-2.61787 0.05317,-0.05342 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.43603,-0.600356 -0.369788,-2.228658 -1.899104,-3.750363 -1.53298,-1.525355 -3.201157,-2.362234 -3.795696,-1.916096 l -0.05317,0.05342 -2.605096,2.617869 h 4e-6 z" />
-      <path
-         style="fill:url(#linearGradient3171);fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3233-3"
-         d="m 47.398481,26.140433 c 0.594536,-0.446138 2.262717,0.390741 3.795698,1.916096 1.529315,1.521705 2.335133,3.150007 1.899095,3.750365 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 L 53.394912,31.5754 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436038,-0.600357 -0.36978,-2.22866 -1.899097,-3.750363 -1.532981,-1.525356 -3.20116,-2.362234 -3.795696,-1.916097 l -0.265827,0.26713 v 2e-6 z" />
-      <path
-         style="fill:url(#linearGradient3168);fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3216-5"
-         d="m 47.154867,26.38524 c 0.594539,-0.446138 2.262718,0.39074 3.795697,1.916095 1.529319,1.521706 2.335136,3.150007 1.899097,3.750364 -0.0016,0.0023 0.03751,0.03339 0.03581,0.03564 l 0.265825,-0.267132 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436041,-0.600355 -0.369777,-2.228658 -1.899095,-3.750363 C 49.68341,26.50885 48.015232,25.67197 47.420692,26.118108 l -0.265825,0.267131 z" />
-      <path
-         style="fill:url(#linearGradient3165);fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3248-6"
-         d="m 48.245034,25.28973 c 0.594537,-0.446138 2.262715,0.39074 3.795697,1.916096 1.529316,1.521705 2.335134,3.150006 1.899097,3.750364 -0.0016,0.0023 0.03751,0.03338 0.03581,0.03564 l 0.265826,-0.26713 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 C 54.641691,30.088704 53.835875,28.4604 52.306556,26.938696 50.773576,25.413341 49.1054,24.576462 48.510859,25.0226 Z" />
-      <path
-         style="fill:url(#linearGradient3162);fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3250-2"
-         d="m 48.00142,25.534537 c 0.59454,-0.446138 2.262718,0.39074 3.795697,1.916095 1.529318,1.521706 2.335135,3.150007 1.899098,3.750364 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 l 0.265825,-0.267131 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436039,-0.600357 -0.369778,-2.228661 -1.899095,-3.750364 -1.53298,-1.525355 -3.201159,-2.362235 -3.795699,-1.916096 l -0.265826,0.267131 z" />
-      <path
-         style="fill:url(#linearGradient3159);fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3256-9"
-         d="m 49.095679,24.434915 c 0.594536,-0.446137 2.262714,0.390741 3.795696,1.916096 1.529316,1.521705 2.335134,3.150007 1.899097,3.750364 -0.0016,0.0023 0.0375,0.03339 0.03581,0.03564 l 0.265824,-0.267131 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436038,-0.600356 -0.36978,-2.22866 -1.899097,-3.750365 -1.532978,-1.525354 -3.201157,-2.362234 -3.795696,-1.916094 l -0.265825,0.267129 z" />
-      <path
-         style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none;stroke-width:0.636916"
-         id="path3258-1"
-         d="m 48.852067,24.679722 c 0.594534,-0.446138 2.262715,0.39074 3.795696,1.916097 1.529315,1.521704 2.335135,3.150007 1.899095,3.750362 -0.0016,0.0023 0.03752,0.03339 0.03581,0.03564 l 0.265826,-0.267128 c 0.0017,-0.0023 -0.03748,-0.03336 -0.03581,-0.03564 0.436038,-0.600359 -0.36978,-2.228661 -1.899096,-3.750365 -1.532981,-1.525356 -3.20116,-2.362235 -3.795697,-1.916096 l -0.265825,0.267129 v 0 z" />
-      <path
-         style="fill:url(#linearGradient3151);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3153);stroke-width:0.318458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3270-2"
-         d="m 27.487084,51.747568 9.711253,-3.960957 0.08274,-0.08273 c 0.436037,-0.600362 -0.380288,-2.22879 -1.909605,-3.7505 -1.532982,-1.525354 -3.199188,-2.357607 -3.793726,-1.911469 l -4.090658,9.705656 h -7e-6 z" />
-      <path
-         style="fill:#333333;fill-opacity:1;fill-rule:evenodd;stroke:#1a1a1a;stroke-width:0.318458;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         id="path3281-7"
-         d="m 28.595131,49.118873 -1.108643,2.618307 2.648745,-1.085868 C 29.92294,50.397024 29.726959,50.138742 29.472072,49.885124 29.178629,49.59314 28.890001,49.35623 28.595131,49.118873 Z" />
-    </g>
+    <rect
+       ry="2.5"
+       rx="2.5"
+       style="fill:#fafafa;fill-opacity:1"
+       y="-59"
+       x="45"
+       height="54"
+       width="14"
+       id="rect152"
+       transform="rotate(90)" />
+    <rect
+       id="rect924"
+       width="13"
+       height="53"
+       x="45.499203"
+       y="-58.499203"
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient926);stroke-opacity:1"
+       rx="2"
+       ry="2"
+       transform="rotate(90)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-55.5"
+       x="48.5"
+       height="7"
+       width="7"
+       id="rect154"
+       style="fill:#ff8c82;stroke:none;stroke-width:1;stroke-opacity:1"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#ed5353;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect156"
+       width="7"
+       height="7"
+       x="48.5"
+       y="-45.5"
+       rx="1"
+       ry="1"
+       transform="rotate(90)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-35.5"
+       x="48.5"
+       height="7"
+       width="7"
+       id="rect158"
+       style="fill:#c6262e;stroke:none;stroke-width:1;stroke-opacity:1"
+       transform="rotate(90)" />
+    <rect
+       style="fill:#a10705;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect160"
+       width="7"
+       height="7"
+       x="48.5"
+       y="-25.500002"
+       rx="1"
+       ry="1"
+       transform="rotate(90)" />
+    <rect
+       id="rect162"
+       width="15"
+       height="55"
+       x="44.5"
+       y="-59.5"
+       style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+       rx="3"
+       ry="3"
+       transform="rotate(90)" />
+    <rect
+       style="opacity:0.4;fill:none;stroke:#7a0000;stroke-width:1;stroke-opacity:1"
+       id="rect4715"
+       width="7"
+       height="7"
+       x="48.5"
+       y="-55.5"
+       rx="1"
+       ry="1"
+       transform="rotate(90)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-45.5"
+       x="48.5"
+       height="7"
+       width="7"
+       id="rect4717"
+       style="opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-opacity:1"
+       transform="rotate(90)" />
+    <rect
+       style="opacity:0.6;fill:none;stroke:#7a0000;stroke-width:1;stroke-opacity:1"
+       id="rect4719"
+       width="7"
+       height="7"
+       x="48.5"
+       y="-35.5"
+       rx="1"
+       ry="1"
+       transform="rotate(90)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-25.500002"
+       x="48.5"
+       height="7"
+       width="7"
+       id="rect4721"
+       style="opacity:0.7;fill:none;stroke:#7a0000;stroke-width:1;stroke-opacity:1"
+       transform="rotate(90)" />
+    <rect
+       id="rect138"
+       width="14"
+       height="54"
+       x="44.036716"
+       y="-31.389887"
+       style="fill:#fafafa;fill-opacity:1"
+       rx="2.5"
+       ry="2.5"
+       transform="rotate(60)" />
+    <rect
+       style="fill:#ffc27d;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect140"
+       width="7"
+       height="7"
+       x="47.536716"
+       y="-27.889887"
+       rx="1"
+       ry="1"
+       transform="rotate(60)" />
+    <rect
+       transform="rotate(60)"
+       ry="2"
+       rx="2"
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient922);stroke-opacity:1"
+       y="-30.891907"
+       x="44.532631"
+       height="53"
+       width="13"
+       id="rect920" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-17.889887"
+       x="47.536716"
+       height="7"
+       width="7"
+       id="rect142"
+       style="fill:#ffa154;stroke:none;stroke-width:1;stroke-opacity:1"
+       transform="rotate(60)" />
+    <rect
+       style="fill:#f37329;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect144"
+       width="7"
+       height="7"
+       x="47.536716"
+       y="-7.8898878"
+       rx="1"
+       ry="1"
+       transform="rotate(60)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="2.1101122"
+       x="47.536716"
+       height="7"
+       width="7"
+       id="rect146"
+       style="fill:#cc3b02;stroke:none;stroke-width:1;stroke-opacity:1"
+       transform="rotate(60)" />
+    <rect
+       ry="3"
+       rx="3"
+       style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+       y="-31.889887"
+       x="43.536716"
+       height="55"
+       width="15"
+       id="rect148"
+       transform="rotate(60)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-27.889887"
+       x="47.536716"
+       height="7"
+       width="7"
+       id="rect4707"
+       style="opacity:0.4;fill:none;stroke:#a62100;stroke-width:1;stroke-opacity:1"
+       transform="rotate(60)" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:#a62100;stroke-width:1;stroke-opacity:1"
+       id="rect4709"
+       width="7"
+       height="7"
+       x="47.536716"
+       y="-17.889887"
+       rx="1"
+       ry="1"
+       transform="rotate(60)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-7.8898878"
+       x="47.536716"
+       height="7"
+       width="7"
+       id="rect4711"
+       style="opacity:0.6;fill:none;stroke:#a62100;stroke-width:1;stroke-opacity:1"
+       transform="rotate(60)" />
+    <rect
+       style="opacity:0.7;fill:none;stroke:#a62100;stroke-width:1;stroke-opacity:1"
+       id="rect4713"
+       width="7"
+       height="7"
+       x="47.536716"
+       y="2.1101122"
+       rx="1"
+       ry="1"
+       transform="rotate(60)" />
+    <rect
+       ry="2.5"
+       rx="2.5"
+       style="fill:#fafafa;fill-opacity:1"
+       y="-7.9650154"
+       x="29.393679"
+       height="54"
+       width="14"
+       id="rect124"
+       transform="rotate(30)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="-4.4650154"
+       x="32.893681"
+       height="7"
+       width="7"
+       id="rect126"
+       style="fill:#8cd5ff;stroke:none;stroke-width:1;stroke-opacity:1"
+       transform="rotate(30)" />
+    <rect
+       style="fill:#64baff;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect128"
+       width="7"
+       height="7"
+       x="32.893681"
+       y="5.5349846"
+       rx="1"
+       ry="1"
+       transform="rotate(30)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="15.534985"
+       x="32.893681"
+       height="7"
+       width="7"
+       id="rect130"
+       style="fill:#3689e6;stroke:none;stroke-width:1;stroke-opacity:1"
+       transform="rotate(30)" />
+    <rect
+       style="fill:#0d52bf;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect132"
+       width="7"
+       height="7"
+       x="32.893681"
+       y="25.534985"
+       rx="1"
+       ry="1"
+       transform="rotate(30)" />
+    <rect
+       id="rect134"
+       width="15"
+       height="55"
+       x="28.893679"
+       y="-8.4650154"
+       style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+       rx="3"
+       ry="3"
+       transform="rotate(30)" />
+    <rect
+       style="opacity:0.4;fill:none;stroke:#002e99;stroke-width:1;stroke-opacity:1"
+       id="rect4699"
+       width="7"
+       height="7"
+       x="32.893681"
+       y="-4.4650154"
+       rx="1"
+       ry="1"
+       transform="rotate(30)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="5.5349846"
+       x="32.893681"
+       height="7"
+       width="7"
+       id="rect4701"
+       style="opacity:0.5;fill:none;stroke:#002e99;stroke-width:1;stroke-opacity:1"
+       transform="rotate(30)" />
+    <rect
+       style="opacity:0.6;fill:none;stroke:#002e99;stroke-width:1;stroke-opacity:1"
+       id="rect4703"
+       width="7"
+       height="7"
+       x="32.893681"
+       y="15.534985"
+       rx="1"
+       ry="1"
+       transform="rotate(30)" />
+    <rect
+       ry="1"
+       rx="1"
+       y="25.534985"
+       x="32.893681"
+       height="7"
+       width="7"
+       id="rect4705"
+       style="opacity:0.7;fill:none;stroke:#002e99;stroke-width:1;stroke-opacity:1"
+       transform="rotate(30)" />
+    <rect
+       id="rect916"
+       width="13"
+       height="53"
+       x="29.891907"
+       y="-7.4665723"
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient918);stroke-opacity:1"
+       rx="2"
+       ry="2"
+       transform="rotate(30)" />
+    <rect
+       id="rect86"
+       width="14"
+       height="54"
+       x="5"
+       y="5"
+       style="fill:#fafafa;fill-opacity:1"
+       rx="2.5"
+       ry="2.5" />
+    <rect
+       style="fill:#d1ff82;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect88"
+       width="7"
+       height="7"
+       x="8.5"
+       y="8.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="18.5"
+       x="8.5"
+       height="7"
+       width="7"
+       id="rect90"
+       style="fill:#9bdb4d;stroke:none;stroke-width:1;stroke-opacity:1" />
+    <rect
+       style="fill:#68b723;stroke:none;stroke-width:1;stroke-opacity:1"
+       id="rect92"
+       width="7"
+       height="7"
+       x="8.5"
+       y="28.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="38.5"
+       x="8.5"
+       height="7"
+       width="7"
+       id="rect94"
+       style="fill:#3a9104;stroke:none;stroke-width:1;stroke-opacity:1" />
+    <rect
+       ry="3"
+       rx="3"
+       style="opacity:0.4;fill:none;stroke:#555761;stroke-opacity:1"
+       y="4.5"
+       x="4.5"
+       height="55"
+       width="15"
+       id="rect98" />
+    <rect
+       ry="1"
+       rx="1"
+       y="8.5"
+       x="8.5"
+       height="7"
+       width="7"
+       id="rect4691"
+       style="opacity:0.4;fill:none;stroke:#206b00;stroke-width:1;stroke-opacity:1" />
+    <rect
+       style="opacity:0.5;fill:none;stroke:#206b00;stroke-width:1;stroke-opacity:1"
+       id="rect4693"
+       width="7"
+       height="7"
+       x="8.5"
+       y="18.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="1"
+       rx="1"
+       y="28.5"
+       x="8.5"
+       height="7"
+       width="7"
+       id="rect4695"
+       style="opacity:0.6;fill:none;stroke:#206b00;stroke-width:1;stroke-opacity:1" />
+    <rect
+       style="opacity:0.7;fill:none;stroke:#206b00;stroke-width:1;stroke-opacity:1"
+       id="rect4697"
+       width="7"
+       height="7"
+       x="8.5"
+       y="38.5"
+       rx="1"
+       ry="1" />
+    <rect
+       ry="2"
+       rx="2"
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient910);stroke-opacity:1"
+       y="5.5"
+       x="5.5"
+       height="53"
+       width="13"
+       id="rect902" />
+    <circle
+       r="2.5"
+       cy="52"
+       cx="12"
+       id="circle173"
+       style="fill:url(#linearGradient4689);fill-opacity:1;stroke:none;stroke-width:1;stroke-opacity:1" />
+    <circle
+       style="opacity:0.5;fill:none;fill-opacity:1;stroke:#555761;stroke-width:1;stroke-opacity:1"
+       id="path96"
+       cx="12"
+       cy="52"
+       r="2.5" />
+    <circle
+       r="1.5"
+       cy="52"
+       cx="12"
+       id="circle4723"
+       style="opacity:0.2;fill:none;fill-opacity:1;stroke:url(#linearGradient4731);stroke-width:1;stroke-opacity:1" />
   </g>
 </svg>


### PR DESCRIPTION
Upstream uses this color swatch/card for `preferences-desktop-theme`. `xfce4-appearance` is symlinked to `preferences-desktop-theme`, so this will change the icon of Xfce4 Appearance. Xfce4 Appearance's official icon is also a color swatch, so upstream's is actually a little closer to the official Xfce icon.

Will wait for a review or feedback on this one since it is a style/concept change.

Current:
![theme-current](https://github.com/user-attachments/assets/632f3eda-b16c-4e03-a77d-748815bf0335)

Proposed (upstream elementary):
![theme-upstream](https://github.com/user-attachments/assets/103fc96f-75bc-42b2-a09c-5f9b2a7c87e6)