### PR TITLE
Apps: Add screenshot tool from upstream

### DIFF
--- a/elementary-xfce/apps/128/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/128/accessories-screenshot-tool.svg
@@ -1,0 +1,521 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="svg4113"
+   height="128"
+   width="128"
+   version="1.1"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4115">
+    <linearGradient
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135184,1.488321)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient4136"
+       y2="43"
+       x2="23.99999"
+       y1="4.999989"
+       x1="23.99999" />
+    <linearGradient
+       id="linearGradient3924">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.06316455"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.95056331"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749-5"
+       id="radialGradient4093"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749-5">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-0" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-5" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient4095"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309-8">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889-9" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891-4" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757-0"
+       id="linearGradient4097"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757-0">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-0" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-2" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-6" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3811">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop3813" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop3815" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270355,102.1321)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
+       id="radialGradient4111"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" />
+    <linearGradient
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-6"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4917">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4919" />
+      <stop
+         offset="0.44444457"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4921" />
+      <stop
+         offset="0.77777803"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4923" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         offset="0"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         id="stop3766" />
+      <stop
+         offset="1"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         id="stop3768" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4685-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4687-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4689-3" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4685-6"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.6490975,0,0,4.0652103,-33.36623,46.578036)"
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12" />
+    <linearGradient
+       id="linearGradient6592-2-7">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:0.27450982"
+         id="stop6594-0-2" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop6596-2-5" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5155">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop5157" />
+      <stop
+         offset="0.27272767"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop5159" />
+      <stop
+         offset="0.85491264"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop5161" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop5163" />
+    </linearGradient>
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="64.586945"
+       y1="15.556156"
+       x2="64.586945"
+       y2="118.47137"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-134.00362)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient4443-0-0"
+       xlink:href="#linearGradient3811"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0395279,0,0,0.29384563,44.941711,116.45212)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient4443-6"
+       xlink:href="#linearGradient3811"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0395279,0,0,0.29384563,25.711664,116.45212)" />
+    <radialGradient
+       xlink:href="#linearGradient3764"
+       id="radialGradient3125-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.4989921,-3.0166668,-4.4969234,2.2625116,4789.1829,-2214.3551)"
+       cx="14.999991"
+       cy="1039.7"
+       fx="14.999991"
+       fy="1039.7"
+       r="3.5266583" />
+    <radialGradient
+       xlink:href="#linearGradient3764"
+       id="radialGradient3129-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4989933,-3.0167041,4.496927,2.2625397,-4588.1898,-2214.3837)"
+       cx="14.999991"
+       cy="1039.7"
+       fx="14.999991"
+       fy="1039.7"
+       r="3.5266583" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9941158"
+       fx="9.4231873"
+       cy="9.9941158"
+       cx="9.4231873"
+       gradientTransform="matrix(0,2.2077219,-4.3722044,0,95.229125,20.927301)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4957-1"
+       xlink:href="#linearGradient3242-7" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9941158"
+       fx="9.4231873"
+       cy="9.9941158"
+       cx="9.4231873"
+       gradientTransform="matrix(0,2.2077219,4.3722044,0,6.051624,20.927301)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4957-6-6"
+       xlink:href="#linearGradient3242-7" />
+    <linearGradient
+       y2="72.077164"
+       x2="53.42622"
+       y1="64.397041"
+       x1="53.392788"
+       gradientTransform="matrix(1.0368452,0,-0.00451336,1.0845986,-6.6171935,-19.466744)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5165-5"
+       xlink:href="#linearGradient4917" />
+    <linearGradient
+       y2="65.334999"
+       x2="51.930618"
+       y1="70.493774"
+       x1="51.953075"
+       gradientTransform="matrix(1.0368452,0,-0.00451336,1.0845986,-6.6171935,-19.466744)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5153-4"
+       xlink:href="#linearGradient5155" />
+    <linearGradient
+       y2="72.077164"
+       x2="53.42622"
+       y1="64.397041"
+       x1="53.392788"
+       gradientTransform="matrix(1.0368452,0,-0.00451336,1.0845986,-6.6171935,-19.466743)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5165-8-7"
+       xlink:href="#linearGradient4917" />
+    <linearGradient
+       y2="65.334999"
+       x2="51.930618"
+       y1="70.493774"
+       x1="51.953075"
+       gradientTransform="matrix(1.0368452,0,-0.00451336,1.0845986,-6.6171935,-19.466743)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5153-1-4"
+       xlink:href="#linearGradient5155" />
+    <linearGradient
+       gradientTransform="matrix(-1.9772607,0,0,1.9889104,304.01357,-70.817228)"
+       xlink:href="#linearGradient6592-2-7"
+       id="linearGradient3131"
+       gradientUnits="userSpaceOnUse"
+       x1="106.7119"
+       y1="76.834648"
+       x2="109.24065"
+       y2="79.348587" />
+    <linearGradient
+       xlink:href="#linearGradient6592-2-7"
+       id="linearGradient4817"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.9772607,0,0,1.9889104,-102.99724,-70.817228)"
+       x1="106.7119"
+       y1="76.834648"
+       x2="109.24065"
+       y2="79.348587" />
+  </defs>
+  <metadata
+     id="metadata4118">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     d="m 119,118.00181 a 55,6 0 0 1 -109.9999982,0 55,6 0 1 1 109.9999982,0 z"
+     id="path3041"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4111);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+  <g
+     transform="matrix(2.6999989,0,0,0.55555607,-0.80000812,94.890691)"
+     id="g2036"
+     style="display:inline">
+    <g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
+       id="g3712"
+       style="opacity:0.4">
+      <rect
+         width="5"
+         height="7"
+         x="38"
+         y="40"
+         id="rect2801"
+         style="fill:url(#radialGradient4093);fill-opacity:1;stroke:none" />
+      <rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient4095);fill-opacity:1;stroke:none" />
+      <rect
+         width="28"
+         height="7.0000005"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient4097);fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <rect
+     width="103"
+     height="103"
+     rx="10"
+     ry="10"
+     x="12.499988"
+     y="-118.50181"
+     id="rect5505-21-3"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:1;marker:none;enable-background:accumulate;stroke-opacity:0.69999999"
+     transform="scale(1,-1)" />
+  <path
+     id="rect3872-3-2"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 22.5 15.501953 C 16.960006 15.501953 12.5 19.961959 12.5 25.501953 L 12.5 75.404297 L 115.5 45.849609 L 115.5 25.501953 C 115.5 19.961959 111.03999 15.501953 105.5 15.501953 L 22.5 15.501953 z " />
+  <path
+     id="rect5150-2"
+     style="fill:#000000;stroke:none;stroke-width:1.00000064;stroke-opacity:1;stop-color:#000000;font-variation-settings:normal;opacity:0.3;vector-effect:none;fill-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;-inkscape-stroke:none;stop-opacity:1"
+     d="m 26,38 c -3.323994,0 -6,2.676006 -6,6 v 4.087891 C 20.438716,48.034963 20.888534,48 21.351562,48 H 24 v -3 c 0,-1.661996 1.338004,-3 3,-3 h 3 v -4 z m 16,0 v 4 h 16 v -4 z m 28,0 v 4 h 16 v -4 z m 28,0 v 4 h 3 c 1.662,0 3,1.338004 3,3 v 3 h 3.61914 c 0.13049,0 0.25209,0.02105 0.38086,0.02539 V 44 c 0,-3.323994 -2.676,-6 -6,-6 z M 20,59.912109 V 76.087891 C 20.438716,76.034963 20.888534,76 21.351562,76 H 24 V 60 H 21.351562 C 20.888534,60 20.438716,59.965037 20,59.912109 Z m 88,0.0625 C 107.87123,59.97895 107.74963,60 107.61914,60 H 104 v 16 h 3.61914 c 0.13049,0 0.25209,0.02105 0.38086,0.02539 z m -88,27.9375 V 92 c 0,3.323994 2.676006,6 6,6 h 4.119141 C 30.045694,97.649487 30,97.288481 30,96.914062 V 94 h -3 c -1.661996,0 -3,-1.338004 -3,-3 V 88 H 21.351562 C 20.888534,88 20.438716,87.965037 20,87.912109 Z m 88,0.0625 C 107.87123,87.97895 107.74963,88 107.61914,88 H 104 v 3 c 0,1.661996 -1.338,3 -3,3 h -3 v 2.914062 C 98,97.288481 97.954306,97.649487 97.880859,98 H 102 c 3.324,0 6,-2.676006 6,-6 z M 42,94 v 2.914062 C 42,97.288481 41.954306,97.649487 41.880859,98 H 58.119141 C 58.045694,97.649487 58,97.288481 58,96.914062 V 94 Z m 28,0 v 2.914062 C 70,97.288481 69.954306,97.649487 69.880859,98 H 86.119141 C 86.045694,97.649487 86,97.288481 86,96.914062 V 94 Z" />
+  <path
+     id="rect5150-2-6"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+     d="m 26,36.994141 c -3.863487,0 -7.005859,3.142372 -7.005859,7.005859 v 4.087891 a 1.0052955,1.0052955 0 0 0 1.126953,0.998047 c 0.409861,-0.04945 0.818042,-0.08008 1.230468,-0.08008 H 24 A 1.0052955,1.0052955 0 0 0 25.005859,48 v -3 c 0,-1.122502 0.871639,-1.994141 1.994141,-1.994141 h 3 A 1.0052955,1.0052955 0 0 0 31.005859,42 V 38 A 1.0052955,1.0052955 0 0 0 30,36.994141 Z m 16,0 A 1.0052955,1.0052955 0 0 0 40.994141,38 v 4 A 1.0052955,1.0052955 0 0 0 42,43.005859 H 58 A 1.0052955,1.0052955 0 0 0 59.005859,42 V 38 A 1.0052955,1.0052955 0 0 0 58,36.994141 Z m 28,0 A 1.0052955,1.0052955 0 0 0 68.994141,38 v 4 A 1.0052955,1.0052955 0 0 0 70,43.005859 H 86 A 1.0052955,1.0052955 0 0 0 87.005859,42 V 38 A 1.0052955,1.0052955 0 0 0 86,36.994141 Z m 28,0 A 1.0052955,1.0052955 0 0 0 96.994141,38 v 4 A 1.0052955,1.0052955 0 0 0 98,43.005859 h 3 c 1.12251,0 1.99414,0.871637 1.99414,1.994141 v 3 A 1.0052955,1.0052955 0 0 0 104,49.005859 h 3.61914 c 0.0224,0 0.13081,0.01613 0.34766,0.02344 a 1.0052955,1.0052955 0 0 0 1.03906,-1.003906 V 44 c 0,-3.863486 -3.14237,-7.005859 -7.00586,-7.005859 z M 20.121094,58.914062 a 1.0052955,1.0052955 0 0 0 -1.126953,0.998047 v 16.175782 a 1.0052955,1.0052955 0 0 0 1.126953,0.998047 c 0.409861,-0.04945 0.818042,-0.08008 1.230468,-0.08008 H 24 A 1.0052955,1.0052955 0 0 0 25.005859,76 V 60 A 1.0052955,1.0052955 0 0 0 24,58.994141 h -2.648438 c -0.412426,0 -0.820607,-0.03063 -1.230468,-0.08008 z m 87.845706,0.05664 c -0.21684,0.0073 -0.32527,0.02344 -0.34766,0.02344 H 104 A 1.0052955,1.0052955 0 0 0 102.99414,60 V 76 A 1.0052955,1.0052955 0 0 0 104,77.005859 h 3.61914 c 0.0224,0 0.13081,0.01613 0.34766,0.02344 a 1.0052955,1.0052955 0 0 0 1.03906,-1.003906 V 59.974609 A 1.0052955,1.0052955 0 0 0 107.9668,58.970703 Z M 20.121094,86.914062 a 1.0052955,1.0052955 0 0 0 -1.126953,0.998047 V 92 c 0,3.863487 3.142372,7.005859 7.005859,7.005859 h 4.119141 a 1.0052955,1.0052955 0 0 0 0.984375,-1.21289 c -0.0622,-0.296825 -0.09766,-0.586269 -0.09766,-0.878907 V 94 A 1.0052955,1.0052955 0 0 0 30,92.994141 h -3 c -1.122502,0 -1.994141,-0.871639 -1.994141,-1.994141 V 88 A 1.0052955,1.0052955 0 0 0 24,86.994141 h -2.648438 c -0.412426,0 -0.820607,-0.03063 -1.230468,-0.08008 z m 87.845706,0.05664 c -0.21684,0.0073 -0.32527,0.02344 -0.34766,0.02344 H 104 A 1.0052955,1.0052955 0 0 0 102.99414,88 v 3 c 0,1.122504 -0.87163,1.994141 -1.99414,1.994141 H 98 A 1.0052955,1.0052955 0 0 0 96.994141,94 v 2.914062 c 0,0.292638 -0.03546,0.582082 -0.09766,0.878907 a 1.0052955,1.0052955 0 0 0 0.984375,1.21289 H 102 c 3.86349,0 7.00586,-3.142373 7.00586,-7.005859 V 87.974609 A 1.0052955,1.0052955 0 0 0 107.9668,86.970703 Z M 42,92.994141 A 1.0052955,1.0052955 0 0 0 40.994141,94 v 2.914062 c 0,0.292638 -0.03546,0.582082 -0.09766,0.878907 a 1.0052955,1.0052955 0 0 0 0.984375,1.21289 h 16.238282 a 1.0052955,1.0052955 0 0 0 0.984375,-1.21289 c -0.0622,-0.296825 -0.09766,-0.586269 -0.09766,-0.878907 V 94 A 1.0052955,1.0052955 0 0 0 58,92.994141 Z m 28,0 A 1.0052955,1.0052955 0 0 0 68.994141,94 v 2.914062 c 0,0.292638 -0.03546,0.582082 -0.09766,0.878907 a 1.0052955,1.0052955 0 0 0 0.984375,1.21289 h 16.238282 a 1.0052955,1.0052955 0 0 0 0.984375,-1.21289 c -0.0622,-0.296825 -0.09766,-0.586269 -0.09766,-0.878907 V 94 A 1.0052955,1.0052955 0 0 0 86,92.994141 Z" />
+  <path
+     id="rect5150"
+     style="opacity:1;fill:#fafafa;stroke:none;stroke-width:1;stroke-opacity:0.7;stop-color:#000000"
+     d="M 26 37 C 22.676006 37 20 39.676006 20 43 L 20 47.087891 C 20.438716 47.034963 20.888534 47 21.351562 47 L 24 47 L 24 44 C 24 42.338004 25.338004 41 27 41 L 30 41 L 30 37 L 26 37 z M 42 37 L 42 41 L 58 41 L 58 37 L 42 37 z M 70 37 L 70 41 L 86 41 L 86 37 L 70 37 z M 98 37 L 98 41 L 101 41 C 102.662 41 104 42.338004 104 44 L 104 47 L 107.61914 47 C 107.74963 47 107.87123 47.02105 108 47.025391 L 108 43 C 108 39.676006 105.324 37 102 37 L 98 37 z M 20 58.912109 L 20 75.087891 C 20.438716 75.034963 20.888534 75 21.351562 75 L 24 75 L 24 59 L 21.351562 59 C 20.888534 59 20.438716 58.965037 20 58.912109 z M 108 58.974609 C 107.87123 58.97895 107.74963 59 107.61914 59 L 104 59 L 104 75 L 107.61914 75 C 107.74963 75 107.87123 75.02105 108 75.025391 L 108 58.974609 z M 20 86.912109 L 20 91 C 20 94.323994 22.676006 97 26 97 L 30.119141 97 C 30.045694 96.649487 30 96.288481 30 95.914062 L 30 93 L 27 93 C 25.338004 93 24 91.661996 24 90 L 24 87 L 21.351562 87 C 20.888534 87 20.438716 86.965037 20 86.912109 z M 108 86.974609 C 107.87123 86.97895 107.74963 87 107.61914 87 L 104 87 L 104 90 C 104 91.661996 102.662 93 101 93 L 98 93 L 98 95.914062 C 98 96.288481 97.954306 96.649487 97.880859 97 L 102 97 C 105.324 97 108 94.323994 108 91 L 108 86.974609 z M 42 93 L 42 95.914062 C 42 96.288481 41.954306 96.649487 41.880859 97 L 58.119141 97 C 58.045694 96.649487 58 96.288481 58 95.914062 L 58 93 L 42 93 z M 70 93 L 70 95.914062 C 70 96.288481 69.954306 96.649487 69.880859 97 L 86.119141 97 C 86.045694 96.649487 86 96.288481 86 95.914062 L 86 93 L 70 93 z " />
+  <path
+     id="rect5150-8"
+     style="fill:#000000;stroke:none;stroke-width:1;stroke-opacity:1;stop-color:#000000;font-variation-settings:normal;opacity:0.15;vector-effect:none;fill-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;-inkscape-stroke:none;stop-opacity:1"
+     d="M 27 40 C 25.338006 40 24 41.338006 24 43 L 24 44 C 24 42.338006 25.338006 41 27 41 L 30 41 L 30 40 L 27 40 z M 42 40 L 42 41 L 58 41 L 58 40 L 42 40 z M 70 40 L 70 41 L 86 41 L 86 40 L 70 40 z M 98 40 L 98 41 L 101 41 C 102.662 41 104 42.338006 104 44 L 104 43 C 104 41.338006 102.662 40 101 40 L 98 40 z M 21.351562 46 C 20.888535 46 20.438716 46.034963 20 46.087891 L 20 47.087891 C 20.438716 47.034963 20.888535 47 21.351562 47 L 24 47 L 24 46 L 21.351562 46 z M 104 46 L 104 47 L 107.61914 47 C 107.74963 47 107.87123 47.021051 108 47.025391 L 108 46.025391 C 107.87123 46.021051 107.74963 46 107.61914 46 L 104 46 z M 21.351562 74 C 20.888535 74 20.438716 74.034963 20 74.087891 L 20 75.087891 C 20.438716 75.034963 20.888535 75 21.351562 75 L 24 75 L 24 74 L 21.351562 74 z M 104 74 L 104 75 L 107.61914 75 C 107.74963 75 107.87123 75.021051 108 75.025391 L 108 74.025391 C 107.87123 74.021051 107.74963 74 107.61914 74 L 104 74 z M 20 90 L 20 91 C 20 94.323991 22.676009 97 26 97 L 30.119141 97 C 30.0514 96.676719 30.010355 96.343424 30.003906 96 L 26 96 C 22.676009 96 20 93.323991 20 90 z M 108 90 C 108 93.323991 105.324 96 102 96 L 97.996094 96 C 97.989645 96.343424 97.9486 96.676719 97.880859 97 L 102 97 C 105.324 97 108 94.323991 108 91 L 108 90 z M 41.996094 96 C 41.989645 96.343424 41.9486 96.676719 41.880859 97 L 58.119141 97 C 58.0514 96.676719 58.010355 96.343424 58.003906 96 L 41.996094 96 z M 69.996094 96 C 69.989645 96.343424 69.9486 96.676719 69.880859 97 L 86.119141 97 C 86.0514 96.676719 86.010355 96.343424 86.003906 96 L 69.996094 96 z " />
+  <rect
+     width="101"
+     height="101"
+     rx="9"
+     ry="9"
+     x="13.499988"
+     y="16.501808"
+     id="rect6741-7"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient4136);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     id="g4853"
+     transform="translate(4,3.0004872)">
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient4443-0-0);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+       id="path8836-7"
+       d="m 121.08713,117.81118 c 0,1.72435 -4.94501,3.12212 -11.04499,3.12212 -6.09997,0 -11.044979,-1.39777 -11.044979,-3.12212 0,-1.72434 4.945009,-3.12211 11.044979,-3.12211 6.09998,0 11.04499,1.39777 11.04499,3.12211 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient4443-6);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+       id="path8836"
+       d="m 101.85708,117.81118 c 0,1.72435 -4.945006,3.12212 -11.044983,3.12212 -6.099978,0 -11.044983,-1.39777 -11.044983,-3.12212 0,-1.72434 4.945005,-3.12211 11.044983,-3.12211 6.099977,0 11.044983,1.39777 11.044983,3.12211 z" />
+    <path
+       style="fill:url(#radialGradient3125-3);fill-opacity:1;stroke:none"
+       id="path3782"
+       d="M 100.49865,92.728311 86.489532,66.663028 c 0,0 -9.779941,20.745841 14.009118,34.044452 z" />
+    <path
+       style="fill:url(#radialGradient3129-6);fill-opacity:1;stroke:none"
+       id="path2990"
+       d="m 100.49853,92.728207 14.00913,-26.065608 c 0,0 9.77995,20.746098 -14.00913,34.044881 z" />
+    <g
+       transform="matrix(1.9733255,0,0,1.9659725,0.38800841,0.95784844)"
+       id="g3133">
+      <path
+         id="path4949"
+         d="m 48.238901,49.59336 c -0.101183,0.0013 -0.220547,0.0069 -0.352356,0.01391 -1.845322,0.09848 -6.781858,1.226209 -6.781857,4.68816 0,3.956383 2.932907,5.343849 4.687519,5.343849 1.754611,0 4.619446,-1.332501 4.687519,-5.343849 0.05426,-3.197735 -1.083968,-4.491311 -1.999323,-4.68816 -0.05721,-0.01231 -0.140319,-0.01523 -0.241502,-0.01391 z m -0.352356,2.545259 c 0,0 0.593767,6.842878 -2.999972,4.156655 -3.99622,-2.986975 2.999972,-4.156655 2.999972,-4.156655 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4957-1);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+      <path
+         id="path4949-6"
+         d="m 53.041846,49.59336 c 0.101183,0.0013 0.220547,0.0069 0.352356,0.01391 1.845322,0.09848 6.781858,1.226209 6.781857,4.68816 0,3.956383 -2.932907,5.343849 -4.687519,5.343849 -1.754611,0 -4.619446,-1.332501 -4.687519,-5.343849 -0.05426,-3.197735 1.083968,-4.491311 1.999323,-4.68816 0.05721,-0.01231 0.140319,-0.01523 0.241502,-0.01391 z m 0.352356,2.545259 c 0,0 -0.593767,6.842878 2.999972,4.156655 3.99622,-2.986975 -2.999972,-4.156655 -2.999972,-4.156655 z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4957-6-6);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
+      <path
+         id="path4947-9"
+         d="m 53.038833,49.58442 c -0.09736,0.0031 -0.175384,0.01054 -0.232592,0.02285 -0.915354,0.196849 -2.054575,1.490426 -2.000314,4.688161 0.06807,4.011348 2.901235,5.343849 4.655846,5.343849 1.754612,0 4.687519,-1.387466 4.687519,-5.343849 0,-3.709233 -5.649985,-4.756787 -7.110459,-4.711011 z m 0.329591,2.5542 c 0,0 7.026874,1.16968 3.030655,4.156655 -3.59374,2.686223 -3.030655,-4.156655 -3.030655,-4.156655 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#640000;stroke-width:0.507709;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path4949-1"
+         d="m 48.238901,49.59336 c -0.101183,0.0013 -0.220547,0.0069 -0.352356,0.01391 -1.845322,0.09848 -6.781858,1.226212 -6.781857,4.688162 0,3.956383 2.932907,5.343849 4.687518,5.343849 1.754612,0 4.619447,-1.332501 4.68752,-5.343849 0.05426,-3.197735 -1.083968,-4.491313 -1.999323,-4.688162 -0.05721,-0.0123 -0.140319,-0.01522 -0.241502,-0.01391 z m -0.352356,2.545259 c 0,0 0.593767,6.842878 -2.999972,4.156655 -3.99622,-2.986974 2.999972,-4.156655 2.999972,-4.156655 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.6;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#640000;stroke-width:0.507709;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path5113"
+         d="m 48.244365,50.094066 c -0.08854,0.0011 -0.201149,0.006 -0.330581,0.01291 -0.844987,0.0451 -2.511635,0.34782 -3.88878,1.031217 -1.377145,0.683397 -2.419972,1.662897 -2.419971,3.156239 0,1.854635 0.667152,3.030302 1.518297,3.782123 0.851145,0.751817 1.923872,1.062014 2.669391,1.062014 0.750741,0 1.802748,-0.29891 2.644648,-1.043137 0.8419,-0.744233 1.511006,-1.920322 1.543041,-3.807953 0.0261,-1.538389 -0.23932,-2.579675 -0.580001,-3.228763 -0.340684,-0.649089 -0.746028,-0.902589 -1.025395,-0.962668 0,0 -0.04187,-0.0032 -0.130649,-0.002 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5165-5);stroke-width:0.507709;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <path
+         id="path5077"
+         d="m 47.854398,51.638907 c 0.01648,-0.001 0.033,-0.001 0.04949,0 0.252863,0.0087 0.459382,0.204906 0.481025,0.45699 0,0 0.164309,1.740747 -0.162321,3.233733 -0.163315,0.74649 -0.434122,1.492493 -1.097648,1.881618 -0.331763,0.194565 -0.754246,0.257211 -1.181777,0.165913 -0.42753,-0.0913 -0.867646,-0.317242 -1.354986,-0.68152 -0.533812,-0.398999 -0.910212,-0.782997 -1.149115,-1.180235 -0.238903,-0.397239 -0.330863,-0.824707 -0.261297,-1.216996 0.139133,-0.784579 0.791343,-1.278111 1.474747,-1.642195 1.366807,-0.728174 3.152396,-1.011352 3.152396,-1.011352 0.01639,-0.0031 0.0329,-0.0046 0.04948,-0.006 z"
+         style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5153-4);stroke-width:0.507709;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+      <g
+         transform="matrix(-1,0,0,1,101.28122,0)"
+         id="g5211">
+        <path
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5165-8-7);stroke-width:0.507709;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 48.244365,50.094066 c -0.08854,0.0011 -0.201149,0.006 -0.330581,0.01291 -0.844987,0.0451 -2.511635,0.34782 -3.88878,1.031217 -1.377145,0.683397 -2.419972,1.662897 -2.419971,3.156239 0,1.854635 0.667152,3.030302 1.518297,3.782123 0.851145,0.751817 1.923872,1.062014 2.669391,1.062014 0.750741,0 1.802748,-0.29891 2.644648,-1.043137 0.8419,-0.744233 1.511006,-1.920322 1.543041,-3.807953 0.0261,-1.538389 -0.23932,-2.579675 -0.580001,-3.228763 -0.340684,-0.649089 -0.746028,-0.902589 -1.025395,-0.962668 0,0 -0.04187,-0.0032 -0.130649,-0.002 z"
+           id="path5113-3" />
+        <path
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.3;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient5153-1-4);stroke-width:0.507709;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           d="m 47.854398,51.638907 c 0.01648,-0.001 0.033,-0.001 0.04949,0 0.252863,0.0087 0.459382,0.204906 0.481025,0.45699 0,0 0.164309,1.740747 -0.162321,3.233733 -0.163315,0.74649 -0.434122,1.492493 -1.097648,1.881618 -0.331763,0.194565 -0.754246,0.257211 -1.181777,0.165913 -0.42753,-0.0913 -0.867646,-0.317242 -1.354986,-0.68152 -0.533812,-0.398999 -0.910212,-0.782997 -1.149115,-1.180235 -0.238903,-0.397239 -0.330863,-0.824707 -0.261297,-1.216996 0.139133,-0.784579 0.791343,-1.278111 1.474747,-1.642195 1.366807,-0.728174 3.152396,-1.011352 3.152396,-1.011352 0.01639,-0.0031 0.0329,-0.0046 0.04948,-0.006 z"
+           id="path5077-9" />
+      </g>
+    </g>
+    <path
+       d="m 114.29492,69.199219 -12.7832,23.785156 v 5.888672 c 10.35197,-6.34146 13.41901,-13.993937 13.90234,-20.253906 0.34543,-4.473844 -0.46501,-7.498288 -1.11914,-9.419922 z"
+       id="path4879"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient4817);stroke-width:1.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       d="m 86.72141,69.199219 12.7832,23.785156 v 5.888672 C 89.15264,92.531587 86.0856,84.87911 85.60227,78.619141 c -0.34543,-4.473844 0.46501,-7.498288 1.11914,-9.419922 z"
+       id="path4879-5"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3131);stroke-width:1.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+    <path
+       id="path3782-0"
+       d="m 86.490234,66.662109 c 0,0 -9.781246,20.746309 14.007816,34.044921 23.78907,-13.298784 14.00976,-34.044921 14.00976,-34.044921 l -14.00976,26.066407 z"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1.00001px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/16/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/16/accessories-screenshot-tool.svg
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="16"
+   height="16"
+   id="svg4060"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4062">
+    <linearGradient
+       x1="23.99999"
+       y1="7.1818104"
+       x2="23.99999"
+       y2="40.818172"
+       id="linearGradient3896"
+       xlink:href="#linearGradient3924-4-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486973,0.8648672)" />
+    <linearGradient
+       id="linearGradient3924-4-8">
+      <stop
+         id="stop3926-0-4"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-6-8"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3930-2-1"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3932-9-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient4407"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.39994776,-0.79806438,-1.1998291,0.59855136,1276.2546,-586.23106)" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         id="stop3766"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3768"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient4409"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39994776,-0.79806438,1.1998291,0.59855136,-1225.064,-586.23106)" />
+    <radialGradient
+       cx="8.8626814"
+       cy="9.9941158"
+       r="12.671875"
+       fx="8.8626814"
+       fy="9.9941158"
+       id="radialGradient4411"
+       xlink:href="#linearGradient3242-7-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.0856738,-2.5766464,0,51.561592,1.9538421)" />
+    <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="55.986927"
+       y1="39.96907"
+       x2="56.968643"
+       y2="40.586102"
+       id="linearGradient4413"
+       xlink:href="#linearGradient3880"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.45322724,0,0,0.46248718,2.9687467,2.9029638)" />
+    <linearGradient
+       id="linearGradient3880">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop3883" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0;"
+         offset="1"
+         id="stop3885" />
+    </linearGradient>
+    <linearGradient
+       y2="40.586102"
+       x2="56.968643"
+       y1="39.96907"
+       x1="55.986927"
+       gradientTransform="matrix(-0.41287028,0,0,0.42130569,45.873249,4.4875969)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1113"
+       xlink:href="#linearGradient3880" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="19.005375"
+       y1="202.81076"
+       x2="19.005375"
+       y2="242.78731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-248.00361)" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12"
+       id="linearGradient3887"
+       xlink:href="#linearGradient3880"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.55063676,0,0,0.48148146,-3.5320049,5.3518514)" />
+  </defs>
+  <metadata
+     id="metadata4065">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-7"
+     y="1.4999985"
+     x="1.5000014"
+     ry="2"
+     rx="2"
+     height="13"
+     width="13" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3896);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-0-3"
+     y="2.4999969"
+     x="2.5"
+     height="11"
+     width="11"
+     rx="1"
+     ry="1" />
+  <g
+     transform="matrix(0.65216929,0,0,0.65925644,0.06523819,2.3742091)"
+     style="opacity:0.2;stroke:#000000;stroke-width:1.52508;stroke-linejoin:round;stroke-opacity:1"
+     id="g1148">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 16.766754,4.7413882 H 19.06677 V 7.0166789"
+       id="path1128" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 19.06677,8.5335393 V 10.0504"
+       id="path1130" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 19.06677,11.56726 v 2.275291 h -2.300016"
+       id="path1132" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 7.5666884,13.842551 H 5.2666721 V 11.56726"
+       id="path1134" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 5.2666721,10.0504 V 8.5335393"
+       id="path1136" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 5.2666721,7.0166789 V 4.7413882 h 2.3000163"
+       id="path1138" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 9.1000326,4.7413882 H 12.166721"
+       id="path1140" />
+    <path
+       id="path1142"
+       d="m 12.166721,13.842551 h 3.066688"
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1144"
+       d="M 9.8667047,14.600981 V 13.08412"
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 14.466737,5.499819 V 3.982958"
+       id="path1146" />
+  </g>
+  <g
+     id="g1063"
+     style="opacity:1;stroke:#ffffff;stroke-width:1.52508;stroke-linejoin:round;stroke-opacity:1"
+     transform="matrix(0.65216929,0,0,0.65925644,0.06523819,1.3769187)">
+    <path
+       id="path1029"
+       d="M 16.766754,4.7413882 H 19.06677 V 7.0166789"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1031"
+       d="M 19.06677,8.5335393 V 10.0504"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1035"
+       d="m 19.06677,11.56726 v 2.275291 h -2.300016"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1039"
+       d="M 7.5666884,13.842551 H 5.2666721 V 11.56726"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1041"
+       d="M 5.2666721,10.0504 V 8.5335393"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1043"
+       d="M 5.2666721,7.0166789 V 4.7413882 h 2.3000163"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       id="path1045"
+       d="M 9.1000326,4.7413882 H 12.166721"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 12.166721,13.842551 h 3.066688"
+       id="path1078" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="M 9.8667047,14.600981 V 13.08412"
+       id="path1080" />
+    <path
+       id="path1082"
+       d="M 14.466737,5.499819 V 3.982958"
+       style="fill:none;stroke:#ffffff;stroke-width:1.52508px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+  </g>
+  <path
+     id="rect3872"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient3887);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 3.5 1.5 C 2.3920011 1.5 1.5 2.3920011 1.5 3.5 L 1.5 8.8808594 L 14.5 5.1503906 L 14.5 3.5 C 14.5 2.3920011 13.607999 1.5 12.5 1.5 L 3.5 1.5 z " />
+  <g
+     transform="matrix(0.84406958,0,0,0.73536309,-10.58863,-7.6306311)"
+     id="g4397"
+     style="stroke-width:1.42178">
+    <path
+       d="m 25.261533,24.111839 -3.737787,-6.895616 c 0,0 -2.609397,5.488347 3.737787,9.006519 z"
+       id="path3782"
+       style="fill:url(#radialGradient4407);fill-opacity:1;stroke:none;stroke-width:1.42178" />
+    <path
+       d="m 25.929176,24.111839 3.737786,-6.895616 c 0,0 2.609399,5.488347 -3.737786,9.006519 z"
+       id="path2990"
+       style="fill:url(#radialGradient4409);fill-opacity:1;stroke:none;stroke-width:1.42178" />
+    <path
+       d="m 23.857525,26.222742 c -0.973509,0.05182 -3.570293,0.64117 -3.570293,2.462721 0,2.081701 1.542697,2.814537 2.468351,2.814537 0.925653,0 2.432439,-0.703916 2.468349,-2.814537 0.02862,-1.68253 -0.574964,-2.359146 -1.057864,-2.462721 -0.06036,-0.01295 -0.169471,-0.0074 -0.308543,0 z m 3.129515,0 c -0.4829,0.103577 -1.086491,0.780191 -1.057864,2.462721 0.03592,2.110621 1.542696,2.814537 2.468349,2.814537 0.925654,0 2.468351,-0.732836 2.468351,-2.814537 0,-2.081773 -3.395937,-2.566295 -3.878836,-2.462721 z m -3.129515,1.319315 c 0,0 0.309098,3.612247 -1.586797,2.198857 -2.108225,-1.571638 1.586797,-2.198857 1.586797,-2.198857 z m 3.438058,0 c 0,0 3.695022,0.627219 1.586796,2.198857 -1.895894,1.41339 -1.586796,-2.198857 -1.586796,-2.198857 z"
+       id="path3788"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4411);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.42178;marker:none;enable-background:accumulate" />
+    <path
+       d="m 25.261533,24.111839 -3.737787,-6.895617 c 0,0 -2.609398,5.488349 3.737787,9.006521 z"
+       id="path3782-0"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1.26929px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 25.929175,24.111839 3.737787,-6.895617 c 0,0 2.609398,5.488349 -3.737787,9.006521 z"
+       id="path2990-3"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1.26929px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 29.131046,20.422066 -2.271796,4.455495 -4e-5,0.457721 c 1.929278,-1.830883 2.374217,-3.370225 2.374217,-3.661767 0,-0.457721 -0.170244,-0.773841 -0.08273,-1.109849 z"
+       id="path4683"
+       style="fill:none;stroke:url(#linearGradient4413);stroke-width:1.26929px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 23.857524,26.222743 c -0.973508,0.05182 -3.570292,0.641169 -3.570292,2.462719 0,2.081703 1.542696,2.814538 2.46835,2.814538 0.925654,0 2.432439,-0.703916 2.46835,-2.814538 0.02862,-1.682529 -0.574964,-2.359145 -1.057864,-2.462719 -0.06036,-0.01295 -0.169471,-0.0074 -0.308544,0 z m 3.129515,0 c -0.4829,0.103577 -1.08649,0.78019 -1.057864,2.462719 0.03592,2.110622 1.542696,2.814538 2.468351,2.814538 0.925653,0 2.468349,-0.732835 2.468349,-2.814538 0,-2.081771 -3.395936,-2.566294 -3.878836,-2.462719 z m -3.129515,1.319313 c 0,0 0.309098,3.612249 -1.586796,2.198857 -2.108225,-1.571636 1.586796,-2.198857 1.586796,-2.198857 z m 3.438059,0 c 0,0 3.695021,0.627221 1.586797,2.198857 -1.895895,1.413392 -1.586797,-2.198857 -1.586797,-2.198857 z"
+       id="path3788-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:none;stroke:#640000;stroke-width:1.26929;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1113);stroke-width:1.26929px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path1111"
+       d="m 22.040532,20.446736 2.069508,4.058762 3.6e-5,0.416964 c -1.757488,-1.667855 -2.162808,-3.070129 -2.162808,-3.33571 0,-0.416965 0.155085,-0.704936 0.07536,-1.011024 z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/22/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/22/accessories-screenshot-tool.svg
@@ -1,0 +1,373 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="22"
+   height="22"
+   id="svg3426"
+   sodipodi:docname="accessories-screenshot-tool.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview66"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="12.49222"
+     inkscape:cx="15.96994"
+     inkscape:cy="27.45709"
+     inkscape:window-width="1386"
+     inkscape:window-height="1051"
+     inkscape:window-x="12"
+     inkscape:window-y="395"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg3426" />
+  <defs
+     id="defs3428">
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3152"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3154"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3156"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-64">
+      <stop
+         id="stop3926-3-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3930-3-59"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3932-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="41.414425"
+       x2="23.99999"
+       y1="6.5908957"
+       x1="23.99999"
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,-0.0257811,-0.0282768)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3101"
+       xlink:href="#linearGradient3924-64" />
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient4407"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.39994776,-0.79806438,-1.1998291,0.59855136,1276.2546,-586.23106)" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         id="stop3766"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3768"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient4409"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39994776,-0.79806438,1.1998291,0.59855136,-1225.064,-586.23106)" />
+    <radialGradient
+       cx="8.8626814"
+       cy="9.9941158"
+       r="12.671875"
+       fx="8.8626814"
+       fy="9.9941158"
+       id="radialGradient4411"
+       xlink:href="#linearGradient3242-7-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.0856738,-2.5766464,0,51.561592,1.9538421)" />
+    <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="55.986927"
+       y1="39.96907"
+       x2="56.968643"
+       y2="40.586102"
+       id="linearGradient4413"
+       xlink:href="#linearGradient3880-3-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.49043499,0,0,0.50045513,1.0074558,0.78026574)" />
+    <linearGradient
+       id="linearGradient3880-3-9">
+      <stop
+         id="stop3883-1-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3885-5-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.586102"
+       x2="56.968643"
+       y1="39.96907"
+       x1="55.986927"
+       gradientTransform="matrix(-0.49043499,0,0,0.50045513,50.161546,0.64855975)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1113"
+       xlink:href="#linearGradient3880-3-9" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3880-3-9"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.85760065,0,0,0.74989316,-6.9607625,7.2324812)"
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient1241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26213595,0,0,0.26213592,-33.840623,-38.052195)"
+       x1="163.56833"
+       y1="225.06929"
+       x2="163.56833"
+       y2="149.44096" />
+  </defs>
+  <metadata
+     id="metadata3431">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="g2036"
+     transform="matrix(0.55,0,0,0.3333336,-2.2000011,6.3332826)">
+    <g
+       style="opacity:0.4"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
+         id="rect3696"
+         transform="scale(-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+  </g>
+  <rect
+     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient1241);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-6"
+     y="1.4999995"
+     x="1.499999"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     width="17"
+     height="17"
+     x="2.5012493"
+     y="2.4987464"
+     id="rect6741-9-5"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3101);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <path
+     id="rect3872-3-2"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="m 3.6111113,1.4999725 c -1.1695545,0 -2.1111112,0.941557 -2.1111112,2.1111113 V 12.550321 L 20.500001,7.0979908 v -3.486907 c 0,-1.1695543 -0.941557,-2.1111113 -2.111111,-2.1111113 z" />
+  <path
+     id="rect3640-9"
+     style="font-variation-settings:normal;opacity:0.3;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="m 5,6.9999726 c -0.5539988,0 -1,0.4460012 -1,1 v 1 h 1 v -0.75 c 0,-0.1384998 0.1115002,-0.25 0.25,-0.25 H 6 v -1 z m 3,0 v 1 h 2 v -1 z m 4,0 v 1 h 2 v -1 z m 4,0 v 1 h 0.75 c 0.1385,0 0.25,0.1115002 0.25,0.25 v 0.75 h 1 v -1 c 0,-0.5539988 -0.446002,-1 -1,-1 z M 4,10.999973 v 2 h 1 v -2 z m 13,0 v 2 h 1 v -2 z m -13,4 v 1 c 0,0.553998 0.4460012,1 1,1 h 1 v -1 H 5.25 c -0.1384998,0 -0.25,-0.1115 -0.25,-0.25 v -0.75 z m 13,0 v 0.75 c 0,0.1385 -0.1115,0.25 -0.25,0.25 H 16 v 1 h 1 c 0.553998,0 1,-0.446002 1,-1 v -1 z m -9,1 v 1 h 2 v -1 z m 4,0 v 1 h 2 v -1 z" />
+  <path
+     id="rect3640-9-6"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="m 5,6.0038788 c -1.088195,0 -1.9960937,0.9078988 -1.9960938,1.9960938 v 1 A 0.99542444,0.99542444 0 0 0 4,9.9960666 h 1 a 0.99542444,0.99542444 0 0 0 0.9960938,-0.996094 v -0.00391 H 6 a 0.99542444,0.99542444 0 0 0 0.9960938,-0.99609 v -1 A 0.99542444,0.99542444 0 0 0 6,6.0038788 Z m 3,0 A 0.99542444,0.99542444 0 0 0 7.0039062,6.9999726 v 1 A 0.99542444,0.99542444 0 0 0 8,8.9960664 h 2 a 0.99542444,0.99542444 0 0 0 0.996094,-0.9960938 v -1 A 0.99542444,0.99542444 0 0 0 10,6.0038788 Z m 4,0 a 0.99542444,0.99542444 0 0 0 -0.996094,0.9960938 v 1 A 0.99542444,0.99542444 0 0 0 12,8.9960664 h 2 a 0.99542444,0.99542444 0 0 0 0.996094,-0.9960938 v -1 A 0.99542444,0.99542444 0 0 0 14,6.0038788 Z m 4,0 a 0.99542444,0.99542444 0 0 0 -0.996094,0.9960938 v 1 A 0.99542444,0.99542444 0 0 0 16,8.9960664 h 0.0039 v 0.00391 A 0.99542444,0.99542444 0 0 0 17,9.9960666 h 1 a 0.99542444,0.99542444 0 0 0 0.996094,-0.996094 v -1 C 18.996094,6.9117766 18.088195,6.0038788 17,6.0038788 Z M 4,10.003879 a 0.99542444,0.99542444 0 0 0 -0.9960938,0.996094 v 2 A 0.99542444,0.99542444 0 0 0 4,13.996067 h 1 a 0.99542444,0.99542444 0 0 0 0.9960938,-0.996094 v -2 A 0.99542444,0.99542444 0 0 0 5,10.003879 Z m 13,0 a 0.99542444,0.99542444 0 0 0 -0.996094,0.996094 v 2 A 0.99542444,0.99542444 0 0 0 17,13.996067 h 1 a 0.99542444,0.99542444 0 0 0 0.996094,-0.996094 v -2 A 0.99542444,0.99542444 0 0 0 18,10.003879 Z m -13,4 a 0.99542444,0.99542444 0 0 0 -0.9960938,0.996094 v 1 c 0,1.088195 0.9078978,1.996094 1.9960938,1.996094 h 1 a 0.99542444,0.99542444 0 0 0 0.9960938,-0.996094 v -1 A 0.99542444,0.99542444 0 0 0 6,15.003879 H 5.99609 v -0.0039 A 0.99542444,0.99542444 0 0 0 5,14.003879 Z m 13,0 a 0.99542444,0.99542444 0 0 0 -0.996094,0.996094 v 0.0039 H 16 a 0.99542444,0.99542444 0 0 0 -0.996094,0.9961 v 1 A 0.99542444,0.99542444 0 0 0 16,17.996067 h 1 c 1.088196,0 1.996094,-0.907898 1.996094,-1.996094 v -1 A 0.99542444,0.99542444 0 0 0 18,14.003879 Z m -9,1 a 0.99542444,0.99542444 0 0 0 -0.9960938,0.996094 v 1 A 0.99542444,0.99542444 0 0 0 8,17.996067 h 2 a 0.99542444,0.99542444 0 0 0 0.996094,-0.996094 v -1 A 0.99542444,0.99542444 0 0 0 10,15.003879 Z m 4,0 a 0.99542444,0.99542444 0 0 0 -0.996094,0.996094 v 1 A 0.99542444,0.99542444 0 0 0 12,17.996067 h 2 a 0.99542444,0.99542444 0 0 0 0.996094,-0.996094 v -1 A 0.99542444,0.99542444 0 0 0 14,15.003879 Z" />
+  <path
+     id="rect3640"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="m 5,5.9999726 c -0.5539988,0 -1,0.4460012 -1,1 v 1 h 1 v -0.75 c 0,-0.1384998 0.1115002,-0.25 0.25,-0.25 H 6 v -1 z m 3,0 v 1 h 2 v -1 z m 4,0 v 1 h 2 v -1 z m 4,0 v 1 h 0.75 c 0.1385,0 0.25,0.1115002 0.25,0.25 v 0.75 h 1 v -1 c 0,-0.5539988 -0.446002,-1 -1,-1 z m -12,4 V 11.999973 H 5 V 9.9999726 Z m 13,0 v 2.0000004 h 1 V 9.9999726 Z M 4,13.999973 v 1 c 0,0.553998 0.4460012,1 1,1 h 1 v -1 H 5.25 c -0.1384998,0 -0.25,-0.1115 -0.25,-0.25 v -0.75 z m 13,0 v 0.75 c 0,0.1385 -0.1115,0.25 -0.25,0.25 H 16 v 1 h 1 c 0.553998,0 1,-0.446002 1,-1 v -1 z m -9,1 v 1 h 2 v -1 z m 4,0 v 1 h 2 v -1 z" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-6-5"
+     y="1.4999995"
+     x="1.499999"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <g
+     transform="matrix(1.0384919,0,0,1.0094942,-10.560996,-10.292119)"
+     id="g4397"
+     style="stroke-width:1.094">
+    <path
+       d="m 25.261533,24.111839 -3.737787,-6.895616 c 0,0 -2.609397,5.488347 3.737787,9.006519 z"
+       id="path3782"
+       style="fill:url(#radialGradient4407);fill-opacity:1;stroke:none;stroke-width:1.094" />
+    <path
+       d="m 25.929176,24.111839 3.737786,-6.895616 c 0,0 2.609399,5.488347 -3.737786,9.006519 z"
+       id="path2990"
+       style="fill:url(#radialGradient4409);fill-opacity:1;stroke:none;stroke-width:1.094" />
+    <path
+       d="m 23.857525,26.222742 c -0.973509,0.05182 -3.570293,0.64117 -3.570293,2.462721 0,2.081701 1.542697,2.814537 2.468351,2.814537 0.925653,0 2.432439,-0.703916 2.468349,-2.814537 0.02862,-1.68253 -0.574964,-2.359146 -1.057864,-2.462721 -0.06036,-0.01295 -0.169471,-0.0074 -0.308543,0 z m 3.129515,0 c -0.4829,0.103577 -1.086491,0.780191 -1.057864,2.462721 0.03592,2.110621 1.542696,2.814537 2.468349,2.814537 0.925654,0 2.468351,-0.732836 2.468351,-2.814537 0,-2.081773 -3.395937,-2.566295 -3.878836,-2.462721 z m -3.129515,1.319315 c 0,0 0.309098,3.612247 -1.586797,2.198857 -2.108225,-1.571638 1.586797,-2.198857 1.586797,-2.198857 z m 3.438058,0 c 0,0 3.695022,0.627219 1.586796,2.198857 -1.895894,1.41339 -1.586796,-2.198857 -1.586796,-2.198857 z"
+       id="path3788"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4411);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.094;marker:none;enable-background:accumulate" />
+    <path
+       d="m 25.261533,24.111839 -3.737787,-6.895617 c 0,0 -2.609398,5.488349 3.737787,9.006521 z"
+       id="path3782-0"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 25.929175,24.111839 3.737787,-6.895617 c 0,0 2.609398,5.488349 -3.737787,9.006521 z"
+       id="path2990-3"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 29.317553,19.737601 -2.4583,4.821269 -4.3e-5,0.495298 c 2.087662,-1.98119 2.569129,-3.646904 2.569129,-3.96238 0,-0.495298 -0.184221,-0.83737 -0.08952,-1.200962 z"
+       id="path4683"
+       style="fill:none;stroke:url(#linearGradient4413);stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 23.857524,26.222743 c -0.973508,0.05182 -3.570292,0.641169 -3.570292,2.462719 0,2.081703 1.542696,2.814538 2.46835,2.814538 0.925654,0 2.432439,-0.703916 2.46835,-2.814538 0.02862,-1.682529 -0.574964,-2.359145 -1.057864,-2.462719 -0.06036,-0.01295 -0.169471,-0.0074 -0.308544,0 z m 3.129515,0 c -0.4829,0.103577 -1.08649,0.78019 -1.057864,2.462719 0.03592,2.110622 1.542696,2.814538 2.468351,2.814538 0.925653,0 2.468349,-0.732835 2.468349,-2.814538 0,-2.081771 -3.395936,-2.566294 -3.878836,-2.462719 z m -3.129515,1.319313 c 0,0 0.309098,3.612249 -1.586796,2.198857 -2.108225,-1.571636 1.586796,-2.198857 1.586796,-2.198857 z m 3.438059,0 c 0,0 3.695021,0.627221 1.586797,2.198857 -1.895895,1.413392 -1.586797,-2.198857 -1.586797,-2.198857 z"
+       id="path3788-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#640000;stroke-width:0.976667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1113);stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path1111"
+       d="m 21.851448,19.605895 2.4583,4.821269 4.3e-5,0.495298 c -2.087662,-1.98119 -2.569129,-3.646904 -2.569129,-3.96238 0,-0.495298 0.184221,-0.83737 0.08952,-1.200962 z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/24/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/24/accessories-screenshot-tool.svg
@@ -1,0 +1,350 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="24"
+   height="24"
+   id="svg3426"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs3428">
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3152"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3154"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3156"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3924-64">
+      <stop
+         id="stop3926-3-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-0"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0" />
+      <stop
+         id="stop3930-3-59"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="1" />
+      <stop
+         id="stop3932-0"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="41.414425"
+       x2="23.99999"
+       y1="6.5908957"
+       x1="23.99999"
+       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742189,0.9717506)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3101"
+       xlink:href="#linearGradient3924-64" />
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient4407"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.39994776,-0.79806438,-1.1998291,0.59855136,1276.2546,-586.23106)" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         id="stop3766"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3768"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient4409"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.39994776,-0.79806438,1.1998291,0.59855136,-1225.064,-586.23106)" />
+    <radialGradient
+       cx="8.8626814"
+       cy="9.9941158"
+       r="12.671875"
+       fx="8.8626814"
+       fy="9.9941158"
+       id="radialGradient4411"
+       xlink:href="#linearGradient3242-7-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.0856738,-2.5766464,0,51.561592,1.9538421)" />
+    <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="55.986927"
+       y1="39.96907"
+       x2="56.968643"
+       y2="40.586102"
+       id="linearGradient4413"
+       xlink:href="#linearGradient3880-3-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.49043499,0,0,0.50045513,1.0074558,0.78026574)" />
+    <linearGradient
+       id="linearGradient3880-3-9">
+      <stop
+         id="stop3883-1-6"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         id="stop3885-5-6"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       y2="40.586102"
+       x2="56.968643"
+       y1="39.96907"
+       x1="55.986927"
+       gradientTransform="matrix(-0.49043499,0,0,0.50045513,50.161546,0.64855975)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient1113"
+       xlink:href="#linearGradient3880-3-9" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3880-3-9"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.85760065,0,0,0.74989316,-5.9607625,8.2325086)"
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient1241"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26213595,0,0,0.26213592,-32.840623,-37.052168)"
+       x1="163.56833"
+       y1="225.06929"
+       x2="163.56833"
+       y2="149.44096" />
+  </defs>
+  <metadata
+     id="metadata3431">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="g2036"
+     transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33331)">
+    <g
+       style="opacity:0.4"
+       id="g3712"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient3152);fill-opacity:1;stroke:none"
+         id="rect2801"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient3154);fill-opacity:1;stroke:none"
+         id="rect3696"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient3156);fill-opacity:1;stroke:none"
+         id="rect3700"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+  </g>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient1241);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-6"
+     y="2.5000269"
+     x="2.499999"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <rect
+     width="17"
+     height="17"
+     x="3.5012493"
+     y="3.4987738"
+     id="rect6741-9-5"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3101);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" />
+  <path
+     id="rect3872-3-2"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 4.6111113,2.5 C 3.4415568,2.5 2.5000001,3.4415569 2.5000001,4.6111112 V 13.550348 L 21.500001,8.0980182 V 4.6111112 C 21.500001,3.4415569 20.558444,2.5 19.38889,2.5 Z" />
+  <path
+     id="rect3640-9"
+     style="font-variation-settings:normal;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;opacity:0.3;stop-opacity:1"
+     d="M 6,8 C 5.4460012,8 5,8.4460012 5,9 v 1 H 6 V 9.25 C 6,9.1115002 6.1115002,9 6.25,9 H 7 V 8 Z m 3,0 v 1 h 2 V 8 Z m 4,0 v 1 h 2 V 8 Z m 4,0 v 1 h 0.75 C 17.8885,9 18,9.1115002 18,9.25 V 10 h 1 V 9 C 19,8.4460012 18.553998,8 18,8 Z M 5,12 v 2 h 1 v -2 z m 13,0 v 2 h 1 V 12 Z M 5,16 v 1 c 0,0.553998 0.4460012,1 1,1 H 7 V 17 H 6.25 C 6.1115002,17 6,16.8885 6,16.75 V 16 Z m 13,0 v 0.75 C 18,16.8885 17.8885,17 17.75,17 H 17 v 1 h 1 c 0.553998,0 1,-0.446002 1,-1 v -1 z m -9,1 v 1 h 2 v -1 z m 4,0 v 1 h 2 v -1 z" />
+  <path
+     id="rect3640-9-6"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 6,7.0039062 C 4.911805,7.0039062 4.0039063,7.911805 4.0039062,9 v 1 A 0.99542444,0.99542444 0 0 0 5,10.996094 H 6 A 0.99542444,0.99542444 0 0 0 6.9960938,10 v -0.00391 H 7 A 0.99542444,0.99542444 0 0 0 7.9960938,9 V 8 A 0.99542444,0.99542444 0 0 0 7,7.0039062 Z m 3,0 A 0.99542444,0.99542444 0 0 0 8.0039062,8 V 9 A 0.99542444,0.99542444 0 0 0 9,9.9960938 h 2 A 0.99542444,0.99542444 0 0 0 11.996094,9 V 8 A 0.99542444,0.99542444 0 0 0 11,7.0039062 Z m 4,0 A 0.99542444,0.99542444 0 0 0 12.003906,8 V 9 A 0.99542444,0.99542444 0 0 0 13,9.9960938 h 2 A 0.99542444,0.99542444 0 0 0 15.996094,9 V 8 A 0.99542444,0.99542444 0 0 0 15,7.0039062 Z m 4,0 A 0.99542444,0.99542444 0 0 0 16.003906,8 V 9 A 0.99542444,0.99542444 0 0 0 17,9.9960938 h 0.0039 V 10 A 0.99542444,0.99542444 0 0 0 18,10.996094 h 1 A 0.99542444,0.99542444 0 0 0 19.996094,10 V 9 C 19.996094,7.911804 19.088195,7.0039062 18,7.0039062 Z M 5,11.003906 A 0.99542444,0.99542444 0 0 0 4.0039062,12 v 2 A 0.99542444,0.99542444 0 0 0 5,14.996094 H 6 A 0.99542444,0.99542444 0 0 0 6.9960938,14 V 12 A 0.99542444,0.99542444 0 0 0 6,11.003906 Z m 13,0 A 0.99542444,0.99542444 0 0 0 17.003906,12 v 2 A 0.99542444,0.99542444 0 0 0 18,14.996094 h 1 A 0.99542444,0.99542444 0 0 0 19.996094,14 V 12 A 0.99542444,0.99542444 0 0 0 19,11.003906 Z m -13,4 A 0.99542444,0.99542444 0 0 0 4.0039062,16 v 1 c 0,1.088195 0.9078978,1.996094 1.9960938,1.996094 H 7 A 0.99542444,0.99542444 0 0 0 7.9960938,18 V 17 A 0.99542444,0.99542444 0 0 0 7,16.003906 h -0.00391 V 16 A 0.99542444,0.99542444 0 0 0 6,15.003906 Z m 13,0 A 0.99542444,0.99542444 0 0 0 17.003906,16 v 0.0039 H 17 A 0.99542444,0.99542444 0 0 0 16.003906,17 v 1 A 0.99542444,0.99542444 0 0 0 17,18.996094 h 1 c 1.088196,0 1.996094,-0.907898 1.996094,-1.996094 V 16 A 0.99542444,0.99542444 0 0 0 19,15.003906 Z m -9,1 A 0.99542444,0.99542444 0 0 0 8.0039062,17 v 1 A 0.99542444,0.99542444 0 0 0 9,18.996094 h 2 A 0.99542444,0.99542444 0 0 0 11.996094,18 V 17 A 0.99542444,0.99542444 0 0 0 11,16.003906 Z m 4,0 A 0.99542444,0.99542444 0 0 0 12.003906,17 v 1 A 0.99542444,0.99542444 0 0 0 13,18.996094 h 2 A 0.99542444,0.99542444 0 0 0 15.996094,18 V 17 A 0.99542444,0.99542444 0 0 0 15,16.003906 Z" />
+  <path
+     id="rect3640"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.999995;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 6 7 C 5.4460012 7 5 7.4460012 5 8 L 5 9 L 6 9 L 6 8.25 C 6 8.1115002 6.1115002 8 6.25 8 L 7 8 L 7 7 L 6 7 z M 9 7 L 9 8 L 11 8 L 11 7 L 9 7 z M 13 7 L 13 8 L 15 8 L 15 7 L 13 7 z M 17 7 L 17 8 L 17.75 8 C 17.8885 8 18 8.1115002 18 8.25 L 18 9 L 19 9 L 19 8 C 19 7.4460012 18.553998 7 18 7 L 17 7 z M 5 11 L 5 13 L 6 13 L 6 11 L 5 11 z M 18 11 L 18 13 L 19 13 L 19 11 L 18 11 z M 5 15 L 5 16 C 5 16.553998 5.4460012 17 6 17 L 7 17 L 7 16 L 6.25 16 C 6.1115002 16 6 15.8885 6 15.75 L 6 15 L 5 15 z M 18 15 L 18 15.75 C 18 15.8885 17.8885 16 17.75 16 L 17 16 L 17 17 L 18 17 C 18.553998 17 19 16.553998 19 16 L 19 15 L 18 15 z M 9 16 L 9 17 L 11 17 L 11 16 L 9 16 z M 13 16 L 13 17 L 15 17 L 15 16 L 13 16 z " />
+  <rect
+     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-6-5"
+     y="2.5000269"
+     x="2.499999"
+     ry="2"
+     rx="2"
+     height="19"
+     width="19" />
+  <g
+     transform="matrix(1.0384919,0,0,1.0094942,-8.5610918,-8.2920373)"
+     id="g4397"
+     style="stroke-width:1.094">
+    <path
+       d="m 25.261533,24.111839 -3.737787,-6.895616 c 0,0 -2.609397,5.488347 3.737787,9.006519 z"
+       id="path3782"
+       style="fill:url(#radialGradient4407);fill-opacity:1;stroke:none;stroke-width:1.094" />
+    <path
+       d="m 25.929176,24.111839 3.737786,-6.895616 c 0,0 2.609399,5.488347 -3.737786,9.006519 z"
+       id="path2990"
+       style="fill:url(#radialGradient4409);fill-opacity:1;stroke:none;stroke-width:1.094" />
+    <path
+       d="m 23.857525,26.222742 c -0.973509,0.05182 -3.570293,0.64117 -3.570293,2.462721 0,2.081701 1.542697,2.814537 2.468351,2.814537 0.925653,0 2.432439,-0.703916 2.468349,-2.814537 0.02862,-1.68253 -0.574964,-2.359146 -1.057864,-2.462721 -0.06036,-0.01295 -0.169471,-0.0074 -0.308543,0 z m 3.129515,0 c -0.4829,0.103577 -1.086491,0.780191 -1.057864,2.462721 0.03592,2.110621 1.542696,2.814537 2.468349,2.814537 0.925654,0 2.468351,-0.732836 2.468351,-2.814537 0,-2.081773 -3.395937,-2.566295 -3.878836,-2.462721 z m -3.129515,1.319315 c 0,0 0.309098,3.612247 -1.586797,2.198857 -2.108225,-1.571638 1.586797,-2.198857 1.586797,-2.198857 z m 3.438058,0 c 0,0 3.695022,0.627219 1.586796,2.198857 -1.895894,1.41339 -1.586796,-2.198857 -1.586796,-2.198857 z"
+       id="path3788"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4411);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.094;marker:none;enable-background:accumulate" />
+    <path
+       d="m 25.261533,24.111839 -3.737787,-6.895617 c 0,0 -2.609398,5.488349 3.737787,9.006521 z"
+       id="path3782-0"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 25.929175,24.111839 3.737787,-6.895617 c 0,0 2.609398,5.488349 -3.737787,9.006521 z"
+       id="path2990-3"
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 29.317553,19.737601 -2.4583,4.821269 -4.3e-5,0.495298 c 2.087662,-1.98119 2.569129,-3.646904 2.569129,-3.96238 0,-0.495298 -0.184221,-0.83737 -0.08952,-1.200962 z"
+       id="path4683"
+       style="fill:none;stroke:url(#linearGradient4413);stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       d="m 23.857524,26.222743 c -0.973508,0.05182 -3.570292,0.641169 -3.570292,2.462719 0,2.081703 1.542696,2.814538 2.46835,2.814538 0.925654,0 2.432439,-0.703916 2.46835,-2.814538 0.02862,-1.682529 -0.574964,-2.359145 -1.057864,-2.462719 -0.06036,-0.01295 -0.169471,-0.0074 -0.308544,0 z m 3.129515,0 c -0.4829,0.103577 -1.08649,0.78019 -1.057864,2.462719 0.03592,2.110622 1.542696,2.814538 2.468351,2.814538 0.925653,0 2.468349,-0.732835 2.468349,-2.814538 0,-2.081771 -3.395936,-2.566294 -3.878836,-2.462719 z m -3.129515,1.319313 c 0,0 0.309098,3.612249 -1.586796,2.198857 -2.108225,-1.571636 1.586796,-2.198857 1.586796,-2.198857 z m 3.438059,0 c 0,0 3.695021,0.627221 1.586797,2.198857 -1.895895,1.413392 -1.586797,-2.198857 -1.586797,-2.198857 z"
+       id="path3788-5"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#640000;stroke-width:0.976667;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="fill:none;stroke:url(#linearGradient1113);stroke-width:0.976667px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path1111"
+       d="m 21.851448,19.605895 2.4583,4.821269 4.3e-5,0.495298 c -2.087662,-1.98119 -2.569129,-3.646904 -2.569129,-3.96238 0,-0.495298 0.184221,-0.83737 0.08952,-1.200962 z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/32/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/32/accessories-screenshot-tool.svg
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg4151"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4153">
+    <linearGradient
+       id="linearGradient4281">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4283" />
+      <stop
+         offset="0.07475055"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4285" />
+      <stop
+         offset="0.93857974"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4287" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4289" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.2399855"
+       x2="23.99999"
+       y2="41.759987"
+       id="linearGradient3174"
+       xlink:href="#linearGradient4281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.21621703,-0.21620627)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2976"
+       xlink:href="#linearGradient3688-166-749-6"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <linearGradient
+       id="linearGradient3688-166-749-6">
+      <stop
+         id="stop2883-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient2978"
+       xlink:href="#linearGradient3688-464-309-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       id="linearGradient3688-464-309-7">
+      <stop
+         id="stop2889-0"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891-66"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient2980"
+       xlink:href="#linearGradient3702-501-757-3"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3702-501-757-3">
+      <stop
+         id="stop2895-3"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-28"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-8"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(-0.39994776,-0.79806438,-1.1998291,0.59855136,1276.2546,-586.23106)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3764"
+       id="radialGradient4407"
+       fy="1039.7"
+       fx="14.999991"
+       r="3.5266583"
+       cy="1039.7"
+       cx="14.999991" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         id="stop3766"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3768"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.39994776,-0.79806438,1.1998291,0.59855136,-1225.064,-586.23106)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3764"
+       id="radialGradient4409"
+       fy="1039.7"
+       fx="14.999991"
+       r="3.5266583"
+       cy="1039.7"
+       cx="14.999991" />
+    <radialGradient
+       gradientTransform="matrix(0,2.0856738,-2.5766464,0,51.561592,1.9538421)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3242-7-6"
+       id="radialGradient4411"
+       fy="9.9941158"
+       fx="8.8626814"
+       r="12.671875"
+       cy="9.9941158"
+       cx="8.8626814" />
+    <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.49043499,0,0,0.50045513,1.0074558,0.78026574)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4685"
+       id="linearGradient4413"
+       y2="42.054295"
+       x2="58.032764"
+       y1="40"
+       x1="56" />
+    <linearGradient
+       id="linearGradient4685">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4687" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4689" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(-0.49043499,0,0,0.50045513,50.23125,0.78026596)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4685"
+       id="linearGradient4415"
+       y2="42.054295"
+       x2="58.032764"
+       y1="40"
+       x1="56" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="41.609329"
+       y1="241.85577"
+       x2="41.609329"
+       y2="136.2437"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.26213595,0,0,0.26213592,-0.77669845,-33.563582)" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4685"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.2186956,0,0,1.0656376,-9.5231885,10.646196)"
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12" />
+  </defs>
+  <metadata
+     id="metadata4156">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     id="g2036-2"
+     transform="matrix(0.6999997,0,0,0.3333336,-0.8000002,15.33333)">
+    <g
+       style="opacity:0.4"
+       id="g3712-3"
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
+      <rect
+         style="fill:url(#radialGradient2976);fill-opacity:1;stroke:none"
+         id="rect2801-0"
+         y="40"
+         x="38"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#radialGradient2978);fill-opacity:1;stroke:none"
+         id="rect3696-2"
+         transform="scale(-1,-1)"
+         y="-47"
+         x="-10"
+         height="7"
+         width="5" />
+      <rect
+         style="fill:url(#linearGradient2980);fill-opacity:1;stroke:none"
+         id="rect3700-1"
+         y="40"
+         x="10"
+         height="7.0000005"
+         width="28" />
+    </g>
+  </g>
+  <rect
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21"
+     y="2.5"
+     x="2.5000002"
+     ry="3"
+     rx="3"
+     height="27"
+     width="27" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3174);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7-4"
+     y="3.4999998"
+     x="3.5"
+     ry="2"
+     rx="2"
+     height="25"
+     width="25" />
+  <path
+     id="rect3872-3-2"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 5.5 2.5 C 3.8380017 2.5 2.5 3.8380017 2.5 5.5 L 2.5 18.203125 L 29.5 10.455078 L 29.5 5.5 C 29.5 3.8380017 28.161998 2.5 26.5 2.5 L 5.5 2.5 z " />
+  <path
+     id="rect3540-2"
+     style="font-variation-settings:normal;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;opacity:0.3;stop-opacity:1"
+     d="M 7.5,9 C 6.6690016,9 6,9.6690016 6,10.5 V 12 H 7 V 10.75 C 7,10.334501 7.3345008,10 7.75,10 H 9 V 9 Z M 11,9 v 1 h 4 V 9 Z m 6,0 v 1 h 4 V 9 Z m 6,0 v 1 h 1.25 C 24.6655,10 25,10.334501 25,10.75 V 12 h 1 V 10.5 C 26,9.6690016 25.330998,9 24.5,9 Z M 6,15 v 4 h 1 v -4 z m 19,0 v 4 h 1 V 15 Z M 6,22 v 1.5 C 6,24.330998 6.6690016,25 7.5,25 H 9 V 24 H 7.75 C 7.3345008,24 7,23.6655 7,23.25 V 22 Z m 19,0 v 1.25 C 25,23.6655 24.6655,24 24.25,24 H 23 v 1 h 1.5 C 25.330998,25 26,24.330998 26,23.5 V 22 Z m -14,2 v 1 h 4 v -1 z m 6,0 v 1 h 4 v -1 z" />
+  <path
+     id="rect3540-2-7"
+     style="font-variation-settings:normal;opacity:0.15;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 7.5,7.9882812 C 6.1261875,7.9882813 4.9882812,9.1261875 4.9882812,10.5 V 12 A 1.0114836,1.0114836 0 0 0 6,13.011719 H 7 A 1.0114836,1.0114836 0 0 0 8.0117188,12 V 11.011719 H 9 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 0.988281 V 12 A 1.0114836,1.0114836 0 0 0 25,13.011719 h 1 A 1.0114836,1.0114836 0 0 0 27.011719,12 V 10.5 C 27.011719,9.1261872 25.873812,7.9882813 24.5,7.9882812 H 23 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 z M 6,13.988281 A 1.0114836,1.0114836 0 0 0 4.9882812,15 v 4 A 1.0114836,1.0114836 0 0 0 6,20.011719 H 7 A 1.0114836,1.0114836 0 0 0 8.0117188,19 V 15 A 1.0114836,1.0114836 0 0 0 7,13.988281 Z m 19,0 A 1.0114836,1.0114836 0 0 0 23.988281,15 v 4 A 1.0114836,1.0114836 0 0 0 25,20.011719 h 1 A 1.0114836,1.0114836 0 0 0 27.011719,19 V 15 A 1.0114836,1.0114836 0 0 0 26,13.988281 Z m -19,7 A 1.0114836,1.0114836 0 0 0 4.9882812,22 v 1.5 c 0,1.373812 1.137906,2.511719 2.5117188,2.511719 H 9 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 4 a 1.0114836,1.0114836 0 0 0 1,-1 1.0114836,1.0114836 0 0 0 1,1 h 1.5 c 1.373813,0 2.511719,-1.137906 2.511719,-2.511719 V 22 A 1.0114836,1.0114836 0 0 0 26,20.988281 H 25 A 1.0114836,1.0114836 0 0 0 23.988281,22 v 0.988281 H 23 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 h -4 a 1.0114836,1.0114836 0 0 0 -1,1 1.0114836,1.0114836 0 0 0 -1,-1 H 8.0117188 V 22 A 1.0114836,1.0114836 0 0 0 7,20.988281 Z" />
+  <path
+     id="rect3540"
+     style="font-variation-settings:normal;opacity:1;vector-effect:none;fill:#fafafa;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;stop-color:#000000;stop-opacity:1"
+     d="M 7.5,8 C 6.6690016,8 6,8.6690016 6,9.5 V 11 H 7 V 9.75 C 7,9.3345008 7.3345008,9 7.75,9 H 9 V 8 Z M 11,8 v 1 h 4 V 8 Z m 6,0 v 1 h 4 V 8 Z m 6,0 v 1 h 1.25 C 24.6655,9 25,9.3345008 25,9.75 V 11 h 1 V 9.5 C 26,8.6690016 25.330998,8 24.5,8 Z M 6,14 v 4 h 1 v -4 z m 19,0 v 4 h 1 V 14 Z M 6,21 v 1.5 C 6,23.330998 6.6690016,24 7.5,24 H 9 V 23 H 7.75 C 7.3345008,23 7,22.6655 7,22.25 V 21 Z m 19,0 v 1.25 C 25,22.6655 24.6655,23 24.25,23 H 23 v 1 h 1.5 C 25.330998,24 26,23.330998 26,22.5 V 21 Z m -14,2 v 1 h 4 v -1 z m 6,0 v 1 h 4 v -1 z" />
+  <g
+     id="g4397"
+     transform="matrix(1.1201367,0,0,1.1201367,-3.073999,-3.7843059)">
+    <path
+       style="fill:url(#radialGradient4407);fill-opacity:1;stroke:none"
+       id="path3782-1"
+       d="m 25.261533,24.111839 -3.737787,-6.895616 c 0,0 -2.609397,5.488347 3.737787,9.006519 z" />
+    <path
+       style="fill:url(#radialGradient4409);fill-opacity:1;stroke:none"
+       id="path2990-2"
+       d="m 25.929176,24.111839 3.737786,-6.895616 c 0,0 2.609399,5.488347 -3.737786,9.006519 z" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4411);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       id="path3788-7"
+       d="m 23.857525,26.222742 c -0.973509,0.05182 -3.570293,0.64117 -3.570293,2.462721 0,2.081701 1.542697,2.814537 2.468351,2.814537 0.925653,0 2.432439,-0.703916 2.468349,-2.814537 0.02862,-1.68253 -0.574964,-2.359146 -1.057864,-2.462721 -0.06036,-0.01295 -0.169471,-0.0074 -0.308543,0 z m 3.129515,0 c -0.4829,0.103577 -1.086491,0.780191 -1.057864,2.462721 0.03592,2.110621 1.542696,2.814537 2.468349,2.814537 0.925654,0 2.468351,-0.732836 2.468351,-2.814537 0,-2.081773 -3.395937,-2.566295 -3.878836,-2.462721 z m -3.129515,1.319315 c 0,0 0.309098,3.612247 -1.586797,2.198857 -2.108225,-1.571638 1.586797,-2.198857 1.586797,-2.198857 z m 3.438058,0 c 0,0 3.695022,0.627219 1.586796,2.198857 -1.895894,1.41339 -1.586796,-2.198857 -1.586796,-2.198857 z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.892748px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3782-0-0"
+       d="m 25.261533,24.111839 -3.737787,-6.895617 c 0,0 -2.609398,5.488349 3.737787,9.006521 z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.892748px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path2990-3-9"
+       d="m 25.929175,24.111839 3.737787,-6.895617 c 0,0 2.609398,5.488349 -3.737787,9.006521 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4413);stroke-width:0.892748px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4683-3"
+       d="m 29.468012,18.968681 -2.744172,5.35367 -0.04518,0.650423 c 2.138932,-1.487483 2.641626,-3.243227 2.746573,-4.649906 0.04711,-0.63148 0.131731,-0.89997 0.04277,-1.354187 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4415);stroke-width:0.892748px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4683-1-6"
+       d="m 21.770696,18.968681 2.744172,5.35367 0.04518,0.650423 c -2.138931,-1.487483 -2.641626,-3.243227 -2.746573,-4.649906 -0.04711,-0.63148 -0.131731,-0.89997 -0.04277,-1.354187 z" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#640000;stroke-width:0.892748;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path3788-5-0"
+       d="m 23.857524,26.222743 c -0.973508,0.05182 -3.570292,0.641169 -3.570292,2.462719 0,2.081703 1.542696,2.814538 2.46835,2.814538 0.925654,0 2.432439,-0.703916 2.46835,-2.814538 0.02862,-1.682529 -0.574964,-2.359145 -1.057864,-2.462719 -0.06036,-0.01295 -0.169471,-0.0074 -0.308544,0 z m 3.129515,0 c -0.4829,0.103577 -1.08649,0.78019 -1.057864,2.462719 0.03592,2.110622 1.542696,2.814538 2.468351,2.814538 0.925653,0 2.468349,-0.732835 2.468349,-2.814538 0,-2.081771 -3.395936,-2.566294 -3.878836,-2.462719 z m -3.129515,1.319313 c 0,0 0.309098,3.612249 -1.586796,2.198857 -2.108225,-1.571636 1.586796,-2.198857 1.586796,-2.198857 z m 3.438059,0 c 0,0 3.695021,0.627221 1.586797,2.198857 -1.895895,1.413392 -1.586797,-2.198857 -1.586797,-2.198857 z" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/48/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/48/accessories-screenshot-tool.svg
@@ -1,0 +1,436 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="48"
+   height="48"
+   id="svg4296"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4298">
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3899"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03030945" />
+      <stop
+         id="stop3901"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97833663" />
+      <stop
+         id="stop3903"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.0315123"
+       x2="23.99999"
+       y2="41.934097"
+       id="linearGradient3024"
+       xlink:href="#linearGradient3895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(4e-6,1.0000062)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3038"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3040"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3042"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient3525"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.56710644,-1.1342033,-1.7012993,0.85065685,1811.4006,-832.4149)" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         id="stop3766"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3768"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient3520"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56710644,-1.1342033,1.7012993,0.85065685,-1735.3473,-832.4149)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient3517"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5647059,0,0,0.2823525,-1.364705,43.6941)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient3514"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5647059,0,0,0.2823525,6.635295,43.6941)" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-6"
+       id="radialGradient4230-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.9641444,-3.6535591,0,74.845518,3.5092146)"
+       cx="8.8626814"
+       cy="9.9941158"
+       fx="8.8626814"
+       fy="9.9941158"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4685"
+       id="linearGradient3415"
+       gradientUnits="userSpaceOnUse"
+       x1="56"
+       y1="40"
+       x2="58.032764"
+       y2="42.054295"
+       gradientTransform="matrix(0.69541292,0,0,0.71124318,3.1622172,1.8413367)" />
+    <linearGradient
+       id="linearGradient4685">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4687" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4689" />
+    </linearGradient>
+    <linearGradient
+       y2="42.054295"
+       x2="58.032764"
+       y1="40"
+       x1="56"
+       gradientTransform="matrix(-0.69541292,0,0,0.71124318,72.959161,1.841337)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4203"
+       xlink:href="#linearGradient4685" />
+    <linearGradient
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12"
+       id="linearGradient3887"
+       xlink:href="#linearGradient4685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6519103,0,0,1.4444444,-10.596019,17.555554)" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="19.005375"
+       y1="202.81076"
+       x2="19.005375"
+       y2="242.78731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-248.00361)" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4301">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(1.1578952,0,0,0.6428571,-3.789476,16.035716)"
+     id="g3712-5"
+     style="opacity:0.6">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801-3"
+       style="fill:url(#radialGradient3038);fill-opacity:1;stroke:none" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1,-1)"
+       id="rect3696-6"
+       style="fill:url(#radialGradient3040);fill-opacity:1;stroke:none" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-4"
+       style="fill:url(#linearGradient3042);fill-opacity:1;stroke:none" />
+  </g>
+  <rect
+     width="39"
+     height="39"
+     rx="4"
+     ry="4"
+     x="4.5000124"
+     y="-44.499996"
+     id="rect5505-21"
+     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     transform="scale(1,-1)" />
+  <rect
+     width="37"
+     height="37"
+     rx="3"
+     ry="3"
+     x="5.5000124"
+     y="6.5000005"
+     id="rect6741"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3024);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     transform="translate(-3.4983966e-8,5.000293)"
+     style="opacity:0.1"
+     id="g4537-9">
+    <path
+       id="path4477-8"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       d="M 17,10.011719 A 0.98778123,0.98778123 0 0 0 16.011719,11 v 2 A 0.98778123,0.98778123 0 0 0 17,13.988281 h 5 A 0.98778123,0.98778123 0 0 0 22.988281,13 V 11 A 0.98778123,0.98778123 0 0 0 22,10.011719 Z m 9,0 A 0.98778123,0.98778123 0 0 0 25.011719,11 v 2 A 0.98778123,0.98778123 0 0 0 26,13.988281 h 5 A 0.98778123,0.98778123 0 0 0 31.988281,13 V 11 A 0.98778123,0.98778123 0 0 0 31,10.011719 Z m -17,8 A 0.98778123,0.98778123 0 0 0 8.0117188,19 v 5 A 0.98778123,0.98778123 0 0 0 9,24.988281 h 2 A 0.98778123,0.98778123 0 0 0 11.988281,24 V 19 A 0.98778123,0.98778123 0 0 0 11,18.011719 Z m 28,0 A 0.98778123,0.98778123 0 0 0 36.011719,19 v 5 A 0.98778123,0.98778123 0 0 0 37,24.988281 h 2 A 0.98778123,0.98778123 0 0 0 39.988281,24 V 19 A 0.98778123,0.98778123 0 0 0 39,18.011719 Z m -20,11 A 0.98778123,0.98778123 0 0 0 16.011719,30 v 2 A 0.98778123,0.98778123 0 0 0 17,32.988281 h 5 A 0.98778123,0.98778123 0 0 0 22.988281,32 V 30 A 0.98778123,0.98778123 0 0 0 22,29.011719 Z m 9,0 A 0.98778123,0.98778123 0 0 0 25.011719,30 v 2 A 0.98778123,0.98778123 0 0 0 26,32.988281 h 5 A 0.98778123,0.98778123 0 0 0 31.988281,32 V 30 A 0.98778123,0.98778123 0 0 0 31,29.011719 Z" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4459-2"
+       d="m 38.000202,14.666497 c 0,-2.666684 0,-2.666684 -2.666687,-2.666684" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2387-2"
+       d="m 12.666698,11.999813 c -2.666685,0 -2.666685,0 -2.666685,2.666684" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4457-9"
+       d="M 10.000013,28.333315 C 10.000013,31 10.000013,31 12.666698,31" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4461-7"
+       d="m 35.333515,31 c 2.666687,0 2.666687,0 2.666687,-2.666685" />
+  </g>
+  <g
+     id="g4537"
+     style="opacity:0.3"
+     transform="translate(0,5.000293)">
+    <path
+       d="m 38.000202,14.666497 c 0,-2.666684 0,-2.666684 -2.666687,-2.666684"
+       id="path4459"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 12.666698,11.999813 c -2.666685,0 -2.666685,0 -2.666685,2.666684"
+       id="path2387"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 17,11 v 2 h 5 v -2 z m 9,0 v 2 h 5 V 11 Z M 9,19 v 5 h 2 v -5 z m 28,0 v 5 h 2 V 19 Z M 17,30 v 2 h 5 v -2 z m 9,0 v 2 h 5 v -2 z"
+       id="path4477"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+    <path
+       d="M 10.000013,28.333315 C 10.000013,31 10.000013,31 12.666698,31"
+       id="path4457"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 35.333515,31 c 2.666687,0 2.666687,0 2.666687,-2.666685"
+       id="path4461"
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     id="g1739"
+     transform="translate(0,-1.9948242e-4)">
+    <path
+       id="path4477-4"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       d="m 17,15 v 2 h 5 v -2 z m 9,0 v 2 h 5 V 15 Z M 9,23 v 5 h 2 v -5 z m 28,0 v 5 h 2 V 23 Z M 17,34 v 2 h 5 v -2 z m 9,0 v 2 h 5 v -2 z" />
+    <path
+       id="path4461-0"
+       style="opacity:1;fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.333515,35.000293 c 2.666687,0 2.666687,0 2.666687,-2.666685 M 12.666698,16.000106 c -2.666685,0 -2.666685,0 -2.666685,2.666684 m 28.000189,0 c 0,-2.666684 0,-2.666684 -2.666687,-2.666684 M 10.000013,32.333608 c 0,2.666685 0,2.666685 2.666685,2.666685" />
+  </g>
+  <g
+     id="g2269"
+     transform="translate(10.479915,38.270346)">
+    <path
+       id="path4477-4-3"
+       style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+       d="m 6.520085,-22.270053 v 2 h 5 v -2 z m 9,0 v 2 h 5 v -2 z m -17,8 v 5 h 2 v -5 z m 28,0 v 5 h 2 v -5 z m -20,11 v 2 h 5 v -2 z m 9,0 v 2 h 5 v -2 z" />
+    <path
+       id="path4461-0-5"
+       style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+       d="m 24.8536,-2.26976 c 2.666687,0 2.666687,0 2.666687,-2.666685 M 2.186783,-21.269947 c -2.666685,0 -2.666685,0 -2.666685,2.666684 m 28.000189,0 c 0,-2.666684 0,-2.666684 -2.666687,-2.666684 M -0.479902,-4.936445 c 0,2.666685 0,2.666685 2.666685,2.666685" />
+  </g>
+  <path
+     id="rect3872"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient3887);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 6.5585938 6 C 5.3292702 6.6809589 4.5 7.9897029 4.5 9.5 L 4.5 28.142578 L 43.5 16.953125 L 43.5 9.5 C 43.5 7.9897029 42.67073 6.6809589 41.441406 6 L 6.5585938 6 z " />
+  <g
+     id="g108">
+    <path
+       style="fill:url(#radialGradient3525);fill-opacity:1;stroke:none"
+       id="path3782"
+       d="m 37.553316,35 -5.3,-9.8 c 0,0 -3.699999,7.8 5.3,12.8 z" />
+    <path
+       style="fill:url(#radialGradient3520);fill-opacity:1;stroke:none"
+       id="path2990"
+       d="m 38.5,35 5.3,-9.8 c 0,0 3.7,7.8 -5.3,12.8 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3517);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+       id="path8836"
+       d="m 40,45 c 0,1.6569 -2.686291,3 -6,3 -3.313709,0 -6,-1.3431 -6,-3 0,-1.6569 2.686291,-3 6,-3 3.313709,0 6,1.3431 6,3 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3514);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+       id="path4007"
+       d="m 48,45 c 0,1.6569 -2.686291,3 -6,3 -3.313709,0 -6,-1.3431 -6,-3 0,-1.6569 2.686291,-3 6,-3 3.313709,0 6,1.3431 6,3 z" />
+    <path
+       id="path3788"
+       d="M 35.5625,38 C 34.182113,38.07364 30.5,38.911225 30.5,41.5 c 0,2.9585 2.187468,4 3.5,4 1.312532,0 3.44908,-1.0004 3.5,-4 C 37.54059,39.1088 36.684728,38.1472 36,38 35.91441,37.9816 35.759698,37.98948 35.5625,38 Z M 40,38 c -0.684728,0.1472 -1.54059,1.1088 -1.5,3.5 0.05092,2.9996 2.187468,4 3.5,4 1.312532,0 3.5,-1.0415 3.5,-4 0,-2.9586 -4.815272,-3.6472 -5.5,-3.5 z m -4.4375,1.875 c 0,0 0.438286,5.1337 -2.25,3.125 -2.98936,-2.2336 2.25,-3.125 2.25,-3.125 z m 4.875,0 c 0,0 5.23936,0.8914 2.25,3.125 -2.688286,2.0087 -2.25,-3.125 -2.25,-3.125 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4230-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3782-0"
+       d="m 37.553316,35 -5.3,-9.8 c 0,0 -3.699999,7.8 5.3,12.8 z" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path2990-3"
+       d="m 38.5,35 5.3,-9.8 c 0,0 3.7,7.8 -5.3,12.8 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3415);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4683"
+       d="m 43.517898,27.690581 -3.891101,7.608596 -0.06406,0.924377 c 3.032901,-2.113999 3.745697,-4.609251 3.894507,-6.608411 0.0668,-0.897456 0.186789,-1.279032 0.06065,-1.924562 z" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4203);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4683-1"
+       d="m 32.60348,27.690581 3.891101,7.608596 0.06406,0.924377 c -3.032901,-2.113999 -3.745697,-4.609251 -3.894507,-6.608411 -0.0668,-0.897456 -0.186789,-1.279032 -0.06065,-1.924562 z" />
+    <path
+       id="path3788-5"
+       d="M 35.5625,38 C 34.182113,38.07364 30.5,38.911225 30.5,41.5 c 0,2.9585 2.187468,4 3.5,4 1.312532,0 3.44908,-1.0004 3.5,-4 C 37.54059,39.1088 36.684728,38.1472 36,38 35.91441,37.9816 35.759698,37.98948 35.5625,38 Z M 40,38 c -0.684728,0.1472 -1.54059,1.1088 -1.5,3.5 0.05092,2.9996 2.187468,4 3.5,4 1.312532,0 3.5,-1.0415 3.5,-4 0,-2.9586 -4.815272,-3.6472 -5.5,-3.5 z m -4.4375,1.875 c 0,0 0.438286,5.1337 -2.25,3.125 -2.98936,-2.2336 2.25,-3.125 2.25,-3.125 z m 4.875,0 c 0,0 5.23936,0.8914 2.25,3.125 -2.688286,2.0087 -2.25,-3.125 -2.25,-3.125 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;fill-opacity:1;stroke:#640000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/64/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/64/accessories-screenshot-tool.svg
@@ -1,0 +1,478 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="64"
+   height="64"
+   id="svg4161"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs4163">
+    <linearGradient
+       x1="23.99999"
+       y1="4.999989"
+       x2="23.99999"
+       y2="43"
+       id="linearGradient3180"
+       xlink:href="#linearGradient3924-2-2-5-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.378381,-2.4707781)" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06316455" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.95056331" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749-4-0-3-8">
+      <stop
+         id="stop2883-4-0-1-8"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885-9-2-9-6"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-8-4-1-1">
+      <stop
+         id="stop2895-8-9-9-1"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897-7-8-7-7"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899-4-5-1-5"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3337-2-2-3"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,41.985755,15.500001)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3339-1-4-5"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,-22.014244,-102.5)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient6394"
+       xlink:href="#linearGradient3702-501-757-8-4-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5714286,0,0,0.7142857,-5.7142853,27.928572)" />
+    <radialGradient
+       gradientTransform="matrix(0.65882358,0,0,0.37758803,5.0042103,58.25133)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8838"
+       id="radialGradient4443"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
+    <linearGradient
+       id="linearGradient8838">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:1"
+         id="stop8840" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0"
+         id="stop8842" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.65882354,0,0,0.37758803,15.698729,58.25133)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient8838"
+       id="radialGradient4440"
+       fy="4.625"
+       fx="62.625"
+       r="10.625"
+       cy="4.625"
+       cx="62.625" />
+    <radialGradient
+       r="3.5266583"
+       fy="1039.7"
+       fx="14.999991"
+       cy="1039.7"
+       cx="14.999991"
+       gradientTransform="matrix(-0.75811615,-1.5167622,-2.2743217,1.1375775,2421.3389,-1113.3631)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3125"
+       xlink:href="#linearGradient3764" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         offset="0"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         id="stop3766" />
+      <stop
+         offset="1"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         id="stop3768" />
+    </linearGradient>
+    <linearGradient
+       y2="43"
+       x2="59"
+       y1="40"
+       x1="56"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3127"
+       xlink:href="#linearGradient4685-6" />
+    <linearGradient
+       id="linearGradient4685-6">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4687-7" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4689-3" />
+    </linearGradient>
+    <radialGradient
+       r="3.5266583"
+       fy="1039.7"
+       fx="14.999991"
+       cy="1039.7"
+       cx="14.999991"
+       gradientTransform="matrix(0.75811615,-1.5167622,2.2743217,1.1375775,-2320.0054,-1113.3631)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3129"
+       xlink:href="#linearGradient3764" />
+    <radialGradient
+       r="12.671875"
+       fy="9.9941158"
+       fx="8.276144"
+       cy="9.9941158"
+       cx="8.276144"
+       gradientTransform="matrix(0,3.5613537,-4.3722044,0,94.717932,9.7303381)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient3139"
+       xlink:href="#linearGradient3242-7" />
+    <linearGradient
+       id="linearGradient3242-7">
+      <stop
+         id="stop3244-6"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       y2="72.330383"
+       x2="61.182655"
+       y1="64.032387"
+       x1="61.146534"
+       gradientTransform="matrix(1.0368452,0,-0.00451336,1.0845986,-6.11049,-18.449436)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3142"
+       xlink:href="#linearGradient4917" />
+    <linearGradient
+       id="linearGradient4917">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4919" />
+      <stop
+         offset="0.44444457"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop4921" />
+      <stop
+         offset="0.77777803"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop4923" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop4925" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4685-6"
+       id="linearGradient2019"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.4586572,0,0,2.1498707,-19.491749,21.198966)"
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12" />
+    <linearGradient
+       xlink:href="#linearGradient4685-6"
+       id="linearGradient1079"
+       gradientUnits="userSpaceOnUse"
+       x1="56"
+       y1="40"
+       x2="59"
+       y2="43" />
+    <linearGradient
+       xlink:href="#linearGradient4917"
+       id="linearGradient1081"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0368452,0,-0.00451336,1.0845986,-6.11049,-18.449436)"
+       x1="61.146534"
+       y1="64.032387"
+       x2="61.182655"
+       y2="72.330383" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="38.542343"
+       y1="138.22308"
+       x2="38.542343"
+       y2="193.82295"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(0,-198.00362)" />
+  </defs>
+  <metadata
+     id="metadata4166">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g866">
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3337-2-2-3);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect2801-5-5-7-9"
+       y="56.5"
+       x="54"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.6;fill:url(#radialGradient3339-1-4-5);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-61.5"
+       x="-10"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.6;fill:url(#linearGradient6394);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3700-5-6-8-4"
+       y="56.5"
+       x="10"
+       height="5.0000005"
+       width="44" />
+  </g>
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     id="rect5505-21-3-8-5-2"
+     y="-59.5"
+     x="4.5"
+     ry="6"
+     rx="6"
+     height="55"
+     width="55"
+     transform="scale(1,-1)" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3180);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3"
+     y="5.4287739"
+     x="5.4999986"
+     ry="5"
+     rx="5"
+     height="53.142479"
+     width="53" />
+  <g
+     id="g2822"
+     transform="translate(0,-0.99975234)"
+     style="opacity:0.15">
+    <path
+       id="path2387-7-3"
+       style="fill:none;stroke:#000000;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 15,20.000059 c -4,0 -4,0 -4,4 m 0,20 c 0,4 0,4 4,4 m 38,-24 c 0,-4 0,-4 -4,-4 m 0,28 c 4,0 4,0 4,-4" />
+    <path
+       id="path4577-1"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       d="m 21,16 a 1.0001,1.0001 0 0 0 -1,1 v 2 a 1.0001,1.0001 0 0 0 1,1 h 8 a 1.0001,1.0001 0 0 0 1,-1 v -2 a 1.0001,1.0001 0 0 0 -1,-1 z m 14,0 a 1.0001,1.0001 0 0 0 -1,1 v 2 a 1.0001,1.0001 0 0 0 1,1 h 8 a 1.0001,1.0001 0 0 0 1,-1 V 17 A 1.0001,1.0001 0 0 0 43,16 Z M 10,27 a 1.0001,1.0001 0 0 0 -1,1 v 8 a 1.0001,1.0001 0 0 0 1,1 h 2 a 1.0001,1.0001 0 0 0 1,-1 v -8 a 1.0001,1.0001 0 0 0 -1,-1 z m 42,0 a 1.0001,1.0001 0 0 0 -1,1 v 8 a 1.0001,1.0001 0 0 0 1,1 h 2 a 1.0001,1.0001 0 0 0 1,-1 V 28 A 1.0001,1.0001 0 0 0 54,27 Z M 21,44 a 1.0001,1.0001 0 0 0 -1,1 v 2 a 1.0001,1.0001 0 0 0 1,1 h 8 a 1.0001,1.0001 0 0 0 1,-1 v -2 a 1.0001,1.0001 0 0 0 -1,-1 z m 14,0 a 1.0001,1.0001 0 0 0 -1,1 v 2 a 1.0001,1.0001 0 0 0 1,1 h 8 a 1.0001,1.0001 0 0 0 1,-1 v -2 a 1.0001,1.0001 0 0 0 -1,-1 z"
+       transform="translate(0,2)" />
+  </g>
+  <g
+     style="opacity:0.3;fill:#000000"
+     id="g4587-1"
+     transform="translate(0.395366,7.1633072)">
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4585-4"
+       d="m 48.604634,39.836752 c 4,0 4,0 4,-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4583-2"
+       d="m 52.604634,15.836752 c 0,-4 0,-4 -4,-4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4581-8"
+       d="m 10.604634,35.836752 c 0,4 0,4 4,4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2387-7-9"
+       d="m 14.604634,11.836752 c -4,0 -4,0 -4,4" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path4577-3"
+       d="m 51.604633,21.836751 h 2 v 8 h -2 z" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path4573-8"
+       d="m 28.604633,38.836751 v 2 h -8 v -2 z" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path4571-8"
+       d="m 42.604633,38.836751 v 2 h -8 v -2 z" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path4567-7"
+       d="M 11.604634,29.836751 H 9.604635 v -8 h 1.999999 z" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path4565-7"
+       d="m 34.604633,12.836752 v -1.999999 h 8 v 1.999999 z" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path2385-7"
+       d="m 20.604633,12.836752 v -1.999999 h 8 v 1.999999 z" />
+  </g>
+  <path
+     id="path2387-7"
+     style="fill:none;stroke:#ffffff;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 15,18.000059 c -4,0 -4,0 -4,4 m 0,20 c 0,4 0,4 4,4 m 38,-24 c 0,-4 0,-4 -4,-4 m 0,28 c 4,0 4,0 4,-4" />
+  <path
+     id="path4577"
+     style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="m 21,17 v 2 h 8 v -2 z m 14,0 v 2 h 8 V 17 Z M 10,28 v 8 h 2 v -8 z m 42,0 v 8 h 2 V 28 Z M 21,45 v 2 h 8 v -2 z m 14,0 v 2 h 8 v -2 z" />
+  <path
+     id="rect2978"
+     style="font-variation-settings:normal;opacity:0.15;fill:#000000;fill-opacity:1;stroke:none;stroke-width:4;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;marker:none;stop-color:#000000"
+     d="m 12,18 v 1 h 3 v -1 z m 9,0 v 1 h 8 v -1 z m 14,0 v 1 h 8 v -1 z m 14,0 v 1 h 3 v -1 z m -39,3 v 1 h 2 v -1 z m 42,0 v 1 h 2 V 21 Z M 10,35 v 1 h 2 v -1 z m 42,0 v 1 h 2 V 35 Z M 12,46 v 1 h 3 v -1 z m 9,0 v 1 h 8 v -1 z m 14,0 v 1 h 8 v -1 z m 14,0 v 1 h 3 v -1 z" />
+  <path
+     id="rect3872-3-2"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient2019);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="M 10.5 4.5 C 7.176 4.5 4.5 7.176 4.5 10.5 L 4.5 36.519531 L 59.5 20.738281 L 59.5 10.5 C 59.5 7.176 56.824 4.5 53.5 4.5 L 10.5 4.5 z " />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient4443);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+     id="path8836"
+     d="m 53.263035,59.997701 c 0,2.215761 -3.134007,4.011879 -7,4.011879 -3.865995,0 -7,-1.796118 -7,-4.011879 0,-2.215761 3.134005,-4.011879 7,-4.011879 3.865993,0 7,1.796118 7,4.011879 z" />
+  <path
+     style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient4440);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1;marker:none"
+     id="path4007"
+     d="m 63.957551,59.997701 c 0,2.215761 -3.134006,4.011879 -7,4.011879 -3.865994,0 -7,-1.796118 -7,-4.011879 0,-2.215761 3.134006,-4.011879 7,-4.011879 3.865994,0 7,1.796118 7,4.011879 z" />
+  <g
+     transform="translate(0.82146014)"
+     id="g3115">
+    <g
+       id="g3106"
+       transform="translate(0.27299895)">
+      <path
+         style="fill:url(#radialGradient3125);fill-opacity:1;stroke:none"
+         id="path3782"
+         d="M 50.034046,46.62477 42.948929,33.519299 c 0,0 -4.946212,10.430886 7.085117,17.11735 z" />
+      <path
+         transform="matrix(-1,0,0,1,101.3083,0)"
+         style="fill:none;stroke:url(#linearGradient1079);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path4683-6"
+         d="m 58.03125,36.34375 -5.6875,10.5625 v 1.75 C 56.705045,45.683991 58.098512,42.310796 58.3125,39.5 58.40856,38.238187 58.21262,37.251357 58.03125,36.34375 Z" />
+      <path
+         style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3782-0"
+         d="M 50.034047,46.62477 42.94893,33.519299 c 0,0 -4.946213,10.430885 7.085117,17.11735 z" />
+    </g>
+    <g
+       id="g3101">
+      <path
+         style="fill:url(#radialGradient3129);fill-opacity:1;stroke:none"
+         id="path2990"
+         d="m 51.299587,46.62477 7.085118,-13.105471 c 0,0 4.946213,10.430886 -7.085118,17.11735 z" />
+      <path
+         style="fill:none;stroke:url(#linearGradient3127);stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path4683"
+         d="m 58.03125,36.34375 -5.6875,10.5625 v 1.75 C 56.705045,45.683991 58.098512,42.310796 58.3125,39.5 58.40856,38.238187 58.21262,37.251357 58.03125,36.34375 Z" />
+      <path
+         style="opacity:0.5;fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path2990-3"
+         d="m 51.299588,46.62477 7.085117,-13.105471 c 0,0 4.946213,10.430885 -7.085117,17.11735 z" />
+    </g>
+  </g>
+  <g
+     transform="matrix(0.99844347,0,0,0.99447084,0.93723297,0.17912811)"
+     id="g3133">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3139);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       d="m 47.375,50.625 c -1.845322,0.09848 -6.78125,1.225549 -6.78125,4.6875 0,3.956381 2.932889,5.34375 4.6875,5.34375 1.754612,0 4.61943,-1.332405 4.6875,-5.34375 0.05426,-3.197735 -1.084645,-4.490651 -2,-4.6875 -0.114419,-0.02461 -0.330133,-0.01407 -0.59375,0 z m 5.9375,0 c -0.915354,0.196849 -2.054262,1.489765 -2,4.6875 0.06807,4.011345 2.901639,5.34375 4.65625,5.34375 1.754612,0 4.6875,-1.387369 4.6875,-5.34375 0,-3.956515 -6.428395,-4.88435 -7.34375,-4.6875 z m -5.9375,2.53125 c 0,0 0.593739,6.842471 -3,4.15625 -3.99622,-2.986978 3,-4.15625 3,-4.15625 z m 6.5,0 c 0,0 7.02747,1.169272 3.03125,4.15625 C 53.312511,59.998721 53.875,53.15625 53.875,53.15625 Z"
+       id="path3788" />
+    <path
+       d="m 53.5,51.5625 c -0.114128,0.02454 -0.394709,0.160908 -0.6875,0.71875 -0.292791,0.557842 -0.556404,1.517657 -0.53125,3 0.03022,1.780742 0.635481,2.84082 1.375,3.5 0.739519,0.65918 1.679047,0.90625 2.3125,0.90625 0.623394,0 1.617825,-0.268685 2.375,-0.9375 0.757175,-0.668815 1.34375,-1.69736 1.34375,-3.4375 0,-0.728254 -0.266179,-1.247884 -0.75,-1.75 -0.483821,-0.502116 -1.191793,-0.93321 -1.96875,-1.25 C 56.191793,51.99571 55.356588,51.767056 54.6875,51.65625 54.018412,51.545444 53.350165,51.594722 53.5,51.5625 Z"
+       id="path4799"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient1081);stroke-width:1.00356;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       d="m 53.46875,51.5625 c -0.114128,0.02454 -0.394709,0.160908 -0.6875,0.71875 -0.292791,0.557842 -0.556404,1.517657 -0.53125,3 0.03022,1.780742 0.635481,2.84082 1.375,3.5 0.739519,0.65918 1.679047,0.90625 2.3125,0.90625 0.623394,0 1.617825,-0.268685 2.375,-0.9375 0.757175,-0.668815 1.34375,-1.69736 1.34375,-3.4375 0,-0.728254 -0.266179,-1.247884 -0.75,-1.75 -0.483821,-0.502116 -1.191793,-0.93321 -1.96875,-1.25 -0.776957,-0.31679 -1.612162,-0.545444 -2.28125,-0.65625 -0.669088,-0.110806 -1.337335,-0.06153 -1.1875,-0.09375 z"
+       id="path4799-4"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:url(#linearGradient3142);stroke-width:1.00356;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       transform="matrix(-1,0,0,1,101.26839,0.0140868)" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;stroke:#640000;stroke-width:1.00356;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 47.40625,50.625 c -1.845322,0.09848 -6.78125,1.225549 -6.78125,4.6875 0,3.956381 2.932889,5.34375 4.6875,5.34375 1.754612,0 4.61943,-1.332405 4.6875,-5.34375 0.05426,-3.197735 -1.084645,-4.490651 -2,-4.6875 -0.114419,-0.02461 -0.330133,-0.01407 -0.59375,0 z m 5.90625,0 c -0.915354,0.196849 -2.054262,1.489765 -2,4.6875 0.06807,4.011345 2.901639,5.34375 4.65625,5.34375 1.754612,0 4.6875,-1.387369 4.6875,-5.34375 0,-3.956515 -6.428395,-4.88435 -7.34375,-4.6875 z m -5.90625,2.53125 c 0,0 0.593739,6.842471 -3,4.15625 -3.99622,-2.986978 3,-4.15625 3,-4.15625 z m 6.46875,0 c 0,0 7.02747,1.169272 3.03125,4.15625 C 53.312511,59.998721 53.875,53.15625 53.875,53.15625 Z"
+       id="path3788-4" />
+  </g>
+</svg>

--- a/elementary-xfce/apps/96/accessories-screenshot-tool.svg
+++ b/elementary-xfce/apps/96/accessories-screenshot-tool.svg
@@ -1,0 +1,476 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="96"
+   height="96"
+   id="svg4296"
+   sodipodi:docname="accessories-screenshot-tool.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview86"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="4.4166668"
+     inkscape:cx="61.018867"
+     inkscape:cy="47.094339"
+     inkscape:window-width="1386"
+     inkscape:window-height="1051"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="g2269" />
+  <defs
+     id="defs4298">
+    <linearGradient
+       id="linearGradient3895">
+      <stop
+         id="stop3897"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3899"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.03030945" />
+      <stop
+         id="stop3901"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.97833663" />
+      <stop
+         id="stop3903"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         id="stop2883"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2885"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         id="stop2889"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop2891"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
+         style="stop-color:#181818;stop-opacity:1"
+         offset="0.5" />
+      <stop
+         id="stop2899"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       x1="23.99999"
+       y1="6.0315123"
+       x2="23.99999"
+       y2="41.934097"
+       id="linearGradient3024"
+       xlink:href="#linearGradient3895"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0810811,0,0,2.0810811,-1.945964,0.05406599)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3038"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3040"
+       xlink:href="#linearGradient3688-464-309"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
+    <linearGradient
+       x1="25.058096"
+       y1="47.027729"
+       x2="25.058096"
+       y2="39.999443"
+       id="linearGradient3042"
+       xlink:href="#linearGradient3702-501-757"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient5060">
+      <stop
+         id="stop5062"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5064"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient3525"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.56710644,-1.1342033,-1.7012993,0.85065685,1811.4006,-832.4149)" />
+    <linearGradient
+       id="linearGradient3764">
+      <stop
+         id="stop3766"
+         style="stop-color:#d1d1d1;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3768"
+         style="stop-color:#eaeaea;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <radialGradient
+       cx="14.999991"
+       cy="1039.7"
+       r="3.5266583"
+       fx="14.999991"
+       fy="1039.7"
+       id="radialGradient3520"
+       xlink:href="#linearGradient3764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.56710644,-1.1342033,1.7012993,0.85065685,-1735.3473,-832.4149)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient3517"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5647059,0,0,0.2823525,-1.364705,43.6941)" />
+    <radialGradient
+       cx="62.625"
+       cy="4.625"
+       r="10.625"
+       fx="62.625"
+       fy="4.625"
+       id="radialGradient3514"
+       xlink:href="#linearGradient5060"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.5647059,0,0,0.2823525,6.635295,43.6941)" />
+    <radialGradient
+       xlink:href="#linearGradient3242-7-6"
+       id="radialGradient4230-4"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,2.9641444,-3.6535591,0,74.845518,3.5092146)"
+       cx="8.8626814"
+       cy="9.9941158"
+       fx="8.8626814"
+       fy="9.9941158"
+       r="12.671875" />
+    <linearGradient
+       id="linearGradient3242-7-6">
+      <stop
+         id="stop3244-6-4"
+         style="stop-color:#f89b7e;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3246-7-5"
+         style="stop-color:#e35d4f;stop-opacity:1"
+         offset="0.26238" />
+      <stop
+         id="stop3248-8-6"
+         style="stop-color:#c6262e;stop-opacity:1"
+         offset="0.66093999" />
+      <stop
+         id="stop3250-6-8"
+         style="stop-color:#690b2c;stop-opacity:1"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient4685"
+       id="linearGradient3415"
+       gradientUnits="userSpaceOnUse"
+       x1="56"
+       y1="40"
+       x2="58.032764"
+       y2="42.054295"
+       gradientTransform="matrix(0.69541292,0,0,0.71124318,3.1622172,1.8413367)" />
+    <linearGradient
+       id="linearGradient4685">
+      <stop
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop4687" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0"
+         id="stop4689" />
+    </linearGradient>
+    <linearGradient
+       y2="42.054295"
+       x2="58.032764"
+       y1="40"
+       x1="56"
+       gradientTransform="matrix(-0.78258383,0,0,0.80039844,77.771182,-1.9179845)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient4203"
+       xlink:href="#linearGradient4685" />
+    <linearGradient
+       x1="10"
+       y1="-3"
+       x2="20"
+       y2="12"
+       id="linearGradient3887"
+       xlink:href="#linearGradient4685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.3038206,0,0,2.8888888,-21.192038,35.111108)" />
+    <linearGradient
+       xlink:href="#outerBackgroundGradient-5-0"
+       id="linearGradient4158"
+       x1="19.005375"
+       y1="202.81076"
+       x2="19.005375"
+       y2="242.78731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.025641,0,0,2.025641,-0.61538498,-501.72526)" />
+    <linearGradient
+       id="outerBackgroundGradient-5-0">
+      <stop
+         id="stop3864-8-6-4"
+         offset="0"
+         style="stop-color:#261e2b;stop-opacity:1;" />
+      <stop
+         id="stop3866-9-1-86"
+         offset="1"
+         style="stop-color:#352f39;stop-opacity:1;" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata4301">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="matrix(2.3157904,0,0,1.2857142,-7.578952,32.071432)"
+     id="g3712-5"
+     style="opacity:0.6;stroke-width:0.5">
+    <rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801-3"
+       style="fill:url(#radialGradient3038);fill-opacity:1;stroke:none;stroke-width:0.5" />
+    <rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3696-6"
+       style="fill:url(#radialGradient3040);fill-opacity:1;stroke:none;stroke-width:0.5" />
+    <rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-4"
+       style="fill:url(#linearGradient3042);fill-opacity:1;stroke:none;stroke-width:0.5" />
+  </g>
+  <rect
+     width="79"
+     height="79"
+     rx="8"
+     ry="8"
+     x="8.5000248"
+     y="-89.499992"
+     id="rect5505-21"
+     style="color:#000000;font-variation-settings:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:url(#linearGradient4158);fill-opacity:1;fill-rule:nonzero;stroke:#1a0e1f;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.7;-inkscape-stroke:none;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     transform="scale(1,-1)" />
+  <rect
+     width="77"
+     height="77"
+     rx="7"
+     ry="7"
+     x="9.499999"
+     y="11.499999"
+     id="rect6741"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3024);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+  <g
+     transform="matrix(2,0,0,2,-7.350609e-8,10.000586)"
+     style="opacity:0.1;stroke-width:0.5"
+     id="g4537-9">
+    <path
+       id="path4477-8"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.5"
+       d="M 17,10.011719 C 16.454073,10.011443 16.011443,10.454073 16.011719,11 v 1.000066 C 16.011443,12.545993 16.454073,12.988624 17,12.988348 h 5 c 0.545927,2.76e-4 0.988557,-0.442355 0.988281,-0.988282 V 11 C 22.988557,10.454073 22.545927,10.011443 22,10.011719 Z m 9,0 C 25.454073,10.011443 25.011443,10.454073 25.011719,11 v 1.000066 C 25.011443,12.545993 25.454073,12.988624 26,12.988348 h 5 c 0.545927,2.76e-4 0.988557,-0.442355 0.988281,-0.988282 V 11 C 31.988557,10.454073 31.545927,10.011443 31,10.011719 Z M 9.4881406,17.999566 c -0.545927,-2.76e-4 -0.9885575,0.442355 -0.9882812,0.988281 v 4.523719 c -2.763e-4,0.545928 0.4423542,0.988559 0.9882812,0.988282 H 10.51186 c 0.545927,2.77e-4 0.988557,-0.442355 0.988281,-0.988282 v -4.523719 c 2.76e-4,-0.545926 -0.442354,-0.988557 -0.988281,-0.988281 z m 28.0000004,3e-6 c -0.545927,-2.76e-4 -0.988557,0.442355 -0.988281,0.988281 v 4.523716 c -2.76e-4,0.545927 0.442354,0.988559 0.988281,0.988282 h 1.023719 c 0.545927,2.77e-4 0.988557,-0.442355 0.988281,-0.988282 V 18.987847 C 39.500417,18.441921 39.057787,17.99929 38.51186,17.999566 Z M 17,29.511893 c -0.545927,-2.76e-4 -0.988557,0.442354 -0.988281,0.988281 v 0.999893 C 16.011443,32.045993 16.454073,32.488624 17,32.488348 h 5 c 0.545927,2.76e-4 0.988557,-0.442355 0.988281,-0.988281 V 30.500174 C 22.988557,29.954247 22.545927,29.511617 22,29.511893 Z m 9,0 c -0.545927,-2.76e-4 -0.988557,0.442354 -0.988281,0.988281 v 0.999893 C 25.011443,32.045993 25.454073,32.488624 26,32.488348 h 5 c 0.545927,2.76e-4 0.988557,-0.442355 0.988281,-0.988281 V 30.500174 C 31.988557,29.954247 31.545927,29.511617 31,29.511893 Z"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4459-2"
+       d="m 38.000202,14.666497 c 0,-2.666684 0,-2.666684 -2.666687,-2.666684" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path2387-2"
+       d="m 12.666698,11.999813 c -2.666685,0 -2.666685,0 -2.666685,2.666684" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4457-9"
+       d="M 10.000013,28.333315 C 10.000013,31 10.000013,31 12.666698,31" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4461-7"
+       d="m 35.333515,31 c 2.666687,0 2.666687,0 2.666687,-2.666685" />
+  </g>
+  <g
+     id="g4537"
+     style="opacity:0.3;stroke-width:0.499996"
+     transform="matrix(2.0000134,0,0,2.000019,-2.1327909e-4,10.000084)">
+    <path
+       d="m 38.000202,14.666497 c 0,-2.666684 0,-2.666684 -2.666687,-2.666684"
+       id="path4459"
+       style="fill:none;stroke:#000000;stroke-width:0.999992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 12.666698,11.999813 c -2.666685,0 -2.666685,0 -2.666685,2.666684"
+       id="path2387"
+       style="fill:none;stroke:#000000;stroke-width:0.999992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 17,11 v 0.999844 h 5 V 11 Z m 9,0 v 0.999844 h 5 V 11 Z M 9,19 v 4.99973 h 2 V 19 Z m 28,0 v 4.99973 h 2 V 19 Z M 17,30 v 1.499659 h 5 V 30 Z m 9,0 v 1.499659 h 5 V 30 Z"
+       id="path4477"
+       style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.499996"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+    <path
+       d="M 10.000013,28.333315 C 10.000013,31 10.000013,31 12.666698,31"
+       id="path4457"
+       style="fill:none;stroke:#000000;stroke-width:0.999992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 35.333515,31 c 2.666687,0 2.666687,0 2.666687,-2.666685"
+       id="path4461"
+       style="fill:none;stroke:#000000;stroke-width:0.999992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     id="g1739"
+     transform="matrix(2.0000134,0,0,2.000019,-2.1327909e-4,-6.8397488e-4)"
+     style="stroke-width:0.499996">
+    <path
+       id="path4477-4"
+       style="opacity:1;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.499996"
+       d="m 17,15 v 1.500185 h 5 V 15 Z m 9,0 v 1.500185 h 5 V 15 Z M 9,23 v 5 h 1.500036 v -5 z m 28.499855,0 v 5 H 39 V 23 Z M 17,34.500014 V 36 h 5 v -1.499986 z m 9,0 V 36 h 5 v -1.499986 z"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+    <path
+       id="path4461-0"
+       style="opacity:1;fill:none;stroke:#ffffff;stroke-width:1.49999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.499869,35.250007 c 2.666687,0 2.749981,-0.08329 2.749981,-2.749974 M 12.500023,15.75038 c -2.6666851,0 -2.7498331,0.0831 -2.7498331,2.749786 m 28.5000131,0 c 0,-2.666684 -0.08365,-2.749828 -2.750334,-2.749828 M 9.7501899,32.500033 c 0,2.666685 0.083148,2.750329 2.7498331,2.750329"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <g
+     id="g2269"
+     transform="matrix(2.0000134,0,0,2.000019,20.959757,76.541115)"
+     style="stroke-width:0.499996">
+    <path
+       id="path4477-4-3"
+       style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999992;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;stop-color:#000000"
+       d="m 6.520085,-22.770195 v 0.999844 h 5 v -0.999844 z m 9,0 v 0.999844 h 5 v -0.999844 z m -16.49995693,8.499773 v 3.999962 h 0.9999933 v -3.999962 z m 27.99981193,0 v 3.999962 h 0.999994 v -3.999962 z M 6.520085,-3.270053 v 0.9995169 h 5 V -3.270053 Z m 9,0 v 0.9995169 h 5 V -3.270053 Z"
+       sodipodi:nodetypes="cccccccccccccccccccccccccccccc" />
+    <path
+       id="path4461-0-5"
+       style="font-variation-settings:normal;opacity:0.1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1.49999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;stop-color:#000000"
+       d="m 25.019954,-2.5205336 c 2.666687,0 2.749981,-0.083289 2.749981,-2.7499738 M 2.020108,-21.520353 c -2.66668503,0 -2.74983304,0.08329 -2.74983304,2.749974 m 28.49966004,0 c 0,-2.666684 -0.08329,-2.749974 -2.749981,-2.749974 M -0.72972504,-4.7705122 c 0,2.666685 0.083148,2.4999763 2.74983304,2.4999763"
+       sodipodi:nodetypes="cccccccc" />
+  </g>
+  <path
+     id="rect3872"
+     style="display:inline;opacity:0.15;fill:url(#linearGradient3887);fill-opacity:1;stroke:none;stroke-width:1.33358"
+     d="m 17,11 c -5.092671,0 -8,3.489368 -8,8 V 56 L 87,34 V 19 c 0,-4.821574 -3.155666,-8 -7,-8 z"
+     sodipodi:nodetypes="csccscc" />
+  <g
+     id="g108"
+     transform="matrix(2,0,0,2.048468,0,-2.3264627)"
+     style="stroke-width:0.494049">
+    <path
+       style="fill:url(#radialGradient3525);fill-opacity:1;stroke:none;stroke-width:0.494049"
+       id="path3782"
+       d="m 37.553316,35 -5.3,-9.8 c 0,0 -3.699999,7.8 5.3,12.8 z" />
+    <path
+       style="fill:url(#radialGradient3520);fill-opacity:1;stroke:none;stroke-width:0.494049"
+       id="path2990"
+       d="m 38.5,35 5.3,-9.8 c 0,0 3.7,7.8 -5.3,12.8 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3517);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.494049;marker:none"
+       id="path8836"
+       d="m 40,45 c 0,1.6569 -2.686291,3 -6,3 -3.313709,0 -6,-1.3431 -6,-3 0,-1.6569 2.686291,-3 6,-3 3.313709,0 6,1.3431 6,3 z" />
+    <path
+       style="display:inline;overflow:visible;visibility:visible;opacity:0.4;fill:url(#radialGradient3514);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.494049;marker:none"
+       id="path4007"
+       d="m 48,45 c 0,1.6569 -2.686291,3 -6,3 -3.313709,0 -6,-1.3431 -6,-3 0,-1.6569 2.686291,-3 6,-3 3.313709,0 6,1.3431 6,3 z" />
+    <path
+       id="path3788"
+       d="m 35.8125,38 c -1.380387,0.07364 -5.0625,0.911225 -5.0625,3.5 0,2.9585 2.187468,4 3.5,4 1.312532,0 3.44908,-1.0004 3.5,-4 0.04059,-2.3912 -0.815272,-3.3528 -1.5,-3.5 -0.08559,-0.0184 -0.240302,-0.01052 -0.4375,0 z m 3.9375,0 c -0.684728,0.1472 -1.54059,1.1088 -1.5,3.5 0.05092,2.9996 2.187468,4 3.5,4 1.312532,0 3.5,-1.0415 3.5,-4 0,-2.9586 -4.815272,-3.6472 -5.5,-3.5 z m -3.9375,1.875 c 0,0 0.438286,5.1337 -2.25,3.125 -2.98936,-2.2336 2.25,-3.125 2.25,-3.125 z m 4.375,0 c 0,0 5.23936,0.8914 2.25,3.125 -2.688286,2.0087 -2.25,-3.125 -2.25,-3.125 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4230-4);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.494049;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ssssssssssscccccc" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.494049px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path3782-0"
+       d="m 37.75,35 -5.496684,-9.8 c 0,0 -3.503315,7.8 5.496684,12.8 z"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="opacity:0.5;fill:none;stroke:#000000;stroke-width:0.494049px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path2990-3"
+       d="m 38.25,35 5.55,-9.8 c 0,0 3.45,7.8 -5.55,12.8 z"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:none;stroke:url(#linearGradient3415);stroke-width:0.494049px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4683"
+       d="M 43.686423,26.435949 38.75,35.182146 v 2.03132 c 3.032901,-2.113999 4.978867,-5.447223 5.127677,-7.446383 0.0216,-0.703237 0.220833,-1.824916 -0.191254,-3.331134 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:none;stroke:url(#linearGradient4203);stroke-width:0.494049px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       id="path4683-1"
+       d="M 32.365285,26.453766 C 32.712235,27.040484 37.25,35.137684 37.25,35.137684 v 1.636404 c -3.413079,-2.378991 -4.980163,-5.056884 -5.147627,-7.306641 -0.06206,-0.720582 0.08469,-2.264453 0.262912,-3.013681 z"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       id="path3788-5"
+       d="m 35.8125,38 c -1.380387,0.07364 -5.0625,0.911225 -5.0625,3.5 0,2.9585 2.187468,4 3.5,4 1.312532,0 3.44908,-1.0004 3.5,-4 0.04059,-2.3912 -0.815272,-3.3528 -1.5,-3.5 -0.08559,-0.0184 -0.240302,-0.01052 -0.4375,0 z m 3.9375,0 c -0.684728,0.1472 -1.54059,1.1088 -1.5,3.5 0.05092,2.9996 2.187468,4 3.5,4 1.312532,0 3.5,-1.0415 3.5,-4 0,-2.9586 -4.815272,-3.6472 -5.5,-3.5 z m -3.9375,1.875 c 0,0 0.438286,5.1337 -2.25,3.125 -2.98936,-2.2336 2.25,-3.125 2.25,-3.125 z m 4.375,0 c 0,0 5.23936,0.8914 2.25,3.125 -2.688286,2.0087 -2.25,-3.125 -2.25,-3.125 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.6;fill:none;fill-opacity:1;stroke:#640000;stroke-width:0.494049;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="ssssssssssscccccc" />
+  </g>
+</svg>


### PR DESCRIPTION
While we have an Xfce-specific screenshot app icon, the FreeDesktop.Org named `accessories-screenshot-tool` app icon was missing. This adds the icon pulled from upstream and created missing sizes.