### PR TITLE
Dark: Add deprecation warning

### DIFF
--- a/elementary-xfce-dark/index.theme
+++ b/elementary-xfce-dark/index.theme
@@ -1,6 +1,6 @@
 [Icon Theme]
 Name=elementary Xfce dark
-Comment=Provides light panel icons for dark panels
+Comment=Deprecated, please use elementary-xfce
 Inherits=elementary-xfce
 
 Example=directory-x-normal


### PR DESCRIPTION
With the move to colorize and unify these icon themes, the -dark variant is no longer needed or used.

This adds a deprecation warning but leaves the folder and index.theme installed so that a user's icon theme will not abruptly change. It simply falls back to elementary-xfce. At some point in the future, after people have had time to switch to the main theme in their settings, the -dark theme will be removed.