### PR TITLE
Fix workflow not building icon theme correctly

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,14 +5,14 @@ on: pull_request
 jobs:
   check:
     name: Check for dangling symlinks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     permissions:
       pull-requests: write
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check symlinks and build theme
         shell: bash
         run: |

--- a/.github/workflows/symlinks-check.yml
+++ b/.github/workflows/symlinks-check.yml
@@ -9,11 +9,11 @@ on:
 jobs:
   check:
     name: Check for dangling symlinks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Check symlinks
         shell: bash
         run: |


### PR DESCRIPTION
There seems to be some issue with the png to svg
conversion in the github actions workflow when
using `ubuntu-latest` (which is currently Ubuntu 24.04).
This is resolved by using `ubuntu-22.04`.

Not sure why this happens, I've tested on Ubuntu 24.04
on my machine (and VM) and do not get the build errors.

This fix feels like a band-aid but it works for now.