### PR TITLE
Apps: Add htop icon

### DIFF
--- a/elementary-xfce/apps/128/htop.svg
+++ b/elementary-xfce/apps/128/htop.svg
@@ -1,1 +1,488 @@
-utilities-system-monitor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg4113"
+   height="128"
+   width="128"
+   version="1.1"
+   sodipodi:docname="htop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview12245"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.8558349"
+     inkscape:cx="63.01697"
+     inkscape:cy="58.486338"
+     inkscape:window-width="1407"
+     inkscape:window-height="939"
+     inkscape:window-x="509"
+     inkscape:window-y="32"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4113" />
+  <defs
+     id="defs4115">
+    <linearGradient
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135184,1.488321)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient4136"
+       y2="42.311825"
+       x2="23.99999"
+       y1="5.6827893"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.08524508"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.91000003"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,24.139622,-29.635745,0,361.28116,-204.72681)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
+       id="radialGradient3936-3"
+       fy="9.9571075"
+       fx="7.1183534"
+       r="8.9330635"
+       cy="9.9571075"
+       cx="7.1183534" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#404648;stop-opacity:1"
+         id="stop3750-1-0-7-6-6-1-3-9-3-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#0c1011;stop-opacity:1"
+         id="stop3754-1-8-5-2-7-6-7-1-9-1-0" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-5">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-0" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-5" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-9" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-0">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-0" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3813" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3815" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270355,102.1321)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
+       id="radialGradient4111"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" />
+  </defs>
+  <metadata
+     id="metadata4118">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 119,118.00181 a 55,6 0 0 1 -109.9999982,0 55,6 0 1 1 109.9999982,0 z"
+     id="path3041"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4111);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <g
+     transform="matrix(2.6999989,0,0,0.55555607,-0.80000812,94.890691)"
+     id="g2036"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <rect
+     width="103"
+     height="103"
+     rx="10"
+     ry="10"
+     x="12.499988"
+     y="15.501808"
+     id="rect5505-21-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:url(#radialGradient3936-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0.15;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 32,35 v 66 H 54 V 75 h 20 v 26 H 96 V 35 H 74 V 61 H 54 V 35 Z"
+     id="path13997"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     id="rect8669"
+     style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 33,36 v 12 h 6 V 36 Z m 7,0 v 12 h 6 V 36 Z m 7,0 v 12 h 6 V 36 Z m 28,0 v 12 h 6 V 36 Z m 7,0 v 12 h 6 V 36 Z m 7,0 v 12 h 6 V 36 Z M 33,49 v 12 h 6 V 49 Z m 7,0 v 12 h 6 V 49 Z m 7,0 v 12 h 6 V 49 Z m 28,0 v 12 h 6 V 49 Z m 7,0 v 12 h 6 V 49 Z m 7,0 v 12 h 6 V 49 Z M 33,62 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z m 7,0 v 12 h 6 V 62 Z M 33,75 v 12 h 6 V 75 Z m 7,0 v 12 h 6 V 75 Z m 7,0 v 12 h 6 V 75 Z m 28,0 v 12 h 6 V 75 Z m 7,0 v 12 h 6 V 75 Z m 7,0 v 12 h 6 V 75 Z M 33,88 v 12 h 6 V 88 Z m 7,0 v 12 h 6 V 88 Z m 7,0 v 12 h 6 V 88 Z m 28,0 v 12 h 6 V 88 Z m 7,0 v 12 h 6 V 88 Z m 7,0 v 12 h 6 V 88 Z" />
+  <rect
+     width="101"
+     height="101"
+     rx="9"
+     ry="9"
+     x="13.499988"
+     y="16.501808"
+     id="rect6741-7"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient4136);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     width="103"
+     height="103"
+     rx="10"
+     ry="10"
+     x="12.499988"
+     y="15.501808"
+     id="rect5505-21-3-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27345"
+     width="6"
+     height="12"
+     x="33"
+     y="35" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27399"
+     width="6"
+     height="12"
+     x="40"
+     y="35" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27401"
+     width="6"
+     height="12"
+     x="47"
+     y="35" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27403"
+     width="6"
+     height="12"
+     x="33"
+     y="48" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27405"
+     width="6"
+     height="12"
+     x="40"
+     y="48" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27407"
+     width="6"
+     height="12"
+     x="47"
+     y="48" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27409"
+     width="6"
+     height="12"
+     x="33"
+     y="61" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27411"
+     width="6"
+     height="12"
+     x="40"
+     y="61" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27413"
+     width="6"
+     height="12"
+     x="47"
+     y="61" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27415"
+     width="6"
+     height="12"
+     x="33"
+     y="74" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27417"
+     width="6"
+     height="12"
+     x="40"
+     y="74" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27419"
+     width="6"
+     height="12"
+     x="47"
+     y="74" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27421"
+     width="6"
+     height="12"
+     x="33"
+     y="87" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27423"
+     width="6"
+     height="12"
+     x="40"
+     y="87" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27425"
+     width="6"
+     height="12"
+     x="47"
+     y="87" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27427"
+     width="6"
+     height="12"
+     x="61"
+     y="61" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27431"
+     width="6"
+     height="12"
+     x="68"
+     y="61" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12551"
+     width="6"
+     height="12"
+     x="75"
+     y="35" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12553"
+     width="6"
+     height="12"
+     x="82"
+     y="35" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12555"
+     width="6"
+     height="12"
+     x="89"
+     y="35" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12557"
+     width="6"
+     height="12"
+     x="75"
+     y="48" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12559"
+     width="6"
+     height="12"
+     x="82"
+     y="48" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12561"
+     width="6"
+     height="12"
+     x="89"
+     y="48" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12563"
+     width="6"
+     height="12"
+     x="75"
+     y="61" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12565"
+     width="6"
+     height="12"
+     x="82"
+     y="61" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12567"
+     width="6"
+     height="12"
+     x="89"
+     y="61" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12569"
+     width="6"
+     height="12"
+     x="75"
+     y="74" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12571"
+     width="6"
+     height="12"
+     x="82"
+     y="74" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12573"
+     width="6"
+     height="12"
+     x="89"
+     y="74" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12575"
+     width="6"
+     height="12"
+     x="75"
+     y="87" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12577"
+     width="6"
+     height="12"
+     x="82"
+     y="87" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12579"
+     width="6"
+     height="12"
+     x="89"
+     y="87" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect12779"
+     width="6"
+     height="12"
+     x="54"
+     y="61" />
+</svg>

--- a/elementary-xfce/apps/16/htop.svg
+++ b/elementary-xfce/apps/16/htop.svg
@@ -1,1 +1,188 @@
-utilities-system-monitor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg4060"
+   sodipodi:docname="htop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview34343"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="6.546875"
+     inkscape:cy="8.046875"
+     inkscape:window-width="1278"
+     inkscape:window-height="918"
+     inkscape:window-x="638"
+     inkscape:window-y="36"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4060" />
+  <defs
+     id="defs4062">
+    <linearGradient
+       x1="23.99999"
+       y1="6.9298882"
+       x2="23.99999"
+       y2="41.079269"
+       id="linearGradient3896"
+       xlink:href="#linearGradient3924-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.43242666,-0.43242611)" />
+    <linearGradient
+       id="linearGradient3924-4-8">
+      <stop
+         id="stop3926-0-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-6-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.0464583" />
+      <stop
+         id="stop3930-2-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93727428" />
+      <stop
+         id="stop3932-9-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,2.2838591,-2.8038497,0,36.237876,-22.480835)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
+       id="radialGradient3988-3-3"
+       fy="9.9571075"
+       fx="6.952919"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.952919" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#404648;stop-opacity:1"
+         id="stop3750-1-0-7-6-6-1-3-9-3-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#0c1011;stop-opacity:1"
+         id="stop3754-1-8-5-2-7-6-7-1-9-1-0" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4065">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.9;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-3-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect5505-21-7"
+     y="0.50000155"
+     x="0.50000155"
+     ry="2"
+     rx="2"
+     height="15.000001"
+     width="15.000001" />
+  <path
+     style="color:#000000;fill:#000000;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.15000001"
+     d="m 2,4 v 10 h 5 v -3 h 2 v 3 h 5 V 4 H 9 V 7 H 7 V 4 Z"
+     id="path5417"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     id="rect5027"
+     style="fill:#000000;fill-opacity:0.30000001;fill-rule:evenodd;stroke:none;stroke-width:0.999995;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 3,5 V 7 H 4 V 5 Z M 5,5 V 7 H 6 V 5 Z m 5,0 v 2 h 1 V 5 Z m 2,0 v 2 h 1 V 5 Z M 3,8 v 2 H 4 V 8 Z m 2,0 v 2 H 6 V 8 Z m 2,0 v 2 H 9 V 8 Z m 3,0 v 2 h 1 V 8 Z m 2,0 v 2 h 1 V 8 Z m -9,3 v 2 h 1 v -2 z m 2,0 v 2 h 1 v -2 z m 5,0 v 2 h 1 v -2 z m 2,0 v 2 h 1 v -2 z" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3896);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-0-3"
+     y="1.4999999"
+     x="1.5"
+     height="13"
+     width="13"
+     rx="1"
+     ry="1" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-2-8"
+     y="0.5"
+     x="0.5"
+     ry="2"
+     rx="2"
+     height="15"
+     width="15" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27405"
+     width="2"
+     height="2"
+     x="-6"
+     y="4"
+     transform="scale(-1,1)" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27423"
+     width="2"
+     height="2"
+     x="-6"
+     y="10"
+     transform="scale(-1,1)" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2902"
+     width="2"
+     height="2"
+     x="-6"
+     y="7"
+     transform="scale(-1,1)" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4530"
+     width="2"
+     height="2"
+     x="10"
+     y="4" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999995;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4534"
+     width="2"
+     height="2"
+     x="10"
+     y="10" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4536"
+     width="2"
+     height="2"
+     x="10"
+     y="7" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect15154"
+     width="2"
+     height="2"
+     x="-9"
+     y="7"
+     transform="scale(-1,1)" />
+</svg>

--- a/elementary-xfce/apps/22/htop.svg
+++ b/elementary-xfce/apps/22/htop.svg
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
    version="1.1"
-   width="24"
-   height="24"
+   width="22"
+   height="22"
    id="svg3426"
    sodipodi:docname="htop.svg"
    inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
@@ -24,9 +24,9 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="36.625"
-     inkscape:cx="11.153584"
-     inkscape:cy="13.515358"
+     inkscape:zoom="9.1562501"
+     inkscape:cx="25.010239"
+     inkscape:cy="11.358362"
      inkscape:window-width="1420"
      inkscape:window-height="847"
      inkscape:window-x="698"
@@ -35,71 +35,6 @@
      inkscape:current-layer="svg3426" />
   <defs
      id="defs3428">
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3152"
-       xlink:href="#linearGradient3688-166-749"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749">
-      <stop
-         id="stop2883"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3154"
-       xlink:href="#linearGradient3688-464-309"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309">
-      <stop
-         id="stop2889"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3156"
-       xlink:href="#linearGradient3702-501-757"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757">
-      <stop
-         id="stop2895"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
     <linearGradient
        id="linearGradient3924-64">
       <stop
@@ -124,7 +59,7 @@
        x2="23.99999"
        y1="6.5908957"
        x1="23.99999"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742189,0.9717506)"
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,-0.02577919,-0.02827539)"
        gradientUnits="userSpaceOnUse"
        id="linearGradient3101"
        xlink:href="#linearGradient3924-64" />
@@ -140,7 +75,7 @@
          id="stop3754-1-8-5-2-7-6-7-1-9-1-0" />
     </linearGradient>
     <radialGradient
-       gradientTransform="matrix(0,2.8928881,-3.5515428,0,47.767971,-26.609032)"
+       gradientTransform="matrix(0,2.8928881,-3.5515428,0,46.767973,-27.609058)"
        gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
        id="radialGradient3988-3-3"
@@ -161,71 +96,39 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     style="display:inline"
-     id="g2036"
-     transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33331)">
-    <g
-       style="opacity:0.4"
-       id="g3712"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-      <rect
-         style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
-         id="rect3700"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
-  </g>
   <rect
      style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.9;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-3-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
      id="rect5505-21-6"
-     y="2.5000269"
-     x="2.499999"
+     y="1.500001"
+     x="1.500001"
      ry="2"
      rx="2"
      height="19"
      width="19" />
   <path
      style="color:#000000;fill:#000000;fill-opacity:0.15;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
-     d="m 5,5 v 16 h 5 v -5 h 4 v 5 h 5 V 5 h -5 v 5 H 10 V 5 Z"
+     d="m 4.0000019,3.999974 v 16 h 5 v -5 h 4.0000001 v 5 h 5 v -16 h -5 v 5 H 9.0000019 v -5 z"
      id="path3914"
      sodipodi:nodetypes="ccccccccccccc" />
   <path
      id="rect3306"
      style="fill:#000000;fill-opacity:0.3;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
-     d="m 6,6 v 4 H 9 V 6 Z m 9,0 v 4 h 3 V 6 Z m -9,5 v 4 h 3 v -4 z m 4,0 v 4 h 4 v -4 z m 5,0 v 4 h 3 v -4 z m -9,5 v 4 h 3 v -4 z m 9,0 v 4 h 3 v -4 z"
+     d="m 5.0000019,4.999974 v 4 h 3 v -4 z m 9.0000001,0 v 4 h 3 v -4 z m -9.0000001,5 v 4 h 3 v -4 z m 4,0 v 4 h 4.0000001 v -4 z m 5.0000001,0 v 4 h 3 v -4 z m -9.0000001,5 v 4 h 3 v -4 z m 9.0000001,0 v 4 h 3 v -4 z"
      sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccc" />
   <rect
      width="19.000002"
      height="19.000002"
      rx="2"
      ry="2"
-     x="2.4999981"
-     y="2.500026"
+     x="1.5"
+     y="1.5"
      id="rect5505-21-8-1"
      style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
   <rect
      width="17"
      height="17"
-     x="3.5012493"
-     y="3.4987738"
+     x="2.5012512"
+     y="2.4987478"
      id="rect6741-9-5"
      style="opacity:0.3;fill:none;stroke:url(#linearGradient3101);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      rx="1"
@@ -235,48 +138,48 @@
      id="rect2902"
      width="4"
      height="4"
-     x="10"
-     y="10" />
+     x="9.0000019"
+     y="8.9999743" />
   <rect
      style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
      id="rect4589"
      width="3"
      height="4"
-     x="6"
-     y="10" />
+     x="5.0000019"
+     y="8.9999743" />
   <rect
      style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
      id="rect4591"
      width="3"
      height="4"
-     x="6"
-     y="15" />
+     x="5.0000019"
+     y="13.999974" />
   <rect
      style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
      id="rect4593"
      width="3"
      height="4"
-     x="6"
-     y="5" />
+     x="5.0000019"
+     y="3.999974" />
   <rect
      style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
      id="rect4595"
      width="3"
      height="4"
-     x="15"
-     y="10" />
+     x="14.000002"
+     y="8.9999743" />
   <rect
      style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
      id="rect4597"
      width="3"
      height="4"
-     x="15"
-     y="15" />
+     x="14.000002"
+     y="13.999974" />
   <rect
      style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
      id="rect4599"
      width="3"
      height="4"
-     x="15"
-     y="5" />
+     x="14.000002"
+     y="3.999974" />
 </svg>

--- a/elementary-xfce/apps/32/htop.svg
+++ b/elementary-xfce/apps/32/htop.svg
@@ -1,1 +1,337 @@
-utilities-system-monitor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg4151"
+   sodipodi:docname="htop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview1505"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="19.423339"
+     inkscape:cx="6.6672368"
+     inkscape:cy="14.441389"
+     inkscape:window-width="1432"
+     inkscape:window-height="862"
+     inkscape:window-x="910"
+     inkscape:window-y="71"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4151" />
+  <defs
+     id="defs4153">
+    <linearGradient
+       id="linearGradient4281">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4283" />
+      <stop
+         offset="0.02591527"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4285" />
+      <stop
+         offset="0.95833325"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4287" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4289" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.2399855"
+       x2="23.99999"
+       y2="41.759987"
+       id="linearGradient3174"
+       xlink:href="#linearGradient4281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.21621703,-0.21620627)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2976"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2978"
+       xlink:href="#linearGradient3688-464-309-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-7">
+      <stop
+         id="stop2889-0"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-66"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2980"
+       xlink:href="#linearGradient3702-501-757-3"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0,4.1109463,-5.0469293,0,66.828173,-38.865506)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
+       id="radialGradient3988-3"
+       fy="9.9571075"
+       fx="6.952919"
+       r="12.671875"
+       cy="9.9571075"
+       cx="6.952919" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8">
+      <stop
+         offset="0"
+         style="stop-color:#404648;stop-opacity:1"
+         id="stop3750-1-0-7-6-6-1-3-9-3-9-2" />
+      <stop
+         offset="1"
+         style="stop-color:#0c1011;stop-opacity:1"
+         id="stop3754-1-8-5-2-7-6-7-1-9-1-0" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4156">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.9;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+     id="rect5505-21"
+     y="2.5"
+     x="2.5000002"
+     ry="3"
+     rx="3"
+     height="27"
+     width="27" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0.15;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 5,6 v 22 h 7 v -7 h 8 v 7 h 7 V 6 h -7 v 7 H 12 V 6 Z"
+     id="path3722"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     id="rect11475"
+     style="fill:#000000;fill-opacity:0.30000001;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 6 7 L 6 13 L 8 13 L 8 7 L 6 7 z M 9 7 L 9 13 L 11 13 L 11 7 L 9 7 z M 21 7 L 21 13 L 23 13 L 23 7 L 21 7 z M 24 7 L 24 13 L 26 13 L 26 7 L 24 7 z M 6 14 L 6 20 L 8 20 L 8 14 L 6 14 z M 9 14 L 9 20 L 11 20 L 11 14 L 9 14 z M 12 14 L 12 20 L 14 20 L 14 14 L 12 14 z M 15 14 L 15 20 L 17 20 L 17 14 L 15 14 z M 18 14 L 18 20 L 20 20 L 20 14 L 18 14 z M 21 14 L 21 20 L 23 20 L 23 14 L 21 14 z M 24 14 L 24 20 L 26 20 L 26 14 L 24 14 z M 6 21 L 6 27 L 8 27 L 8 21 L 6 21 z M 9 21 L 9 27 L 11 27 L 11 21 L 9 21 z M 21 21 L 21 27 L 23 27 L 23 21 L 21 21 z M 24 21 L 24 27 L 26 27 L 26 21 L 24 21 z " />
+  <g
+     style="display:inline"
+     id="g2036-2"
+     transform="matrix(0.6999997,0,0,0.3333336,-0.8000002,15.33333)">
+    <g
+       style="opacity:0.4"
+       id="g3712-3"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2976);fill-opacity:1;stroke:none"
+         id="rect2801-0"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2978);fill-opacity:1;stroke:none"
+         id="rect3696-2"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2980);fill-opacity:1;stroke:none"
+         id="rect3700-1"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+  </g>
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3174);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4"
+     y="3.4999998"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-6"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
+     height="27"
+     width="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27405"
+     width="2"
+     height="6"
+     x="9"
+     y="6" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27417"
+     width="2"
+     height="6"
+     x="9"
+     y="20" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2079"
+     width="2"
+     height="6"
+     x="21"
+     y="6" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2083"
+     width="2"
+     height="6"
+     x="21"
+     y="20" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2902"
+     width="2"
+     height="6"
+     x="9"
+     y="13" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2904"
+     width="2"
+     height="6"
+     x="12"
+     y="13" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2906"
+     width="2"
+     height="6"
+     x="18"
+     y="13" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2908"
+     width="2"
+     height="6"
+     x="21"
+     y="13" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect2910"
+     width="2"
+     height="6"
+     x="15"
+     y="13" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10709"
+     width="2"
+     height="6"
+     x="6"
+     y="6" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10711"
+     width="2"
+     height="6"
+     x="6"
+     y="20" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10713"
+     width="2"
+     height="6"
+     x="6"
+     y="13" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999997;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10719"
+     width="2"
+     height="6"
+     x="24"
+     y="6" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10721"
+     width="2"
+     height="6"
+     x="24"
+     y="20" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999996;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10723"
+     width="2"
+     height="6"
+     x="24"
+     y="13" />
+</svg>

--- a/elementary-xfce/apps/48/htop.svg
+++ b/elementary-xfce/apps/48/htop.svg
@@ -1,1 +1,333 @@
-utilities-system-monitor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4296"
+   sodipodi:docname="htop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3012"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="36.625"
+     inkscape:cx="15.535836"
+     inkscape:cy="30.825939"
+     inkscape:window-width="1409"
+     inkscape:window-height="929"
+     inkscape:window-x="507"
+     inkscape:window-y="86"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4296" />
+  <defs
+     id="defs4298">
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3899"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06482168" />
+      <stop
+         id="stop3901"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94037783" />
+      <stop
+         id="stop3903"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.0018754"
+       x2="23.99999"
+       y2="41.996876"
+       id="linearGradient3024"
+       xlink:href="#linearGradient3895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4e-6,1.0000062)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3038"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3040"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3042"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       cx="6.952919"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.952919"
+       fy="9.9571075"
+       id="radialGradient3988-3"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,5.9380335,-7.2900091,0,97.418486,-54.250182)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-3-9-2"
+         style="stop-color:#404648;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-9-1-0"
+         style="stop-color:#0c1011;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4301">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.1578952,0,0,0.6428571,-3.789476,16.035716)"
+     id="g3712-5"
+     style="opacity:0.6">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801-3"
+       style="fill:url(#radialGradient3038);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696-6"
+       style="fill:url(#radialGradient3040);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-4"
+       style="fill:url(#linearGradient3042);fill-opacity:1;stroke:none" />
+  </g>
+  <rect
+     width="39"
+     height="39"
+     rx="4"
+     ry="4"
+     x="4.5000124"
+     y="5.4999948"
+     id="rect5505-21"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.9;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;font-variation-settings:normal;opacity:1;vector-effect:none;fill:#000000;fill-opacity:0.15;fill-rule:evenodd;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     d="m 13,15 v 22 h 7 v -7 h 8 v 7 h 7 V 15 h -7 v 7 h -8 v -7 z"
+     id="path23492"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     id="rect1103"
+     style="opacity:1;fill:#000000;fill-opacity:0.3;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 14,16 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 12,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m -18,7 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m -18,7 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z m 12,0 v 6 h 2 v -6 z m 3,0 v 6 h 2 v -6 z"
+     sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+  <rect
+     width="39"
+     height="39"
+     rx="4"
+     ry="4"
+     x="4.5000124"
+     y="5.4999952"
+     id="rect5505-21-3-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="37"
+     height="37"
+     rx="3"
+     ry="3"
+     x="5.5000124"
+     y="6.5000005"
+     id="rect6741"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3024);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect940"
+     width="2"
+     height="6"
+     x="14"
+     y="15" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect994"
+     width="2"
+     height="6"
+     x="17"
+     y="15" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect996"
+     width="2"
+     height="6"
+     x="14"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect998"
+     width="2"
+     height="6"
+     x="17"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1000"
+     width="2"
+     height="6"
+     x="14"
+     y="29" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1002"
+     width="2"
+     height="6"
+     x="17"
+     y="29" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1004"
+     width="2"
+     height="6"
+     x="20"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1006"
+     width="2"
+     height="6"
+     x="23"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1008"
+     width="2"
+     height="6"
+     x="26"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1010"
+     width="2"
+     height="6"
+     x="29"
+     y="15" />
+  <rect
+     style="opacity:1;fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1012"
+     width="2"
+     height="6"
+     x="32"
+     y="15" />
+  <rect
+     style="opacity:1;fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1014"
+     width="2"
+     height="6"
+     x="29"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1016"
+     width="2"
+     height="6"
+     x="32"
+     y="22" />
+  <rect
+     style="opacity:1;fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1018"
+     width="2"
+     height="6"
+     x="29"
+     y="29" />
+  <rect
+     style="opacity:1;fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect1020"
+     width="2"
+     height="6"
+     x="32"
+     y="29" />
+</svg>

--- a/elementary-xfce/apps/64/htop.svg
+++ b/elementary-xfce/apps/64/htop.svg
@@ -1,1 +1,405 @@
-utilities-system-monitor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg4161"
+   sodipodi:docname="htop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview23683"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="54.9375"
+     inkscape:cx="27.276451"
+     inkscape:cy="45.542662"
+     inkscape:window-width="1420"
+     inkscape:window-height="885"
+     inkscape:window-x="496"
+     inkscape:window-y="58"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4161"
+     showguides="true" />
+  <defs
+     id="defs4163">
+    <linearGradient
+       x1="23.99999"
+       y1="5.8519015"
+       x2="23.99999"
+       y2="42.150478"
+       id="linearGradient3180"
+       xlink:href="#linearGradient3924-2-2-5-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.4324324,-2.378381,-2.3783727)" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.08576974" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.91249013" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="6.952919"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.952919"
+       fy="9.9571075"
+       id="radialGradient3988-3"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,8.3741498,-10.280782,0,135.53887,-79.76307)" />
+    <linearGradient
+       id="linearGradient3688-166-749-4-0-3-8">
+      <stop
+         id="stop2883-4-0-1-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-9-2-9-6"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-8-4-1-1">
+      <stop
+         id="stop2895-8-9-9-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-7-8-7-7"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-4-5-1-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-3-9-2"
+         style="stop-color:#404648;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-9-1-0"
+         style="stop-color:#0c1011;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2-3"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,41.985755,15.500001)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4-5"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,-22.014244,-102.5)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient6394"
+       xlink:href="#linearGradient3702-501-757-8-4-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5714286,0,0,0.7142857,-5.7142853,27.928572)" />
+  </defs>
+  <metadata
+     id="metadata4166">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g866">
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3337-2-2-3);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect2801-5-5-7-9"
+       y="56.5"
+       x="54"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3339-1-4-5);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-61.5"
+       x="-10"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.6;fill:url(#linearGradient6394);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3700-5-6-8-4"
+       y="56.5"
+       x="10"
+       height="5.0000005"
+       width="44" />
+  </g>
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.9;fill:url(#radialGradient3988-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-3-8-5-2"
+     y="4.5"
+     x="4.5"
+     ry="6"
+     rx="6"
+     height="55"
+     width="55" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0.15;fill-rule:evenodd;paint-order:markers fill stroke;stroke-width:1;stroke-dasharray:none"
+     d="M 15,16 V 50 H 28 V 39 h 8 V 50 H 49 V 16 H 36 V 27 H 28 V 16 Z"
+     id="path1046"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     id="rect4279"
+     style="fill:#000000;fill-opacity:0.3;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 16,17 v 10 h 2 V 17 Z m 3,0 v 10 h 2 V 17 Z m 3,0 v 10 h 2 V 17 Z m 3,0 v 10 h 2 V 17 Z m 12,0 v 10 h 2 V 17 Z m 3,0 v 10 h 2 V 17 Z m 3,0 v 10 h 2 V 17 Z m 3,0 v 10 h 2 V 17 Z M 16,28 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z m 3,0 v 10 h 2 V 28 Z M 16,39 v 10 h 2 V 39 Z m 3,0 v 10 h 2 V 39 Z m 3,0 v 10 h 2 V 39 Z m 3,0 v 10 h 2 V 39 Z m 12,0 v 10 h 2 V 39 Z m 3,0 v 10 h 2 V 39 Z m 3,0 v 10 h 2 V 39 Z m 3,0 v 10 h 2 V 39 Z" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3180);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3"
+     y="5.5"
+     x="5.4999986"
+     ry="5"
+     rx="5"
+     height="53"
+     width="53" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+     id="rect5505-21-3-8-9-1-1"
+     y="4.5000019"
+     x="4.4999986"
+     ry="6"
+     rx="6"
+     height="55"
+     width="55" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27403"
+     width="2"
+     height="10"
+     x="19"
+     y="16" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27405"
+     width="2"
+     height="10"
+     x="22"
+     y="16" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27407"
+     width="2"
+     height="10"
+     x="25"
+     y="16" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27409"
+     width="2"
+     height="10"
+     x="19"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27411"
+     width="2"
+     height="10"
+     x="22"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27413"
+     width="2"
+     height="10"
+     x="25"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27415"
+     width="2"
+     height="10"
+     x="19"
+     y="38" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27417"
+     width="2"
+     height="10"
+     x="22"
+     y="38" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27419"
+     width="2"
+     height="10"
+     x="25"
+     y="38" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27427"
+     width="2"
+     height="10"
+     x="28"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27429"
+     width="2"
+     height="10"
+     x="31"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27435"
+     width="2"
+     height="10"
+     x="34"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27443"
+     width="2"
+     height="10"
+     x="37"
+     y="16" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27445"
+     width="2"
+     height="10"
+     x="40"
+     y="16" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27447"
+     width="2"
+     height="10"
+     x="43"
+     y="16" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27449"
+     width="2"
+     height="10"
+     x="37"
+     y="27" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27451"
+     width="2"
+     height="10"
+     x="40"
+     y="27" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27453"
+     width="2"
+     height="10"
+     x="43"
+     y="27" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27455"
+     width="2"
+     height="10"
+     x="37"
+     y="38" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27457"
+     width="2"
+     height="10"
+     x="40"
+     y="38" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27459"
+     width="2"
+     height="10"
+     x="43"
+     y="38" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3366"
+     width="2"
+     height="10"
+     x="16"
+     y="16" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3368"
+     width="2"
+     height="10"
+     x="16"
+     y="27" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3370"
+     width="2"
+     height="10"
+     x="16"
+     y="38" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3429"
+     width="2"
+     height="10"
+     x="46"
+     y="16" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3431"
+     width="2"
+     height="10"
+     x="46"
+     y="27" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3433"
+     width="2"
+     height="10"
+     x="46"
+     y="38" />
+</svg>

--- a/elementary-xfce/apps/96/htop.svg
+++ b/elementary-xfce/apps/96/htop.svg
@@ -1,0 +1,459 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="96"
+   height="96"
+   id="svg4296"
+   sodipodi:docname="htop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview39"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="7.9999999"
+     inkscape:cx="42.1875"
+     inkscape:cy="66.125001"
+     inkscape:window-width="1278"
+     inkscape:window-height="1035"
+     inkscape:window-x="771"
+     inkscape:window-y="54"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4296" />
+  <defs
+     id="defs4298">
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3899"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03030945" />
+      <stop
+         id="stop3901"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97833663" />
+      <stop
+         id="stop3903"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.0315123"
+       x2="23.99999"
+       y2="41.934097"
+       id="linearGradient3024"
+       xlink:href="#linearGradient3895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0810811,0,0,2.0810811,-1.945964,0.05406598)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3038"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.124458,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3040"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3042"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.96915383,0,0,1,0.30846167,0)" />
+    <radialGradient
+       cx="6.952919"
+       cy="9.9571075"
+       r="12.671875"
+       fx="6.952919"
+       fy="9.9571075"
+       id="radialGradient3988-3"
+       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,12.028324,-14.766941,0,196.71948,-110.5324)" />
+    <linearGradient
+       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5-7-8">
+      <stop
+         id="stop3750-1-0-7-6-6-1-3-9-3-9-2"
+         style="stop-color:#404648;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3754-1-8-5-2-7-6-7-1-9-1-0"
+         style="stop-color:#0c1011;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4301">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(2.3157904,0,0,1.2857142,-6.578952,32.071432)"
+     id="g3712-5"
+     style="opacity:0.6;stroke-width:0.5">
+    <rect
+       width="5"
+       height="7"
+       x="37.13633"
+       y="40"
+       id="rect2801-3"
+       style="fill:url(#radialGradient3038);fill-opacity:1;stroke:none;stroke-width:0.5" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3696-6"
+       style="fill:url(#radialGradient3040);fill-opacity:1;stroke:none;stroke-width:0.5" />
+    <rect
+       width="27.136307"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-4"
+       style="fill:url(#linearGradient3042);fill-opacity:1;stroke:none;stroke-width:0.5" />
+  </g>
+  <rect
+     width="79"
+     height="79"
+     rx="8"
+     ry="8"
+     x="8.5"
+     y="10.5"
+     id="rect5505-21"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.9;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#radialGradient3988-3);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  <path
+     style="color:#000000;fill:#000000;fill-rule:evenodd;-inkscape-stroke:none;paint-order:markers fill stroke;fill-opacity:0.15000001"
+     d="M 25,28 V 74 H 41 V 56 H 55 V 74 H 71 V 28 H 55 V 46 H 41 V 28 Z"
+     id="path7479"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     id="rect7049"
+     style="fill:#000000;fill-opacity:0.30000001;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 26,29 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 20,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m -40,9 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 20,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m -40,9 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m -40,9 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 20,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m -40,9 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 20,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z m 5,0 v 8 h 4 v -8 z" />
+  <rect
+     width="79"
+     height="79"
+     rx="8"
+     ry="8"
+     x="8.5000248"
+     y="10.49999"
+     id="rect5505-21-3-2"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.7;fill:none;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     width="77"
+     height="77"
+     rx="7"
+     ry="7"
+     x="9.499999"
+     y="11.499999"
+     id="rect6741"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3024);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27345"
+     width="4"
+     height="8"
+     x="26"
+     y="28" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27399"
+     width="4"
+     height="8"
+     x="31"
+     y="28" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27401"
+     width="4"
+     height="8"
+     x="36"
+     y="28" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27403"
+     width="4"
+     height="8"
+     x="26"
+     y="37" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27405"
+     width="4"
+     height="8"
+     x="31"
+     y="37" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27407"
+     width="4"
+     height="8"
+     x="36"
+     y="37" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27409"
+     width="4"
+     height="8"
+     x="26"
+     y="46" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27411"
+     width="4"
+     height="8"
+     x="31"
+     y="46" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27413"
+     width="4"
+     height="8"
+     x="36"
+     y="46" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27415"
+     width="4"
+     height="8"
+     x="26"
+     y="55" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27417"
+     width="4"
+     height="8"
+     x="31"
+     y="55" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27419"
+     width="4"
+     height="8"
+     x="36"
+     y="55" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27421"
+     width="4"
+     height="8"
+     x="26"
+     y="64" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27423"
+     width="4"
+     height="8"
+     x="31"
+     y="64" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27425"
+     width="4"
+     height="8"
+     x="36"
+     y="64" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27431"
+     width="4"
+     height="8"
+     x="46"
+     y="46" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27437"
+     width="4"
+     height="8"
+     x="56"
+     y="28" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27439"
+     width="4"
+     height="8"
+     x="61"
+     y="28" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27441"
+     width="4"
+     height="8"
+     x="66"
+     y="28" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27443"
+     width="4"
+     height="8"
+     x="56"
+     y="37" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27445"
+     width="4"
+     height="8"
+     x="61"
+     y="37" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27447"
+     width="4"
+     height="8"
+     x="66"
+     y="37" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27449"
+     width="4"
+     height="8"
+     x="56"
+     y="46" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27451"
+     width="4"
+     height="8"
+     x="61"
+     y="46" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27453"
+     width="4"
+     height="8"
+     x="66"
+     y="46" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27455"
+     width="4"
+     height="8"
+     x="56"
+     y="55" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27457"
+     width="4"
+     height="8"
+     x="61"
+     y="55" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27459"
+     width="4"
+     height="8"
+     x="66"
+     y="55" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27461"
+     width="4"
+     height="8"
+     x="56"
+     y="64" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27463"
+     width="4"
+     height="8"
+     x="61"
+     y="64" />
+  <rect
+     style="fill:#ff8c82;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect27465"
+     width="4"
+     height="8"
+     x="66"
+     y="64" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect10176"
+     width="4"
+     height="8"
+     x="41"
+     y="46" />
+  <rect
+     style="fill:#9bdb4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999999;stroke-dasharray:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11569"
+     width="4"
+     height="8"
+     x="51"
+     y="46" />
+</svg>


### PR DESCRIPTION
Replace htop symlink, which pointed to task manager, with unique htop icon closer to its original design using the terminal icon as the base.


There is some variance in look between sizes. Some of it is a bit unavoidable trying to keep it all grid-aligned. But I wasn't sure if going for the more obvious "H" was better (like in 96, 128px) or a little closer to the original logo (like the 32px one). Any input would be appreciated!