### PR TITLE
Apps: New File Manager icon using upstream design

### DIFF
--- a/elementary-xfce/apps/128/system-file-manager.svg
+++ b/elementary-xfce/apps/128/system-file-manager.svg
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="128"
+   id="svg4379"
    height="128"
-   id="svg4000"
+   width="128"
+   version="1.1"
+   xml:space="preserve"
    sodipodi:docname="system-file-manager.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -13,284 +14,295 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview60"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview73"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="2.6640625"
-     inkscape:cx="68.504399"
-     inkscape:cy="72.070381"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="149"
-     inkscape:window-y="35"
+     inkscape:zoom="9.170291"
+     inkscape:cx="68.100347"
+     inkscape:cy="77.478457"
+     inkscape:window-width="1267"
+     inkscape:window-height="816"
+     inkscape:window-x="649"
+     inkscape:window-y="199"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1" />
-  <defs
-     id="defs4002">
-    <linearGradient
-       x1="97.538795"
-       y1="16.962049"
-       x2="97.538795"
-       y2="44.260689"
-       id="linearGradient3097"
-       xlink:href="#linearGradient8272"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6658408,0,0,2.7170994,-143.33284,-73.19882)" />
-    <linearGradient
-       id="linearGradient8272">
-      <stop
-         id="stop8274"
+     inkscape:current-layer="svg4379" /><defs
+     id="defs4381"><linearGradient
+       id="linearGradient2029"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8276"
+         id="stop2021" /><stop
+         offset="0.08351079"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0221225" />
-      <stop
-         id="stop8278"
+         id="stop2023" /><stop
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97909725" />
-      <stop
-         id="stop8280"
+         id="stop2025" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-91"
-       y1="43.999817"
-       x2="-91"
-       y2="119.05979"
-       id="linearGradient3103"
-       xlink:href="#linearGradient4632-0-6-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0266674,147,-74.18659)" />
-    <linearGradient
-       id="linearGradient4632-0-6-4">
-      <stop
-         id="stop4634-4-4-7"
-         style="stop-color:#e9e9e9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4636-3-1-5"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient22388"
-       xlink:href="#linearGradient5048-585"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.19689695,0,0,0.06641689,-7.1757955,67.45321)" />
-    <linearGradient
-       id="linearGradient5048-585">
-      <stop
-         id="stop2667"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2669"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2671"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient22390"
-       xlink:href="#linearGradient5060-179"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.08277507,0,0,0.06641689,61.640156,67.45321)" />
-    <linearGradient
-       id="linearGradient5060-179">
-      <stop
-         id="stop2675"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2677"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient22392"
-       xlink:href="#linearGradient5060-820"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.08277505,0,0,0.06641689,66.336923,67.45321)" />
-    <linearGradient
-       id="linearGradient5060-820">
-      <stop
-         id="stop2681"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2683"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="97.538795"
-       y1="8.8103228"
-       x2="97.538795"
-       y2="44.260689"
-       id="linearGradient3110"
-       xlink:href="#linearGradient9235"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6658408,0,0,2.6469079,-143.33284,-67.049055)" />
-    <linearGradient
-       id="linearGradient9235">
-      <stop
-         id="stop9237"
+         id="stop2027" /></linearGradient><linearGradient
+       id="linearGradient2019"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop9239"
+         id="stop2011" /><stop
+         offset="0.09165263"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.1088333" />
-      <stop
-         id="stop9241"
+         id="stop2013" /><stop
+         offset="0.95056331"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97909725" />
-      <stop
-         id="stop9243"
+         id="stop2015" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="53.514328"
-       x2="-51.786404"
-       y2="3.6336823"
-       id="linearGradient3113"
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5-1-0"
+         id="stop2017" /></linearGradient><linearGradient
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135124,1.486514)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.1683519,0,0,2.2464645,141.9485,-69.590015)" />
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5-1-0">
-      <stop
-         id="stop3106-5-4-3-5-0-2-1-0-1-2"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-0-7-9-4-9"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6404-7-5">
-      <stop
-         id="stop6406-1-8"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6408-9-6"
-         style="stop-color:#c9c9c9;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="62.988873"
-       y1="14.090554"
-       x2="62.988873"
-       y2="16.997795"
-       id="linearGradient3998"
-       xlink:href="#linearGradient6404-7-5"
+       xlink:href="#linearGradient2029"
+       id="linearGradient3159"
+       y2="42.888447"
+       x2="9.4649124"
+       y1="5.6946011"
+       x1="9.4649124" /><linearGradient
+       id="linearGradient3924-776"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3124" /><stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3126" /><stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3128" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3130" /></linearGradient><linearGradient
+       id="linearGradient3688-166-749-5"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-0" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-5" /></linearGradient><linearGradient
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7209303,0,0,2.6722576,-117.22021,-67.213415)" />
-  </defs>
-  <metadata
-     id="metadata4005">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     transform="translate(0,64)"
-     id="layer1">
-    <path
-       d="m 16.999605,-41.96791 c -1.108,0 -2,0.892 -2,2 v 5.96875 h -3 c -1.108,0 -2.0000002,0.892 -2.0000002,2 v 11 c 0,1.108 0.8920002,2 2.0000002,2 H 115.99966 c 1.108,0 2,-0.892 2,-2 v -11 c 0,-1.108 -0.89264,-1.962458 -2,-2 H 56.999995 v -5.96875 c 0,-1.108 -0.892,-2 -2,-2 z"
-       id="use13971"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3998);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="sscsssssssscsss" />
-    <path
-       d="m 17.662395,-42.499 c -1.87818,0.0205 -3.16279,0.9143 -3.16279,2.67225 v 5.32743 c -0.9606,0 -1.4771,-0.003 -2.1044,0 -1.67856,0.008 -2.8776202,0.94491 -2.8776202,2.83298 0.0936,27.49765 -0.018,26.921715 -0.018,29.256325 3.9058102,0 109.0000552,-7.886415 109.0000552,-12.142075 v -17.14209 c 0,-1.75796 -1.15786,-2.82564 -3.03605,-2.80514 H 57.499975 v -5.19887 c 0,-1.75795 -1.18743,-2.80081 -2.94827,-2.80081 h -36.88933 z"
-       id="use13973"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3113);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="csccccssccsscc" />
-    <path
-       d="m 17.499605,-41.49916 c -1.108,0 -2,0.892 -2,2 v 6 h -3 c -1.108,0 -2,0.892 -2,2 v 11 c 0,1.108 0.892,2 2,2 H 115.49966 c 1.108,0 2,-0.892 2,-2 v -11 c 0,-1.108 -0.892,-2 -2,-2 H 56.499995 v -6 c 0,-1.108 -0.892,-2 -2,-2 z"
-       id="use13975"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3110);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="sscsssssssscsss" />
-    <g
-       transform="matrix(1.0027339,0,0,0.9919518,-0.16331336,-57.0664)"
-       id="use13977">
-      <rect
-         width="95.073082"
-         height="16.129816"
-         x="16.451834"
-         y="91.804817"
-         id="rect22382"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient22388);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;marker:none" />
-      <path
-         d="m 111.52541,90.797154 v 16.128926 c 4.26271,0.0304 10.30516,-3.61367 10.30516,-8.0655 0,-4.451834 -4.75687,-8.063426 -10.30516,-8.063426 z"
-         id="path22384"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient22390);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         sodipodi:nodetypes="ccsc" />
-      <path
-         d="m 16.451668,90.797154 v 16.128926 c -4.262711,0.0304 -10.3051586,-3.61367 -10.3051586,-8.0655 0,-4.451834 4.7568636,-8.063426 10.3051586,-8.063426 z"
-         id="path22386"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient22392);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-         sodipodi:nodetypes="ccsc" />
-    </g>
-    <path
-       d="m 10.249605,-26.499825 107.500045,0.001 c 1.66861,0 2.75001,1.18375 2.75001,2.65543 l -2.71648,65.780818 c 0.0386,1.86211 -0.55015,2.60044 -2.48884,2.56139 l -101.933475,-0.0467 c -1.66859,0 -3.35116,-1.09895 -3.35116,-2.57064 L 7.4996048,-23.843355 c 0,-1.47169 1.0814,-2.65647 2.7500002,-2.65647 z"
-       id="use13979"
-       style="display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3103);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 10.249605,-25.499625 c -2.8488202,0.29656 -1.4093302,3.76689 -1.6398902,5.72017 0.78584,22.54795 1.5742802,39.095965 2.3582602,61.643948 1.18868,2.48974 4.43009,1.28205 6.63832,1.57433 35.235138,0.0205 62.47072,0.0412 97.705865,0.0617 2.566,-0.16531 1.15721,-3.81803 1.65357,-5.65555 0.85465,-22.569493 2.54292,-61.571488 2.54292,-61.571488 0,-1.16209 -0.78017,-1.746433 -2.20738,-1.7731 H 10.249605 Z"
-       id="use13983"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3097);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="cccccccscc" />
-    <path
-       d="m 64,-10 -23.25,23.25 4.5,4.5 L 49,14 V 32.000003 H 61 V 23 c 0,-1.662 1.338,-3 3,-3 1.662,0 3,1.338 3,3 v 9.000003 H 79 V 14 l 3.75,3.75 4.5,-4.5 z m 9,3 v 2.25 l 6,6 V -7 Z"
-       id="path2998-49-0-8-6"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccsssccccccccccc" />
-    <path
-       d="m 10.249605,-26.499835 107.500045,0.001 c 1.66861,0 2.75001,1.18375 2.75001,2.65543 l -2.71648,65.780818 c 0.0386,1.86211 -0.55015,2.60044 -2.48884,2.56139 l -101.933475,-0.0467 c -1.66859,0 -3.35116,-1.09895 -3.35116,-2.57064 L 7.4996048,-23.843365 c 0,-1.47169 1.0814,-2.65647 2.7500002,-2.65647 z"
-       id="path3369-7-0"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 64,-11 -23.25,23.25 4.5,4.5 L 49,13 V 31.000003 H 61 V 22 c 0,-1.662 1.338,-3 3,-3 1.662,0 3,1.338 3,3 v 9.000003 H 79 V 13 l 3.75,3.75 4.5,-4.5 z m 9,3 v 2.25 l 6,6 V -8 Z"
-       id="path2998-49-0-0-9"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:5.1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccsssccccccccccc" />
-  </g>
-</svg>
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient2459-7"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-0"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-0" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-6" /></linearGradient><linearGradient
+       id="linearGradient3811"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3813" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3815" /></linearGradient><radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270358,102.13029)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
+       id="radialGradient4377"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" /><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6075127,0,0,2.5079099,-128.96559,3.8893066)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient2455-1-3"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient2457-5-2"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270358,102.13029)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
+       id="radialGradient4377-9"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" /><linearGradient
+       xlink:href="#linearGradient3924-776"
+       id="linearGradient657"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7297298,0,0,2.2432433,-1.5135124,22.162185)"
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43" /><linearGradient
+       id="linearGradient909"><stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient1356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.8545455,0,0,1.52013,4.6545636,27.355841)"
+       x1="31.781376"
+       y1="-17.786936"
+       x2="31.781376"
+       y2="66.189484" /><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1534"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-120.87499,34.352158)"
+       x1="225.28664"
+       y1="103.37166"
+       x2="225.28664"
+       y2="-12.009387" /><linearGradient
+       xlink:href="#linearGradient2019"
+       id="linearGradient2006"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.7305747,0,0,2.7297298,-1.5337883,1.470889)"
+       x1="36.753304"
+       y1="8.62854"
+       x2="36.753304"
+       y2="42.730869" /></defs><metadata
+     id="metadata4384"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><path
+     id="rect5505-21-6-9-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;stroke:none;stroke-width:0.999852;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 22.500498,16.007813 c -5.267313,0 -9.492685,4.22548 -9.492686,9.492792 V 42.375163 H 114.99219 v -8.875694 c 0,-5.267312 -4.22538,-9.490838 -9.49269,-9.490839 H 61.473043 c -4.181352,0 -7.756429,-3.430157 -11.215079,-6.065545 -1.594698,-1.215111 -3.58662,-1.935272 -5.758883,-1.935272 z"
+     transform="matrix(1.0001532,0,0,1.000142,-0.00980454,-0.01008572)" /><path
+     id="rect5505-21-6-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1534);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 115.5,42.646484 V 33.5 c 0,-5.539988 -4.46002,-10 -10,-10 H 61.472656 c -3.894101,0 -7.417413,-3.302549 -10.90625,-5.960938 C 48.886245,16.258831 46.784756,15.5 44.5,15.5 h -22 c -5.539988,0 -10,4.460012 -10,10 v 17.146484" /><g
+     id="layer4-0"
+     transform="matrix(0.9047486,0,0,0.9047486,-702.22529,-649.07614)" /><g
+     id="layer4-0-7"
+     transform="matrix(0.9047486,0,0,0.9047486,-702.22529,-641.83815)" /><g
+     id="layer1-3"
+     transform="matrix(0.9047486,0,0,0.9047486,-205.51831,26.980992)" /><path
+     id="rect5505-21-6-9-6-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3159);stroke-width:0.999845;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 61.473438,24.517578 c -4.463885,0 -8.10576,-3.563014 -11.529635,-6.171875 -1.508447,-1.149377 -3.388862,-1.830078 -5.447533,-1.830078 H 22.493315 c -4.992451,0 -8.97769,3.986124 -8.977691,8.978516 v 15.695312"
+     transform="matrix(1.0003095,0,0,1,-0.01980744,-0.015625)" /><path
+     id="rect5505-21-6-9-6-9-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient2006);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 114.46859,41.173828 v -7.695312 c 0,-4.992391 -3.98512,-8.976562 -8.97769,-8.976563 H 61.457659" /><path
+     d="M 119,118 A 55,6 0 0 1 9.0000016,118 55,6 0 1 1 119,118 Z"
+     id="path3041"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4377);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" /><path
+     d="M 119,118 A 55,6 0 0 1 9.0000016,118 55,6 0 1 1 119,118 Z"
+     id="path3041-0"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4377-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" /><g
+     transform="matrix(2.6999989,0,0,0.55555607,-0.8000019,94.888882)"
+     id="g2036"
+     style="display:inline"><g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4"><rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient2455-1-3);fill-opacity:1;stroke:none" /><rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2457-5-2);fill-opacity:1;stroke:none" /><rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" /></g></g><path
+     id="rect5505-21-3-3-0"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.05;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 21.957031,31.013672 c -4.465397,0.151547 -8.612954,3.328405 -9.927703,7.59742 C 11.184386,41.157421 11.599384,43.871358 11.5,46.5 c 0.01043,20.362542 -0.02085,40.725786 0.01563,61.08789 0.170401,4.44923 3.34132,8.57207 7.595467,9.88278 2.546329,0.84494 5.260266,0.42995 7.888908,0.52933 26.354757,-0.009 52.709998,0.0182 79.06445,-0.0137 4.42231,-0.16286 8.53434,-3.28481 9.874,-7.50275 0.88739,-2.57034 0.46105,-5.32319 0.56155,-7.98358 -0.0104,-20.362542 0.0208,-40.725786 -0.0156,-61.087891 -0.17041,-4.44923 -3.34133,-8.572073 -7.59547,-9.882781 C 106.34258,30.684386 103.62864,31.099384 101,31 c -26.34759,0.0091 -52.695683,-0.01825 -79.042969,0.01367 z" /><rect
+     width="103"
+     height="85"
+     rx="10"
+     ry="10"
+     x="12.5"
+     y="32"
+     id="rect5505-21-3-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><rect
+     width="103"
+     height="85"
+     rx="10"
+     ry="10"
+     x="12.5"
+     y="33.5"
+     id="rect5505-21-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1356);fill-opacity:1;fill-rule:nonzero;stroke:#0d52bf;stroke-width:0.999999;marker:none;enable-background:accumulate;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" /><path
+     style="color:#000000;fill:#002e99;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 63.316406,55.269531 -23.75,22.25 c -0.398772,0.373499 -0.423991,0.997901 -0.05664,1.402344 l 5,5.501953 c 0.384473,0.422221 1.043836,0.437346 1.447265,0.0332 L 48,82.414062 V 98 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 11 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -8.5 c 0,-1.047158 1.029392,-2.5 3,-2.5 1.970608,0 3,1.452842 3,2.5 V 98 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 11 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 V 82.414062 l 2.042969,2.042969 c 0.403429,0.404146 1.062792,0.389021 1.447265,-0.0332 l 5,-5.501953 c 0.367351,-0.404443 0.342132,-1.028845 -0.05664,-1.402344 l -23.75,-22.25 c -0.384582,-0.360134 -0.982606,-0.360134 -1.367188,0 z M 73,58 c -0.552262,5.5e-5 -0.999945,0.447738 -1,1 v 2.25 c -4e-5,0.2729 0.111441,0.533963 0.308594,0.722656 l 6,5.75 C 78.944729,68.331157 79.999961,67.880308 80,67 v -8 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 z"
+     id="path1207"
+     sodipodi:nodetypes="ccccccccccsssccccccccccscccccccccc" /><rect
+     width="101"
+     height="83"
+     rx="9"
+     ry="9"
+     x="13.5"
+     y="34.5"
+     id="rect6741-7-6"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient657);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><path
+     d="M 64,54.000214 40.25,76.25 l 5,5.500214 3.75,-3.75 V 96.000217 H 60 V 87.5 c 0,-1.662 2.338,-3.499786 4,-3.499786 1.662,0 4,1.837786 4,3.499786 v 8.500217 H 79 V 78.000214 l 3.75,3.75 5,-5.500214 z m 9,3 v 2.25 L 79,65 v -7.999786 z"
+     id="path4626"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:5.1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccsssccccccccccc" /><path
+     d="M 64,56.000214 40.25,78.25 l 5,5.500214 3.75,-3.75 v 18 H 60 V 89.5 c 0,-1.662 1.532799,-3.499786 4,-3.499786 2.467201,0 4,1.837786 4,3.499786 v 8.500214 h 11 v -18 l 3.75,3.75 5,-5.500214 z m 9,3 v 2.25 L 79,67 v -7.999786 z"
+     id="path4459"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:5.1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /><path
+     d="M 64,55.000214 40.25,77.25 l 5,5.500214 3.75,-3.75 V 97.000217 H 60 V 88.5 c 0,-1.662 1.532799,-3.499786 4,-3.499786 2.467201,0 4,1.837786 4,3.499786 v 8.500217 H 79 V 79.000214 l 3.75,3.75 5,-5.500214 z m 9,3 v 2.25 L 79,66 v -7.999786 z"
+     id="path2998-49-0-0-9"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5.1;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /></svg>

--- a/elementary-xfce/apps/16/system-file-manager.svg
+++ b/elementary-xfce/apps/16/system-file-manager.svg
@@ -1,160 +1,188 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg8860">
-  <defs
-     id="defs8862">
-    <linearGradient
-       id="linearGradient3454-2-5-0-3-8">
-      <stop
-         id="stop3456-4-9-38-1-9"
+   id="svg4372"
+   xml:space="preserve"
+   sodipodi:docname="system-file-manager.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview2674"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64"
+     inkscape:cx="10.09375"
+     inkscape:cy="10.5"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="608"
+     inkscape:window-y="22"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4372" /><defs
+     id="defs4374"><linearGradient
+       id="linearGradient1236"><stop
+         id="stop1228"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3458-39-80-3-5-6"
+         offset="0" /><stop
+         id="stop1230"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0097359" />
-      <stop
-         id="stop3460-7-0-2-4-4"
+         offset="0.08861272" /><stop
+         id="stop1232"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop3462-0-9-8-7-8"
+         offset="0.93451154" /><stop
+         id="stop1234"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6129-963-697-142-998-580-273-44-2-2-2">
-      <stop
-         id="stop2661-01-6-2-4"
-         style="stop-color:#0a0a0a;stop-opacity:0.498"
-         offset="0" />
-      <stop
-         id="stop2663-64-5-5-3"
-         style="stop-color:#0a0a0a;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4632-0-6-4-4">
-      <stop
-         id="stop4634-4-4-7-5"
-         style="stop-color:#e9e9e9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4636-3-1-5-4"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5-4-4">
-      <stop
-         id="stop3106-5-4-3-5-0-2-1-0-7-7"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-0-7-9-0-6"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4346">
-      <stop
-         id="stop4348"
+         offset="1" /></linearGradient><linearGradient
+       x1="12.295501"
+       y1="7.2729368"
+       x2="12.295501"
+       y2="40.591042"
+       id="linearGradient3304"
+       xlink:href="#linearGradient3924-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486906,0.8648672)" /><linearGradient
+       id="linearGradient3924-4-8"><stop
+         id="stop3926-0-4"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4350"
-         style="stop-color:#d8d8d8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3454-2-5-0-3-8"
-       id="linearGradient3013"
+         offset="0" /><stop
+         id="stop3928-6-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.05749262" /><stop
+         id="stop3930-2-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95056331" /><stop
+         id="stop3932-9-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient2140"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189031,0,0,0.94046961,3.14398,5.346537)"
-       x1="11.350123"
-       y1="0.66696572"
-       x2="11.350123"
-       y2="8.1721792" />
-    <linearGradient
-       xlink:href="#linearGradient6129-963-697-142-998-580-273-44-2-2-2"
-       id="linearGradient3016"
+       gradientTransform="matrix(0.3726957,0,0,0.89471714,-16.017319,-22.660761)"
+       x1="56.408016"
+       y1="42.392338"
+       x2="56.408016"
+       y2="26.595999" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient2184"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.38156409,0,0,0.32896952,-18.24159,0.28216731)"
-       x1="76.041"
-       y1="49.372032"
-       x2="76.041"
-       y2="35.430561" />
-    <linearGradient
-       xlink:href="#linearGradient4632-0-6-4-4"
-       id="linearGradient3019"
+       gradientTransform="matrix(0.3067662,0,0,0.29504822,-14.701832,0.57521328)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><linearGradient
+       x1="23.99999"
+       y1="7.6758323"
+       x2="23.99999"
+       y2="40.1782"
+       id="linearGradient3304-3"
+       xlink:href="#linearGradient1236"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33333327,0,0,0.34148555,-17.08621,-0.60407268)"
-       x1="84.30883"
-       y1="16.110577"
-       x2="84.30883"
-       y2="42.923553" />
-    <linearGradient
-       xlink:href="#linearGradient4346"
-       id="linearGradient3025"
+       gradientTransform="matrix(0.2972973,0,0,0.21621622,0.86486906,4.3108131)" /><linearGradient
+       id="linearGradient909"><stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient1111"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.33333327,0,0,0.32971018,-17.44063,-0.64784268)"
-       x1="62.988873"
-       y1="11.645091"
-       x2="62.988873"
-       y2="15.385052" />
-    <linearGradient
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5-4-4"
-       id="linearGradient3031"
+       gradientTransform="matrix(0.23636365,0,0,0.17355377,0.43636507,3.9462795)"
+       x1="31.781376"
+       y1="-11.234498"
+       x2="31.781376"
+       y2="67.800774" /><linearGradient
+       x1="33.010906"
+       y1="10.566592"
+       x2="33.010906"
+       y2="40.907867"
+       id="linearGradient3304-5"
+       xlink:href="#linearGradient3924-4-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.31070043,0,0,0.27489387,20.17717,-0.10316268)"
-       x1="-51.786404"
-       y1="53.514328"
-       x2="-51.786404"
-       y2="2.0612748" />
-  </defs>
-  <metadata
-     id="metadata8865">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <path
-     style="color:#000000;fill:url(#linearGradient3025);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99992168;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect4170-0"
-     d="m 2.02332,1.976667 0,1 -1,0 0,4 14,0 0,-4 -7,0 0,-1 -6,0 z" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.8;color:#000000;fill:url(#linearGradient3031);fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 1.78125,1 c -0.4068514,0 -0.75,0.3431486 -0.75,0.75 l 0,0.21875 -0.25,0 c -0.40685138,0 -0.75,0.3431486 -0.75,0.75 l 0,1.28125 1,0 0,-1.03125 0.5,0 0.5,0 0,-0.5 0,-0.46875 6,0 0,0.46875 0,0.5 0.5,0 6.5,0 0,1.03125 1,0 0,-1.28125 c 0,-0.4068514 -0.343149,-0.75 -0.75,-0.75 l -6.25,0 0,-0.21875 C 9.03125,1.3431486 8.6881014,1 8.28125,1 l -6.5,0 z"
-     id="rect4170" />
-  <path
-     style="color:#000000;fill:url(#linearGradient3019);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect3086"
-     d="m 0.55988,4.453367 c 0.75732,0 14.39951,0.0316 14.98675,0.0316 0,0.6186 -0.0285,10.00962 -0.0624,10.00962 -5.26001,0.0178 -13.45265,-0.014 -14.98423,-0.014 0,-1.16748 0.0599,-7.62459 0.0599,-10.02721 z" />
-  <path
-     style="opacity:0.4;color:#000000;fill:url(#linearGradient3016);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect3086-1"
-     d="m 0.08698,3.976647 c 0.8053,0 15.31189,0.0341 15.93634,0.0341 0,0.67729 -0.0303,10.95971 -0.0663,10.95971 -5.5933,0.02 -14.30504,-0.0148 -15.93366,-0.0148 0,-1.2783 0.0636,-8.34831 0.0636,-10.97898 z" />
-  <path
-     style="opacity:0.5;color:#000000;fill:none;stroke:url(#linearGradient3013);stroke-width:1.00000012;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect3086-9"
-     d="m 1.57504,5.476667 c 0.65431,0 12.44092,0.0251 12.94828,0.0251 0,0.49259 -0.0246,7.97055 -0.0539,7.97055 -4.54455,0.0142 -11.62285,-0.0111 -12.9461,-0.0111 0,-0.92965 0.0517,-6.07138 0.0517,-7.98455 z" />
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;opacity:0.3;color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 0.40625,3.96875 a 0.50005,0.50005 0 0 0 -0.34375,0.5 0.50005,0.50005 0 0 0 0,0.09375 C 0.06139788,7.0088498 0,13.295273 0,14.46875 a 0.50005,0.50005 0 0 0 0.5,0.5 c 1.5214827,0 9.703777,0.04882 14.96875,0.03125 0.01099,-3.7e-5 0.02028,3.7e-5 0.03125,0 0.0012,-7.95e-4 -0.0019,-0.03002 0,-0.03125 0.06056,-0.03863 0.437378,-0.249737 0.4375,-0.25 1.32e-4,-2.86e-4 0.02699,-0.106637 0.03125,-0.125 0.0085,-0.03673 -0.0014,-0.05081 0,-0.0625 0.0027,-0.02338 0.03044,-0.01757 0.03125,-0.03125 0.0016,-0.02736 -0.0011,-0.05688 0,-0.09375 0.0022,-0.07374 -0.002,-0.182299 0,-0.3125 0.0041,-0.260402 -0.0037,-0.616858 0,-1.0625 0.0074,-0.891284 0.02557,-2.099644 0.03125,-3.3125 0.01137,-2.4257122 0,-4.9017714 0,-5.21875 a 0.50005,0.50005 0 0 0 -0.5,-0.5 C 14.961947,4 1.3337287,3.96875 0.5625,3.96875 a 0.50005,0.50005 0 0 0 -0.15625,0 z m 0.65625,1 c 1.4706431,0.0019 12.618489,0.029346 13.96875,0.03125 -0.0012,0.6360494 0.01027,2.5265847 0,4.71875 C 15.02557,10.930974 15.007429,12.111137 15,13 c -0.0034,0.406338 0.0036,0.748851 0,1 -5.0789999,0.01381 -12.1556038,-0.02935 -14,-0.03125 0.00512,-1.492643 0.057379,-6.4863005 0.0625,-9 z"
-     id="rect3086-0" />
-</svg>
+       gradientTransform="matrix(0.29751073,0,0,0.2972973,0.85974673,0.86092151)" /></defs><metadata
+     id="metadata4377"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient2184);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="2.000001"
+     x="2"
+     ry="1.5"
+     rx="1.5"
+     height="12"
+     width="12" /><path
+     id="rect5505-21-2-8-2-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3304-5);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 13.49175,4.9902344 V 4.4960937 C 13.49175,3.926676 13.065788,3.5000001 12.496371,3.5 H 7.8824955" /><path
+     id="rect5505-21-2-8"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient2140);stroke-width:0.999921;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 14.5,5.9980469 V 4.5 c 0,-1.1079978 -0.892002,-2 -2,-2 H 7.8867188 C 7.2025133,2.5 7.11263,2.1894452 6.6699219,1.8769531 6.3393238,1.6435956 5.9373958,1.5 5.5,1.5 h -2 c -1.1079977,0 -2,0.8920022 -2,2 v 2.5019531" /><path
+     id="rect5505-21-2-8-2"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3304);stroke-width:0.999641;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 7.8868,3.5039457 c -0.4939278,0 -0.987131,-0.168584 -1.2842343,-0.3808594 C 6.3054625,2.9108108 6.210758,2.781687 6.0912141,2.6973051 5.9152203,2.5730773 5.7176084,2.5039458 5.4998418,2.5039457 h -2.000517 c -0.5694174,0 -0.9953792,0.4266762 -0.9953792,0.9960937 v 1.4980469"
+     transform="matrix(1.0007179,0,0,1,-0.00574322,-0.00394569)" /><rect
+     width="13.000003"
+     height="10.000001"
+     rx="2"
+     ry="2"
+     x="1.5"
+     y="4.5"
+     id="rect5505-21-2"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1111);fill-opacity:1;fill-rule:nonzero;stroke:#0d52bf;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><path
+     style="color:#000000;fill:#002e99;stroke-linejoin:round;-inkscape-stroke:none;fill-opacity:0.15000001"
+     d="M 10,6 C 9.6102466,6.0811 9.3057094,6.3856372 9.2246094,6.7753906 L 8.6796875,6.2675781 c -0.3834833,-0.3552825 -0.9758917,-0.3552825 -1.359375,0 l -3.5,3.25 C 3.4051395,9.903044 3.3927344,10.556076 3.7929685,10.957031 l 0.7499999,0.75 c 0.1503018,0.03528 0.3067298,0.03528 0.4570316,0 V 13 c 5.52e-5,0.552262 0.4477381,0.999945 1,1 h 1 c 0.5522619,-5.5e-5 0.9999448,-0.447738 1,-1 5.52e-5,0.552262 0.4477381,0.999945 1,1 h 1 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -1.292969 c 0.150302,0.03528 0.306729,0.03528 0.457031,0 l 0.75,-0.75 c 0.400234,-0.400955 0.38783,-1.0539867 -0.02734,-1.4394529 L 11.769531,9.1367188 C 11.870393,9.0371825 11.948951,8.9173482 12,8.7851563 V 7 C 11.999945,6.4477381 11.552262,6.0000552 11,6 Z"
+     id="path26836"
+     sodipodi:nodetypes="cccccccccccccccccccccccc" /><path
+     id="path4338"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.2;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     d="m 7.9998875,4.999641 -3.5,3.25 0.75,0.7500003 0.75,-0.7500003 V 12 h 1 v -1.5 c 0,-0.277 0.2230003,-0.5 0.5,-0.5 h 1.0000001 c 0.277,0 0.5,0.223 0.5,0.5 V 12 h 1 V 8.249641 l 0.7500004,0.7500003 0.75,-0.7500003 z"
+     sodipodi:nodetypes="ccccccsssscccccc" /><rect
+     width="11"
+     height="8"
+     x="2.5"
+     y="5.4999986"
+     id="rect6741-0-3-5-5"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3304-3);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" /><path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     d="m 7.9998875,6.999641 -3.5,3.25 0.75,0.75 0.75,-0.749641 V 13 h 1 v -1.5 c 0,-0.277 0.2230003,-0.5 0.5,-0.5 h 1.0000001 c 0.277,0 0.5,0.223 0.5,0.5 V 13 h 1 v -2.75 l 0.7500004,0.749641 0.75,-0.75 z"
+     id="path1381"
+     sodipodi:nodetypes="ccccccsssscccccc" /><path
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.3;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     d="m 9.9998876,6 0,1.8576273 L 11,8.7503727 V 6 Z"
+     id="path4299"
+     sodipodi:nodetypes="ccccc" /><path
+     id="path2998-4-8"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     d="M 9.9998876,6 V 6.849641 L 11,7.784641 V 6 Z m -2.0000001,-3.59e-4 -3.5,3.2500003 0.75,0.7499997 0.75,-0.7499997 V 12 h 1 v -1.5 c 0,-0.277 0.2230003,-0.5 0.5,-0.5 h 1.0000001 c 0.277,0 0.5,0.223 0.5,0.5 V 12 h 1 V 9.2496413 l 0.7500004,0.7499997 0.75,-0.7499997 z"
+     sodipodi:nodetypes="cccccccccccsssscccccc" /></svg>

--- a/elementary-xfce/apps/22/system-file-manager.svg
+++ b/elementary-xfce/apps/22/system-file-manager.svg
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="22"
+   id="svg4157"
    height="22"
-   id="svg10994"
+   width="22"
+   version="1.1"
+   xml:space="preserve"
    sodipodi:docname="system-file-manager.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -13,271 +14,251 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview57"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview560"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="16"
-     inkscape:cx="9.46875"
-     inkscape:cy="6.65625"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="637"
-     inkscape:window-y="59"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg10994"
-     inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1"
-     shape-rendering="crispEdges" />
-  <defs
-     id="defs10996">
-    <linearGradient
-       id="linearGradient3454-2-5-0-3-4-1">
-      <stop
-         id="stop3456-4-9-38-1-8-8"
+     showgrid="false"
+     inkscape:zoom="48.90822"
+     inkscape:cx="10.489034"
+     inkscape:cy="14.711229"
+     inkscape:window-width="1264"
+     inkscape:window-height="944"
+     inkscape:window-x="671"
+     inkscape:window-y="56"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" /><defs
+     id="defs4159"><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,-0.02702571,-0.02708995)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.355923"
+       x2="11.728199"
+       y1="6.6191516"
+       x1="11.728199" /><linearGradient
+       id="linearGradient4095"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3458-39-80-3-5-5-8"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0097359" />
-      <stop
-         id="stop3460-7-0-2-4-2-7"
+         id="stop4097" /><stop
+         offset="0.96216732"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop3462-0-9-8-7-2-3"
+         id="stop4102" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4632-0-6-4-3-4-0">
-      <stop
-         id="stop4634-4-4-7-7-4-8"
-         style="stop-color:#e9e9e9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4636-3-1-5-1-3-9"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4325-0">
-      <stop
-         id="stop4327-4"
+         id="stop4104" /></linearGradient><linearGradient
+       id="linearGradient3688-166-749-9"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" /></linearGradient><linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-1"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-42.857271,-24.833501)"
+       x1="70.385941"
+       y1="51.425007"
+       x2="70.385941"
+       y2="29.002073" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45975024,0,0,0.44257234,-23.023215,-0.12943482)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6-3"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3084-4-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.35135136,-0.0257797,4.5662608)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095-2"
+       id="linearGradient3233-1"
+       y2="41.229313"
+       x2="23.99999"
+       y1="6.5493407"
+       x1="23.99999" /><linearGradient
+       id="linearGradient4095-2"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4329-5"
+         id="stop4097-7" /><stop
+         offset="0.06793755"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.1106325" />
-      <stop
-         id="stop4331-6"
+         id="stop4100-0" /><stop
+         offset="0.93777806"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop4333-7"
+         id="stop4102-9" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4646-7-4-3-5-6">
-      <stop
-         id="stop4648-8-0-3-6-5"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4650-1-7-3-4-8"
-         style="stop-color:#d8d8d8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5-0-5">
-      <stop
-         id="stop3106-5-4-3-5-0-2-1-0-6-6"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-0-7-9-1-4"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="27.557428"
-       y1="7.4180675"
-       x2="27.557428"
-       y2="21.223507"
-       id="linearGradient3044"
-       xlink:href="#linearGradient3454-2-5-0-3-4-1"
+         id="stop4104-3" /></linearGradient><linearGradient
+       id="linearGradient909"><stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient1253"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62762637,0,0,0.7245642,1.9730676,2.6273679)" />
-    <linearGradient
-       x1="35.792694"
-       y1="17.118193"
-       x2="35.792694"
-       y2="43.761127"
-       id="linearGradient3050"
-       xlink:href="#linearGradient4632-0-6-4-3-4-0"
+       gradientTransform="matrix(0.34545456,0,0,0.28051952,-0.0545458,3.3090497)"
+       x1="31.781376"
+       y1="-15.284776"
+       x2="31.781376"
+       y2="70.34359" /><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,-0.02702571,-0.02708995)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4666607,0,0,0.46428558,-0.16355235,-1.1607121)" />
-    <linearGradient
-       x1="21.37039"
-       y1="4.73244"
-       x2="21.37039"
-       y2="34.143417"
-       id="linearGradient3053"
-       xlink:href="#linearGradient4325-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.43131243,0,0,0.48638011,0.98985763,1.1854079)" />
-    <linearGradient
-       x1="62.988873"
-       y1="13.924261"
-       x2="62.988873"
-       y2="18.516649"
-       id="linearGradient3056"
-       xlink:href="#linearGradient4646-7-4-3-5-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.49096263,0,0,0.48984879,-25.706223,-1.7127621)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="53.514328"
-       x2="-51.786404"
-       y2="3.6336823"
-       id="linearGradient3064"
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5-0-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40212523,0,0,0.398023,52.314857,-1.72844)" />
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient3028-3"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4240314,0,0,1.6086447,-1765.5495,-652.81675)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3030-3"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.6086447,-1976.2613,-652.81675)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3032-2"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.6086447,197.36375,-652.81675)" />
-  </defs>
-  <metadata
-     id="metadata10999">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     transform="matrix(0.01182013,0,0,0.0076791,21.513239,18.483864)"
-     id="g5022"
-     style="display:inline;opacity:0.25;stroke-width:104.962;stroke-miterlimit:4;stroke-dasharray:none">
-    <rect
-       width="1170.4609"
-       height="390.67087"
-       x="-1474.6656"
-       y="-63.010559"
-       id="rect4173-4"
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3028-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;marker:none" />
-    <path
-       d="m -304.24708,-62.997104 c 0,0 0,390.649324 0,390.649324 142.87417,0.73539 345.400223,-87.52469 345.400143,-195.3498 0,-107.825127 -159.436813,-195.299504 -345.400143,-195.299524 z"
-       id="path5058-9"
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3030-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;marker:none" />
-    <path
-       d="m -1474.6508,-62.997104 c 0,0 0,390.649324 0,390.649324 -142.8742,0.73539 -345.4002,-87.52469 -345.4002,-195.3498 0,-107.825127 159.4368,-195.299504 345.4002,-195.299524 z"
-       id="path5018-53"
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3032-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;marker:none" />
-  </g>
-  <path
-     d="m 2.9999994,2.5 c -0.277,0 -0.5,0.223 -0.5,0.5 v 1.5 h -0.5 c -0.277,0 -0.5,0.223 -0.5,0.5 V 6.5 H 20.499904 V 5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 H 10.499999 V 3 c 0,-0.277 -0.223,-0.5 -0.4999996,-0.5 z"
-     id="rect3186"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3064);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="sscssccsscsss" />
-  <path
-     d="m 3.0359994,2.9999979 v 2 h -1 v 3 H 20.035904 v -3 h -9.999905 v -2 z"
-     id="rect3409-5-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3056);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccccc" />
-  <path
-     d="m 3.4999994,3.4999979 v 2 h -0.964 V 8.5 H 19.535904 V 5.4999979 H 9.4999994 v -2 z"
-     id="rect3409-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3053);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccccc" />
-  <path
-     d="m 1.8452194,6.4999979 c -0.50041,0.0575 -0.23314,0.65186 -0.27303,0.98608 0.0581,0.21599 0.43282,11.3518901 0.43282,11.7342701 0,0.33235 0.16413,0.27604 0.58003,0.27604 H 19.700124 c 0.44803,0.0103 0.35334,0.005 0.35334,-0.28128 0.0327,-0.14639 0.46339,-12.2622301 0.47997,-12.4535901 0,-0.2015 0.0421,-0.26152 -0.22081,-0.26152 z"
-     id="path3388-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3050);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccsscccsc" />
-  <path
-     d="m 2.5359994,7.4999979 0.43982,11.0000001 H 19.096094 l 0.43981,-11.0000001 z"
-     id="path3309-8"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3044);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccc" />
-  <path
-     d="m 1.8452194,6.4999979 c -0.50041,0.0575 -0.23314,0.65186 -0.27303,0.98608 0.0581,0.21599 0.43282,11.3518901 0.43282,11.7342701 0,0.33235 0.16413,0.27604 0.58003,0.27604 H 19.700124 c 0.44803,0.0103 0.35334,0.005 0.35334,-0.28128 0.0327,-0.14639 0.46339,-12.2622301 0.47997,-12.4535901 0,-0.2015 0.0421,-0.26152 -0.22081,-0.26152 z"
-     id="path3388-3-7"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccsscccsc" />
-  <path
-     d="m 10.999999,9.5 -4.4999996,4.375 0.8745,0.75 0.6255,-0.625 -5e-4,4 h 2.0005 v -2.3148 c 0,-0.277 0.1949986,-1.022317 0.9999996,-1.022317 0.805001,0 1,0.745317 1,1.022317 V 18 h 2 v -4 l 0.6255,0.625 0.8745,-0.75 z m 2,0.5 v 0.875 l 1,1 V 10 Z"
-     id="path2575"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccszsccccccccccc" />
-  <path
-     d="m 10.999999,8.5 -4.4999996,4.375 0.8745,0.75 0.6255,-0.625 v 4 h 2 V 14.760636 C 9.9999994,14.483636 10.309276,14 10.999999,14 c 0.690723,0 1,0.495588 1,0.760636 V 17 h 2 v -4 l 0.6255,0.625 0.8745,-0.75 z m 2,0.5 v 0.875 l 1,1 V 9 Z"
+       xlink:href="#linearGradient4095-7"
+       id="linearGradient3233-4"
+       y2="43.522266"
+       x2="35.481865"
+       y1="11.025123"
+       x1="35.481865" /><linearGradient
+       id="linearGradient4095-7"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097-6" /><stop
+         offset="0.03162756"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" /><stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102-5" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104-6" /></linearGradient></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1271);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 20.500038,6.9999342 V 5.5075805 c 0,-1.115922 -0.92444,-2.014299 -2.072736,-2.014299 h -8.102155 c 0,0 -0.770701,-0.7227945 -1.5218298,-1.4391335 C 8.4318484,1.710425 7.9285017,1.499961 7.3727114,1.499961 H 3.5726958 c -1.1482956,0 -2.0727357,0.8980512 -2.0727357,2.0139732 v 3.486"
+     sodipodi:nodetypes="cssccsssc" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 3.5787078,1.9999342 C 2.6872246,1.9999342 2,2.6766579 2,3.5214186 v 2.9941406 h 18 v -1 C 20,4.6707985 19.312777,3.9940748 18.421292,3.9940748 H 10.324805 A 0.4908645,0.49129058 0 0 1 9.989159,3.8593092 c 0,0 -0.768666,-0.7201861 -1.5182134,-1.4355469 C 8.1882483,2.1619532 7.8072999,1.9999342 7.3761928,1.9999342 Z" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1-0"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 10.324219,4.4940748 c -0.254743,7.46e-5 -0.499923,-0.097019 -0.685547,-0.2714844 0,0 -0.7658703,-0.7187305 -1.5156251,-1.4335937 h -0.00195 C 7.9300565,2.612797 7.674982,2.4999342 7.3730469,2.4999342 H 3.5722656 C 2.9454214,2.4999342 2.5,2.9499344 2.5,3.5136061 v 4.38193" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1-0-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3233-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 19.5,7.8955361 V 5.5077467 c 0,-0.5636715 -0.44542,-1.0136719 -1.072266,-1.0136719 h -8.103515" /><rect
+     width="19.000002"
+     height="15"
+     rx="2.5"
+     ry="2.5"
+     x="1.4999981"
+     y="3.9999342"
+     id="rect5505-21-8-1-6-8"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><g
+     transform="matrix(0.55,0,0,0.3333336,-2.2000011,6.3332642)"
+     id="g2036-4"
+     style="display:inline"><g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.4"><rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6-3);fill-opacity:1;stroke:none" /><rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4-5);fill-opacity:1;stroke:none" /><rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" /></g></g><rect
+     width="19.000002"
+     height="15"
+     rx="2.5"
+     ry="2.5"
+     x="1.4999981"
+     y="5.4999599"
+     id="rect5505-21-8-1-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1253);fill-opacity:1;stroke:#0d52bf;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><path
+     style="color:#000000;fill:#0d52bf;fill-opacity:0.1;-inkscape-stroke:none"
+     d="M 12,7 V 8 8.046875 L 11,7.171875 10.341797,7.7480469 4.5839844,12.785156 6.9570312,15.457031 7,15.414063 V 18 h 4 4 v -2.585937 l 0.04297,0.04297 2.373047,-2.671875 L 16,11.546875 V 7 Z"
+     id="path5347"
+     sodipodi:nodetypes="ccccccccccccccccc" /><rect
+     width="17"
+     height="13"
+     x="2.5012455"
+     y="6.4986906"
+     id="rect6741-9-0"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233-1);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" /><path
+     d="m 11,7.4999342 -5,4.3749998 1,1.125 1.0000001,-1 v 4 H 10 V 13.76057 c 0,-0.277 0.309277,-0.760636 1,-0.760636 0.690723,0 1,0.495588 1,0.760636 v 2.239364 h 2 v -4 l 1,1 1,-1.125 z"
+     id="path4814"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.2;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszscccccc" /><path
+     d="m 11,9.4999342 -5,4.3749998 1,1.125 1.0000001,-1 v 4 H 10 V 15.76057 c 0,-0.277 0.309277,-0.760636 1,-0.760636 0.690723,0 1,0.495588 1,0.760636 v 2.239364 h 2 v -4 l 1,1 1,-1.125 z m 2,-0.5 v 1.2499998 l 2,1.75 V 8.9999342 Z"
+     id="path4754"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.4;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /><path
+     d="m 11,8.4999342 -5,4.3749998 1,1.125 1.0000001,-1 v 4 H 10 V 14.76057 c 0,-0.277 0.309277,-0.760636 1,-0.760636 0.690723,0 1,0.495588 1,0.760636 v 2.239364 h 2 v -4 l 1,1 1,-1.125 z m 2,-0.5 v 1.25 l 2,1.7499998 V 7.9999342 Z"
      id="path2998-4-8"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccszsccccccccccc" />
-</svg>
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.994851;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /></svg>

--- a/elementary-xfce/apps/24/system-file-manager.svg
+++ b/elementary-xfce/apps/24/system-file-manager.svg
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="24"
+   id="svg4157"
    height="24"
-   id="svg10994"
+   width="24"
+   version="1.1"
+   xml:space="preserve"
    sodipodi:docname="system-file-manager.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
@@ -13,271 +14,252 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview57"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview560"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
-     showgrid="false"
-     inkscape:zoom="128"
-     inkscape:cx="19.058594"
-     inkscape:cy="20.136719"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="637"
-     inkscape:window-y="59"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="svg10994"
-     inkscape:showpageshadow="2"
      inkscape:deskcolor="#d1d1d1"
-     shape-rendering="crispEdges" />
-  <defs
-     id="defs10996">
-    <linearGradient
-       id="linearGradient3454-2-5-0-3-4-1">
-      <stop
-         id="stop3456-4-9-38-1-8-8"
+     showgrid="false"
+     inkscape:zoom="45.254834"
+     inkscape:cx="11.004349"
+     inkscape:cy="15.987242"
+     inkscape:window-width="1264"
+     inkscape:window-height="944"
+     inkscape:window-x="592"
+     inkscape:window-y="83"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" /><defs
+     id="defs4159"><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,0.97297429,0.97297586)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.355923"
+       x2="11.728199"
+       y1="6.6191516"
+       x1="11.728199" /><linearGradient
+       id="linearGradient4095"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3458-39-80-3-5-5-8"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0097359" />
-      <stop
-         id="stop3460-7-0-2-4-2-7"
+         id="stop4097" /><stop
+         offset="0.96216732"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop3462-0-9-8-7-2-3"
+         id="stop4102" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4632-0-6-4-3-4-0">
-      <stop
-         id="stop4634-4-4-7-7-4-8"
-         style="stop-color:#e9e9e9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4636-3-1-5-1-3-9"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4325-0">
-      <stop
-         id="stop4327-4"
+         id="stop4104" /></linearGradient><linearGradient
+       id="linearGradient3688-166-749-9"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" /></linearGradient><linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-1"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-1"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-2" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-89" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-36" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-41.857271,-23.833435)"
+       x1="70.385941"
+       y1="51.425007"
+       x2="70.385941"
+       y2="29.002073" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46014931,0,0,0.44257234,-22.052748,0.86281849)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3082-6-3"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-9"
+       id="radialGradient3084-4-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.35135136,0.9742203,5.5663266)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095-2"
+       id="linearGradient3233-1"
+       y2="41.229313"
+       x2="23.99999"
+       y1="6.5493407"
+       x1="23.99999" /><linearGradient
+       id="linearGradient4095-2"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4329-5"
+         id="stop4097-7" /><stop
+         offset="0.06793755"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.1106325" />
-      <stop
-         id="stop4331-6"
+         id="stop4100-0" /><stop
+         offset="0.93777806"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop4333-7"
+         id="stop4102-9" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4646-7-4-3-5-6">
-      <stop
-         id="stop4648-8-0-3-6-5"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4650-1-7-3-4-8"
-         style="stop-color:#d8d8d8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5048">
-      <stop
-         id="stop5050"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop5056"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop5052"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient5060">
-      <stop
-         id="stop5062"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop5064"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5-0-5">
-      <stop
-         id="stop3106-5-4-3-5-0-2-1-0-6-6"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-0-7-9-1-4"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="27.557428"
-       y1="7.4180675"
-       x2="27.557428"
-       y2="21.223507"
-       id="linearGradient3044"
-       xlink:href="#linearGradient3454-2-5-0-3-4-1"
+         id="stop4104-3" /></linearGradient><linearGradient
+       id="linearGradient909"><stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient1253"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.62762637,0,0,0.7245642,2.9730682,3.6273679)" />
-    <linearGradient
-       x1="35.792694"
-       y1="17.118193"
-       x2="35.792694"
-       y2="43.761127"
-       id="linearGradient3050"
-       xlink:href="#linearGradient4632-0-6-4-3-4-0"
+       gradientTransform="matrix(0.34545456,0,0,0.28051952,0.9454542,4.3091155)"
+       x1="31.781376"
+       y1="-15.284776"
+       x2="31.781376"
+       y2="70.34359" /><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,0.97297429,0.97297586)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.4666607,0,0,0.46428558,0.83644822,-0.1607121)" />
-    <linearGradient
-       x1="21.37039"
-       y1="4.73244"
-       x2="21.37039"
-       y2="34.143417"
-       id="linearGradient3053"
-       xlink:href="#linearGradient4325-0"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.43131243,0,0,0.48638011,1.9898582,2.1854079)" />
-    <linearGradient
-       x1="62.988873"
-       y1="13.924261"
-       x2="62.988873"
-       y2="18.516649"
-       id="linearGradient3056"
-       xlink:href="#linearGradient4646-7-4-3-5-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.49096263,0,0,0.48984879,-24.706222,-0.7127621)" />
-    <linearGradient
-       x1="-51.786404"
-       y1="53.514328"
-       x2="-51.786404"
-       y2="3.6336823"
-       id="linearGradient3064"
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5-0-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40212523,0,0,0.398023,53.314858,-0.72844)" />
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient3028-3"
-       xlink:href="#linearGradient5048"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.4240314,0,0,1.6086447,-1765.5495,-652.81675)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3030-3"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.774389,0,0,1.6086447,-1976.2613,-652.81675)" />
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3032-2"
-       xlink:href="#linearGradient5060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-2.774389,0,0,1.6086447,197.36375,-652.81675)" />
-  </defs>
-  <metadata
-     id="metadata10999">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     transform="matrix(0.01182013,0,0,0.0076791,22.51324,19.483864)"
-     id="g5022"
-     style="display:inline;stroke-width:104.962;stroke-miterlimit:4;stroke-dasharray:none;opacity:0.25">
-    <rect
-       width="1170.4609"
-       height="390.67087"
-       x="-1474.6656"
-       y="-63.010559"
-       id="rect4173-4"
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3028-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;marker:none" />
-    <path
-       d="m -304.24708,-62.997104 c 0,0 0,390.649324 0,390.649324 142.87417,0.73539 345.400223,-87.52469 345.400143,-195.3498 0,-107.825127 -159.436813,-195.299504 -345.400143,-195.299524 z"
-       id="path5058-9"
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3030-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;marker:none" />
-    <path
-       d="m -1474.6508,-62.997104 c 0,0 0,390.649324 0,390.649324 -142.8742,0.73539 -345.4002,-87.52469 -345.4002,-195.3498 0,-107.825127 159.4368,-195.299504 345.4002,-195.299524 z"
-       id="path5018-53"
-       style="display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#radialGradient3032-2);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:104.962;marker:none" />
-  </g>
-  <path
-     d="M 4,3.5 C 3.723,3.5 3.5,3.723 3.5,4 V 5.5 H 3 C 2.723,5.5 2.5,5.723 2.5,6 V 7.5 H 21.499905 V 6 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 H 11.5 V 4 C 11.5,3.723 11.277,3.5 11,3.5 Z"
-     id="rect3186"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3064);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="sscssccsscsss" />
-  <path
-     d="m 4.036,3.9999979 v 2 h -1 v 3 h 17.999905 v -3 H 11.036 v -2 z"
-     id="rect3409-5-2"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3056);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccccc" />
-  <path
-     d="m 4.5,4.4999979 v 2 H 3.536 V 9.5 H 20.535905 V 6.4999979 H 10.5 v -2 z"
-     id="rect3409-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3053);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccccc" />
-  <path
-     d="m 2.84522,7.4999979 c -0.50041,0.0575 -0.23314,0.65186 -0.27303,0.98608 0.0581,0.21599 0.43282,11.3518901 0.43282,11.7342701 0,0.33235 0.16413,0.27604 0.58003,0.27604 h 17.115085 c 0.44803,0.0103 0.35334,0.005 0.35334,-0.28128 0.0327,-0.14639 0.46339,-12.2622301 0.47997,-12.4535901 0,-0.2015 0.0421,-0.26152 -0.22081,-0.26152 z"
-     id="path3388-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3050);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccsscccsc" />
-  <path
-     d="M 3.536,8.4999979 3.97582,19.499998 h 16.120275 l 0.43981,-11.0000001 z"
-     id="path3309-8"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3044);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccc" />
-  <path
-     d="m 2.84522,7.4999979 c -0.50041,0.0575 -0.23314,0.65186 -0.27303,0.98608 0.0581,0.21599 0.43282,11.3518901 0.43282,11.7342701 0,0.33235 0.16413,0.27604 0.58003,0.27604 h 17.115085 c 0.44803,0.0103 0.35334,0.005 0.35334,-0.28128 0.0327,-0.14639 0.46339,-12.2622301 0.47997,-12.4535901 0,-0.2015 0.0421,-0.26152 -0.22081,-0.26152 z"
-     id="path3388-3-7"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccsscccsc" />
-  <path
-     d="M 12,10.5 7.5,14.875 8.3745,15.625 9,15 8.9995,19 H 11 v -2.3148 c 0,-0.277 0.194999,-1.022317 1,-1.022317 0.805001,0 1,0.745317 1,1.022317 V 19 h 2 v -4 l 0.6255,0.625 0.8745,-0.75 z m 2,0.5 v 0.875 l 1,1 V 11 Z"
-     id="path2575"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccszsccccccccccc" />
-  <path
-     d="M 12,9.5 7.5,13.875 8.3745,14.625 9,14 v 4 h 2 V 15.760636 C 11,15.483636 11.309277,15 12,15 c 0.690723,0 1,0.495588 1,0.760636 V 18 h 2 v -4 l 0.6255,0.625 0.8745,-0.75 z m 2,0.5 v 0.875 l 1,1 V 10 Z"
+       xlink:href="#linearGradient4095-7"
+       id="linearGradient3233-4"
+       y2="43.522266"
+       x2="35.481865"
+       y1="11.025123"
+       x1="35.481865" /><linearGradient
+       id="linearGradient4095-7"><stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097-6" /><stop
+         offset="0.03162756"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" /><stop
+         offset="0.96216732"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102-5" /><stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104-6" /></linearGradient></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1271);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 21.500038,8 V 6.5076463 c 0,-1.115922 -0.92444,-2.014299 -2.072736,-2.014299 h -8.102155 c 0,0 -0.770701,-0.7227945 -1.5218298,-1.4391335 C 9.4318484,2.7104908 8.9285017,2.5000268 8.3727114,2.5000268 H 4.5726958 C 3.4244002,2.5000268 2.4999601,3.398078 2.4999601,4.514 V 8"
+     sodipodi:nodetypes="cssccsssc" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.00043;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 4.5722656,2.9921875 c -0.892257,0 -1.5800781,0.6767237 -1.5800781,1.5214844 V 7.5078125 H 21.007812 v -1 c 0,-0.8447607 -0.68782,-1.5214844 -1.580078,-1.5214844 H 11.324219 A 0.49129058,0.49129058 0 0 1 10.988281,4.8515625 c 0,0 -0.769333,-0.7201861 -1.519531,-1.4355469 C 9.1858073,3.1542065 8.8045283,2.9921875 8.3730469,2.9921875 Z"
+     transform="matrix(0.99913273,0,0,1,0.01040755,0.0078125)" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1-0"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 11.324219,5.4941406 c -0.254743,7.46e-5 -0.499923,-0.097019 -0.685547,-0.2714844 0,0 -0.7658703,-0.7187305 -1.5156251,-1.4335937 h -0.00195 C 8.9300565,3.6128628 8.674982,3.5 8.3730469,3.5 H 4.5722656 C 3.9454214,3.5 3.5,3.9500002 3.5,4.5136719 v 4.38193" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3-1-0-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3233-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 20.5,8.8956019 V 6.5078125 C 20.5,5.944141 20.05458,5.4941406 19.427734,5.4941406 h -8.103515" /><rect
+     width="19.000002"
+     height="15"
+     rx="2.5"
+     ry="2.5"
+     x="2.4999981"
+     y="5"
+     id="rect5505-21-8-1-6-8"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#002e99;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><g
+     transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33333)"
+     id="g2036-4"
+     style="display:inline"><g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.4"><rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6-3);fill-opacity:1;stroke:none" /><rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4-5);fill-opacity:1;stroke:none" /><rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" /></g></g><rect
+     width="19.000002"
+     height="15"
+     rx="2.5"
+     ry="2.5"
+     x="2.4999981"
+     y="6.5000257"
+     id="rect5505-21-8-1-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1253);fill-opacity:1;stroke:#0d52bf;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><path
+     style="color:#000000;fill:#0d52bf;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 14,8 c -0.552262,5.52e-5 -0.999945,0.4477381 -1,1 V 9.046875 L 12.658203,8.7480469 c -0.376945,-0.3295022 -0.939461,-0.3295022 -1.316406,0 L 6.3417969,13.123047 c -0.4175519,0.365367 -0.4578695,1.000806 -0.089844,1.416016 l 1,1.125 C 7.4439335,15.873479 7.715919,15.991362 8,15.988281 V 18 c 5.52e-5,0.552262 0.4477381,0.999945 1,1 h 2 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 5.5e-5,0.552262 0.447738,0.999945 1,1 h 2 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -2.011719 c 0.284081,0.0031 0.556066,-0.114802 0.748047,-0.324218 l 1,-1.125 c 0.368027,-0.415209 0.327711,-1.050648 -0.08984,-1.416016 L 16.775391,12.349609 C 16.873912,12.250084 16.950434,12.130977 17,12 V 9 C 16.999945,8.4477381 16.552262,8.0000552 16,8 Z"
+     id="path5347"
+     sodipodi:nodetypes="ccccccccccccccccccccccccc" /><rect
+     width="17"
+     height="13"
+     x="3.5012455"
+     y="7.4987564"
+     id="rect6741-9-0"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233-1);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" /><path
+     d="M 12,8.5 7,12.875 8,14 9.0000001,13 v 4 H 11 V 14.760636 C 11,14.483636 11.309277,14 12,14 c 0.690723,0 1,0.495588 1,0.760636 V 17 h 2 v -4 l 1,1 1,-1.125 z"
+     id="path4814"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.2;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;stroke-dasharray:none"
+     sodipodi:nodetypes="ccccccszscccccc" /><path
+     d="M 12,10.5 7,14.875 8,16 9.0000001,15 v 4 H 11 V 16.760636 C 11,16.483636 11.309277,16 12,16 c 0.690723,0 1,0.495588 1,0.760636 V 19 h 2 v -4 l 1,1 1,-1.125 z M 14,10 v 1.25 L 16,13 v -3 z"
+     id="path4754"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.34999999;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /><path
+     d="M 12,9.5 7,13.875 8,15 9.0000001,14 v 4 H 11 V 15.760636 C 11,15.483636 11.309277,15 12,15 c 0.690723,0 1,0.495588 1,0.760636 V 18 h 2 v -4 l 1,1 1,-1.125 z M 14,9 v 1.25 L 16,12 V 9 Z"
      id="path2998-4-8"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-     sodipodi:nodetypes="ccccccszsccccccccccc" />
-</svg>
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /></svg>

--- a/elementary-xfce/apps/32/system-file-manager.svg
+++ b/elementary-xfce/apps/32/system-file-manager.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="32"
+   id="svg4715"
    height="32"
-   id="svg16113"
+   width="32"
+   version="1.1"
    sodipodi:docname="system-file-manager.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -15,210 +15,227 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview59"
+     id="namedview17264"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="15.070213"
-     inkscape:cx="16.35677"
-     inkscape:cy="16.655372"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="578"
-     inkscape:window-y="358"
+     inkscape:zoom="51.875"
+     inkscape:cx="18.139759"
+     inkscape:cy="16.192771"
+     inkscape:window-width="1278"
+     inkscape:window-height="1005"
+     inkscape:window-x="540"
+     inkscape:window-y="2"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg16113" />
+     inkscape:current-layer="svg4715" />
   <defs
-     id="defs16115">
+     id="defs4717">
     <linearGradient
-       id="linearGradient3454-2-5-0-3-4">
+       id="linearGradient1159">
       <stop
-         id="stop3456-4-9-38-1-8"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop1151" />
+      <stop
+         offset="0.06898633"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop1153" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop1155" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop1157" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.07318898"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.90786326"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3167"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.2162133,-0.21620907)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.75993"
+       x2="13.594253"
+       y1="6.272294"
+       x1="13.594253" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.66466012,0,0,0.63927116,-33.187302,-0.08703975)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" />
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1572"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32898258,0,0,0.89471714,-17.110744,-9.2419267)"
+       x1="72.893349"
+       y1="43.73991"
+       x2="72.893349"
+       y2="12.523938" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2976-3-3"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2978-2-5"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.2399855"
+       x2="23.99999"
+       y2="41.759987"
+       id="linearGradient4161-0-2"
+       xlink:href="#linearGradient3924-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567568,0,0,0.54054054,-0.21621281,5.5269976)" />
+    <linearGradient
+       id="linearGradient3924-0">
+      <stop
+         id="stop3926-6"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3458-39-80-3-5-5"
+         id="stop3928-3"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0097359" />
+         offset="0.08734306" />
       <stop
-         id="stop3460-7-0-2-4-2"
+         id="stop3930-2"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
+         offset="0.88950253" />
       <stop
-         id="stop3462-0-9-8-7-2"
+         id="stop3932-62"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4632-0-6-4-3-4">
+       id="linearGradient909">
       <stop
-         id="stop4634-4-4-7-7-4"
-         style="stop-color:#e9e9e9;stop-opacity:1"
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4636-3-1-5-1-3"
-         style="stop-color:#b4b4b4;stop-opacity:1"
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient14886"
-       xlink:href="#linearGradient5048-585-0"
+       xlink:href="#linearGradient909"
+       id="linearGradient449"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04700148,0,0,0.01591575,-0.98829681,22.29927)" />
+       gradientTransform="matrix(0.49090911,0,0,0.40000005,0.29091166,5.7000015)"
+       x1="31.781376"
+       y1="-14.353104"
+       x2="31.781376"
+       y2="65.626633" />
     <linearGradient
-       id="linearGradient5048-585-0">
-      <stop
-         id="stop2667-18"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2669-9"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2671-33"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient14888"
-       xlink:href="#linearGradient5060-179-67"
+       xlink:href="#linearGradient1159"
+       id="linearGradient1148"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.01983573,0,0,0.01591575,15.387172,22.29927)" />
-    <linearGradient
-       id="linearGradient5060-179-67">
-      <stop
-         id="stop2675-81"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2677-2"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient14890"
-       xlink:href="#linearGradient5060-820-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.01983573,0,0,0.01591575,16.601057,22.29927)" />
-    <linearGradient
-       id="linearGradient5060-820-4">
-      <stop
-         id="stop2681-5"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2683-00"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4325">
-      <stop
-         id="stop4327"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4329"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.1106325" />
-      <stop
-         id="stop4331"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop4333"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4646-7-4-3-5">
-      <stop
-         id="stop4648-8-0-3-6"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4650-1-7-3-4"
-         style="stop-color:#d8d8d8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5-0">
-      <stop
-         id="stop3106-5-4-3-5-0-2-1-0-6"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-0-7-9-1"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient3454-2-5-0-3-4"
-       id="linearGradient3043"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89186139,0,0,1.0539115,3.1212694,3.4125349)"
-       x1="27.557428"
-       y1="7.162672"
-       x2="27.557428"
-       y2="21.386522" />
-    <linearGradient
-       xlink:href="#linearGradient4632-0-6-4-3-4"
-       id="linearGradient3049"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.64444432,0,0,0.64285702,0.53395936,-1.107145)"
-       x1="35.792694"
-       y1="17.118193"
-       x2="35.792694"
-       y2="43.761127" />
-    <linearGradient
-       xlink:href="#linearGradient4325"
-       id="linearGradient3056"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.54383556,0,0,0.61466406,3.2693194,3.0911349)"
-       x1="21.37039"
-       y1="4.73244"
-       x2="21.37039"
-       y2="34.143417" />
-    <linearGradient
-       xlink:href="#linearGradient4646-7-4-3-5"
-       id="linearGradient3059"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.61904762,0,0,0.61904762,-30.391371,-0.57143507)"
-       x1="62.988873"
-       y1="13"
-       x2="62.988873"
-       y2="16" />
-    <linearGradient
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5-0"
-       id="linearGradient3062"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.50703384,0,0,0.50300255,68.029659,-0.67023507)"
-       x1="-51.786404"
-       y1="53.514328"
-       x2="-51.786404"
-       y2="3.6336823" />
+       gradientTransform="matrix(0.67610048,0,0,0.67567572,-0.22640794,-0.22406258)"
+       x1="31.752234"
+       y1="9.1502771"
+       x2="31.752234"
+       y2="41.711662" />
   </defs>
   <metadata
-     id="metadata16118">
+     id="metadata4720">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -229,62 +246,104 @@
     </rdf:RDF>
   </metadata>
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient3062);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="use7669"
-     d="m 5.001,4.5000749 c -0.43342,0.005 -0.5,0.21723 -0.5,0.6349 v 1.36502 c -1.24568,0 -1,-0.002 -1,0.54389 0.0216,6.5331301 0,6.9014301 0,7.4561091 0.90135,0 25,-2.348949 25,-3.360049 V 7.0438849 c 0,-0.41767 -0.34799,-0.54876 -0.78141,-0.54389 H 15.501 v -1.36502 c 0,-0.41767 -0.26424,-0.63977 -0.69767,-0.6349 z"
-     sodipodi:nodetypes="cscccssccscc" />
+     id="rect5505-6-6-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;stroke:none;stroke-width:0.999775;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 5.5,3.0058594 C 4.109218,3.0058594 3.0058594,4.1092182 3.0058594,5.5 V 9.4941406 H 28.994141 V 7.5 c 0,-1.3907816 -1.10336,-2.4941406 -2.494141,-2.4941406 H 15.326172 c -1.81631,0 -2.588652,-0.9329008 -3.337891,-1.5078125 C 11.581509,3.1859201 11.068098,3.0058594 10.5,3.0058594 Z"
+     transform="matrix(1.0004509,0,0,1,-0.00721477,-0.0058594)" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3059);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="use7671"
-     d="m 5.001,4.9999949 v 2 h -1 v 4.0000001 h 24 V 6.9999949 h -13 v -2 z"
-     sodipodi:nodetypes="ccccccccc" />
+     id="rect5505-6-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1572);stroke-width:0.999918;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 29.5,10 V 7.5 c 0,-1.6619966 -1.338004,-3 -3,-3 H 15.326172 C 13.666621,4.5 13.118858,3.7272726 12.297655,3.0971411 11.801917,2.7167483 11.176321,2.5 10.5,2.5 h -5 c -1.6619968,0 -3,1.3380034 -3,3 V 10" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3056);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="use7673"
-     d="m 5.501,5.4999949 v 2 h -1 v 4.0000001 h 23 V 7.4999949 h -13 v -2 z"
-     sodipodi:nodetypes="ccccccccc" />
+     id="rect5505-6-6-8"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient3027);stroke-width:0.999684;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 15.326595,5.5078535 c -1.971948,0 -2.964453,-1.0912424 -3.642242,-1.6113281 -0.31844,-0.244348 -0.724154,-0.3886719 -1.184802,-0.3886719 h -4.99881 c -1.1215026,0 -1.9928877,0.870685 -1.9928877,1.9921875 v 2.984375"
+     transform="matrix(1.0006287,0,0,1,-0.01005871,-0.00785351)" />
+  <path
+     id="rect5505-6-6-8-2"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1148);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 28.5,8.4765625 V 7.4921875 C 28.5,6.3706854 27.628066,5.5 26.505859,5.5 H 15.326172" />
+  <path
+     id="rect5505-21-1-2-1-9-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.05;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 26.494141 4.9804688 C 26.363355 4.9797603 26.230974 4.9866065 26.099609 5 C 19.216048 5.0013 12.332655 4.9973931 5.4492188 5.0019531 C 4.0374173 4.9795661 2.7490501 5.8177673 2.046875 6.9980469 L 2.046875 10 A 0.45408146 0.45408146 0 0 0 2.5 10.453125 L 29.5 10.453125 A 0.45408146 0.45408146 0 0 0 29.953125 10 L 29.953125 7.5 C 29.953125 7.2910935 29.93211 7.0874018 29.896484 6.8886719 C 29.169659 5.7526669 27.86234 4.9878806 26.494141 4.9804688 z " />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-1-2-1-9"
+     y="6"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="22"
+     width="27.000008" />
   <g
-     id="use7675"
-     transform="translate(6.1935663e-4,-3.0000051)">
-    <rect
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient14886);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="rect14880"
-       y="28.134747"
-       x="4.6518807"
-       height="3.8652544"
-       width="22.695" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient14888);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path14882"
-       d="m 27.341381,28.13488 c 0,0 0,3.865041 0,3.865041 1.021491,0.0073 2.469468,-0.86596 2.469468,-1.932769 0,-1.06681 -1.139908,-1.932272 -2.469468,-1.932272 z" />
-    <path
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient14890);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none"
-       id="path14884"
-       d="m 4.6468484,28.13488 c 0,0 0,3.865041 0,3.865041 -1.0214912,0.0073 -2.4694678,-0.86596 -2.4694678,-1.932769 0,-1.06681 1.1399068,-1.932272 2.4694678,-1.932272 z" />
+     style="display:inline"
+     id="g2036-2-8-6"
+     transform="matrix(0.6999997,0,0,0.3333336,-0.79999581,15.33333)">
+    <g
+       style="opacity:0.4"
+       id="g3712-3-7-0"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2976-3-3);fill-opacity:1;stroke:none"
+         id="rect2801-0-9-6"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2978-2-5);fill-opacity:1;stroke:none"
+         id="rect3696-2-2-2"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
+         id="rect3700-1-0-6"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
   </g>
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient449);fill-opacity:1;fill-rule:nonzero;stroke:#0d52bf;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000;opacity:1;-inkscape-stroke:none;stop-opacity:1"
+     id="rect5505-21-1-2-1"
+     y="7.4999623"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="22"
+     width="27.000008" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3049);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-     id="use7677"
-     d="m 2.92784,9.4999949 c -0.69105,0.0796 -0.32196,0.9025801 -0.37705,1.3653501 0.0802,0.29906 0.59771,15.717989 0.59771,16.247439 0,0.46018 0.22667,0.38222 0.80101,0.38222 h 24.39748 c 0.61872,0.0143 0.48796,0.007 0.48796,-0.38947 0.0452,-0.20269 0.63993,-16.978479 0.66282,-17.2434391 0,-0.279 0.0581,-0.3621 -0.30493,-0.3621 z"
-     sodipodi:nodetypes="ccsscccsc" />
+     style="color:#000000;fill:#002e99;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 15.3125,12.275391 -7,6.642578 c -0.4116294,0.390672 -0.4160658,1.04519 -0.00977,1.441406 l 1.650395,1.607422 C 10.247643,22.207852 10.653454,22.26085 11,22.103516 V 25 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 3 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 5.5e-5,0.552262 0.447738,0.999945 1,1 h 3 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -2.896484 c 0.346546,0.157334 0.752357,0.104336 1.046875,-0.136719 l 1.650391,-1.607422 c 0.406288,-0.396225 0.401838,-1.050742 -0.0098,-1.441406 l -7,-6.642578 c -0.38565,-0.365037 -0.98935,-0.365037 -1.375,0 z"
+     id="path2844"
+     sodipodi:nodetypes="ccccccccccccccccccc" />
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient4161-0-2);stroke-width:0.999996;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4-3-8"
+     y="8.4999619"
+     x="3.5000038"
+     ry="2"
+     rx="2"
+     height="20"
+     width="25" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3043);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="use7681"
-     d="M 3.501,10.499995 4.12598,26.499994 H 27.87515 L 28.50013,10.499995 Z"
-     sodipodi:nodetypes="ccccc" />
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:1.69999;marker:none;enable-background:accumulate"
+     id="path20672"
+     d="M 15.999988,13 8.9999999,19.642846 10.65,21.25 12,19.857142 V 25 h 3 v -2.571714 c 0,-0.474868 0.499612,-0.928572 0.999988,-0.928572 0.500397,0 1.000012,0.453704 1.000012,0.928572 V 25 h 3 V 19.857142 L 21.35,21.25 23,19.642846 Z"
+     sodipodi:nodetypes="ccccccssscccccc" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="path3388-5-0"
-     d="m 2.9274,9.4999949 c -0.69105,0.0796 -0.32196,0.9025801 -0.37705,1.3653501 0.0802,0.29906 0.59771,15.717989 0.59771,16.247439 0,0.46018 0.22667,0.38222 0.80101,0.38222 h 24.39748 c 0.61872,0.0143 0.48796,0.007 0.48796,-0.38947 0.0452,-0.20269 0.63993,-16.978479 0.66282,-17.2434391 0,-0.279 0.0581,-0.3621 -0.30493,-0.3621 z"
-     sodipodi:nodetypes="ccsscccsc" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-     id="path2998-4-8-1-6"
-     d="M 16.014276,13.999996 9.925,20.089272 l 1.178571,1.178572 0.982153,-0.982134 v 4.714286 h 3.142857 v -2.357143 c 0,-0.435295 0.350419,-0.785714 0.785695,-0.785714 0.435295,0 0.785715,0.350419 0.785715,0.785714 v 2.357143 h 3.142876 V 20.28571 L 20.925,21.267844 22.103571,20.089272 Z M 18,14 v 1 l 2,2 v -3 z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.3;fill-rule:nonzero;stroke:none;stroke-width:1.69999;marker:none;enable-background:accumulate"
+     id="path23402"
+     d="M 15.999988,11 8.9999999,17.642846 10.65,19.25 12,17.857142 V 23 h 3 v -2.571714 c 0,-0.474868 0.499612,-0.928572 0.999988,-0.928572 0.500397,0 1.000012,0.453704 1.000012,0.928572 V 23 h 3 V 17.857142 L 21.35,19.25 23,17.642846 Z M 18,11.000005 V 16 h 3 v -4.999995 z"
      sodipodi:nodetypes="ccccccsssccccccccccc" />
   <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.69999;marker:none;enable-background:accumulate"
      id="path2998-4-8-11"
-     d="M 16.014276,12.999996 9.925,19.089272 l 1.178571,1.178572 0.982153,-0.982134 v 4.714286 h 3.142857 v -2.357143 c 0,-0.435295 0.350419,-0.785714 0.785695,-0.785714 0.435295,0 0.785715,0.350419 0.785715,0.785714 v 2.357143 h 3.142876 V 19.28571 L 20.925,20.267844 22.103571,19.089272 Z M 18,13 v 1 l 2,1.75 V 13 Z"
+     d="M 15.999988,12 8.9999999,18.642846 10.65,20.25 12,18.857142 V 24 h 3 v -2.571714 c 0,-0.474868 0.499612,-0.928572 0.999988,-0.928572 0.500397,0 1.000012,0.453704 1.000012,0.928572 V 24 h 3 V 18.857142 L 21.35,20.25 23,18.642846 Z M 18,12.000005 V 12.5 l 3,3 v -3.499995 z"
      sodipodi:nodetypes="ccccccsssccccccccccc" />
 </svg>

--- a/elementary-xfce/apps/48/system-file-manager.svg
+++ b/elementary-xfce/apps/48/system-file-manager.svg
@@ -3,9 +3,9 @@
    version="1.1"
    width="48"
    height="48"
-   id="svg20096"
+   id="svg6649"
    sodipodi:docname="system-file-manager.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -15,210 +15,228 @@
    xmlns:cc="http://creativecommons.org/ns#"
    xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
-     id="namedview59"
+     id="namedview61"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="64"
-     inkscape:cx="28.148438"
-     inkscape:cy="23.703125"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="-421"
-     inkscape:window-y="156"
+     inkscape:zoom="17.291667"
+     inkscape:cx="22.554217"
+     inkscape:cy="31.691567"
+     inkscape:window-width="1278"
+     inkscape:window-height="909"
+     inkscape:window-x="909"
+     inkscape:window-y="106"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1" />
+     inkscape:current-layer="svg6649" />
   <defs
-     id="defs20098">
+     id="defs6651">
     <linearGradient
-       x1="42.470848"
-       y1="11.952797"
-       x2="42.470848"
-       y2="35.581654"
-       id="linearGradient3381-56-2-7-5-0-8-0-0"
-       xlink:href="#linearGradient3454-2-8-6-1-1-8-0-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189031,0,0,1.0986542,3.1206758,2.8888085)" />
-    <linearGradient
-       id="linearGradient3454-2-8-6-1-1-8-0-6">
+       id="linearGradient2511">
       <stop
-         id="stop3456-4-7-9-4-0-3-6-2"
+         id="stop2503"
          style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3458-39-0-8-61-3-8-9-0"
+         id="stop2505"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0097359" />
+         offset="0.07311722" />
       <stop
-         id="stop3460-7-5-4-1-6-6-6-2"
+         id="stop2507"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
+         offset="0.94694352" />
       <stop
-         id="stop3462-0-5-6-6-2-1-6-0"
+         id="stop2509"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="35.792694"
-       y1="17.118193"
-       x2="35.792694"
-       y2="43.761127"
-       id="linearGradient4638-4-6-8-9-9-5-8"
-       xlink:href="#linearGradient4632-0-6-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0357143,1.4880025e-5,-2.5890898)" />
-    <linearGradient
-       id="linearGradient4632-0-6-4">
+       id="linearGradient2392">
       <stop
-         id="stop4634-4-4-7"
-         style="stop-color:#e9e9e9;stop-opacity:1"
+         id="stop2384"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4636-3-1-5"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3080-2-3-9-9-8-8-9"
-       xlink:href="#linearGradient5060-820-9-0-7-1-7-7-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.03079083,0,0,0.02470588,25.3898,28.941629)" />
-    <linearGradient
-       id="linearGradient5060-820-9-0-7-1-7-7-1">
+         id="stop2386"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07945278" />
       <stop
-         id="stop2681-5-4-3-6-3-8-2"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop2388"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
       <stop
-         id="stop2683-8-6-9-4-6-6-2"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient3083-4-5-6-4-5-0-5"
-       xlink:href="#linearGradient5060-179-2-0-3-6-2-2-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.03079083,0,0,0.02470588,22.61051,28.941629)" />
-    <linearGradient
-       id="linearGradient5060-179-2-0-3-6-2-2-8">
-      <stop
-         id="stop2675-9-9-4-1-4-4-9"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2677-1-7-2-6-1-8-3"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop2390"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient3086-4-4-0-5-5-7-4"
-       xlink:href="#linearGradient5048-585-4-0-56-2-5-2-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.07110385,0,0,0.02470588,-1.6989947,28.941629)" />
-    <linearGradient
-       id="linearGradient5048-585-4-0-56-2-5-2-1">
+       id="linearGradient1201">
       <stop
-         id="stop2667-5-0-7-4-7-7-2"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2669-4-1-8-0-6-9-3"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop2671-2-6-3-2-0-6-0"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="21.37039"
-       y1="4.2476678"
-       x2="21.37039"
-       y2="34.143417"
-       id="linearGradient3381-5-5-29-4-6-5-0-4"
-       xlink:href="#linearGradient4507-9-2-2-3-6-9-9"
+       x1="13.320448"
+       y1="6.0408597"
+       x2="13.320448"
+       y2="42.617455"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient2392"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.89189031,0,0,1.0580283,3.1207247,4.3536002)" />
+       gradientTransform="translate(4e-6,1.0000062)" />
     <linearGradient
-       id="linearGradient4507-9-2-2-3-6-9-9">
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient1191"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.1428571,0,0,0.6428571,-3.428569,16.035716)" />
+    <linearGradient
+       id="linearGradient3600-9-51">
       <stop
-         id="stop4509-9-8-4-2-3-4-5"
-         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.97142632,0,0,0.93431938,-47.889132,1.4881727)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" />
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4511-7-50-2-1-3-9-4"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.07395859" />
-      <stop
-         id="stop4513-2-0-2-9-2-6-2"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop4515-3-9-8-6-6-0-7"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       x1="62.988873"
-       y1="13"
-       x2="62.988873"
-       y2="16"
-       id="linearGradient3089-5-2-9-8-6-8-0-7-1"
-       xlink:href="#linearGradient4646-6-91-5-0-5-8-4"
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-50.940885,-0.9999998)" />
-    <linearGradient
-       id="linearGradient4646-6-91-5-0-5-8-4">
-      <stop
-         id="stop4648-2-4-6-6-8-7-1"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4650-3-8-5-3-4-5-7"
-         style="stop-color:#d8d8d8;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-2-0-1-4-0-5-8">
-      <stop
-         id="stop3106-5-4-3-5-0-1-61-9-2-7-3-3"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-4-01-9-9-0-6-4"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-86.050987"
-       y1="49.608227"
-       x2="-86.050987"
-       y2="9.8308334"
-       id="linearGradient20094"
-       xlink:href="#linearGradient3104-8-8-97-4-6-2-0-1-4-0-5-8"
+       gradientTransform="matrix(2.003784,0,0,0.89999994,29.98813,4.8500025)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-1"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.80749834,0,0,0.83374395,106.87671,-1.0698398)" />
+       gradientTransform="matrix(2.003784,0,0,0.89999994,-18.01187,-83.149997)" />
+    <linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient930-9-2"
+       x1="16.767664"
+       y1="-3.7705286"
+       x2="16.767664"
+       y2="32.829891"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.444444,0,0,1.1851848,0.888913,9.5369989)" />
+    <linearGradient
+       xlink:href="#linearGradient1201"
+       id="linearGradient1192"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.81081081,4e-6,9.0405055)"
+       x1="38.999996"
+       y1="5.9999938"
+       x2="38.999996"
+       y2="41.945408" />
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,10.835333,2.8677948)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       x1="35.996761"
+       y1="9.0111694"
+       x2="35.996761"
+       y2="41.850147"
+       id="linearGradient3058-5-7"
+       xlink:href="#linearGradient2511"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4e-6,1.0000062)" />
   </defs>
   <metadata
-     id="metadata20101">
+     id="metadata6654">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -229,62 +247,98 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,-1)">
+     id="g1784">
     <rect
-       width="34.333"
-       height="6.0000005"
-       x="6.8334999"
-       y="38"
-       id="rect4173-6-7-7-3-5-1-4"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient3086-4-4-0-5-5-7-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;marker:none" />
-    <path
-       d="m 41.167,38.000199 c 0,0 0,5.99967 0,5.99967 1.5856,0.0113 3.8333,-1.34422 3.8333,-3.00022 0,-1.656 -1.7695,-2.99945 -3.8333,-2.99945 z"
-       id="path5058-7-9-1-3-0-3-4"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3083-4-5-6-4-5-0-5);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="m 6.8333,38.000199 c 0,0 0,5.99967 0,5.99967 C 5.2477,44.011169 3,42.655649 3,40.999649 c 0,-1.656 1.7695,-2.99945 3.8333,-2.99945 z"
-       id="path5018-8-1-1-6-9-4-9"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient3080-2-3-9-9-8-8-9);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="m 7.5,7.5 c -0.554,0 -1,0.4965477 -1,1 v 2 H 5.5005662 c -0.554,0 -1,0.446 -1,1 v 6 c 0,0.554 0.446,1 1,1 H 42.49967 c 0.554,0 1,-0.446 1,-1 v -6 c 0,-0.554 -0.446,-1 -1,-1 H 22.5 v -2 c 0,-0.554 -0.446001,-1 -1,-1 z"
-       id="rect4251-0-0-1-1-9-5-2-3"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient20094);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="sscsssssssscsss" />
-    <path
-       d="M 7.5,8 C 7.223,8 6.8970952,8.2428238 7,8.5 V 11 H 5.5005662 c -0.277,0 -0.5,0.223 -0.5,0.5 v 6 c 0,0.277 0.223,0.5 0.5,0.5 H 42.49967 c 0.277,0 0.5,-0.223 0.5,-0.5 v -6 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 H 22 V 8.5 C 22,8.223 21.777,8 21.5,8 Z"
-       id="rect4251-4-7-62-4-4-9-2"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient3089-5-2-9-8-6-8-0-7-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999922;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="sscsssssssscsss" />
-    <path
-       d="m 7.5,8.5 v 3 H 5.5005662 v 7 H 42.49967 v -7 H 21.5 v -3 z"
-       id="rect4251-9-9-0-05-2-0-5-9"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient3381-5-5-29-4-6-5-0-4);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 4.1631662,14.50019 c -1.0723,0.12829 -0.4996,1.45416 -0.5850999,2.19974 0.1244999,0.48182 0.9274999,24.176795 0.9274999,24.176795 0,0.7414 0.3517001,0.61579 1.2429,0.61579 H 42.70867 c 0.9601,0.0231 0.7572,0.0121 0.7572,-0.62748 0,0 0.993,-25.354575 1.0285,-25.781465 0,-0.44949 0.09,-0.58338 -0.4732,-0.58338 z"
-       id="path3388-1-43-0-7-6-2-7"
-       style="fill:url(#linearGradient4638-4-6-8-9-9-5-8);fill-opacity:1;stroke:none"
-       sodipodi:nodetypes="cccscccsc" />
-    <path
-       d="m 4.5005664,15.5016 1,24.998705 H 42.46843 l 1,-24.998705 z"
-       id="path4587-4-6-3-0-1-2-6"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3381-56-2-7-5-0-8-0-0);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       d="m 24.000015,22 -7.75,7.75 1.5,1.5 1.25,-1.25 v 6 h 4 v -3 c 0,-0.554 0.446,-1 1,-1 0.554,0 1,0.446 1,1 v 3 h 4 v -6 l 1.25,1.25 1.5,-1.5 z m 3,1 v 0.75 L 30,26.75 V 23 Z"
-       id="path2998-0-1"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccsssccccccccccc" />
-    <path
-       d="m 24.000015,21 -7.75,7.75 1.5,1.5 1.25,-1.25 v 6 h 4 v -3 c 0,-0.554 0.446,-1 1,-1 0.554,0 1,0.446 1,1 v 3 h 4 v -6 l 1.25,1.25 1.5,-1.5 z m 3,1 v 0.75 L 30,25.75 V 22 Z"
-       id="path2998-4"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccsssccccccccccc" />
-    <path
-       d="m 4.0001162,14.50019 c -0.5684593,0 -0.5176917,0.584956 -0.5176917,0.584956 l 1.0231417,25.798793 c 0,0.7414 0.3517001,0.61579 1.2429,0.61579 H 42.70867 c 0.9601,0.0231 0.7572,0.0121 0.7572,-0.62748 0,0 0.992869,-25.360216 1.0285,-25.788679 0,-0.44949 0.09,-0.58338 -0.4732,-0.58338 z"
-       id="path3388-1-43-0-7-6-2-7-0"
-       style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
-       sodipodi:nodetypes="cccscccsc" />
+       style="opacity:0.6;fill:url(#radialGradient3013-6);fill-opacity:1;stroke:none;stroke-width:0.862764"
+       id="rect2801-3-7"
+       y="41.75"
+       x="40"
+       height="4.4999995"
+       width="5" />
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3015-1);fill-opacity:1;stroke:none;stroke-width:0.862764"
+       id="rect3696-6-3"
+       transform="scale(-1)"
+       y="-46.25"
+       x="-8"
+       height="4.4999995"
+       width="5" />
+    <rect
+       style="opacity:0.6;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.862764"
+       id="rect3700-4-6"
+       y="41.75"
+       x="8"
+       height="4.5"
+       width="32" />
   </g>
+  <path
+     id="rect5505-21-1-2-8-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1978);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 43.5,15.5 v -3 c 0,-2.215998 -1.784002,-4 -4,-4 H 23 C 21.671334,8.5 19.6928,6.9517957 19.058877,6.4232849 18.366939,5.8464068 17.475825,5.5 16.5,5.5 h -8 c -2.2159977,0 -4,1.7840022 -4,4 v 6" />
+  <path
+     id="rect5505-21-1-2-8-6-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.0008;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 8.5,5.9941406 C 6.5496424,5.9941406 4.9941406,7.5496423 4.9941406,9.5 v 5.505859 H 43.005859 V 12.5 c 0,-1.950358 -1.555501,-3.5058594 -3.505859,-3.5058594 H 23 c -0.856508,0 -1.717225,-0.4389419 -2.490234,-0.9121094 C 19.736756,7.6088638 19.07119,7.0789819 18.742188,6.8046875 18.135763,6.2991031 17.358508,5.9941406 16.5,5.9941406 Z"
+     transform="matrix(0.99969172,0,0,0.99869965,0.00739901,0.01365389)" />
+  <path
+     id="rect5505-21-1-2-8-6-1-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3058-5);stroke-width:0.999067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 23.000302,9.5053108 c -1.055088,0 -1.949887,-0.4946566 -2.756976,-0.988685 C 19.436236,8.0225976 18.755248,7.481097 18.413803,7.1964292 17.895743,6.7645153 17.2376,6.5061049 16.500321,6.5061049 H 8.5007938 c -1.6758618,0 -2.9951853,1.3174937 -2.9951853,2.9933557 v 4.9941264"
+     transform="matrix(1.0003033,0,0,1.0015672,-0.00727833,-0.01630123)" />
+  <path
+     id="rect5505-21-1-2-8-6-1-9-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3058-5-7);stroke-width:0.999067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 42.49439,14.493587 v -1.99297 c 0,-1.675863 -1.319323,-2.9953062 -2.995186,-2.9953062 H 23.000302"
+     transform="matrix(1.0003033,0,0,1.0015672,-0.00727833,-0.01630123)" />
+  <path
+     id="rect5505-21-1-9-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.05;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 8.4472656,10.001953 C 5.7927163,9.958176 3.4316961,12.346757 3.5,15 3.5169715,23.169697 3.466085,31.34119 3.5253906,39.509766 3.7257163,42.066113 6.1443844,44.152497 8.7,44 19.083947,43.98821 29.469177,44.023563 39.852324,43.982354 42.471899,43.876343 44.659101,41.408808 44.5,38.8 44.483028,30.69697 44.533916,22.592143 44.474609,14.490234 44.274284,11.933887 41.855616,9.8475033 39.3,10 c -10.284221,0.0013 -20.568629,-0.0026 -30.8527344,0.002 z" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-1-9"
+     y="11"
+     x="4.5000153"
+     ry="4"
+     rx="4"
+     height="32"
+     width="39" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient930-9-2);fill-opacity:1;fill-rule:nonzero;stroke:#0d52bf;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1"
+     y="12.499956"
+     x="4.5000153"
+     ry="4"
+     rx="4"
+     height="32"
+     width="39" />
+  <path
+     id="path5978"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.3;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate;font-variation-settings:normal;opacity:1;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     d="m 24,22 -9,8.5 1.832031,2.072266 L 18,31.5 V 38 h 4 v -3 c 0,-1.107999 0.892001,-2 2,-2 1.107999,0 2,0.892001 2,2 v 3 h 4 V 31.5 L 31.167969,32.572266 33,30.5 Z m 3,1 v 0.75 l 4,3.75 V 23 Z"
+     sodipodi:nodetypes="ccccccsssccccccccccc" />
+  <path
+     id="path8842"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.15000001;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate"
+     d="m 24,20 -9,8.5 1.832031,2.072266 L 18,29.5 V 36 h 4 v -3 c 0,-1.107999 0.892001,-2 2,-2 1.107999,0 2,0.892001 2,2 v 3 h 4 V 29.5 L 31.167969,30.572266 33,28.5 Z m 3,1 v 1 l 4,3.5 V 21 Z"
+     sodipodi:nodetypes="ccccccsssccccccccccc" />
+  <path
+     style="color:#000000;fill:#002e99;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 23.3125,21.273437 -9,8.5 c -0.391701,0.370391 -0.419344,0.984592 -0.0625,1.388672 l 1.832031,2.072266 C 16.325108,33.469333 16.670433,33.565583 17,33.490234 V 38 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 4 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -3 c 0,-0.571295 0.428705,-1 1,-1 0.571295,0 1,0.428705 1,1 v 3 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 4 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -4.509766 c 0.329567,0.07535 0.674892,-0.0209 0.917969,-0.255859 L 33.75,31.162109 c 0.356844,-0.40408 0.329201,-1.018281 -0.0625,-1.388672 L 31.724609,27.919922 C 31.850626,27.805648 31.945411,27.661118 32,27.5 V 23 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 h -4 c -0.372898,0.08592 -0.664075,0.377102 -0.75,0.75 l -1.5625,-1.476563 c -0.38565,-0.365037 -0.98935,-0.365037 -1.375,0 z"
+     id="path2680"
+     sodipodi:nodetypes="cccccccccssscccccccccccccccc" />
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient1192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2"
+     y="13.499956"
+     x="5.5000153"
+     ry="3"
+     rx="3"
+     height="30"
+     width="37" />
+  <path
+     id="path2998-4"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.999983;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate"
+     d="m 24,21 -9,8.5 1.832031,2.072266 L 18,30.5 V 37 h 4 v -3 c 0,-1.107999 0.892001,-2 2,-2 1.107999,0 2,0.892001 2,2 v 3 h 4 V 30.5 L 31.167969,31.572266 33,29.5 Z m 3,1 v 0.75 l 4,3.75 V 22 Z"
+     sodipodi:nodetypes="ccccccsssccccccccccc" />
 </svg>

--- a/elementary-xfce/apps/64/system-file-manager.svg
+++ b/elementary-xfce/apps/64/system-file-manager.svg
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   version="1.1"
-   width="64"
+   id="svg13986"
    height="64"
-   id="svg24942"
+   width="64"
+   version="1.1"
+   xml:space="preserve"
    sodipodi:docname="system-file-manager.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -13,266 +14,254 @@
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:dc="http://purl.org/dc/elements/1.1/">
-  <sodipodi:namedview
-     id="namedview56"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview61"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="15.070213"
-     inkscape:cx="38.320626"
-     inkscape:cy="35.832273"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="168"
-     inkscape:window-y="40"
+     inkscape:zoom="18.340582"
+     inkscape:cx="32.768862"
+     inkscape:cy="38.575657"
+     inkscape:window-width="1280"
+     inkscape:window-height="954"
+     inkscape:window-x="636"
+     inkscape:window-y="61"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer1" />
-  <defs
-     id="defs24944">
-    <linearGradient
-       x1="97.538795"
-       y1="16.962049"
-       x2="97.538795"
-       y2="44.260689"
-       id="linearGradient22622"
-       xlink:href="#linearGradient8272-8-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3210282,0,0,1.2679796,-70.729885,-0.82613866)" />
-    <linearGradient
-       id="linearGradient8272-8-8">
-      <stop
-         id="stop8274-4"
+     inkscape:current-layer="svg13986"
+     inkscape:lockguides="false" /><defs
+     id="defs13988"><linearGradient
+       id="linearGradient1077"><stop
+         id="stop1069"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop8276-5"
+         offset="0" /><stop
+         id="stop1071"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.0221225" />
-      <stop
-         id="stop8278-0"
+         offset="0.09530682" /><stop
+         id="stop1073"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97909725" />
-      <stop
-         id="stop8280-5-9"
+         offset="0.94268352" /><stop
+         id="stop1075"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-91"
-       y1="43.999817"
-       x2="-91"
-       y2="113.33592"
-       id="linearGradient22614"
-       xlink:href="#linearGradient4632-0-6-4-4-4"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.50413225,0,0,0.49333391,73.843637,-2.4532388)" />
-    <linearGradient
-       id="linearGradient4632-0-6-4-4-4">
-      <stop
-         id="stop4634-4-4-7-4"
-         style="stop-color:#e9e9e9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4636-3-1-5-9"
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient22610"
-       xlink:href="#linearGradient5060-820-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.04016195,0,0,0.0329426,31.205011,36.921441)" />
-    <linearGradient
-       id="linearGradient5060-820-8">
-      <stop
-         id="stop2681-37"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2683-05"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507"
-       id="linearGradient22606"
-       xlink:href="#linearGradient5048-585-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.10355029,0,0,0.03294117,-5.4260416,36.922311)" />
-    <linearGradient
-       id="linearGradient5048-585-1">
-      <stop
-         id="stop2667-0"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2669-91"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2671-6"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="605.71429"
-       cy="486.64789"
-       r="117.14286"
-       fx="605.71429"
-       fy="486.64789"
-       id="radialGradient22602"
-       xlink:href="#linearGradient5060-820-8"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.04016195,0,0,0.0329426,32.79698,36.921441)" />
-    <linearGradient
-       x1="97.538795"
-       y1="8.8103228"
-       x2="97.538795"
-       y2="44.260689"
-       id="linearGradient22598"
-       xlink:href="#linearGradient9235-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.2749674,0,0,1.218292,-67.158525,-1.3391588)" />
-    <linearGradient
-       id="linearGradient9235-9">
-      <stop
-         id="stop9237-7"
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient1041"><stop
+         id="stop1033"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop9239-2-3"
+         offset="0" /><stop
+         id="stop1035"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.1088333" />
-      <stop
-         id="stop9241-1"
+         offset="0.0832339" /><stop
+         id="stop1037"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.97909725" />
-      <stop
-         id="stop9243-5"
+         offset="0.94268352" /><stop
+         id="stop1039"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="-51.786404"
-       y1="53.514328"
-       x2="-51.786404"
-       y2="3.6336823"
-       id="linearGradient22594"
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5-1-0-5"
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient3688-166-749-4-0-3-8"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-4-0-1-8" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-9-2-9-6" /></linearGradient><linearGradient
+       id="linearGradient3702-501-757-8-4-1-1"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-8-9-9-1" /><stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-7-8-7-7" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-4-5-1-5" /></linearGradient><linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient6394"
+       xlink:href="#linearGradient3702-501-757-8-4-1-1"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0563766,0,0,1.0770552,69.975817,-3.5295988)" />
-    <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5-1-0-5">
-      <stop
-         id="stop3106-5-4-3-5-0-2-1-0-1-2-7"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         offset="0" />
-      <stop
-         id="stop3108-4-3-7-8-2-0-7-9-4-9-4-5"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient6404-7-5-7">
-      <stop
-         id="stop6406-1-8-2"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop6408-9-6-4"
-         style="stop-color:#c9c9c9;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="62.988873"
-       y1="14.235775"
-       x2="62.988873"
-       y2="17.888897"
-       id="linearGradient24940"
-       xlink:href="#linearGradient6404-7-5-7"
+       gradientTransform="matrix(1.5714286,0,0,0.7142857,-5.7142853,27.928572)" /><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient909"><stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient4270-4"><stop
+         id="stop4272-9"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" /><stop
+         id="stop4274-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.09665164" /><stop
+         id="stop4276-9"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94268352" /><stop
+         id="stop4278-1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" /></linearGradient><linearGradient
+       xlink:href="#linearGradient1041"
+       id="linearGradient15429"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3135526,0,0,1.2900554,-55.484955,-2.2218088)" />
-  </defs>
-  <metadata
-     id="metadata24947">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     id="layer1">
-    <path
-       d="m 57.001,49.000051 c 0,0 0,7.999911 0,7.999911 2.06824,0.0151 5,-1.79238 5,-4.000471 0,-2.2081 -2.308,-3.99944 -5,-3.99944 z"
-       id="use6506"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient22602);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <rect
-       width="50"
-       height="8"
-       x="7"
-       y="49.000118"
-       id="use6508"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient22606);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999996;marker:none" />
-    <path
-       d="m 7.001,49.000051 c 0,0 0,7.999911 0,7.999911 -2.06825,0.0151 -5,-1.79238 -5,-4.000471 0,-2.2081 2.308,-3.99944 5,-3.99944 z"
-       id="use6510"
-       style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient22610);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-    <path
-       d="m 9.501,9.9999706 c -0.277,0 -0.5,0.2230014 -0.5,0.5000004 v 3.5 h -2.5 c -0.277,0 -0.5,0.223 -0.5,0.5 v 9.5 c 0,0.277 0.223,0.5 0.5,0.5 h 51 c 0.277,0 0.5,-0.223 0.5,-0.5 v -9.5 c 0,-0.277 -0.223,-0.5 -0.5,-0.5 H 28.000667 v -3.5 c 0,-0.277 -0.223,-0.5000004 -0.5,-0.5000004 z"
-       id="use6500"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient24940);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="sscsssssssscsss" />
-    <path
-       d="m 10.001,9.5001306 c -0.91501,0.0102 -1.5,0.45618 -1.5,1.3332904 v 2.66655 H 6.995 c -0.99492,0 -1.494,0.47358 -1.494,1.34217 0.0456,13.71958 0,14.49301 0,15.65783 1.90283,0 52.99999,-4.9328 52.99999,-7.05611 v -8.44389 c 0,-1.00007 -0.500555,-1.535067 -1.49999,-1.5 H 28.500667 v -2.66655 c 0,-0.8771104 -0.22453,-1.3435104 -1.13954,-1.3332904 z"
-       id="use6502"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient22594);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="cscsccssscscc" />
-    <path
-       d="m 9.501,10.499971 v 4 h -3 v 10 h 51 v -10 H 27.500667 v -4 z"
-       id="use6504"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient22598);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccccc" />
-    <path
-       d="m 4.50454,19.532162 c -1.44043,0.16346 -0.87122,1.85289 -0.98607,2.8029 0.5271,11.19318 1.25951,18.809309 1.78336,30.002558 0,1.189961 1.19486,1.136531 1.86516,1.136531 H 57.6575 c 1.46281,-0.140931 0.85463,-1.860241 1.0604,-2.844201 0.52711,-11.19317 1.25992,-18.569348 1.78376,-29.762598 0.0178,-0.7521 -0.50074,-1.33519 -1.21534,-1.33519 z"
-       id="use6512"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient22614);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="cccscccsc" />
-    <path
-       d="m 59.06943,20.500052 -53.11794,0.0313 c -1.70924,0 -1.43419,0.0338 -1.43419,1.07579 L 6.13844,51.52118 c 0.0163,0.94321 -0.0656,0.979301 1.0726,0.979301 H 57.6507 c 0.53983,-11.582251 1.25805,-19.682719 1.81479,-31.322279 0.0519,-0.55489 0.0134,-0.67818 -0.39606,-0.67818 z"
-       id="use6516"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient22622);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccscccc" />
-    <path
-       d="m 31.999997,28.00025 -11.187747,11.1873 2.375,2.34375 1.8125,-1.78125 V 48 h 5.000247 v -3.99995 c 0,-1.10457 0.89543,-2 2,-2 1.10457,0 2,0.89543 2,2 V 48 h 5.000253 v -8.24995 l 1.8125,1.78125 2.375,-2.34375 z M 36.00025,28 v 2.219 L 40,34 v -6 z"
-       id="path3681"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#fefefe;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccsssccccccccccc" />
-    <path
-       d="m 31.999997,27.00025 -11.187747,11.1873 2.375,2.34375 1.8125,-1.78125 V 47 h 5.000247 v -3.99995 c 0,-1.10457 0.89543,-2 2,-2 1.10457,0 2,0.89543 2,2 V 47 h 5.000253 v -8.24995 l 1.8125,1.78125 2.375,-2.34375 z M 36.00025,27 v 2.219 L 40,33 v -6 z"
-       id="path2998-4-3"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="ccccccsssccccccccccc" />
-    <path
-       d="m 4.50454,19.532162 c -1.44043,0.16346 -0.87122,1.85289 -0.98607,2.8029 0.5271,11.19318 1.25951,18.809309 1.78336,30.002558 0,1.189961 1.19486,1.136531 1.86516,1.136531 H 57.6575 c 1.46281,-0.140931 0.85463,-1.860241 1.0604,-2.844201 0.52711,-11.19317 1.25992,-18.569348 1.78376,-29.762598 0.0178,-0.7521 -0.50074,-1.33519 -1.21534,-1.33519 z"
-       id="use6512-8"
-       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-opacity:1;marker:none;enable-background:accumulate"
-       sodipodi:nodetypes="cccscccsc" />
-  </g>
-</svg>
+       gradientTransform="matrix(1.4324324,0,0,1.1081081,-2.378375,11.33418)"
+       x1="23.99999"
+       y1="-1.2218014"
+       x2="23.99999"
+       y2="42.091705" /><linearGradient
+       xlink:href="#linearGradient909"
+       id="linearGradient15431"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,0.81818188,0,10.81818)"
+       x1="31.781376"
+       y1="-11.234498"
+       x2="31.781376"
+       y2="67.800774" /><linearGradient
+       xlink:href="#linearGradient4270-4"
+       id="linearGradient15433"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.1621622,-2.378375,9.03688)"
+       x1="23.99999"
+       y1="5.9093657"
+       x2="23.99999"
+       y2="42.091705" /><radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,41.985755,15.500001)" /><radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,-22.014244,-102.5)" /><linearGradient
+       xlink:href="#linearGradient1077"
+       id="linearGradient15429-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.1081081,-2.378375,11.33418)"
+       x1="11.575833"
+       y1="-4.7840924"
+       x2="11.575833"
+       y2="42.193623" /><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,10.835333,-0.132171)"
+       x1="12.879265"
+       y1="66.950981"
+       x2="12.879265"
+       y2="4.7802162" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3804479,0,0,1.327717,-70.158247,-1.4115461)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" /></defs><metadata
+     id="metadata13991"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-7-8-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99983468;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000;opacity:1;vector-effect:none;-inkscape-stroke:none;stop-opacity:1"
+     d="M 10.5,5.0039062 C 7.4459419,5.0039062 5.0039062,7.4459419 5.0039062,10.5 V 46.996094 H 58.996094 V 14.5 c 0,-3.054058 -2.442036,-5.4960938 -5.496094,-5.4960938 H 30.046875 A 0.50301378,0.50301378 0 0 1 29.998047,9 c 0,0 -2.421334,-0.2478661 -4.705078,-2.4863281 l -0.0039,-0.00391 C 24.304204,5.5738641 22.976321,5.0039062 21.5,5.0039062 Z"
+     transform="matrix(1.0001447,0,0,1.000186,-0.00463022,-0.00483712)" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-6-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000;opacity:1;vector-effect:none;-inkscape-stroke:none;stop-opacity:1"
+     d="m 59.49953,19.5 v -5 c 0,-3.324 -2.676,-6 -6,-6 H 30.04602 c 0,0 -2.23097,-0.21547 -4.40528,-2.34924 C 24.56544,5.12691 23.10839,4.5 21.49953,4.5 h -11 c -3.324,0 -6,2.676 -6,6 v 9" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-4-8-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient15429);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 58.500002,47.27464 C 58.489602,36.22162 58.520782,25.16751 58.484442,14.11517 58.347691,11.49872 55.882759,9.33447 53.274609,9.5 45.454334,9.4843 37.630651,9.5313 29.8125,9.4766" /><path
+     id="rect5505-21-3-8-5-2-9-1-7-8-0-6-4-8-7-5"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient15429-3);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 29.8125,9.4766 C 27.755508,9.1503 26.003386,7.91429 24.522198,6.51602 23.109367,5.34319 21.205489,5.47837 19.490234,5.5 16.398484,5.505 13.306411,5.4895 10.214844,5.508 V 5.50781 C 7.599997,5.59551 5.373462,8.012 5.5,10.62539 5.51023,23.04509 5.47954,35.46583 5.51534,47.88487" /><g
+     id="g866"><rect
+       style="opacity:0.6;fill:url(#radialGradient3337-2-2);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect2801-5-5-7-9"
+       y="56.5"
+       x="54"
+       height="5"
+       width="6" /><rect
+       style="opacity:0.6;fill:url(#radialGradient3339-1-4);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-61.5"
+       x="-10"
+       height="5"
+       width="6" /><rect
+       style="opacity:0.6;fill:url(#linearGradient6394);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3700-5-6-8-4"
+       y="56.5"
+       x="10"
+       height="5.0000005"
+       width="44" /></g><path
+     id="rect5505-21-1-7-2-9-9-3-9-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.05;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 10.455078,12.00195 C 7.4582,11.95105 4.44656,14.15974 4.058488,17.21865 3.594602,20.08693 5.68396,22.92102 8.420635,23.68269 10.326431,24.24726 12.343748,23.90578 14.3,24 27.514675,23.9867 40.730664,24.0266 53.944518,23.9801 56.946237,23.87831 59.836053,21.45233 59.981375,18.36477 60.239186,15.3947 57.831591,12.68529 54.975698,12.15914 53.03837,11.83594 51.056008,12.07244 49.1,12 36.218389,12.001 23.336541,11.997 10.455078,12.002 Z" /><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-9-2-0"
+     y="13"
+     x="5"
+     ry="5.5000005"
+     rx="5.5"
+     height="10"
+     width="54" /><rect
+     width="55"
+     height="45.000004"
+     rx="6"
+     ry="6"
+     x="4.5"
+     y="14.5"
+     id="rect5505-21-3-8-5-2-9-7-3-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient15431);fill-opacity:1;fill-rule:nonzero;stroke:#0d52bf;stroke-width:0.999999;stroke-opacity:0.5;marker:none;enable-background:accumulate" /><path
+     style="color:#000000;fill:#002e99;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 36,25 c -0.552262,5.5e-5 -0.999945,0.447738 -1,1 v 1.425781 l -2.318359,-2.158203 c -0.384036,-0.357702 -0.979246,-0.357702 -1.363282,0 l -14.5,13.5 c -0.392641,0.36541 -0.427112,0.975501 -0.07813,1.382813 l 3,3.5 c 0.379054,0.442614 1.05474,0.468706 1.466797,0.05664 L 22,42.914062 V 51 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 6 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -5.908203 c 0,-0.4705 0.156045,-1.042531 0.458984,-1.429688 C 30.761924,43.274952 31.160985,43 32,43 c 0.839014,0 1.238076,0.274952 1.541016,0.662109 C 33.843956,44.049266 34,44.621298 34,45.091797 V 51 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 6 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -8.085938 l 0.792969,0.792969 c 0.412057,0.412066 1.087743,0.385974 1.466797,-0.05664 l 3,-3.5 c 0.348982,-0.407312 0.314511,-1.017403 -0.07813,-1.382813 L 41.501953,33.480469 C 41.782141,33.320008 41.967624,33.034146 42,32.712891 V 26 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 z"
+     id="path1966"
+     sodipodi:nodetypes="ccccccccccccccssssscccccscccccccc" /><rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient15433);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-8-33-4"
+     y="15.428772"
+     x="5.5"
+     ry="5"
+     rx="5"
+     height="43"
+     width="53" /><path
+     id="path5538"
+     d="M 32,24 17.5,37.5 20.5,41 23,38.5 V 49 h 6 v -5.908393 c 0,-1.336183 0.792054,-3.091214 3,-3.091214 2.207944,0 3,1.755031 3,3.091214 V 49 h 6 V 38.5 l 2.5,2.5 3,-3.5 z m 4,0 v 2.25 l 5,4.462963 V 24 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /><path
+     id="path5469"
+     d="M 32,26 17.5,39.5 20.5,43 23,40.5 V 51 h 6 v -5.908393 c 0,-1.336183 0.792054,-3.091214 3,-3.091214 2.207944,0 3,1.755031 3,3.091214 V 51 h 6 V 40.5 l 2.5,2.5 3,-3.5 z m 4,0 v 2.249518 l 5,4.462964 V 26 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.3;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /><path
+     id="path4050"
+     d="M 32,25 17.5,38.5 20.5,42 23,39.5 V 50 h 6 v -5.908393 c 0,-1.336183 0.792054,-3.091214 3,-3.091214 2.207944,0 3,1.755031 3,3.091214 V 50 h 6 V 39.5 l 2.5,2.5 3,-3.5 z m 4,0 v 2.25 l 5,4.462963 V 25 Z"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
+     sodipodi:nodetypes="ccccccszsccccccccccc" /></svg>

--- a/elementary-xfce/apps/96/system-file-manager.svg
+++ b/elementary-xfce/apps/96/system-file-manager.svg
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
+   version="1.1"
    width="96"
    height="96"
-   id="svg18157"
-   version="1.1"
+   id="svg6649"
    sodipodi:docname="system-file-manager.svg"
-   inkscape:version="1.1.1 (3bf5ae0d25, 2021-09-20)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -17,208 +17,226 @@
   <sodipodi:namedview
      id="namedview61"
      pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageshadow="2"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="20.093618"
-     inkscape:cx="51.782612"
-     inkscape:cy="44.740575"
-     inkscape:window-width="1317"
-     inkscape:window-height="890"
-     inkscape:window-x="175"
-     inkscape:window-y="30"
+     inkscape:zoom="22.627418"
+     inkscape:cx="52.900424"
+     inkscape:cy="48.613589"
+     inkscape:window-width="1278"
+     inkscape:window-height="909"
+     inkscape:window-x="520"
+     inkscape:window-y="41"
      inkscape:window-maximized="0"
-     inkscape:current-layer="g3953" />
+     inkscape:current-layer="svg6649" />
   <defs
-     id="defs18159">
+     id="defs6651">
     <linearGradient
-       xlink:href="#linearGradient4632-0-6-4"
-       id="linearGradient12481"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9997551,0,0,2.0714256,0.0113782,-54.678508)"
-       x1="35.792694"
-       y1="17.118193"
-       x2="35.792694"
-       y2="43.761127" />
-    <linearGradient
-       id="linearGradient4632-0-6-4">
+       id="linearGradient2511">
       <stop
-         style="stop-color:#e9e9e9;stop-opacity:1"
-         offset="0"
-         id="stop4634-4-4-7" />
-      <stop
-         style="stop-color:#b4b4b4;stop-opacity:1"
-         offset="1"
-         id="stop4636-3-1-5" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5060-820-91-9-0"
-       id="radialGradient12475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-0.06158166,0,0,0.04973261,48.7795,10.363907)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       id="linearGradient5060-820-91-9-0">
-      <stop
-         id="stop2681-778-5-1"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2503"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2683-2-86-2"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient5060-179-37-4-0"
-       id="radialGradient12471"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.06158166,0,0,0.04973261,47.22016,10.363907)"
-       cx="605.71429"
-       cy="486.64789"
-       fx="605.71429"
-       fy="486.64789"
-       r="117.14286" />
-    <linearGradient
-       id="linearGradient5060-179-37-4-0">
+         id="stop2505"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.08629532" />
       <stop
-         id="stop2675-91-9-2"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
+         id="stop2507"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93042839" />
       <stop
-         id="stop2677-09-0-9"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop2509"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient5048-585-73-1-5"
-       id="linearGradient12467"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.15049379,0,0,0.04973261,-6.3927619,10.363907)"
-       x1="302.85715"
-       y1="366.64789"
-       x2="302.85715"
-       y2="609.50507" />
-    <linearGradient
-       id="linearGradient5048-585-73-1-5">
+       id="linearGradient2392">
       <stop
-         id="stop2667-99-4-6"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop2384"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop2669-5-9-4"
-         style="stop-color:#000000;stop-opacity:1"
+         id="stop2386"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07945278" />
+      <stop
+         id="stop2388"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop2390"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
          offset="0.5" />
       <stop
-         id="stop2671-56-4-2"
-         style="stop-color:#000000;stop-opacity:0"
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4507-0-4-7"
-       id="linearGradient12463"
+       x1="13.320448"
+       y1="5.8028727"
+       x2="13.320448"
+       y2="42.227989"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient2392"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.8490408,0,0,2.2218594,4.7135631,-41.207439)"
-       x1="21.37039"
-       y1="4.2476678"
-       x2="21.37039"
-       y2="34.143417" />
+       gradientTransform="matrix(2.0577668,0,0,2.1283303,-1.8292498,-0.21879658)" />
     <linearGradient
-       id="linearGradient4507-0-4-7">
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient1191"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.1428571,0,0,0.6428571,-3.428569,16.035716)" />
+    <linearGradient
+       id="linearGradient3600-9-51">
       <stop
-         id="stop4509-35-6-1"
-         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0"
+         style="stop-color:#f4f4f4;stop-opacity:1"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#dbdbdb;stop-opacity:1"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9933657,0,0,2.0735654,-99.516413,0.99975867)"
+       x1="74.838791"
+       y1="4.7853589"
+       x2="74.838791"
+       y2="45.85183" />
+    <linearGradient
+       id="linearGradient909">
+      <stop
+         id="stop901"
+         style="stop-color:#64baff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4511-46-3-8"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.07395859" />
-      <stop
-         id="stop4513-15-5-9"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.99001008" />
-      <stop
-         id="stop4515-1-1-8"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop907"
+         style="stop-color:#3689e6;stop-opacity:1"
          offset="1" />
     </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4646-7-4-3"
-       id="linearGradient12459"
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.047619,0,0,2.0999999,-105.45041,-51.899999)"
-       x1="62.988873"
-       y1="13"
-       x2="62.988873"
-       y2="16" />
+       gradientTransform="matrix(2.003784,0,0,0.89999994,29.98813,4.8500025)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-1"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,0.89999994,-18.01187,-83.149997)" />
     <linearGradient
-       id="linearGradient4646-7-4-3">
-      <stop
-         offset="0"
-         style="stop-color:#f9f9f9;stop-opacity:1"
-         id="stop4648-8-0-3" />
-      <stop
-         offset="1"
-         style="stop-color:#d8d8d8;stop-opacity:1"
-         id="stop4650-1-7-3" />
-    </linearGradient>
+       xlink:href="#linearGradient909"
+       id="linearGradient930-9-2"
+       x1="16.767664"
+       y1="-7.643558"
+       x2="16.767664"
+       y2="32.286724"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.925925,0,0,2.4074066,1.1852336,18.481405)" />
     <linearGradient
-       id="linearGradient3104-8-8-97-4-6-11-5-5">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.32173914"
-         id="stop3106-5-4-3-5-0-2-1-0" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.27826086"
-         id="stop3108-4-3-7-8-2-0-7-9" />
-    </linearGradient>
+       xlink:href="#linearGradient1201"
+       id="linearGradient1192"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0810811,0,0,1.7027027,-1.9459714,16.135156)"
+       x1="23.976463"
+       y1="4.9505701"
+       x2="23.976463"
+       y2="43.098244" />
     <linearGradient
-       y2="3.6336823"
-       x2="-51.786404"
-       y1="53.514328"
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1978"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6356971,0,0,1.8341666,21.333136,5.1040286)"
        x1="-51.786404"
-       gradientTransform="matrix(1.6337756,0,0,1.7432828,215.6808,-51.418758)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient18155"
-       xlink:href="#linearGradient3104-8-8-97-4-6-11-5-5" />
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
     <linearGradient
-       xlink:href="#linearGradient8272"
-       id="linearGradient5891"
+       x1="35.996761"
+       y1="8.8111582"
+       x2="35.996761"
+       y2="40.922527"
+       id="linearGradient3058-5-7"
+       xlink:href="#linearGradient2511"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.9636254,0,0,2.0287677,-104.69613,-53.621911)"
-       x1="97.538795"
-       y1="16.962049"
-       x2="97.538795"
-       y2="44.260689" />
-    <linearGradient
-       id="linearGradient8272">
-      <stop
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop8274" />
-      <stop
-         offset="0.0221225"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop8276" />
-      <stop
-         offset="0.97909725"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop8278" />
-      <stop
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop8280" />
-    </linearGradient>
+       gradientTransform="matrix(2.0519043,0,0,2.205171,-1.6944068,-1.2556523)" />
   </defs>
   <metadata
-     id="metadata18162">
+     id="metadata6654">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -229,70 +247,102 @@
     </rdf:RDF>
   </metadata>
   <g
-     id="layer1"
-     transform="translate(0,48)">
-    <g
-       id="g4111"
-       transform="translate(0,-1)">
-      <path
-         id="rect4251-0-0-61"
-         d="m 12.50027,-31.5 c -1.120885,0 -2.012883,0.932618 -2,2.09091 l 0.04651,3.909091 H 8.5235249 c -1.1208833,0 -2.0232553,0.841636 -2.0232553,2 v 12.909091 c 0,1.1583642 0.9023719,2.0909078 2.0232558,2.0909078 H 87.476391 c 1.120884,0 2.023257,-0.9325436 2.023257,-2.0909078 v -12.909091 c 0,-1.158364 -0.880219,-1.950219 -1.999998,-2 H 42.511629 l -0.01163,-4 c -0.0034,-1.158359 -0.879116,-2.000001 -2,-2.000001 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.8;fill:none;stroke:url(#linearGradient18155);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="sccssssssssccss" />
-      <path
-         id="rect4251-3-2"
-         d="m 12.50027,-30.999999 c -0.838421,0 -1.5,0.832067 -1.5,1.5 v 4.5 H 8.5002696 c -1.1558134,0 -1.5,1.079599 -1.5,1.5 v 12.45 c 0,0.5817 0.456619,1.0500002 1.0238094,1.0500002 H 87.97584 c 0.567191,0 1.02381,-0.4683002 1.02381,-1.0500002 v -12.45 c 0,-0.672063 -0.562261,-1.5 -1.5,-1.5 H 42 v -4.5 c 0,-0.788784 -0.692749,-1.5 -1.5,-1.5 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient12459);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="sscsssssssscsss" />
-      <path
-         id="rect4251-9-21-7"
-         d="m 12.50027,-30.499999 c -0.587226,0.10637 -0.95027,0.447766 -1,1 v 5 H 8.5002696 c -0.5809285,0.05823 -0.9489291,0.353042 -1,1 l -2e-7,13.9999992 H 88.49965 V -23.499999 c -0.09353,-0.778684 -0.49653,-0.982634 -1,-1 H 41.5 v -5 c -0.05959,-0.637493 -0.410196,-0.951634 -1,-1 z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:url(#linearGradient12463);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccccccccccc" />
-      <rect
-         width="72.667"
-         height="12.077923"
-         x="11.6665"
-         y="28.598267"
-         id="rect4173-8-8"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#linearGradient12467);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999998;marker:none" />
-      <path
-         d="m 84.333,28.59869 c 0,0 0,12.077258 0,12.077258 3.1713,0.02275 7.66666,-2.705897 7.66666,-6.039404 0,-3.333506 -3.53894,-6.037854 -7.66666,-6.037854 z"
-         id="path5058-9-0"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient12471);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-      <path
-         d="m 11.66666,28.59869 c 0,0 0,12.077258 0,12.077258 C 8.49536,40.698698 4,37.970051 4,34.636544 4,31.303038 7.53894,28.59869 11.66666,28.59869 Z"
-         id="path5018-6-6"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.3;fill:url(#radialGradient12475);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none" />
-      <path
-         d="m 6.336338,-18.499997 c -1.496068,0.534816 -1.3252964,1.367822 -1.3340199,1.876795 l 2.008001,49.63918 c 0.060237,1.489116 0.9996387,2.483867 2.4990969,2.483867 h 76.97012 c 1.499458,0 2.499096,-0.993547 2.499096,-2.483867 0,0 1.896081,-48.503947 1.967112,-49.357726 0.116149,-0.78283 -0.608381,-2.158251 -1.946094,-2.158251 z"
-         id="path3388-7-1"
-         style="fill:url(#linearGradient12481);fill-opacity:1;stroke:none"
-         sodipodi:nodetypes="ccsssccsc" />
-      <path
-         d="m 6.3253723,-18.498855 c -1.4498058,0.490696 -1.3251137,1.367794 -1.3416418,1.884521 l 2.014212,49.484848 c 0.060305,1.481555 0.7176741,2.629333 2.4993083,2.629339 l 77.0284942,3.02e-4 c 1.919334,0.0462 2.430691,-1.630308 2.434048,-2.9013 0,0 1.927661,-48.249092 1.99867,-49.102854 0,-0.89896 -0.832577,-1.996015 -1.958813,-1.996 z"
-         id="path3388-7-1-7"
-         style="opacity:0.3;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1"
-         sodipodi:nodetypes="ccsscccsc" />
-      <path
-         id="path8263"
-         d="m 7.0002696,-17.50001 c -0.806995,-0.03397 -1.0765593,0.261538 -1,1.000011 0.5788399,16.835802 1.4366806,32.942448 2.0141504,49.778274 0.2505668,1.015256 0.4999205,1.23771 1.98585,1.22157 25.953775,0.01531 50.545615,-0.01531 76.49938,0 0.87582,-0.01003 1.33346,-0.395498 1.5,-2 0.629524,-16.851886 1.95,-48.799844 1.95,-48.799844 0.0098,-0.764126 -0.447953,-1.296561 -1.45,-1.200003 z"
-         style="display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient5891);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccccccc" />
-    </g>
-    <g
-       id="g3953"
-       transform="translate(-0.71875,10)">
-      <path
-         id="path2998-4-3-7"
-         d="m 48.7185,-14.999813 -17.280875,17.2808754 3.5625,3.515625 2.71875,-2.671875 V 16 H 45.7185 V 9.499812 c 0,-1.6568546 1.343144,-2.9999996 3,-2.9999996 1.656855,0 3,1.343145 3,2.9999996 V 16 h 8.000125 V 3.1248124 l 2.71875,2.671875 3.5625,-3.515625 z M 54.71875,-14 v 2.128 l 4.999875,4.6534371 V -14 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#ffffff;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccccsssccccccccccc" />
-      <path
-         id="path2998-4-3"
-         d="m 48.7185,-15.999812 -17.280875,17.2808744 3.5625,3.515625 2.71875,-2.671875 V 15 H 45.7185 V 8.4998124 c 0,-1.656857 1.343144,-3 3,-3 1.656855,0 3,1.343143 3,3 V 15 h 8.000125 V 2.1248124 l 2.71875,2.671875 3.5625,-3.515625 z M 54.71875,-15 v 2.128 l 4.999875,4.653437 V -15 Z"
-         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.6;fill-rule:nonzero;stroke:none;stroke-width:1.7;marker:none;enable-background:accumulate"
-         sodipodi:nodetypes="ccccccsssccccccccccc" />
-    </g>
+     id="g1784"
+     transform="scale(2)"
+     style="stroke-width:0.5">
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3013-6);fill-opacity:1;stroke:none;stroke-width:0.431382"
+       id="rect2801-3-7"
+       y="41.75"
+       x="40"
+       height="4.4999995"
+       width="5" />
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3015-1);fill-opacity:1;stroke:none;stroke-width:0.431382"
+       id="rect3696-6-3"
+       transform="scale(-1)"
+       y="-46.25"
+       x="-8"
+       height="4.4999995"
+       width="5" />
+    <rect
+       style="opacity:0.6;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.431382"
+       id="rect3700-4-6"
+       y="41.75"
+       x="8"
+       height="4.5"
+       width="32" />
   </g>
+  <path
+     id="rect5505-21-1-2-8-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1978);stroke-width:0.999923;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 87.49996,32 v -7.149988 c 0,-4.542788 -3.613744,-8.199985 -8.102556,-8.199985 H 45.97436 c -2.691397,0 -6.699193,-3.173812 -7.983292,-4.257257 -1.401617,-1.182598 -3.206692,-1.892731 -5.183361,-1.892731 H 16.602595 c -4.488812,0 -8.1025562,3.657197 -8.1025562,8.199984 V 32"
+     sodipodi:nodetypes="csssssssc" />
+  <path
+     id="rect5505-21-1-2-8-6-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 16.457795,11 c -4.002133,0 -7.4577949,3.427265 -7.4577949,7.643217 V 32 H 87.000001 V 25.031587 C 87.000001,20.703094 83.808116,17 79.805983,17 H 45.5 C 43.742447,17 41.49715,15.59526 39.949375,14.48927 38.362326,13.355215 37.922797,12.983312 37.210977,12.391794 35.922293,11.320905 34.371668,11 32.610009,11 Z"
+     sodipodi:nodetypes="ssccsssssss" />
+  <path
+     id="rect5505-21-1-2-8-6-1-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3058-5);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 46,17.5 c -2.171125,0 -3.452701,-0.669491 -5.113502,-1.720947 -1.660802,-1.051456 -3.062117,-2.203948 -3.76473,-2.809815 C 36.055719,12.049982 34.701416,11.5 33.184267,11.5 H 16.325202 C 12.876669,11.5 9.5,14.881551 9.5,18.44834 V 28.5"
+     sodipodi:nodetypes="csssssc" />
+  <path
+     id="rect5505-21-1-2-8-6-1-9-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3058-5-7);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 86.5,28.5 V 24.410964 C 86.5,20.715399 83.051102,17.5 79.612393,17.5 H 47"
+     sodipodi:nodetypes="cssc" />
+  <path
+     id="rect5505-21-1-9-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.05;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 16.900094,22.019386 c 20.561967,-0.009 41.124539,-0.0013 61.686738,-0.0039 5.10968,-0.300367 9.945548,3.809133 10.346077,8.844311 0.11858,15.958144 0.01683,31.922034 0.05076,47.882385 0.318106,5.13851 -4.054971,9.998756 -9.29253,10.207564 -20.759991,0.08118 -41.524146,0.01155 -62.285736,0.03477 C 12.295725,89.284886 7.459857,85.175383 7.0593273,80.140205 6.9407513,64.05075 7.0424923,47.955548 7.0085603,31.863884 6.8719939,26.637852 11.592602,21.933116 16.900091,22.019366 l -3e-6,-2e-5"
+     sodipodi:nodetypes="cccccccccc" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.1;vector-effect:none;fill:#002e99;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-1-9"
+     y="23"
+     x="8.5"
+     ry="8"
+     rx="8"
+     height="65"
+     width="79" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient930-9-2);fill-opacity:1;fill-rule:nonzero;stroke:#0d52bf;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1"
+     y="24.499912"
+     x="8.5000305"
+     ry="8"
+     rx="8"
+     height="65"
+     width="79" />
+  <path
+     style="color:#000000;fill:#002e99;fill-opacity:0.15;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 47.3125,41.273437 -18,17 c -0.391701,0.370391 -0.419344,0.984592 -0.0625,1.388672 l 3.664062,4.144532 c 0.37074,0.419393 1.0135,0.452853 1.425782,0.07422 L 35,63.275391 V 74 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 8 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 v -6 c 0,-1.679292 1.320708,-3 3,-3 1.679292,0 3,1.320708 3,3 v 6 c 5.5e-5,0.552262 0.447738,0.999945 1,1 h 8 c 0.552262,-5.5e-5 0.999945,-0.447738 1,-1 V 63.275391 l 0.660156,0.605468 c 0.412282,0.378632 1.055041,0.345173 1.425781,-0.07422 L 66.75,59.662109 c 0.356844,-0.40408 0.329201,-1.018281 -0.0625,-1.388672 L 62.003906,53.849609 C 62.500929,53.853275 62.925222,53.491379 63,53 v -9 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 h -8 c -0.552262,5.5e-5 -0.999945,0.447738 -1,1 v 1.345703 l -4.3125,-4.072266 c -0.38565,-0.365037 -0.98935,-0.365037 -1.375,0 z"
+     id="path897"
+     sodipodi:nodetypes="ccccccccccssscccccccccccccccccc" />
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient1192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2"
+     y="25.5"
+     x="9.5"
+     ry="7"
+     rx="7"
+     height="63"
+     width="77" />
+  <path
+     id="path24604"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.15000001;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate"
+     d="M 48,40 30,57 33.664062,61.144532 36,59 v 13 h 8 v -6 c 0,-2.215998 1.784002,-4 4,-4 2.215998,0 4,1.784002 4,4 v 6 h 8 V 59 L 62.335938,61.144532 66,57 Z m 6,2 v 1.5 l 8,7.5 v -9 z"
+     sodipodi:nodetypes="ccccccsssccccccccccc" />
+  <path
+     id="path23876"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#002e99;fill-opacity:0.30000001;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate"
+     d="M 48,42 30,59 33.664062,63.144532 36,61 v 13 h 8 v -6 c 0,-2.215998 1.784002,-4 4,-4 2.215998,0 4,1.784002 4,4 v 6 h 8 V 61 L 62.335938,63.144532 66,59 Z m 6,2 v 1.5 l 8,7.5 v -9 z"
+     sodipodi:nodetypes="ccccccsssccccccccccc" />
+  <path
+     id="path2998-4"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:0.999983;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-dasharray:none;marker:none;enable-background:accumulate"
+     d="M 48,41 30,58 33.664062,62.144532 36,60 v 13 h 8 v -6 c 0,-2.215998 1.784002,-4 4,-4 2.215998,0 4,1.784002 4,4 v 6 h 8 V 60 L 62.335938,62.144532 66,58 Z m 6,2 v 1.5 l 8,7.5 v -9 z"
+     sodipodi:nodetypes="ccccccsssccccccccccc" />
 </svg>


### PR DESCRIPTION
Upstream redesigned the File Manager icon a while back, it's very nice.

This is a slight modification, replacing upstream's magnifying glass emblem (which we use for Catfish and "find" functions) with the home emblem which we currently use for the default file manager.