### PR TITLE
Update github workflow artifact-action version

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,7 +24,7 @@ jobs:
           cd build
           tar -cf elementary-xfce.tar.gz *
       - name: Upload theme artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: elementary-xfce
           path: build/elementary-xfce.tar.gz


### PR DESCRIPTION
Getting an error when doing PRs, worflow says it needs v4 actions: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/