### PR TITLE
MimeTypes: Removed some unused symlinks

### DIFF
--- a/elementary-xfce/mimetypes/128/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/128/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/media-audio.svg
+++ b/elementary-xfce/mimetypes/128/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/128/media-image.svg
+++ b/elementary-xfce/mimetypes/128/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/128/media-video.svg
+++ b/elementary-xfce/mimetypes/128/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/128/text-enriched.svg
+++ b/elementary-xfce/mimetypes/128/text-enriched.svg
@@ -1,1 +1,0 @@
-office-document.svg

--- a/elementary-xfce/mimetypes/16/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/16/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/media-audio.svg
+++ b/elementary-xfce/mimetypes/16/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/16/media-image.svg
+++ b/elementary-xfce/mimetypes/16/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/16/media-video.svg
+++ b/elementary-xfce/mimetypes/16/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/16/text-enriched.svg
+++ b/elementary-xfce/mimetypes/16/text-enriched.svg
@@ -1,1 +1,0 @@
-office-document.svg

--- a/elementary-xfce/mimetypes/24/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/24/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/media-audio.svg
+++ b/elementary-xfce/mimetypes/24/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/24/media-image.svg
+++ b/elementary-xfce/mimetypes/24/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/24/media-video.svg
+++ b/elementary-xfce/mimetypes/24/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/24/text-enriched.svg
+++ b/elementary-xfce/mimetypes/24/text-enriched.svg
@@ -1,1 +1,0 @@
-office-document.svg

--- a/elementary-xfce/mimetypes/32/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/32/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/media-audio.svg
+++ b/elementary-xfce/mimetypes/32/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/32/media-image.svg
+++ b/elementary-xfce/mimetypes/32/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/32/media-video.svg
+++ b/elementary-xfce/mimetypes/32/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/32/text-enriched.svg
+++ b/elementary-xfce/mimetypes/32/text-enriched.svg
@@ -1,1 +1,0 @@
-office-document.svg

--- a/elementary-xfce/mimetypes/48/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/48/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/media-audio.svg
+++ b/elementary-xfce/mimetypes/48/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/48/media-image.svg
+++ b/elementary-xfce/mimetypes/48/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/48/media-video.svg
+++ b/elementary-xfce/mimetypes/48/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/48/text-enriched.svg
+++ b/elementary-xfce/mimetypes/48/text-enriched.svg
@@ -1,1 +1,0 @@
-office-document.svg

--- a/elementary-xfce/mimetypes/64/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/64/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/media-audio.svg
+++ b/elementary-xfce/mimetypes/64/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/64/media-image.svg
+++ b/elementary-xfce/mimetypes/64/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/64/media-video.svg
+++ b/elementary-xfce/mimetypes/64/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/64/text-enriched.svg
+++ b/elementary-xfce/mimetypes/64/text-enriched.svg
@@ -1,1 +1,0 @@
-office-document.svg

--- a/elementary-xfce/mimetypes/96/audio-mpeg.svg
+++ b/elementary-xfce/mimetypes/96/audio-mpeg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/audio-x-adpcm.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-adpcm.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/audio-x-flac+ogg.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-flac+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/audio-x-ms-wma.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-ms-wma.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/audio-x-speex+ogg.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-speex+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/audio-x-vorbis+ogg.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-vorbis+ogg.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/media-audio.svg
+++ b/elementary-xfce/mimetypes/96/media-audio.svg
@@ -1,1 +1,0 @@
-audio-x-generic.svg

--- a/elementary-xfce/mimetypes/96/media-image.svg
+++ b/elementary-xfce/mimetypes/96/media-image.svg
@@ -1,1 +1,0 @@
-image-x-generic.svg

--- a/elementary-xfce/mimetypes/96/media-video.svg
+++ b/elementary-xfce/mimetypes/96/media-video.svg
@@ -1,1 +1,0 @@
-video-x-generic.svg

--- a/elementary-xfce/mimetypes/96/text-enriched.svg
+++ b/elementary-xfce/mimetypes/96/text-enriched.svg
@@ -1,1 +1,0 @@
-x-office-document.svg


### PR DESCRIPTION
This probably needs some testing. The `audio-*` one, we shouldn't need so many symlinks as a proper FreeDesktop.Org Icon Naming Spec implementation should fall back to `audio-x-generic`.

But there may be some cases (improper implementations) where it just looks for a less-hyphened name. For example, `audio-x-adpcm` may simply look for `audio` if it isn't correctly set to load `audio-x-generic`. In which case we may want to add an `audio` symlink. But fixing the implementation would be ideal.

So if anyone wants to test this it would be appreciated. Thanks!

---

- audio-* (should fallback to FreeDesktop.org `audio-x-generic`)
- media-* (don't seem to be used anywhere)
- text-enriched (emacs enriched mode saves metadata in file but saves file istelf as `text-plain` file, so this one doesn't seem to get used)