### PR TITLE
Emblems: Update read/write restricted emblems

### DIFF
--- a/elementary-xfce/emblems/16/emblem-readonly.svg
+++ b/elementary-xfce/emblems/16/emblem-readonly.svg
@@ -1,75 +1,140 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="16"
    height="16"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(0.74432178,0,0,0.74432178,-10.195459,1022.2551)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-readonly.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="45.254836"
+     inkscape:cx="8.4410868"
+     inkscape:cy="9.4796498"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="612"
+     inkscape:window-y="60"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1"
-     transform="translate(0,-1036.3622)">
-    <rect
-       ry="1.4090825"
-       rx="1.4090825"
-       y="1036.889"
-       x="0.52679348"
-       height="14.946413"
-       width="14.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="12.946413"
-       height="12.946413"
-       x="1.5267935"
-       y="1037.889"
-       rx="1.0088673"
-       ry="1.0088673" />
-    <path
-       style="opacity:0.69886361;fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9999997;marker:none;visibility:visible;display:block;overflow:visible"
-       d="M 7.7500016,1039.3622 C 6,1039.3622 5,1040.3622 5,1042.103 l 0,1.2592 -0.4857136,10e-5 C 4.231276,1043.3623 4,1043.6219 4,1043.8622 l 0,5 c 0,0.2404 0.231276,0.5 0.5142864,0.5 l 6.9785676,0 c 0.283015,0 0.507146,-0.2596 0.507146,-0.5 l 0,-5 c 0,-0.2403 -0.224172,-0.4999 -0.507146,-0.4999 l -0.496404,-4e-4 0.0071,-1.2313 C 11,1040.3622 10,1039.3622 8.0071,1039.3622 c -0.087028,0 -0.3420215,0 -0.2571424,0 z m 0.1714264,1 c 0.03152,0 0.067416,0 0.1000008,0 1.9785712,0 1.947988,1.7759 1.9785712,2.208 l 0,0.7921 -4,0 0,-0.7852 c -0.00736,-0.4286 0,-2.2149 1.921428,-2.2149 z"
-       id="path2086" />
-  </g>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3206.6824"
+       x2="2035.1652"
+       y2="3241.5859"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57484949,0,0,0.42975526,-1163.8311,-1377.5886)" />
+    <linearGradient
+       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.43243148,-0.43242979)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.076916"
+       x2="23.99999"
+       y1="6.9576173"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.05181711"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.95133322"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="14.999998"
+     height="14.999998"
+     x="0.50000119"
+     y="0.5"
+     rx="2"
+     ry="2" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.15;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 7.25,3 C 6.563608,3 5.9000359,3.3360912 5.5195312,3.8320313 5.1390266,4.3279713 5,4.9183059 5,5.5 V 7 H 4.5 C 3.6862947,7 3,7.6862947 3,8.5 v 4 C 3,13.313704 3.6862971,14 4.5,14 h 7 c 0.813702,0 1.5,-0.686298 1.5,-1.5 v -4 C 13,7.6862971 12.313704,7 11.5,7 H 11 V 5.5 C 11,4.9164291 10.860257,4.3242273 10.478516,3.828125 10.096774,3.3320227 9.4338509,3 8.75,3 Z"
+     id="path28609"
+     sodipodi:nodetypes="ssscsssssssscssss" />
+  <rect
+     width="13"
+     height="13"
+     x="1.5"
+     y="1.5"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <rect
+     width="15"
+     height="15"
+     rx="2"
+     ry="2"
+     x="0.5"
+     y="0.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path141573"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.500007,4 C 6.669008,4 6.000003,4.925336 6.000003,5.75 V 8 H 4.5 C 4.223001,8 4,8.223001 4,8.5 v 4 C 4,12.777 4.223001,13 4.5,13 h 7.000008 c 0.277,0 0.5,-0.223 0.5,-0.5 v -4 c 0,-0.276999 -0.223,-0.5 -0.5,-0.5 H 10.000006 V 5.75 C 10.000006,4.919001 9.331001,4 8.500002,4 Z m 0.165999,0.999598 h 0.667997 c 0.369068,0 0.665998,0.305736 0.665998,0.674804 V 8 H 7.000007 V 5.674402 c 0,-0.369068 0.29693,-0.674804 0.665999,-0.674804 z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 7.250004,3 C 6.419005,3 6.000003,3.675336 6.000003,4.5 V 7 H 4.5 C 4.223001,7 4,7.223001 4,7.5 v 4 C 4,11.777 4.223001,12 4.5,12 h 7.000008 c 0.277,0 0.5,-0.223 0.5,-0.5 v -4 c 0,-0.276999 -0.223,-0.5 -0.5,-0.5 H 10.000006 V 4.5 C 10.000006,3.669001 9.581003,3 8.750004,3 Z m 0.416002,0.999598 h 0.667997 c 0.369068,0 0.665998,0.305736 0.665998,0.674804 V 7 H 7.000007 V 4.674402 c 0,-0.369068 0.29693,-0.674804 0.665999,-0.674804 z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
 </svg>

--- a/elementary-xfce/emblems/16/emblem-unreadable.svg
+++ b/elementary-xfce/emblems/16/emblem-unreadable.svg
@@ -1,75 +1,138 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="16"
    height="16"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(0.74432178,0,0,0.74432178,-10.195459,1022.2551)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-unreadable.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="45.254836"
+     inkscape:cx="8.4189897"
+     inkscape:cy="9.4796498"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="1125"
+     inkscape:window-y="77"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1"
-     transform="translate(0,-1036.3622)">
-    <rect
-       ry="1.4090825"
-       rx="1.4090825"
-       y="1036.889"
-       x="0.52679348"
-       height="14.946413"
-       width="14.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="12.946413"
-       height="12.946413"
-       x="1.5267935"
-       y="1037.889"
-       rx="1.0088673"
-       ry="1.0088673" />
-    <path
-       style="fill:#aaaba7;fill-opacity:1;fill-rule:evenodd;stroke:none"
-       d="M 5.411765,1040.3622 4,1041.774 6.588235,1044.3622 4,1046.9504 l 1.411765,1.4118 2.588236,-2.5882 2.588232,2.5882 L 12,1046.9504 9.411765,1044.3622 12,1041.774 l -1.411767,-1.4118 -2.588232,2.5882 -2.588236,-2.5882 z"
-       id="path6930" />
-  </g>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3206.6824"
+       x2="2035.1652"
+       y2="3241.5859"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.57484949,0,0,0.42975526,-1163.8311,-1377.5886)" />
+    <linearGradient
+       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.43243148,-0.43242979)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.076916"
+       x2="23.99999"
+       y1="6.9576173"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.05181711"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.95133322"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="14.999998"
+     height="14.999998"
+     x="0.50000119"
+     y="0.5"
+     rx="2"
+     ry="2" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.3;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 5.5253906,4.3183594 c -0.3810507,0 -0.7719461,0.1508517 -1.0605469,0.4394531 L 3.7578125,5.4648437 c -0.5752837,0.5752837 -0.5752838,1.54581 0,2.1210938 L 5.171875,9 3.7578125,10.414063 c -0.5752818,0.575283 -0.5752815,1.54581 0,2.121093 l 0.7070312,0.707032 c 0.5752833,0.575281 1.5458091,0.575286 2.1210938,0 L 8,11.828125 9.4140625,13.242188 c 0.5752849,0.575284 1.5458085,0.575284 2.1210935,0 l 0.707032,-0.707032 c 0.575282,-0.575283 0.575282,-1.545811 0,-2.121093 L 10.828125,9 12.242188,7.5859375 c 0.575285,-0.5752835 0.575284,-1.5458103 0,-2.1210938 L 11.535156,4.7578125 c -0.575283,-0.5752819 -1.5458101,-0.5752846 -2.1210935,0 L 8,6.171875 6.5859375,4.7578125 C 6.297337,4.4692117 5.9064417,4.3183594 5.5253906,4.3183594 Z"
+     id="path38741" />
+  <rect
+     width="13"
+     height="13"
+     x="1.5"
+     y="1.5"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <rect
+     width="15"
+     height="15"
+     rx="2"
+     ry="2"
+     x="0.5"
+     y="0.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path38739"
+     style="fill:#7a0000;fill-opacity:0.5;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-opacity:0.3;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 5.5253906,5.3184171 c -0.1278094,0 -0.2555814,0.04855 -0.3535156,0.1464844 L 4.4648438,6.1719327 c -0.1958684,0.1958684 -0.1958685,0.5111628 0,0.7070313 L 6.5859373,9.0000575 4.4648435,11.121151 c -0.1958684,0.195869 -0.1958682,0.511163 3e-7,0.707032 l 0.7070312,0.707031 c 0.1958685,0.195868 0.5111631,0.195869 0.7070315,0 l 2.1210937,-2.121094 2.1210938,2.121094 c 0.195868,0.195868 0.511163,0.195868 0.707031,0 l 0.707031,-0.707031 c 0.195869,-0.195869 0.195869,-0.511163 0,-0.707032 L 9.4140627,9.0000579 11.535156,6.8789642 c 0.195869,-0.1958684 0.195869,-0.511163 0,-0.7070316 L 10.828125,5.4649015 c -0.195869,-0.1958686 -0.511163,-0.1958687 -0.707031,-3e-7 L 7.9999998,7.585995 5.8789063,5.4649015 C 5.7809721,5.3669672 5.6532001,5.3184171 5.5253906,5.3184171 Z" />
+  <path
+     id="rect38621"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-opacity:0.3;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 6.9605824 -0.85349998 C 6.8702075 -0.76312507 6.8141892 -0.63844645 6.8141892 -0.49994659 L 6.8141892 0.49994659 C 6.8141892 0.77694631 7.037136 0.99989318 7.3141358 0.99989318 L 10.313815 0.99989318 L 10.313815 3.9995727 C 10.313815 4.2765725 10.536762 4.4995193 10.813762 4.4995193 L 11.813655 4.4995193 C 12.090655 4.4995193 12.313602 4.2765725 12.313602 3.9995727 L 12.313602 0.99989318 L 15.313281 0.99989318 C 15.590281 0.99989318 15.813228 0.77694631 15.813228 0.49994659 L 15.813228 -0.49994659 C 15.813228 -0.77694631 15.590281 -0.99989318 15.313281 -0.99989318 L 12.313602 -0.99989318 L 12.313602 -3.9995727 C 12.313602 -4.2765725 12.090655 -4.4995193 11.813655 -4.4995193 L 10.813762 -4.4995193 C 10.536762 -4.4995193 10.313815 -4.2765725 10.313815 -3.9995727 L 10.313815 -0.99989318 L 7.3141358 -0.99989318 C 7.1756359 -0.99989318 7.0509573 -0.94387489 6.9605824 -0.85349998 z "
+     transform="rotate(45)" />
 </svg>

--- a/elementary-xfce/emblems/22/emblem-readonly.svg
+++ b/elementary-xfce/emblems/22/emblem-readonly.svg
@@ -1,75 +1,225 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="22"
    height="22"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(0.94351924,0,0,0.94351924,-12.064978,1013.3387)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-readonly.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16.000001"
+     inkscape:cx="10.125"
+     inkscape:cy="12.999999"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="340"
+     inkscape:window-y="99"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3206.6824"
+       x2="2035.1652"
+       y2="3241.5859"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72814277,0,0,0.54435672,-1473.3196,-1744.0791)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,-0.0257797,-0.02829286)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.229313"
+       x2="23.99999"
+       y1="6.5493407"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.01652508"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.98001981"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="19"
+     height="19"
+     x="1.5"
+     y="1.5"
+     rx="2"
+     ry="2" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.15;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 10.5,6 C 8.8379996,6 8,7.138 8,8.8 V 11 H 9.499984 V 8.8320155 c 0,-0.738137 0.593893,-1.332031 1.332031,-1.332031 h 0.335969 c 0.738138,0 1.332032,0.593894 1.332032,1.332031 V 11 H 14 V 8.8 C 14,7.138 13.161999,6 11.5,6 Z M 6,11 v 5 c 0,0.553999 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446001 1,-1 v -5 z"
+     id="path1754"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 10.5,6 C 8.8379996,6 8,7.138 8,8.7999995 V 10.999999 H 9.499984 V 8.8320155 c 0,-0.738137 0.593893,-1.332031 1.332031,-1.332031 h 0.335969 c 0.738138,0 1.332032,0.593894 1.332032,1.332031 V 10.999999 H 14 V 8.7999995 C 14,7.138 13.161999,6 11.5,6 Z M 6,11 v 5 c 0,0.553999 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446001 1,-1 v -5 z"
+     id="path995"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 10.300781,5 C 8.6387825,5 8,6.1387829 8,7.8007812 V 10 H 7 c -0.5539994,0 -1,0.446001 -1,1 v 4 c 0,0.553999 0.4460006,1 1,1 h 8 c 0.553999,0 1,-0.446001 1,-1 v -4 c 0,-0.553999 -0.446001,-1 -1,-1 H 14 V 7.8007812 C 14,6.1387829 13.361216,5 11.699219,5 Z m 0.332031,1.5 h 0.734376 C 12.105325,6.5 12.5,7.093895 12.5,7.8320312 V 10 h -3 V 7.8320312 C 9.5,7.093895 9.894675,6.5 10.632812,6.5 Z" />
   <g
-     id="layer1"
-     transform="translate(0,-1030.3622)">
-    <rect
-       ry="1.7861851"
-       rx="1.7861851"
-       y="1031.889"
-       x="1.5267935"
-       height="18.946413"
-       width="18.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="16.946413"
-       height="16.946413"
-       x="2.5267935"
-       y="1032.889"
-       rx="1.3205729"
-       ry="1.3205729" />
-    <path
-       style="opacity:0.69886361;fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9999997;marker:none;visibility:visible;display:block;overflow:visible"
-       d="m 10.687502,1035.3644 c -2.1423269,0.066 -3.1875019,1.0817 -3.1875019,3.1732 l 0,1.8245 -0.857142,2e-4 c -0.353763,10e-5 -0.642858,0.3995 -0.642858,0.6999 l 0,5.762 c 0,0.3004 0.289095,0.5402 0.642858,0.5402 l 8.7232089,0 c 0.353769,0 0.633933,-0.2398 0.633933,-0.5402 l 0,-5.762 c 0,-0.3004 -0.327469,-0.8766 -0.633933,-0.6999 l -0.870765,0 0.0089,-1.7896 c 0,-2.2202 -1.161985,-3.1809 -3.495302,-3.2083 -0.108785,0 -0.216068,-0.01 -0.321428,0 z m 0.214283,1.5 c 0.0394,0 0.08427,0 0.125001,0 2.080953,0 1.934752,1.7171 1.972981,2.2572 l 0,1.2407 -3.999767,0 0,-1.232 c -0.0092,-0.5358 -0.07422,-2.222 1.901785,-2.2659 z"
-       id="path2086" />
+     transform="matrix(0.55,0,0,0.3333336,-2.2000011,6.3333039)"
+     id="g2036-4"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+    </g>
   </g>
+  <rect
+     width="17"
+     height="17"
+     x="2.501246"
+     y="2.4987307"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="2"
+     ry="2"
+     x="1.4999986"
+     y="1.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/emblems/22/emblem-unreadable.svg
+++ b/elementary-xfce/emblems/22/emblem-unreadable.svg
@@ -1,75 +1,224 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="22"
    height="22"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(0.94351924,0,0,0.94351924,-12.064978,1013.3387)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-unreadable.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627418"
+     inkscape:cx="11.22532"
+     inkscape:cy="15.688931"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="340"
+     inkscape:window-y="92"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3206.6824"
+       x2="2035.1652"
+       y2="3241.5859"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72814277,0,0,0.54435672,-1473.3196,-1744.0791)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,-0.0257797,-0.02829286)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.229313"
+       x2="23.99999"
+       y1="6.5493407"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.01652508"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.98001981"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="19"
+     height="19"
+     x="1.5"
+     y="1.5"
+     rx="2"
+     ry="2" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.3;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 7.8183594,6.4628906 c -0.5139566,-2e-7 -1.0298796,0.2037081 -1.4140625,0.5878907 L 6.0507812,7.4042969 c -0.7711523,0.7711525 -0.771153,2.0569731 0,2.8281251 L 7.8183594,12 6.0507812,13.767578 c -0.7711519,0.771152 -0.7711527,2.056973 0,2.828125 l 0.3535157,0.353516 c 0.7711518,0.771151 2.0569722,0.771153 2.8281251,0 L 11,15.181641 l 1.767578,1.767578 c 0.771152,0.771152 2.056973,0.771152 2.828125,0 l 0.353516,-0.353516 c 0.771152,-0.771153 0.771151,-2.056973 0,-2.828125 L 14.181641,12 15.949219,10.232422 c 0.771152,-0.771152 0.771153,-2.0569733 0,-2.8281251 L 15.595703,7.0507813 c -0.771152,-0.7711513 -2.056973,-0.771152 -2.828125,0 L 11,8.8183594 9.232422,7.0507813 C 8.8482378,6.666597 8.3323134,6.4628908 7.8183594,6.4628906 Z"
+     id="path35895"
+     sodipodi:nodetypes="sssscsssscsssscsssscss" />
   <g
-     id="layer1"
-     transform="translate(0,-1030.3622)">
-    <rect
-       ry="1.7861851"
-       rx="1.7861851"
-       y="1031.889"
-       x="1.5267935"
-       height="18.946413"
-       width="18.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="16.946413"
-       height="16.946413"
-       x="2.5267935"
-       y="1032.889"
-       rx="1.3205729"
-       ry="1.3205729" />
-    <path
-       style="fill:#aaaba7;fill-opacity:1;fill-rule:evenodd;stroke:none"
-       d="M 7.117647,1035.3622 5,1037.4799 8.882353,1041.3622 5,1045.2445 l 2.117647,2.1177 3.882354,-3.8823 3.882349,3.8823 L 17,1045.2445 13.117647,1041.3622 17,1037.4799 l -2.11765,-2.1177 -3.882349,3.8823 -3.882354,-3.8823 z"
-       id="path6930" />
+     transform="matrix(0.55,0,0,0.3333336,-2.2000011,6.3333039)"
+     id="g2036-4"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+    </g>
   </g>
+  <rect
+     width="17"
+     height="17"
+     x="2.501246"
+     y="2.4987307"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="2"
+     ry="2"
+     x="1.4999986"
+     y="1.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path35893"
+     style="opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-dasharray:none;stroke-opacity:0.3;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 7.8183592,7.463 c -0.255619,-1e-7 -0.5111627,0.099054 -0.707031,0.2949221 L 6.7578125,8.1114377 C 6.3660758,8.5031745 6.3660759,9.133764 6.7578124,9.5255 l 2.4746096,2.474609 -2.4746097,2.47461 c -0.3917368,0.391737 -0.3917366,1.022326 -1e-7,1.414062 l 0.3535159,0.353516 c 0.3917364,0.391736 1.0223256,0.391737 1.4140624,0 L 11,13.767688 l 2.474609,2.474609 c 0.391737,0.391737 1.022326,0.391737 1.414063,0 l 0.353516,-0.353515 c 0.391737,-0.391737 0.391736,-1.022326 -1e-6,-1.414063 L 12.767578,12.000109 15.242187,9.5255 c 0.391737,-0.391737 0.391737,-1.0223259 0,-1.4140623 L 14.888672,7.7579218 c -0.391737,-0.3917365 -1.022326,-0.3917367 -1.414063,1e-7 L 11,10.232531 8.5253905,7.757922 C 8.329522,7.5620534 8.0739782,7.4630001 7.8183592,7.463 Z" />
+  <path
+     id="rect35778"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-dasharray:none;stroke-opacity:0.3;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 7.8183592,6.4628904 c -0.255619,-1e-7 -0.5111627,0.099054 -0.707031,0.2949221 L 6.7578125,7.1113282 c -0.3917367,0.3917367 -0.3917366,1.0223259 -1e-7,1.4140623 L 9.232422,11 6.7578123,13.474609 c -0.3917368,0.391737 -0.3917366,1.022326 -1e-7,1.414063 l 0.3535159,0.353515 c 0.3917364,0.391737 1.0223256,0.391737 1.4140624,0 L 11,12.767578 l 2.474609,2.474609 c 0.391737,0.391737 1.022326,0.391738 1.414063,1e-6 l 0.353516,-0.353516 c 0.391737,-0.391737 0.391736,-1.022326 -1e-6,-1.414063 L 12.767578,11 15.242187,8.5253905 c 0.391737,-0.3917368 0.391737,-1.022326 0,-1.4140624 L 14.888672,6.7578122 c -0.391737,-0.3917365 -1.022326,-0.3917367 -1.414063,1e-7 L 11,9.232422 8.5253905,6.7578124 C 8.329522,6.5619438 8.0739782,6.4628905 7.8183592,6.4628904 Z" />
 </svg>

--- a/elementary-xfce/emblems/24/emblem-readonly.svg
+++ b/elementary-xfce/emblems/24/emblem-readonly.svg
@@ -1,75 +1,226 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="24"
    height="24"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(0.94351924,0,0,0.94351924,-11.064978,1012.3387)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-readonly.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="9.15625"
+     inkscape:cy="4.5625"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="595"
+     inkscape:window-y="798"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3206.6824"
+       x2="2035.1652"
+       y2="3241.5859"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72814277,0,0,0.54435672,-1472.3196,-1742.0791)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,1.9717071)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.414463"
+       x2="23.99999"
+       y1="6.6007442"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.03488447"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.97236514"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="19"
+     height="19"
+     x="2.5"
+     y="3.5"
+     rx="2.5"
+     ry="2.5" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.15;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="M 11.5,7 C 10.440762,7 9.4761315,7.4078502 8.8632813,8.1308594 8.250431,8.8538685 8,9.8017117 8,10.800781 V 12 H 7 c -0.5522619,5.5e-5 -0.9999448,0.447738 -1,1 v 5 c 0,1.090702 0.9092971,2 2,2 h 8 c 1.090703,0 2,-0.909297 2,-2 v -5 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 H 16 V 10.800781 C 16,9.8017115 15.749569,8.8538683 15.136719,8.1308594 14.523868,7.4078504 13.559238,7 12.5,7 Z"
+     id="path1754"
+     sodipodi:nodetypes="ssscccsssscccssss" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 11.5,8 C 9.8379996,8 9,9.138 9,10.8 v 2.199999 h 2 v -1.667983 c 0,-0.738137 0.09388,-1.3320315 0.832015,-1.3320315 h 0.335969 C 12.906122,9.9999845 13,10.593879 13,11.332016 v 1.667983 h 2 V 10.8 C 15,9.138 14.161999,8 12.5,8 Z M 7,13 v 5 c 0,0.553999 0.446,1 1,1 h 8 c 0.553999,0 1,-0.446001 1,-1 v -5 z"
+     id="path995"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="M 11.300781,7 C 9.6387825,7 9,8.1387829 9,9.8007812 V 12 H 8 c -0.5539994,0 -1,0.446001 -1,1 v 4 c 0,0.553999 0.4460006,1 1,1 h 8 c 0.553999,0 1,-0.446001 1,-1 v -4 c 0,-0.553999 -0.446001,-1 -1,-1 H 15 V 9.8007812 C 15,8.1387829 14.361216,7 12.699219,7 Z m 0.332031,1.9999844 h 0.734376 C 13.105325,8.9999844 13,9.5938794 13,10.332016 V 12 H 11 V 10.332016 C 11,9.5938794 10.894675,8.9999844 11.632812,8.9999844 Z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
   <g
-     id="layer1"
-     transform="translate(0,-1028.3622)">
-    <rect
-       ry="1.7861851"
-       rx="1.7861851"
-       y="1030.889"
-       x="2.5267935"
-       height="18.946413"
-       width="18.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="16.946413"
-       height="16.946413"
-       x="3.5267935"
-       y="1031.889"
-       rx="1.3205729"
-       ry="1.3205729" />
-    <path
-       style="opacity:0.69886361;fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9999997;marker:none;visibility:visible;display:block;overflow:visible"
-       d="m 11.687502,1034.3644 c -2.1423269,0.066 -3.1875019,1.0817 -3.1875019,3.1732 l 0,1.8245 -0.857142,2e-4 c -0.353763,10e-5 -0.642858,0.3995 -0.642858,0.6999 l 0,5.762 c 0,0.3004 0.289095,0.5402 0.642858,0.5402 l 8.7232089,0 c 0.353769,0 0.633933,-0.2398 0.633933,-0.5402 l 0,-5.762 c 0,-0.3004 -0.327469,-0.8766 -0.633933,-0.6999 l -0.870765,0 0.0089,-1.7896 c 0,-2.2202 -1.161985,-3.1809 -3.495302,-3.2083 -0.108785,0 -0.216068,-0.01 -0.321428,0 z m 0.214283,1.5 c 0.0394,0 0.08427,0 0.125001,0 2.080953,0 1.934752,1.7171 1.972981,2.2572 l 0,1.2407 -3.999767,0 0,-1.232 c -0.0092,-0.5358 -0.07422,-2.222 1.901785,-2.2659 z"
-       id="path2086" />
+     transform="matrix(0.55,0,0,0.3333336,-1.2000011,8.3333039)"
+     id="g2036-4"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+    </g>
   </g>
+  <rect
+     width="17"
+     height="17"
+     x="3.501246"
+     y="4.4987307"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="2.5"
+     ry="2.5"
+     x="2.4999986"
+     y="3.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
 </svg>

--- a/elementary-xfce/emblems/24/emblem-unreadable.svg
+++ b/elementary-xfce/emblems/24/emblem-unreadable.svg
@@ -1,75 +1,224 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="24"
    height="24"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(0.94351924,0,0,0.94351924,-11.064978,1012.3387)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-unreadable.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.905126"
+     inkscape:cy="14.584077"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="573"
+     inkscape:window-y="702"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3206.6824"
+       x2="2035.1652"
+       y2="3241.5859"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.72814277,0,0,0.54435672,-1472.3196,-1742.0791)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3082-6"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-6"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,1.9717071)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4095"
+       id="linearGradient3233"
+       y2="41.414463"
+       x2="23.99999"
+       y1="6.5896411"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient4095">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4097" />
+      <stop
+         offset="0.03553865"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4100" />
+      <stop
+         offset="0.97433835"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4102" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4104" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="19"
+     height="19"
+     x="2.5"
+     y="3.5"
+     rx="2.5"
+     ry="2.5" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.3;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 8.8183594,8.4628906 c -0.5139566,-2e-7 -1.0298796,0.2037081 -1.4140625,0.5878907 L 7.0507812,9.4042969 c -0.7711523,0.7711521 -0.771153,2.0569731 0,2.8281251 L 8.8183594,14 7.0507812,15.767578 c -0.7711519,0.771152 -0.7711527,2.056973 0,2.828125 l 0.3535157,0.353516 c 0.7711518,0.771151 2.0569722,0.771153 2.8281251,0 L 12,17.181641 l 1.767578,1.767578 c 0.771152,0.771152 2.056973,0.771152 2.828125,0 l 0.353516,-0.353516 c 0.771152,-0.771153 0.771151,-2.056973 0,-2.828125 L 15.181641,14 16.949219,12.232422 c 0.771152,-0.771152 0.771153,-2.056973 0,-2.8281251 L 16.595703,9.0507813 c -0.771152,-0.7711513 -2.056973,-0.771152 -2.828125,0 L 12,10.818359 10.232422,9.0507813 C 9.8482378,8.666597 9.3323134,8.4628908 8.8183594,8.4628906 Z"
+     id="path35895"
+     sodipodi:nodetypes="sssscsssscsssscsssscss" />
   <g
-     id="layer1"
-     transform="translate(0,-1028.3622)">
-    <rect
-       ry="1.7861851"
-       rx="1.7861851"
-       y="1030.889"
-       x="2.5267935"
-       height="18.946413"
-       width="18.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="16.946413"
-       height="16.946413"
-       x="3.5267935"
-       y="1031.889"
-       rx="1.3205729"
-       ry="1.3205729" />
-    <path
-       style="fill:#aaaba7;fill-opacity:1;fill-rule:evenodd;stroke:none"
-       d="M 8.117647,1034.3622 6,1036.4799 9.882353,1040.3622 6,1044.2445 l 2.117647,2.1177 3.882354,-3.8823 3.882349,3.8823 L 18,1044.2445 14.117647,1040.3622 18,1036.4799 l -2.11765,-2.1177 -3.882349,3.8823 -3.882354,-3.8823 z"
-       id="path6930" />
+     transform="matrix(0.55,0,0,0.3333336,-1.2000011,8.3333039)"
+     id="g2036-4"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712-8"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801-6"
+         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1)"
+         id="rect3696-20"
+         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700-5"
+         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none" />
+    </g>
   </g>
+  <rect
+     width="17"
+     height="17"
+     x="3.501246"
+     y="4.4987307"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" />
+  <rect
+     width="19.000002"
+     height="19.000002"
+     rx="2.5"
+     ry="2.5"
+     x="2.4999986"
+     y="3.5"
+     id="rect5505-21-8-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#7a0000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path35893"
+     style="opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-dasharray:none;stroke-opacity:0.3;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 8.8183592,9.463 c -0.255619,-10e-8 -0.5111627,0.099054 -0.707031,0.2949221 L 7.7578125,10.111438 c -0.3917367,0.391737 -0.3917366,1.022326 -1e-7,1.414062 l 2.4746096,2.474609 -2.4746097,2.47461 c -0.3917368,0.391737 -0.3917366,1.022326 -1e-7,1.414062 l 0.3535159,0.353516 c 0.3917364,0.391736 1.0223256,0.391737 1.4140624,0 L 12,15.767688 l 2.474609,2.474609 c 0.391737,0.391737 1.022326,0.391737 1.414063,0 l 0.353516,-0.353515 c 0.391737,-0.391737 0.391736,-1.022326 -10e-7,-1.414063 l -2.474609,-2.47461 2.474609,-2.474609 c 0.391737,-0.391737 0.391737,-1.022326 0,-1.414062 L 15.888672,9.7579218 c -0.391737,-0.3917365 -1.022326,-0.3917367 -1.414063,10e-8 L 12,12.232531 9.5253905,9.757922 C 9.329522,9.5620534 9.0739782,9.4630001 8.8183592,9.463 Z" />
+  <path
+     id="rect35778"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-dasharray:none;stroke-opacity:0.3;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 8.8183592,8.4628904 c -0.255619,-10e-8 -0.5111627,0.099054 -0.707031,0.2949221 L 7.7578125,9.1113282 c -0.3917367,0.3917367 -0.3917366,1.0223258 -1e-7,1.4140628 L 10.232422,13 7.7578123,15.474609 c -0.3917368,0.391737 -0.3917366,1.022326 -1e-7,1.414063 l 0.3535159,0.353515 c 0.3917364,0.391737 1.0223256,0.391737 1.4140624,0 L 12,14.767578 l 2.474609,2.474609 c 0.391737,0.391737 1.022326,0.391738 1.414063,10e-7 l 0.353516,-0.353516 c 0.391737,-0.391737 0.391736,-1.022326 -10e-7,-1.414063 L 13.767578,13 16.242187,10.52539 c 0.391737,-0.391736 0.391737,-1.0223255 0,-1.4140619 L 15.888672,8.7578122 c -0.391737,-0.3917365 -1.022326,-0.3917367 -1.414063,10e-8 L 12,11.232422 9.5253905,8.7578124 C 9.329522,8.5619438 9.0739782,8.4628905 8.8183592,8.4628904 Z" />
 </svg>

--- a/elementary-xfce/emblems/32/emblem-readonly.svg
+++ b/elementary-xfce/emblems/32/emblem-readonly.svg
@@ -1,75 +1,225 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="32"
    height="32"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(1.3419141,0,0,1.3419141,-16.804015,996.50596)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-readonly.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="2.8284273"
+     inkscape:cx="70.180345"
+     inkscape:cy="27.930717"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="340"
+     inkscape:window-y="108"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3208.0737"
+       x2="2035.1652"
+       y2="3241.9966"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0347292,0,0,0.77355955,-2093.2963,-2478.0598)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.2399855"
+       x2="23.99999"
+       y2="41.759987"
+       id="linearGradient4161-0-2"
+       xlink:href="#linearGradient3924-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.21621228,-0.21620224)" />
+    <linearGradient
+       id="linearGradient3924-0">
+      <stop
+         id="stop3926-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.04166666" />
+      <stop
+         id="stop3930-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95833325" />
+      <stop
+         id="stop3932-62"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2976-3-3"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2978-2-5"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient963"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="27"
+     height="27"
+     x="2.5"
+     y="2.5"
+     rx="3"
+     ry="3" />
+  <path
+     style="color:#000000;opacity:1;fill:#7a0000;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;fill-opacity:0.30000001"
+     d="m 15,8 c -2.210591,0 -4,1.8274253 -4,4.017578 V 15 h -1 c -0.5522619,5.5e-5 -0.9999448,0.447738 -1,1 v 7 c 0,1.090702 0.9092983,2 2,2 h 10 c 1.090702,0 2,-0.909297 2,-2 v -7 c -5.5e-5,-0.552262 -0.447738,-0.999945 -1,-1 H 21 V 12.017578 C 21,9.8188772 19.205508,8 17,8 Z m 0.332031,4 h 1.335938 C 16.854389,12 17,12.147863 17,12.349609 V 15 H 15 V 12.349609 C 15,12.147862 15.145611,12 15.332031,12 Z"
+     id="path26209"
+     sodipodi:nodetypes="sscccsssscccssssssccss" />
   <g
-     id="layer1"
-     transform="translate(0,-1020.3622)">
-    <rect
-       ry="2.5403903"
-       rx="2.5403903"
-       y="1022.889"
-       x="2.5267935"
-       height="26.946413"
-       width="26.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="24.946413"
-       height="24.946413"
-       x="3.5267935"
-       y="1023.889"
-       rx="1.943984"
-       ry="1.943984" />
-    <path
-       style="opacity:0.69886361;fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9999997;marker:none;visibility:visible;display:block;overflow:visible"
-       d="M 15.562503,1028.3622 C 13,1028.3622 11,1030.3622 11,1032.3182 l 0,3.0439 -1.0999987,2e-4 c -0.4952682,10e-5 -0.9000012,0.5793 -0.9000012,0.9999 l 0,7 c 0,0.4204 0.404733,1 0.9000012,1 l 12.2124927,0 c 0.495276,0 0.887506,-0.5796 0.887506,-1 l 0,-7 c 0,-0.4206 -0.392232,-0.9999 -0.887506,-0.9999 l -1.118724,0 0.01246,-2.995 C 21,1030.3622 19,1028.3622 16.01246,1028.3622 c -0.152299,0 -0.598167,0 -0.449999,0 z m 0.299996,2 c 0.05516,0 0.117978,0 0.175001,0 2.9625,0 2.90898,2.0174 2.9625,2.7736 l 0,2.2266 -6,0 0,-2.2144 c -0.01288,-0.7502 0,-2.7858 2.862499,-2.7858 z"
-       id="path2086" />
+     style="display:inline"
+     id="g2036-2-8-6"
+     transform="matrix(0.6999997,0,0,0.3333336,-0.79999528,15.333334)">
+    <g
+       style="opacity:0.4"
+       id="g3712-3-7-0"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2976-3-3);fill-opacity:1;stroke:none"
+         id="rect2801-0-9-6"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2978-2-5);fill-opacity:1;stroke:none"
+         id="rect3696-2-2-2"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient963);fill-opacity:1;stroke:none"
+         id="rect3700-1-0-6"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
   </g>
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient4161-0-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4-3-8"
+     y="3.5000038"
+     x="3.5000038"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect23779"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="27.000008"
+     width="27.000008" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 15,9 c -1.662,0 -3,1.367643 -3,3.016972 V 16 h 1.999985 v -3.650498 c 0,-0.738137 0.593893,-1.349003 1.332031,-1.349003 h 1.335968 c 0.738138,0 1.332032,0.610866 1.332032,1.349003 V 16 H 20 V 12.016972 C 20,10.354972 18.661999,9 17,9 Z m -5,7 v 7 c 0,0.554 0.446,1 1,1 h 10 c 0.553999,0 1,-0.446 1,-1 v -7 z"
+     id="path873"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 15,8 c -1.661998,0 -3,1.3682503 -3,3.017578 V 15 h -1 c -0.553999,0 -1,0.446001 -1,1 v 6 c 0,0.553999 0.446001,1 1,1 h 10 c 0.553999,0 1,-0.446001 1,-1 v -6 c 0,-0.553999 -0.446001,-1 -1,-1 H 20 V 11.017578 C 20,9.3555794 18.661997,8 17,8 Z m 0.332031,2 h 1.335938 C 17.406106,10 18,10.611473 18,11.349609 V 15 H 14 V 11.349609 C 14,10.611473 14.593894,10 15.332031,10 Z" />
 </svg>

--- a/elementary-xfce/emblems/32/emblem-unreadable.svg
+++ b/elementary-xfce/emblems/32/emblem-unreadable.svg
@@ -1,75 +1,225 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
+   version="1.1"
    width="32"
    height="32"
-   id="svg3067"
-   version="1.1">
-  <defs
-     id="defs3069">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       r="20.530962"
-       fy="35.87817"
-       fx="24.44569"
-       cy="35.87817"
-       cx="24.44569"
-       gradientTransform="matrix(1.3419141,0,0,1.3419141,-16.804015,996.50596)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3092"
-       xlink:href="#linearGradient11520" />
-  </defs>
+   id="svg3803"
+   sodipodi:docname="emblem-unreadable.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="2.8284273"
+     inkscape:cx="27.400387"
+     inkscape:cy="63.993161"
+     inkscape:window-width="1570"
+     inkscape:window-height="911"
+     inkscape:window-x="467"
+     inkscape:window-y="30"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata3072">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
+  <defs
+     id="defs3805">
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3208.0737"
+       x2="2035.1652"
+       y2="3241.9966"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0347292,0,0,0.77355955,-2093.2963,-2478.0598)" />
+    <linearGradient
+       x1="23.99999"
+       y1="6.2399855"
+       x2="23.99999"
+       y2="41.759987"
+       id="linearGradient4161-0-2"
+       xlink:href="#linearGradient3924-0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.21621228,-0.21620224)" />
+    <linearGradient
+       id="linearGradient3924-0">
+      <stop
+         id="stop3926-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-3"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.04166666" />
+      <stop
+         id="stop3930-2"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95833325" />
+      <stop
+         id="stop3932-62"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2976-3-3"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2978-2-5"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757-3"
+       id="linearGradient963"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443" />
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <rect
+     style="font-variation-settings:normal;opacity:0.99;vector-effect:none;fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     id="rect4031"
+     width="27"
+     height="27"
+     x="2.5"
+     y="2.5"
+     rx="3"
+     ry="3" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.3;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 11.050781,9.3417969 c -0.513945,0 -1.029873,0.203694 -1.4140622,0.5878906 L 8.9296875,10.636719 c -0.7711518,0.771152 -0.7711512,2.056972 0,2.828125 L 12.464844,17 8.9296875,20.535156 c -0.771154,0.771153 -0.7711532,2.056973 0,2.828125 l 0.7070313,0.707031 c 0.7711522,0.771151 2.0569722,0.771151 2.8281252,0 L 16,20.535156 l 3.535156,3.535156 c 0.771152,0.771153 2.056973,0.771151 2.828125,0 l 0.707031,-0.707031 c 0.771155,-0.771152 0.771155,-2.056973 0,-2.828125 L 19.535156,17 23.070312,13.464844 c 0.771153,-0.771152 0.771153,-2.056973 0,-2.828125 L 22.363281,9.9296875 c -0.771152,-0.7711521 -2.056973,-0.7711521 -2.828125,0 L 16,13.464844 12.464844,9.9296875 C 12.080659,9.5455008 11.564735,9.3417969 11.050781,9.3417969 Z"
+     id="path30257"
+     sodipodi:nodetypes="scsccsssccsssccssssccs" />
   <g
-     id="layer1"
-     transform="translate(0,-1020.3622)">
-    <rect
-       ry="2.5403903"
-       rx="2.5403903"
-       y="1022.889"
-       x="2.5267935"
-       height="26.946413"
-       width="26.946413"
-       id="rect11518"
-       style="fill:url(#radialGradient3092);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="24.946413"
-       height="24.946413"
-       x="3.5267935"
-       y="1023.889"
-       rx="1.943984"
-       ry="1.943984" />
-    <path
-       style="fill:#aaaba7;fill-opacity:1;fill-rule:evenodd;stroke:none"
-       d="M 11.470588,1029.3622 9,1031.8329 13.529412,1036.3622 9,1040.8916 l 2.470588,2.4706 4.529413,-4.5293 4.529407,4.5293 L 23,1040.8916 18.470588,1036.3622 23,1031.8329 l -2.470592,-2.4707 -4.529407,4.5294 -4.529413,-4.5294 z"
-       id="path6930" />
+     style="display:inline"
+     id="g2036-2-8-6"
+     transform="matrix(0.6999997,0,0,0.3333336,-0.79999528,15.333334)">
+    <g
+       style="opacity:0.4"
+       id="g3712-3-7-0"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2976-3-3);fill-opacity:1;stroke:none"
+         id="rect2801-0-9-6"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2978-2-5);fill-opacity:1;stroke:none"
+         id="rect3696-2-2-2"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient963);fill-opacity:1;stroke:none"
+         id="rect3700-1-0-6"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
   </g>
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient4161-0-2);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4-3-8"
+     y="3.5000038"
+     x="3.5000038"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#7a0000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect23779"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="27.000008"
+     width="27.000008" />
+  <path
+     id="path30255"
+     style="opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 11.050781,10.342 c -0.255619,0 -0.511163,0.09905 -0.707031,0.294922 l -0.7070312,0.707031 c -0.3917367,0.391737 -0.3917366,1.022326 -2e-7,1.414063 l 4.2421874,4.242187 -4.2421874,4.242188 c -0.3917368,0.391736 -0.3917366,1.022326 -2e-7,1.414062 l 0.7070316,0.707032 c 0.391737,0.391736 1.022326,0.391736 1.414063,0 L 16,19.121297 l 4.242188,4.242188 c 0.391736,0.391736 1.022325,0.391736 1.414062,0 l 0.707031,-0.707032 c 0.391737,-0.391736 0.391737,-1.022326 0,-1.414062 l -4.242187,-4.242188 4.242187,-4.242187 c 0.391737,-0.391737 0.391737,-1.022326 1e-6,-1.414062 L 21.65625,10.636922 c -0.391737,-0.391737 -1.022326,-0.391737 -1.414063,0 L 16,14.879109 11.757812,10.636922 C 11.561944,10.441053 11.3064,10.342 11.050781,10.342 Z" />
+  <path
+     id="rect28568"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-dasharray:none;stroke-opacity:1;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 1.2084344 14.41973 C 1.0276846 14.23898 0.77694631 14.128325 0.49994659 14.128325 L -0.49994659 14.128325 C -1.053946 14.128325 -1.4998398 14.574219 -1.4998398 15.128218 L -1.4998398 21.127577 L -7.4991989 21.127577 C -8.0531983 21.127577 -8.4990921 21.573471 -8.4990921 22.12747 L -8.4990921 23.127364 C -8.4990921 23.681363 -8.0531983 24.127257 -7.4991989 24.127257 L -1.4998398 24.127257 L -1.4998398 30.126616 C -1.4998398 30.680615 -1.053946 31.126509 -0.49994659 31.126509 L 0.49994659 31.126509 C 1.053946 31.126509 1.4998398 30.680615 1.4998398 30.126616 L 1.4998398 24.127257 L 7.4991989 24.127257 C 8.0531983 24.127257 8.4990921 23.681363 8.4990921 23.127364 L 8.4990921 22.12747 C 8.4990921 21.573471 8.0531983 21.127577 7.4991989 21.127577 L 1.4998398 21.127577 L 1.4998398 15.128218 C 1.4998398 14.851218 1.3891843 14.60048 1.2084344 14.41973 z "
+     transform="rotate(-45)" />
 </svg>

--- a/elementary-xfce/emblems/48/emblem-readonly.svg
+++ b/elementary-xfce/emblems/48/emblem-readonly.svg
@@ -1,104 +1,140 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3803"
+   sodipodi:docname="emblem-readonly.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="48px"
-   height="48px"
-   id="svg11300"
-   version="1.1">
-  <defs
-     id="defs3">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient11520"
-       id="radialGradient3009"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0391051,0,0,2.0391051,-25.847328,-36.563417)"
-       cx="24.445690"
-       cy="35.878170"
-       fx="24.445690"
-       fy="35.878170"
-       r="20.530962" />
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="16.970562"
+     inkscape:cy="15.46796"
+     inkscape:window-width="1569"
+     inkscape:window-height="947"
+     inkscape:window-x="341"
+     inkscape:window-y="72"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata4">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>Jakub Steiner</dc:title>
-          </cc:Agent>
-        </dc:creator>
-        <dc:source>http://jimmac.musichall.cz</dc:source>
-        <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
-        <dc:title>Read Only Emblem</dc:title>
-        <dc:subject>
-          <rdf:Bag>
-            <rdf:li>emblem</rdf:li>
-            <rdf:li>read-only</rdf:li>
-            <rdf:li>nowrite</rdf:li>
-          </rdf:Bag>
-        </dc:subject>
       </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
-        <cc:permits
-           rdf:resource="http://web.resource.org/cc/Reproduction" />
-        <cc:permits
-           rdf:resource="http://web.resource.org/cc/Distribution" />
-        <cc:requires
-           rdf:resource="http://web.resource.org/cc/Notice" />
-        <cc:requires
-           rdf:resource="http://web.resource.org/cc/Attribution" />
-        <cc:permits
-           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
-        <cc:requires
-           rdf:resource="http://web.resource.org/cc/ShareAlike" />
-      </cc:License>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       ry="3.860249"
-       rx="3.860249"
-       y="3.5267944"
-       x="3.5267944"
-       height="40.946411"
-       width="40.946411"
-       id="rect11518"
-       style="fill:url(#radialGradient3009);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="38.946411"
-       height="38.946411"
-       x="4.5267944"
-       y="4.5267944"
-       rx="3.0349534"
-       ry="3.0349534" />
-    <path
-       style="opacity:0.69886361;fill:#888a85;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.9999997;marker:none;visibility:visible;display:block;overflow:visible"
-       d="M 23.375004,12 C 19.090351,12.132141 17,14.163344 17,18.346415 L 17,22.999584 15.285715,23 C 14.578189,23.000172 14,23.399251 14,24 l 0,10.91955 c 0,0.600749 0.578189,1.080451 1.285715,1.08045 l 17.44642,0 C 33.439671,36 34,35.520298 34,34.91955 L 34,24 c 0,-0.600748 -0.608825,-0.742564 -1.267865,-1 l -1.74153,0 0.01786,-4.583462 c 0,-4.440426 -2.323972,-6.36173 -6.990605,-6.416538 -0.217569,-0.0026 -0.432135,-0.0065 -0.642856,0 z m 0.428566,3 c 0.07879,-0.0018 0.168535,0 0.250002,0 4.161907,0 3.869505,3.434233 3.945963,4.514415 L 27.999535,23 20,23 20,19.531841 C 19.98162,18.460236 19.851556,15.087759 23.80357,15 z"
-       id="path2086" />
-  </g>
+  <defs
+     id="defs3805">
+    <linearGradient
+       xlink:href="#linearGradient1201"
+       id="linearGradient1192"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0540541,0,0,1.0540541,-1.2973095,-1.2972858)"
+       x1="38.999996"
+       y1="5.9999938"
+       x2="38.999996"
+       y2="41.945408" />
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3208.0737"
+       x2="2035.1652"
+       y2="3241.9966"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5712555,0,0,1.1746645,-3179.0054,-3763.2759)" />
+  </defs>
+  <rect
+     style="fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stop-color:#000000;font-variation-settings:normal;opacity:0.99;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-opacity:1"
+     id="rect4031"
+     width="41"
+     height="41"
+     x="3.5"
+     y="3.5"
+     rx="5"
+     ry="5" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.30000001;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none"
+     d="m 23,11 c -3.860697,0 -7,3.139303 -7,7 v 4 c -1.644701,0 -3,1.355299 -3,3 v 9 c 0,1.644701 1.355299,3 3,3 h 16 c 1.644701,0 3,-1.355299 3,-3 v -9 c 0,-1.644701 -1.355299,-3 -3,-3 v -4 c 0,-3.860697 -3.139305,-7 -7,-7 z m -0.335938,5 h 2.671875 C 26.27582,16 27,16.724182 27,17.664062 V 22 H 21 V 17.664062 C 21,16.724182 21.72418,16 22.664062,16 Z"
+     id="path4842"
+     sodipodi:nodetypes="sscsssssscssssssccss" />
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient1192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2"
+     y="4.5"
+     x="4.5"
+     ry="4"
+     rx="4"
+     height="39"
+     width="39" />
+  <rect
+     style="fill:none;stroke:#7a0000;stroke-width:1;stroke-dasharray:none;stroke-opacity:0.5;stop-color:#000000"
+     id="rect3666"
+     width="41"
+     height="41"
+     x="3.5"
+     y="3.5"
+     rx="5"
+     ry="5" />
+  <path
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#7a0000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 23,13 c -3.324,0 -6,2.676 -6,6 v 3 h 3 v -4.335969 c 0,-1.476274 1.187786,-2.664061 2.664062,-2.664061 h 2.671874 C 26.812212,14.999969 28,16.187757 28,17.664031 V 22 h 3 v -3 c 0,-3.324 -2.676002,-6 -6,-6 z m -9,11 v 10.000001 c 0,1.107999 0.892,2 2,2 h 16 c 1.107998,0 2,-0.892001 2,-2 V 24 Z"
+     id="path955"
+     sodipodi:nodetypes="ssccssssccsssccssccc" />
+  <path
+     id="rect4382-7"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     d="m 23,11 c -3.323997,0 -6,2.676003 -6,6 v 5 h -1 c -1.107999,0 -2,0.892001 -2,2 v 9.000001 c 0,1.107999 0.892001,2 2,2 h 16 c 1.107999,0 2,-0.892001 2,-2 V 24 c 0,-1.107999 -0.892001,-2 -2,-2 h -1 v -5 c 0,-3.323997 -2.676005,-6 -6,-6 z m -0.335938,3 h 2.671876 C 26.812212,14 28,15.18779 28,16.664062 V 22 H 20 V 16.664062 C 20,15.18779 21.187788,14 22.664062,14 Z"
+     sodipodi:nodetypes="sscsssssssscssssssccss" />
 </svg>

--- a/elementary-xfce/emblems/48/emblem-unreadable.svg
+++ b/elementary-xfce/emblems/48/emblem-unreadable.svg
@@ -1,104 +1,139 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg3803"
+   sodipodi:docname="emblem-unreadable.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="48px"
-   height="48px"
-   id="svg11300"
-   version="1.1">
-  <defs
-     id="defs3">
-    <linearGradient
-       id="linearGradient11520">
-      <stop
-         id="stop11522"
-         offset="0.0000000"
-         style="stop-color:#ffffff;stop-opacity:1.0000000;" />
-      <stop
-         id="stop11524"
-         offset="1.0000000"
-         style="stop-color:#dcdcdc;stop-opacity:1.0000000;" />
-    </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient11520"
-       id="radialGradient3009"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.0391051,0,0,2.0391051,-25.847328,-36.563417)"
-       cx="24.445690"
-       cy="35.878170"
-       fx="24.445690"
-       fy="35.878170"
-       r="20.530962" />
-  </defs>
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3509"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="25.809398"
+     inkscape:cy="18.031223"
+     inkscape:window-width="1569"
+     inkscape:window-height="947"
+     inkscape:window-x="341"
+     inkscape:window-y="10"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3803" />
   <metadata
-     id="metadata4">
+     id="metadata25386">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:creator>
-          <cc:Agent>
-            <dc:title>Jakub Steiner</dc:title>
-          </cc:Agent>
-        </dc:creator>
-        <dc:source>http://jimmac.musichall.cz</dc:source>
-        <cc:license
-           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
-        <dc:title />
-        <dc:subject>
-          <rdf:Bag>
-            <rdf:li>emblem</rdf:li>
-            <rdf:li>read-only</rdf:li>
-            <rdf:li>nowrite</rdf:li>
-          </rdf:Bag>
-        </dc:subject>
       </cc:Work>
-      <cc:License
-         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
-        <cc:permits
-           rdf:resource="http://web.resource.org/cc/Reproduction" />
-        <cc:permits
-           rdf:resource="http://web.resource.org/cc/Distribution" />
-        <cc:requires
-           rdf:resource="http://web.resource.org/cc/Notice" />
-        <cc:requires
-           rdf:resource="http://web.resource.org/cc/Attribution" />
-        <cc:permits
-           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
-        <cc:requires
-           rdf:resource="http://web.resource.org/cc/ShareAlike" />
-      </cc:License>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1">
-    <rect
-       ry="3.860249"
-       rx="3.860249"
-       y="3.5267944"
-       x="3.5267944"
-       height="40.946411"
-       width="40.946411"
-       id="rect11518"
-       style="fill:url(#radialGradient3009);fill-opacity:1;fill-rule:evenodd;stroke:#9b9b9b;stroke-width:1.05358744;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible" />
-    <rect
-       style="fill:none;stroke:#ffffff;stroke-width:1.0535872;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:10;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible"
-       id="rect11528"
-       width="38.946411"
-       height="38.946411"
-       x="4.5267944"
-       y="4.5267944"
-       rx="3.0349534"
-       ry="3.0349534" />
-    <path
-       style="fill:#aaaba7;fill-opacity:1;fill-rule:evenodd;stroke:none"
-       d="M 16.235294,12 12,16.235294 19.764707,24 12,31.764706 16.235294,36 24.000002,28.235294 31.764699,36 36,31.764706 28.235294,24 36,16.235294 31.764699,12 24.000002,19.764706 16.235294,12 z"
-       id="path6930" />
-  </g>
+  <defs
+     id="defs3805">
+    <linearGradient
+       xlink:href="#linearGradient1201"
+       id="linearGradient1192"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0540541,0,0,1.0540541,-1.2973095,-1.2972858)"
+       x1="38.999996"
+       y1="5.9999938"
+       x2="38.999996"
+       y2="41.945408" />
+    <linearGradient
+       id="linearGradient1201">
+      <stop
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient947">
+      <stop
+         offset="0"
+         style="stop-color:#ed5353;stop-opacity:1"
+         id="stop943" />
+      <stop
+         offset="1"
+         style="stop-color:#c6262e;stop-opacity:1"
+         id="stop945" />
+    </linearGradient>
+    <linearGradient
+       x1="2035.1652"
+       y1="3208.0737"
+       x2="2035.1652"
+       y2="3241.9966"
+       id="linearGradient11527-6-5"
+       xlink:href="#linearGradient947"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5712555,0,0,1.1746645,-3179.0054,-3763.2759)" />
+  </defs>
+  <rect
+     style="fill:url(#linearGradient11527-6-5);fill-opacity:1;stroke:none;stroke-width:1;stroke-dasharray:none;stop-color:#000000;font-variation-settings:normal;opacity:0.99;vector-effect:none;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-opacity:1"
+     id="rect4031"
+     width="41"
+     height="41"
+     x="3.5"
+     y="3.5"
+     rx="5"
+     ry="5" />
+  <path
+     style="color:#000000;fill:#7a0000;fill-opacity:0.3;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 16.222656,12.806641 c -0.764479,0 -1.539469,0.29533 -2.123047,0.878906 l -1.414062,1.414062 c -1.163476,1.163476 -1.163477,3.080664 0,4.244141 L 18.341797,25 l -5.65625,5.65625 c -1.163475,1.163476 -1.163477,3.080664 0,4.244141 l 1.414062,1.414062 c 1.163476,1.163477 3.080665,1.163475 4.244141,0 L 24,30.658203 l 5.65625,5.65625 c 1.163477,1.163477 3.080665,1.163476 4.244141,0 l 1.414062,-1.414062 c 1.163476,-1.163476 1.163477,-3.080665 0,-4.244141 L 29.658203,25 l 5.65625,-5.65625 c 1.163475,-1.163476 1.163477,-3.080665 0,-4.244141 l -1.414062,-1.414062 c -1.163476,-1.163477 -3.080665,-1.163476 -4.244141,0 L 24,19.341797 18.34375,13.685547 c -0.582403,-0.582401 -1.356614,-0.878906 -2.121094,-0.878906 z"
+     id="path7294"
+     sodipodi:nodetypes="sssscsssscsssscssssccs" />
+  <path
+     id="path7292"
+     style="opacity:1;fill:#7a0000;fill-opacity:0.5;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.15;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 16.222656,13.806668 c -0.511237,0 -1.024278,0.194201 -1.416015,0.585937 l -1.414063,1.414063 c -0.783473,0.783473 -0.783474,2.046604 0,2.830078 l 6.363281,6.363281 -6.363281,6.363281 c -0.783473,0.783474 -0.783474,2.046605 0,2.830079 l 1.414063,1.414062 c 0.783473,0.783474 2.046604,0.783473 2.830078,0 L 24,29.244168 l 6.363281,6.363281 c 0.783474,0.783474 2.046605,0.783473 2.830078,0 l 1.414063,-1.414063 c 0.783473,-0.783473 0.783474,-2.046604 0,-2.830077 l -6.363281,-6.363282 6.363281,-6.363281 c 0.783473,-0.783474 0.783474,-2.046605 0,-2.830078 l -1.414063,-1.414063 c -0.783473,-0.783474 -2.046604,-0.783473 -2.830078,1e-6 L 24,20.755887 17.636719,14.392605 c -0.391737,-0.391736 -0.902825,-0.585937 -1.414063,-0.585937 z" />
+  <path
+     id="rect7152"
+     style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:0.15;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 20.526813 -2.4154878 C 20.165313 -2.0539882 19.939859 -1.5538926 19.939859 -0.99989318 L 19.939859 0.99989318 C 19.939859 2.1078921 20.833027 3.0010606 21.941026 3.0010606 L 30.940065 3.0010606 L 30.940065 12.000099 C 30.940065 13.108098 31.833233 14.001267 32.941232 14.001267 L 34.941019 14.001267 C 36.049018 14.001267 36.942186 13.108098 36.942186 12.000099 L 36.942186 3.0010606 L 45.941225 3.0010606 C 47.049224 3.0010606 47.942392 2.1078921 47.942392 0.99989318 L 47.942392 -0.99989318 C 47.942392 -2.1078921 47.049224 -3.0010606 45.941225 -3.0010606 L 36.942186 -3.0010606 L 36.942186 -12.000099 C 36.942186 -13.108098 36.049018 -14.001267 34.941019 -14.001267 L 32.941232 -14.001267 C 31.833233 -14.001267 30.940065 -13.108098 30.940065 -12.000099 L 30.940065 -3.0010606 L 21.941026 -3.0010606 C 21.387027 -3.0010606 20.888312 -2.7769875 20.526813 -2.4154878 z "
+     transform="rotate(45)" />
+  <rect
+     style="opacity:0.35;fill:none;stroke:url(#linearGradient1192);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-2"
+     y="4.5"
+     x="4.5"
+     ry="4"
+     rx="4"
+     height="39"
+     width="39" />
+  <rect
+     style="fill:none;stroke:#7a0000;stroke-width:1;stroke-dasharray:none;stroke-opacity:0.5;stop-color:#000000"
+     id="rect3666"
+     width="41"
+     height="41"
+     x="3.5"
+     y="3.5"
+     rx="5"
+     ry="5" />
 </svg>


### PR DESCRIPTION
Debian was marking these as CC-BY-SA-2.0. I believe they were originally Gnome icons which were relicensed from CC-BY-SA-2.0 to GPL-2-or-later but I'm not totally sure. So best to replace them as newly made GPL3 icons.

This combines the color of the error emblem with the metaphor of the existing read/write restricted emblems.

They may be a little loud. Going to go ahead and replace them just to be sure of licensing stuff, but if there are any complaints as to the colors we can change that later.