### PR TITLE
Dark: Remove broken symlinks

### DIFF
--- a/elementary-xfce-dark/panel/16/gpm-primary-000-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-000-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-000-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-000.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-000.svg
@@ -1,1 +1,0 @@
-gpm-battery-000.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-020-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-020-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-020-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-020.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-020.svg
@@ -1,1 +1,0 @@
-gpm-battery-020.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-040-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-040-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-040-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-040.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-040.svg
@@ -1,1 +1,0 @@
-gpm-battery-040.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-060-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-060-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-060-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-060.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-060.svg
@@ -1,1 +1,0 @@
-gpm-battery-060.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-080-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-080-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-080-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-080.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-080.svg
@@ -1,1 +1,0 @@
-gpm-battery-080.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-100-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-100-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-100-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-100.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-100.svg
@@ -1,1 +1,0 @@
-gpm-battery-100.svg

--- a/elementary-xfce-dark/panel/16/gpm-primary-charged.svg
+++ b/elementary-xfce-dark/panel/16/gpm-primary-charged.svg
@@ -1,1 +1,0 @@
-gpm-battery-charged.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-000-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-000-charging.svg
@@ -1,1 +1,0 @@
-battery-empty-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-000.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-000.svg
@@ -1,1 +1,0 @@
-battery-empty.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-020-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-020-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-020-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-020.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-020.svg
@@ -1,1 +1,0 @@
-gpm-battery-020.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-040-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-040-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-040-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-040.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-040.svg
@@ -1,1 +1,0 @@
-gpm-battery-040.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-060-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-060-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-060-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-060.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-060.svg
@@ -1,1 +1,0 @@
-gpm-battery-060.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-080-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-080-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-080-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-080.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-080.svg
@@ -1,1 +1,0 @@
-gpm-battery-080.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-100-charging.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-100-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-100-charging.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-100.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-100.svg
@@ -1,1 +1,0 @@
-gpm-battery-100.svg

--- a/elementary-xfce-dark/panel/16/gpm-ups-missing.svg
+++ b/elementary-xfce-dark/panel/16/gpm-ups-missing.svg
@@ -1,1 +1,0 @@
-gpm-battery-missing.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-000-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-000-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-000-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-000.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-000.svg
@@ -1,1 +1,0 @@
-gpm-battery-000.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-020-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-020-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-020-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-020.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-020.svg
@@ -1,1 +1,0 @@
-gpm-battery-020.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-040-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-040-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-040-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-040.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-040.svg
@@ -1,1 +1,0 @@
-gpm-battery-040.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-060-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-060-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-060-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-060.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-060.svg
@@ -1,1 +1,0 @@
-gpm-battery-060.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-080-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-080-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-080-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-080.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-080.svg
@@ -1,1 +1,0 @@
-gpm-battery-080.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-100-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-100-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-100-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-100.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-100.svg
@@ -1,1 +1,0 @@
-gpm-battery-100.svg

--- a/elementary-xfce-dark/panel/22/gpm-primary-charged.svg
+++ b/elementary-xfce-dark/panel/22/gpm-primary-charged.svg
@@ -1,1 +1,0 @@
-gpm-battery-charged.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-000-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-000-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-000-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-000.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-000.svg
@@ -1,1 +1,0 @@
-gpm-battery-000.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-020-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-020-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-020-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-020.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-020.svg
@@ -1,1 +1,0 @@
-gpm-battery-020.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-040-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-040-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-040-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-040.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-040.svg
@@ -1,1 +1,0 @@
-gpm-battery-040.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-060-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-060-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-060-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-060.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-060.svg
@@ -1,1 +1,0 @@
-gpm-battery-060.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-080-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-080-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-080-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-080.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-080.svg
@@ -1,1 +1,0 @@
-gpm-battery-080.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-100-charging.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-100-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-100-charging.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-100.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-100.svg
@@ -1,1 +1,0 @@
-gpm-battery-100.svg

--- a/elementary-xfce-dark/panel/22/gpm-ups-missing.svg
+++ b/elementary-xfce-dark/panel/22/gpm-ups-missing.svg
@@ -1,1 +1,0 @@
-gpm-battery-missing.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-000-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-000-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-000-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-000.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-000.svg
@@ -1,1 +1,0 @@
-gpm-battery-000.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-020-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-020-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-020-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-020.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-020.svg
@@ -1,1 +1,0 @@
-gpm-battery-020.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-040-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-040-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-040-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-040.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-040.svg
@@ -1,1 +1,0 @@
-gpm-battery-040.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-060-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-060-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-060-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-060.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-060.svg
@@ -1,1 +1,0 @@
-gpm-battery-060.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-080-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-080-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-080-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-080.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-080.svg
@@ -1,1 +1,0 @@
-gpm-battery-080.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-100-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-100-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-100-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-100.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-100.svg
@@ -1,1 +1,0 @@
-gpm-battery-100.svg

--- a/elementary-xfce-dark/panel/24/gpm-primary-charged.svg
+++ b/elementary-xfce-dark/panel/24/gpm-primary-charged.svg
@@ -1,1 +1,0 @@
-gpm-battery-charged.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-000-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-000-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-000-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-000.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-000.svg
@@ -1,1 +1,0 @@
-gpm-battery-000.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-020-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-020-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-020-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-020.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-020.svg
@@ -1,1 +1,0 @@
-gpm-battery-020.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-040-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-040-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-040-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-040.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-040.svg
@@ -1,1 +1,0 @@
-gpm-battery-040.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-060-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-060-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-060-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-060.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-060.svg
@@ -1,1 +1,0 @@
-gpm-battery-060.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-080-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-080-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-080-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-080.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-080.svg
@@ -1,1 +1,0 @@
-gpm-battery-080.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-100-charging.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-100-charging.svg
@@ -1,1 +1,0 @@
-gpm-battery-100-charging.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-100.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-100.svg
@@ -1,1 +1,0 @@
-gpm-battery-100.svg

--- a/elementary-xfce-dark/panel/24/gpm-ups-missing.svg
+++ b/elementary-xfce-dark/panel/24/gpm-ups-missing.svg
@@ -1,1 +1,0 @@
-gpm-battery-missing.svg


### PR DESCRIPTION
Not sure when this happened or how it missed the broken symlink check, but some icons in -dark were pointing to icons that are no longer in the main theme. These are no longer needed.

See #276 (f2d06bd) for more details.