### PR TITLE
MimeTypes: Refresh exe icon, add missing symlink

### DIFF
--- a/elementary-xfce/mimetypes/128/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/128/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/128/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/128/application-x-msdownload.svg
@@ -1,305 +1,307 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="128"
+   id="svg4379"
    height="128"
-   id="svg4379">
-  <defs
-     id="defs4381">
-    <linearGradient
-       id="linearGradient4113">
-      <stop
-         id="stop4115"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4117"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43"
-       id="linearGradient3159"
+   width="128"
+   version="1.1"
+   xml:space="preserve"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview347"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="19.28125"
+     inkscape:cy="12.625"
+     inkscape:window-width="1423"
+     inkscape:window-height="881"
+     inkscape:window-x="596"
+     inkscape:window-y="92"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4379" /><defs
+     id="defs4381"><linearGradient
+       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135124,1.486514)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3924-776"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.7297298,0,0,2.7297298,-1.5135124,1.486514)" />
-    <linearGradient
-       id="linearGradient3924-776">
-      <stop
-         id="stop3124"
+       id="linearGradient3159"
+       y2="42.316269"
+       x2="23.99999"
+       y1="5.6844664"
+       x1="23.99999" /><linearGradient
+       id="linearGradient3924-776"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3126"
+         id="stop3124" /><stop
+         offset="0.08498204"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.06316455" />
-      <stop
-         id="stop3128"
+         id="stop3126" /><stop
+         offset="0.91501039"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.95056331" />
-      <stop
-         id="stop3130"
+         id="stop3128" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="6.7304144"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.2001843"
-       fy="9.9571075"
-       id="radialGradient3395"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
+         id="stop3130" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,25.083279,-30.794253,0,372.81658,-208.0918)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient2455-1"
        xlink:href="#linearGradient3688-166-749-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-5">
-      <stop
-         id="stop2883-0"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885-5"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
+       id="radialGradient2455-1"
        fy="43.5"
-       id="radialGradient2457-5"
-       xlink:href="#linearGradient3688-464-309-8"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-166-749-5"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-0" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-5" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-8">
-      <stop
-         id="stop2889-9"
+       xlink:href="#linearGradient3688-464-309-8"
+       id="radialGradient2457-5"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-464-309-8"><stop
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-4"
+         id="stop2889-9" /><stop
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient2459-7"
+         id="stop2891-4" /></linearGradient><linearGradient
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3702-501-757-0"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757-0">
-      <stop
-         id="stop2895-0"
+       id="linearGradient2459-7"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-0"><stop
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-2"
+         id="stop2895-0" /><stop
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-6"
+         id="stop2897-2" /><stop
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3811">
-      <stop
-         id="stop3813"
+         id="stop2899-6" /></linearGradient><linearGradient
+       id="linearGradient3811"><stop
+         offset="0"
          style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3815"
+         id="stop3813" /><stop
+         offset="1"
          style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="-4.0287771"
-       cy="93.467628"
-       r="35.338131"
-       fx="-4.0287771"
-       fy="93.467628"
+         id="stop3815" /></linearGradient><radialGradient
+       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270358,102.13029)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3811"
        id="radialGradient4377"
+       fy="93.467628"
+       fx="-4.0287771"
+       r="35.338131"
+       cy="93.467628"
+       cx="-4.0287771" /><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31999999;"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.23999999;"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.6330762,0,0,2.5324969,-130.85739,3.2705751)"
+       x1="74.838791"
+       y1="4.8289986"
+       x2="74.838791"
+       y2="45.500317" /><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1;"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient567"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-120.87499,26.352158)"
+       x1="225.28664"
+       y1="102.43221"
+       x2="225.28664"
+       y2="-12.687985" /><linearGradient
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696"
+       id="linearGradient3273"
        xlink:href="#linearGradient3811"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5563924,0,0,0.16978827,70.270358,102.13029)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3309"
-       xlink:href="#linearGradient4113"
+       gradientTransform="matrix(2.4187139,0,0,2.4593125,10.038148,0.36002534)" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient11366"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.596042,0,0,2.6203536,22.46595,23.060968)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3312"
-       xlink:href="#linearGradient4113"
+       gradientTransform="matrix(2.4187139,0,0,2.4593125,-15.961851,0.36006086)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient11370"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6465542,0,0,2.7291358,-0.87045142,43.474927)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3315"
-       xlink:href="#linearGradient4113"
+       gradientTransform="matrix(2.4187139,0,0,2.4593125,10.038114,26.360027)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3811"
+       id="linearGradient11374"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6447223,0,0,2.7299187,-22.864656,21.138598)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3318"
-       xlink:href="#linearGradient4113"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.6921445,0,0,2.6602735,-1.957532,0.501796)" />
-  </defs>
-  <metadata
-     id="metadata4384">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4377);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate"
+       gradientTransform="matrix(2.4187139,0,0,2.4593125,-15.961886,26.360064)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /></defs><metadata
+     id="metadata4384"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><path
+     d="M 119,118 A 55,6 0 0 1 9.0000016,118 55,6 0 1 1 119,118 Z"
      id="path3041"
-     d="M 119,118 A 55,6 0 0 1 9.0000016,118 55,6 0 1 1 119,118 Z" />
-  <g
-     style="display:inline"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:url(#radialGradient4377);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" /><g
+     transform="matrix(2.6999989,0,0,0.55555607,-0.8000019,94.888882)"
      id="g2036"
-     transform="matrix(2.6999989,0,0,0.55555607,-0.8000019,94.888882)">
-    <g
-       style="opacity:0.4"
+     style="display:inline;opacity:0.4"><g
+       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
        id="g3712"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-      <rect
-         style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none"
-         id="rect2801"
-         y="40"
+       style="opacity:0.4"><rect
+         width="5"
+         height="7"
          x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none"
-         id="rect3696"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none"
-         id="rect3700"
          y="40"
-         x="10"
+         id="rect2801"
+         style="fill:url(#radialGradient2455-1);fill-opacity:1;stroke:none" /><rect
+         width="5"
+         height="7"
+         x="-10"
+         y="-47"
+         transform="scale(-1,-1)"
+         id="rect3696"
+         style="fill:url(#radialGradient2457-5);fill-opacity:1;stroke:none" /><rect
+         width="28"
          height="7.0000005"
-         width="28" />
-    </g>
-  </g>
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3395);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect5505-21-3"
-     y="15.5"
-     x="12.5"
-     ry="6.0545406"
-     rx="6.0545406"
-     height="103"
-     width="103" />
-  <rect
-     style="opacity:0.3;fill:none;stroke:url(#linearGradient3159);stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-7"
-     y="16.5"
-     x="13.5"
-     ry="5"
-     rx="5"
+         x="10"
+         y="40"
+         id="rect3700"
+         style="fill:url(#linearGradient2459-7);fill-opacity:1;stroke:none" /></g></g><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
+     y="15.499999"
+     x="12.499999"
+     ry="10"
+     rx="10"
+     height="102.99999"
+     width="102.99999" /><path
+     id="rect4268"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 64,33.352002 47.736328,49.615674 64,65.879347 80.263672,49.615674 Z M 45.615234,51.736768 29.351562,68.00044 45.615234,84.264112 61.878906,68.00044 Z m 36.769532,0 L 66.121094,68.00044 82.384768,84.264114 98.64844,68.000442 Z M 64,70.121534 47.736328,86.385206 64.000002,102.64888 80.263674,86.385208 Z" /><rect
+     width="101"
      height="101"
-     width="101" />
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect5505-21-6"
-     y="15.5"
-     x="12.5"
-     ry="6"
-     rx="6"
+     rx="9"
+     ry="9"
+     x="13.5"
+     y="16.5"
+     id="rect6741-7"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3159);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" /><g
+     id="layer4-0"
+     transform="matrix(0.9047486,0,0,0.9047486,-702.22529,-649.07614)" /><g
+     id="layer4-0-7"
+     transform="matrix(0.9047486,0,0,0.9047486,-702.22529,-641.83815)" /><g
+     id="layer1-3"
+     transform="matrix(0.9047486,0,0,0.9047486,-205.51831,26.980992)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3453"
+     width="23"
+     height="23"
+     x="-26.621485"
+     y="94.131149"
+     transform="rotate(-45)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3923"
+     width="23"
+     height="23"
+     x="-0.62148708"
+     y="94.131149"
+     transform="rotate(-45)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3925"
+     width="23"
+     height="23"
+     x="-26.621485"
+     y="68.131149"
+     transform="rotate(-45)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3927"
+     width="23"
+     height="23"
+     x="-0.62148708"
+     y="68.131149"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3273);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4240"
+     width="22.000032"
+     height="22.000032"
+     x="-0.12161094"
+     y="68.631119"
+     transform="matrix(0.70710775,-0.70710581,0.70710775,0.70710581,0,0)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11366);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11364"
+     width="22.000032"
+     height="22.000032"
+     x="-26.121609"
+     y="68.631149"
+     transform="matrix(0.70710775,-0.70710581,0.70710775,0.70710581,0,0)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11370);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11368"
+     width="22.000032"
+     height="22.000032"
+     x="-0.12164658"
+     y="94.631119"
+     transform="matrix(0.70710775,-0.70710581,0.70710775,0.70710581,0,0)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11374);stroke-width:0.999996;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11372"
+     width="22.000032"
+     height="22.000032"
+     x="-26.121645"
+     y="94.631149"
+     transform="matrix(0.70710775,-0.70710581,0.70710775,0.70710581,0,0)" /><rect
+     width="103"
      height="103"
-     width="103" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5-3"
-     d="M 64.000008,72.04746 81.931046,90.14873 64.000011,108.25 46.06897,90.148733 Z M 41.931036,49.768975 59.862074,67.870245 41.931033,85.97152 23.999998,67.870248 Z M 86.068972,50.528469 104,68.25 86.068972,85.971531 68.137932,68.250008 Z M 64.000006,28.249985 81.931032,45.971516 64.000006,63.693047 46.068968,45.971524 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5"
-     d="M 64.000008,70.797467 81.931045,88.898733 64.000008,107 46.068974,88.898736 Z M 41.931037,48.518987 59.862074,66.620255 41.931037,84.721521 24,66.620255 Z M 86.068971,49.27848 104,67.000008 86.068971,84.721535 68.137934,67.000016 Z M 64.000005,27 81.931034,44.721527 64.000005,62.443055 46.068968,44.721536 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3318);stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5"
-     d="M 64.000009,27.830062 81.498941,44.75909 64.000009,61.688104 46.50107,44.759095 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3315);stroke-width:0.9999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-1"
-     d="M 41.931037,49.182308 59.121725,66.55453 41.931037,83.926745 24.740343,66.554536 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3312);stroke-width:0.99999976;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-9"
-     d="M 63.970125,71.510597 81.172719,88.877833 63.970125,106.24506 46.767523,88.877839 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3309);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-2"
-     d="M 86.068974,49.979145 102.94324,66.654134 86.068974,83.329116 69.194703,66.65414 Z" />
-</svg>
+     rx="10"
+     ry="10"
+     x="12.5"
+     y="15.5"
+     id="rect5505-21-6"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient567);stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;fill-opacity:1;stop-color:#000000;stop-opacity:1" /></svg>

--- a/elementary-xfce/mimetypes/16/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/16/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/16/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/16/application-x-msdownload.svg
@@ -1,118 +1,215 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    version="1.1"
    width="16"
    height="16"
-   id="svg4372">
-  <defs
-     id="defs4374">
-    <linearGradient
+   id="svg4372"
+   xml:space="preserve"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview102701"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="10.783378"
+     inkscape:cy="6.1650872"
+     inkscape:window-width="1326"
+     inkscape:window-height="884"
+     inkscape:window-x="686"
+     inkscape:window-y="82"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4372" /><defs
+     id="defs4374"><linearGradient
        x1="23.99999"
-       y1="7.1818104"
+       y1="6.9229283"
        x2="23.99999"
-       y2="40.818172"
+       y2="41.074005"
        id="linearGradient3304"
        xlink:href="#linearGradient3924-4-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.2972973,0,0,0.2972973,0.86486906,0.8648672)" />
-    <linearGradient
-       id="linearGradient3924-4-8">
-      <stop
+       gradientTransform="matrix(0.35135136,0,0,0.35135136,-0.43246655,-0.43246521)" /><linearGradient
+       id="linearGradient3924-4-8"><stop
          id="stop3926-0-4"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
+         offset="0" /><stop
          id="stop3928-6-8"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0" />
-      <stop
+         offset="0.04136131" /><stop
          id="stop3930-2-1"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="1" />
-      <stop
+         offset="0.95822036" /><stop
          id="stop3932-9-0"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="6.7304144"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.2001843"
-       fy="9.9571075"
-       id="radialGradient4370"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
+         offset="1" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1;"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient2140"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,3.1658508,-3.8866533,0,46.976839,-26.720326)" />
-  </defs>
-  <metadata
-     id="metadata4377">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4370);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect5505-21-2"
-     y="1.499997"
-     x="1.5"
-     ry="1"
-     rx="1"
-     height="13.000003"
-     width="13.000003" />
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect5505-21-2-8"
-     y="1.499997"
-     x="1.5"
-     ry="1"
-     rx="1"
-     height="13.000003"
-     width="13.000003" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5-3"
-     d="M 7.9999989,9.4746843 10.241378,11.737342 7.9999989,14 5.7586185,11.737342 Z M 5.2413775,6.6898743 7.4827569,8.9525323 5.2413765,11.215191 2.9999975,8.9525323 Z m 5.5172415,0.09494 2.241378,2.215191 -2.241378,2.2151907 -2.2413801,-2.2151897 z m -2.7586211,-2.78481 2.2413781,2.215191 -2.2413781,2.215191 -2.2413794,-2.21519 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5"
-     d="M 7.9999984,8.474683 10.241378,10.737341 7.9999984,13 5.7586194,10.737342 Z M 5.2413774,5.6898732 7.4827567,7.9525316 5.2413774,10.21519 2.9999981,7.9525316 Z M 10.758618,5.7848102 12.999997,8.000001 10.758618,10.215192 8.517239,8.0000021 Z M 7.999998,3 10.241376,5.2151908 7.999998,7.4303815 5.7586187,5.2151918 Z" />
-  <rect
-     style="opacity:0.3;fill:none;stroke:url(#linearGradient3304);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       gradientTransform="matrix(0.93173179,0,0,1.0323711,-43.292986,-27.377976)"
+       x1="56.408016"
+       y1="42.392338"
+       x2="56.408016"
+       y2="26.595999" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient2184"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38345777,0,0,0.36881029,-20.377291,-1.2809846)"
+       x1="74.838791"
+       y1="4.8289876"
+       x2="74.838791"
+       y2="45.500317" /><linearGradient
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696"
+       id="linearGradient3273"
+       xlink:href="#linearGradient4213-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32983551,0,0,0.33537185,2.5621688,-2.1730978)" /><linearGradient
+       id="linearGradient4213-9"><stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" /><stop
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" /></linearGradient><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient5677"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32983551,0,0,0.33537185,-2.4378317,-2.1730978)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient5681"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32983551,0,0,0.33537185,2.5621688,2.8269017)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient5685"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.32983551,0,0,0.33537185,-2.4378317,2.8269017)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /></defs><metadata
+     id="metadata4377"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient2184);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="0.5"
+     x="0.5"
+     ry="2"
+     rx="2"
+     height="15"
+     width="15" /><path
+     id="rect5687"
+     style="opacity:0.15;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 8,1.8866797 5.171875,4.7148047 8,7.5429297 10.828125,4.7148047 Z M 4.4648438,5.4218359 2,7.8866797 v 0.7265624 l 2.4648438,2.4648439 2.828125,-2.8281251 z m 7.0703122,0 L 8.7070312,8.2499609 11.535156,11.078086 14,8.6132421 V 7.8866797 Z M 8,8.9569921 5.171875,11.785117 7.1367188,13.749961 h 1.7265624 l 1.9648438,-1.964844 z" /><rect
+     width="13"
+     height="13"
+     x="1.4999609"
+     y="1.4999608"
      id="rect6741-0-3-5"
-     y="2.4999969"
-     x="2.5"
-     height="11"
-     width="11" />
-</svg>
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3304);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1"
+     ry="1" /><rect
+     width="15.000078"
+     height="15.000078"
+     rx="2"
+     ry="2"
+     x="0.4999609"
+     y="0.4999609"
+     id="rect5505-21-2-8"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient2140);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3453"
+     width="4"
+     height="4"
+     x="-4.3231964"
+     y="11.636904"
+     transform="rotate(-45)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3923"
+     width="4"
+     height="4"
+     x="0.67680448"
+     y="11.636904"
+     transform="rotate(-45)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3925"
+     width="4"
+     height="4"
+     x="-4.3231964"
+     y="6.6369047"
+     transform="rotate(-45)" /><rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3927"
+     width="4"
+     height="4"
+     x="0.67680448"
+     y="6.6369047"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3273);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4240"
+     width="3.000103"
+     height="3.000103"
+     x="1.1767014"
+     y="7.1369047"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5677);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect5675"
+     width="3.000103"
+     height="3.000103"
+     x="-3.8232992"
+     y="7.1369047"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5681);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect5679"
+     width="3.000103"
+     height="3.000103"
+     x="1.1767014"
+     y="12.136904"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient5685);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect5683"
+     width="3.000103"
+     height="3.000103"
+     x="-3.8232992"
+     y="12.136904"
+     transform="rotate(-45)" /></svg>

--- a/elementary-xfce/mimetypes/24/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/24/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/24/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/24/application-x-msdownload.svg
@@ -1,278 +1,286 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="24"
+   id="svg4157"
    height="24"
-   id="svg4157">
-  <defs
-     id="defs4159">
-    <linearGradient
-       id="linearGradient4097">
-      <stop
-         id="stop4099"
-         style="stop-color:#000000;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4101"
-         style="stop-color:#000000;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="23.99999"
-       y1="6.5493407"
-       x2="23.99999"
-       y2="41.229313"
-       id="linearGradient3233"
+   width="24"
+   version="1.1"
+   xml:space="preserve"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"><sodipodi:namedview
+     id="namedview14977"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="11.9375"
+     inkscape:cy="-1.84375"
+     inkscape:window-width="1278"
+     inkscape:window-height="954"
+     inkscape:window-x="635"
+     inkscape:window-y="47"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4157" /><defs
+     id="defs4159"><linearGradient
+       gradientTransform="matrix(0.45945947,0,0,0.45945945,0.97297429,0.97297586)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient4095"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.45945947,0,0,0.45945947,0.9742203,0.9717328)" />
-    <linearGradient
-       id="linearGradient4095">
-      <stop
-         id="stop4097"
+       id="linearGradient3233"
+       y2="41.408028"
+       x2="23.99999"
+       y1="6.588356"
+       x1="23.99999" /><linearGradient
+       id="linearGradient4095"><stop
+         offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop4100"
+         id="stop4097" /><stop
+         offset="0.03108484"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.01652508" />
-      <stop
-         id="stop4102"
+         id="stop4100" /><stop
+         offset="0.96885371"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.98001981" />
-      <stop
-         id="stop4104"
+         id="stop4102" /><stop
+         offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="6.7304144"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.2001843"
-       fy="9.9571075"
-       id="radialGradient3215"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
+         id="stop4104" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,4.6270127,-5.6804933,0,68.966159,-38.745063)" />
-    <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3082-6"
        xlink:href="#linearGradient3688-166-749-9"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-9">
-      <stop
-         id="stop2883-2"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885-2"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
+       id="radialGradient3082-6"
        fy="43.5"
-       id="radialGradient3084-4"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-166-749-9"><stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-2" /><stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-2" /></linearGradient><radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3688-464-309-7-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-7-6">
-      <stop
-         id="stop2889-75"
+       id="radialGradient3084-4"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" /><linearGradient
+       id="linearGradient3688-464-309-7-6"><stop
+         offset="0"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-4-9"
+         id="stop2889-75" /><stop
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3086-8"
+         id="stop2891-4-9" /></linearGradient><linearGradient
+       gradientUnits="userSpaceOnUse"
        xlink:href="#linearGradient3702-501-757-1"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757-1">
-      <stop
-         id="stop2895-2"
+       id="linearGradient3086-8"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" /><linearGradient
+       id="linearGradient3702-501-757-1"><stop
+         offset="0"
          style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-89"
+         id="stop2895-2" /><stop
+         offset="0.5"
          style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-36"
+         id="stop2897-89" /><stop
+         offset="1"
          style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3264"
-       xlink:href="#linearGradient4097"
+         id="stop2899-36" /></linearGradient><linearGradient
+       id="linearGradient3600-9-51"><stop
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         id="stop3602-0-0" /><stop
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1;"
+         id="stop3604-9-04" /></linearGradient><linearGradient
+       id="linearGradient3104-6"><stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" /><stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" /></linearGradient><linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1271"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.40155078,0,0,0.40454336,6.0413842,5.2866898)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3267"
-       xlink:href="#linearGradient4097"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-41.857271,-23.833435)"
+       x1="70.385941"
+       y1="51.425007"
+       x2="70.385941"
+       y2="29.002073" /><linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1338"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.39820022,0,0,0.40454334,2.2440927,9.1390108)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3270"
-       xlink:href="#linearGradient4097"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.38479802,0,0,0.40112101,-1.2415975,5.3218458)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
+       gradientTransform="matrix(0.48571318,0,0,0.46715971,-23.944568,0.2440862)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="45.500317" /><linearGradient
+       id="linearGradient4213-9"><stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" /><stop
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" /></linearGradient><linearGradient
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696"
        id="linearGradient3273"
-       xlink:href="#linearGradient4097"
+       xlink:href="#linearGradient4213-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.38479802,0,0,0.39125692,2.6160038,1.6092846)" />
-  </defs>
-  <metadata
-     id="metadata4162">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     style="display:inline"
-     id="g2036-4"
-     transform="matrix(0.55,0,0,0.3333336,-1.2000011,7.33333)">
-    <g
-       style="opacity:0.4"
-       id="g3712-8"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-      <rect
-         style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none"
-         id="rect2801-6"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none"
-         id="rect3696-20"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none"
-         id="rect3700-5"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
-  </g>
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3215);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect5505-21-8"
-     y="2.5000257"
-     x="2.4999981"
-     ry="1"
-     rx="1"
-     height="19.000002"
-     width="19.000002" />
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect5505-21-8-1"
-     y="2.5000257"
-     x="2.4999981"
-     ry="1"
-     rx="1"
-     height="19.000002"
-     width="19.000002" />
-  <rect
-     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-9"
-     y="3.4987564"
-     x="3.5012455"
+       gradientTransform="matrix(0.38479802,0,0,0.39125692,2.7930367,1.4324494)" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient4327"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38479802,0,0,0.39125692,-2.7069631,1.4324504)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient4331"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38479802,0,0,0.39125692,2.7930367,6.9324485)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /><linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient4335"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.38479802,0,0,0.39125692,-2.7069632,6.9324492)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" /></defs><metadata
+     id="metadata4162"><rdf:RDF><cc:Work
+         rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><g
+     transform="matrix(0.55263158,0,0,0.42857134,-1.2631579,2.3571464)"
+     id="g3712-8"
+     style="opacity:0.4;stroke-width:1.02353"><rect
+       width="5"
+       height="7"
+       x="38"
+       y="40"
+       id="rect2801-6"
+       style="fill:url(#radialGradient3082-6);fill-opacity:1;stroke:none;stroke-width:1.02353" /><rect
+       width="5"
+       height="7"
+       x="-10"
+       y="-47"
+       transform="scale(-1)"
+       id="rect3696-20"
+       style="fill:url(#radialGradient3084-4);fill-opacity:1;stroke:none;stroke-width:1.02353" /><rect
+       width="28"
+       height="7.0000005"
+       x="10"
+       y="40"
+       id="rect3700-5"
+       style="fill:url(#linearGradient3086-8);fill-opacity:1;stroke:none;stroke-width:1.02353" /></g><rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1338);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9-5"
+     y="2.5"
+     x="2.5"
+     ry="2.5"
+     rx="2.5"
+     height="19"
+     width="19" /><path
+     id="rect4337"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 12,5.1800008 8.8183595,8.3616414 12,11.543282 15.181641,8.3616412 Z M 8.1113282,9.0686727 4.9296876,12.250313 8.111328,15.431954 11.292969,12.250313 Z m 7.7773438,-4e-7 -3.181641,3.1816407 3.181641,3.181641 3.181641,-3.18164 z M 12,12.957344 8.8183591,16.138985 12,19.320626 15.181641,16.138985 Z" /><rect
+     width="17"
      height="17"
-     width="17" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5-3"
-     d="M 12.000002,13.664557 15.137933,16.832278 12.000002,20 8.86207,16.832279 Z M 8.1379312,9.7658228 11.275863,12.933544 8.1379312,16.101268 4.9999998,12.933545 Z M 15.86207,9.8987338 19,13.000002 15.86207,16.101269 12.724138,13.000003 Z M 12.000001,5.9999998 15.13793,9.1012678 12.000001,12.202535 8.862069,9.1012688 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5"
-     d="m 12.001246,12.663313 3.137932,3.167722 -3.137932,3.167722 -3.1379302,-3.167722 z M 8.1391769,8.7645788 11.277108,11.932301 8.1391769,15.100022 5.0012455,11.932301 Z m 7.7241381,0.132911 3.13793,3.1012672 -3.13793,3.101268 -3.137932,-3.101266 z m -3.862069,-3.898734 3.13793,3.101268 -3.13793,3.1012672 -3.1379311,-3.1012662 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3273);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5"
-     d="M 12.043555,5.6285608 14.544741,8.1183798 12.043555,10.608197 9.5423682,8.1183808 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3270);stroke-width:0.99999982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-1"
-     d="M 8.1859534,9.4424528 10.68714,11.995043 8.1859534,14.547632 5.6847667,11.995044 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3267);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-9"
-     d="m 11.999998,13.294775 2.5883,2.574368 -2.5883,2.574367 -2.5883013,-2.574366 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3264);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-2"
-     d="m 15.879377,9.4424528 2.61008,2.5743692 -2.61008,2.574368 -2.610079,-2.574367 z" />
-</svg>
+     x="3.4999995"
+     y="3.4999995"
+     id="rect6741-9"
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3233);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     rx="1.5"
+     ry="1.5" /><rect
+     width="19.000002"
+     height="19.000002"
+     rx="2.5"
+     ry="2.5"
+     x="2.4999981"
+     y="2.5000257"
+     id="rect5505-21-8-1"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:url(#linearGradient1271);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000;stop-opacity:1" /><rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3453"
+     width="4.5"
+     height="4.5"
+     x="-4.8232708"
+     y="17.293829"
+     transform="rotate(-45)" /><rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3923"
+     width="4.5"
+     height="4.5"
+     x="0.67672879"
+     y="17.293829"
+     transform="rotate(-45)" /><rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3925"
+     width="4.5"
+     height="4.5"
+     x="-4.8232708"
+     y="11.793836"
+     transform="rotate(-45)" /><rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3.00001;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3927"
+     width="4.5"
+     height="4.5"
+     x="0.67672879"
+     y="11.793836"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3273);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect4240"
+     width="3.5000286"
+     height="3.5000286"
+     x="1.1767005"
+     y="12.293835"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4327);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect4325"
+     width="3.5000286"
+     height="3.5000286"
+     x="-4.3232994"
+     y="12.293836"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4331);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect4329"
+     width="3.5000286"
+     height="3.5000286"
+     x="1.1767002"
+     y="17.793829"
+     transform="rotate(-45)" /><rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4335);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect4333"
+     width="3.5000286"
+     height="3.5000286"
+     x="-4.3232994"
+     y="17.793829"
+     transform="rotate(-45)" /></svg>

--- a/elementary-xfce/mimetypes/32/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/32/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/32/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/32/application-x-msdownload.svg
@@ -1,280 +1,363 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   version="1.1"
-   width="32"
+   id="svg4715"
    height="32"
-   id="svg4588">
+   width="32"
+   version="1.1"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview6293"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="32"
+     inkscape:cx="6.765625"
+     inkscape:cy="10.328125"
+     inkscape:window-width="1423"
+     inkscape:window-height="1050"
+     inkscape:window-x="731"
+     inkscape:window-y="18"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg4715" />
   <defs
-     id="defs4590">
+     id="defs4717">
     <linearGradient
-       id="linearGradient4687">
+       id="linearGradient3924">
       <stop
-         id="stop4689"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1"
+         id="stop3926" />
+      <stop
+         offset="0.06256784"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         id="stop3928" />
+      <stop
+         offset="0.93775165"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         id="stop3930" />
+      <stop
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         id="stop3932" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-166-749"
+       id="radialGradient3163"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-166-749">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3688-464-309"
+       id="radialGradient3165"
+       fy="43.5"
+       fx="4.9929786"
+       r="2.5"
+       cy="43.5"
+       cx="4.9929786" />
+    <linearGradient
+       id="linearGradient3688-464-309">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2889" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2891" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient3167"
+       y2="39.999443"
+       x2="25.058096"
+       y1="47.027729"
+       x1="25.058096" />
+    <linearGradient
+       id="linearGradient3702-501-757">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899" />
+    </linearGradient>
+    <linearGradient
+       gradientTransform="matrix(0.67567568,0,0,0.67567572,-0.2162133,-0.21620909)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient3924"
+       id="linearGradient3027"
+       y2="41.754707"
+       x2="23.999996"
+       y1="6.2446342"
+       x1="23.999996" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.69022395,0,0,0.66385849,-35.07912,-0.70577203)"
+       x1="74.838791"
+       y1="4.828999"
+       x2="74.838791"
+       y2="45.500317" />
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1;"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient1572"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,-45.635114,-9.2419267)"
+       x1="72.893349"
+       y1="43.73991"
+       x2="72.893349"
+       y2="12.523938" />
+    <linearGradient
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696"
+       id="linearGradient3273"
+       xlink:href="#linearGradient4213-9"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.54968509,0,0,0.55891165,3.5591399,0.86189612)" />
+    <linearGradient
+       id="linearGradient4213-9">
+      <stop
+         id="stop4215-4"
          style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop4691"
+         id="stop4217-1"
          style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="38.546436"
-       y1="6.3738203"
-       x2="38.546436"
-       y2="41.679485"
-       id="linearGradient3483"
-       xlink:href="#linearGradient3924-0"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient7424"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.67567568,0,0,0.67567568,-0.21621855,-0.2162061)" />
+       gradientTransform="matrix(0.54968509,0,0,0.55891165,-3.94086,0.86189612)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
     <linearGradient
-       id="linearGradient3924-0">
-      <stop
-         id="stop3926-6"
-         style="stop-color:#ffffff;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3928-3"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         offset="0.03798588" />
-      <stop
-         id="stop3930-2"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         offset="0.96200818" />
-      <stop
-         id="stop3932-62"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="6.7304144"
-       cy="9.9571075"
-       r="12.671875"
-       fx="6.2001843"
-       fy="9.9571075"
-       id="radialGradient4388"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient7428"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,6.5752286,-8.07228,0,96.951918,-56.111442)" />
+       gradientTransform="matrix(0.54968509,0,0,0.55891165,3.5591399,8.3618961)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         id="stop3750-1-0-7-6-6-1-3-9-3"
-         style="stop-color:#919caf;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3752-3-7-4-0-32-8-923-0-7"
-         style="stop-color:#68758e;stop-opacity:1"
-         offset="0.26238" />
-      <stop
-         id="stop3754-1-8-5-2-7-6-7-1-9"
-         style="stop-color:#485a6c;stop-opacity:1"
-         offset="0.704952" />
-      <stop
-         id="stop3756-1-6-2-6-6-1-96-6-0"
-         style="stop-color:#444c5c;stop-opacity:1"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3493"
-       xlink:href="#linearGradient3688-166-749-6"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient7434"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-6">
-      <stop
-         id="stop2883-8"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2885-3"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <radialGradient
-       cx="4.9929786"
-       cy="43.5"
-       r="2.5"
-       fx="4.9929786"
-       fy="43.5"
-       id="radialGradient3495"
-       xlink:href="#linearGradient3688-464-309-7"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-7">
-      <stop
-         id="stop2889-0"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop2891-66"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="25.058096"
-       y1="47.027729"
-       x2="25.058096"
-       y2="39.999443"
-       id="linearGradient3497"
-       xlink:href="#linearGradient3702-501-757-3"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3702-501-757-3">
-      <stop
-         id="stop2895-3"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="0" />
-      <stop
-         id="stop2897-28"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop2899-8"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3271"
-       xlink:href="#linearGradient4687"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.59871787,0,0,0.61785256,6.7816397,5.7146551)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3274"
-       xlink:href="#linearGradient4687"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.59425046,0,0,0.62697884,1.4989372,11.09246)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3277"
-       xlink:href="#linearGradient4687"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.59425046,0,0,0.62241571,-3.9803309,5.6097033)" />
-    <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3280"
-       xlink:href="#linearGradient4687"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0.61212008,0,0,0.59574729,1.0030552,0.5192162)" />
+       gradientTransform="matrix(0.54968509,0,0,0.55891165,-3.9408601,8.3618961)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
   </defs>
   <metadata
-     id="metadata4593">
+     id="metadata4720">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     style="display:inline"
-     id="g2036-2"
-     transform="matrix(0.6999997,0,0,0.3333336,-0.8000002,15.33333)">
-    <g
-       style="opacity:0.4"
-       id="g3712-3"
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)">
-      <rect
-         style="fill:url(#radialGradient3493);fill-opacity:1;stroke:none"
-         id="rect2801-0"
-         y="40"
-         x="38"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#radialGradient3495);fill-opacity:1;stroke:none"
-         id="rect3696-2"
-         transform="scale(-1,-1)"
-         y="-47"
-         x="-10"
-         height="7"
-         width="5" />
-      <rect
-         style="fill:url(#linearGradient3497);fill-opacity:1;stroke:none"
-         id="rect3700-1"
-         y="40"
-         x="10"
-         height="7.0000005"
-         width="28" />
-    </g>
+     style="opacity:0.4"
+     id="g3712"
+     transform="matrix(0.73684208,0,0,0.57142853,-1.6842105,4.1428584)">
+    <rect
+       style="fill:url(#radialGradient3163);fill-opacity:1;stroke:none"
+       id="rect2801"
+       y="40"
+       x="38"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#radialGradient3165);fill-opacity:1;stroke:none"
+       id="rect3696"
+       transform="scale(-1)"
+       y="-47"
+       x="-10"
+       height="7"
+       width="5" />
+    <rect
+       style="fill:url(#linearGradient3167);fill-opacity:1;stroke:none"
+       id="rect3700"
+       y="40"
+       x="10"
+       height="7.0000005"
+       width="28" />
   </g>
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4388);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect5505"
-     y="2.5000005"
-     x="2.4999998"
-     ry="2.1600001"
-     rx="2.1600001"
-     height="27"
-     width="27" />
-  <rect
-     style="opacity:0.3;fill:none;stroke:url(#linearGradient3483);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
-     id="rect6741-7-4"
-     y="3.5"
-     x="3.5"
-     ry="1.0869565"
-     rx="1.0869565"
-     height="25"
-     width="25" />
-  <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect5505-6"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
      y="2.5"
      x="2.5"
-     ry="2.1600001"
-     rx="2.1600001"
+     ry="3"
+     rx="3"
+     height="26.999998"
+     width="26.999998" />
+  <path
+     id="rect7436"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 16,7.203 11.757812,11.447141 16,15.689328 20.242187,11.447141 Z m -5.302734,5.304687 -4.244141,4.242188 4.244141,4.242187 4.242187,-4.242187 z m 10.605468,10e-7 -4.242187,4.242187 4.242187,4.242188 4.244141,-4.242188 z M 16,17.810422 11.757813,22.052609 16,26.29675 20.242188,22.052609 Z" />
+  <rect
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient1572);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;fill-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1"
+     id="rect5505-6-6"
+     y="2.5"
+     x="2.5"
+     ry="3"
+     rx="3"
      height="27"
      width="27" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5-3"
-     d="m 16.000002,17.949365 4.48276,4.525318 L 16.000002,27 11.517243,22.474683 Z m -5.517244,-5.569621 4.48276,4.525318 -4.48276,4.525318 L 6,16.905062 Z M 21.517242,12.569617 26,17 21.517242,21.430383 17.034483,17.000002 Z m -5.517241,-5.5696208 4.482756,4.4303828 -4.482756,4.430383 -4.48276,-4.430381 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5"
-     d="M 16.000002,16.949366 20.482761,21.474683 16.000002,26 11.517243,21.474684 Z m -5.517243,-5.56962 4.48276,4.525317 -4.48276,4.525317 L 6,15.905063 Z M 21.517243,11.569619 26,16.000002 l -4.482757,4.430381 -4.48276,-4.430379 z m -5.517241,-5.5696205 4.482756,4.4303825 -4.482756,4.430382 -4.48276,-4.43038 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3280);stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5"
-     d="m 15.999997,6.6391659 3.978779,3.7911221 -3.978779,3.79112 -3.97878,-3.791119 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3277);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-1"
-     d="m 10.578804,12.00361 3.862627,3.96083 -3.862627,3.960829 -3.8626267,-3.960828 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3274);stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-9"
-     d="M 16.058073,17.533242 19.9207,21.52311 16.058073,25.512977 12.195446,21.523112 Z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3271);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-2"
-     d="m 21.450226,12.061686 3.891666,3.931792 -3.891666,3.93179 -3.891665,-3.931789 z" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient3027);stroke-width:0.999998;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-7"
+     y="3.5"
+     x="3.5"
+     ry="1.9999999"
+     rx="2"
+     height="25.000002"
+     width="25" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3453"
+     width="6"
+     height="6"
+     x="-6.75"
+     y="23.377417"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3923"
+     width="6"
+     height="6"
+     x="0.74999994"
+     y="23.377417"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3925"
+     width="6"
+     height="6"
+     x="-6.75"
+     y="15.877417"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3927"
+     width="6"
+     height="6"
+     x="0.74999994"
+     y="15.877417"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3273);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4240"
+     width="4.9998012"
+     height="4.9998012"
+     x="1.2501987"
+     y="16.377417"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient7424);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect7422"
+     width="4.9998012"
+     height="4.9998012"
+     x="-6.2498012"
+     y="16.377417"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient7428);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect7426"
+     width="4.9998012"
+     height="4.9998012"
+     x="1.2501988"
+     y="23.877417"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient7428);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect7430"
+     width="4.9998012"
+     height="4.9998012"
+     x="1.2501988"
+     y="23.877417"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient7434);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect7432"
+     width="4.9998012"
+     height="4.9998012"
+     x="-6.2498012"
+     y="23.877417"
+     transform="rotate(-45)" />
 </svg>

--- a/elementary-xfce/mimetypes/48/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/48/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/48/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/48/application-x-msdownload.svg
@@ -1,275 +1,340 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   id="svg4405"
-   height="48"
+   version="1.1"
    width="48"
-   version="1.1">
+   height="48"
+   id="svg6649"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview8021"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.291667"
+     inkscape:cx="10.5549"
+     inkscape:cy="13.4451"
+     inkscape:window-width="1423"
+     inkscape:window-height="804"
+     inkscape:window-x="630"
+     inkscape:window-y="140"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6649" />
   <defs
-     id="defs4407">
+     id="defs6651">
     <linearGradient
-       id="linearGradient4187">
+       id="linearGradient1201">
       <stop
-         offset="0"
+         id="stop1193"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4189" />
+         offset="0" />
       <stop
-         offset="0.02099473"
+         id="stop1195"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4191" />
+         offset="0.06781636" />
       <stop
-         offset="0.97696"
+         id="stop1197"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4193" />
+         offset="0.94694352" />
       <stop
-         offset="1"
+         id="stop1199"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4195" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3851">
+       id="linearGradient3688-166-749">
       <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:0.43200001"
-         id="stop3853" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0.627451"
-         id="stop3855" />
-    </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-166-749-2-324"
-       id="radialGradient3013-896"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <linearGradient
-       id="linearGradient3688-166-749-2-324">
-      <stop
-         offset="0"
+         id="stop2883"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3216" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop2885"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3218" />
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-8-331"
-       id="radialGradient3015-826"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
     <linearGradient
-       id="linearGradient3688-464-309-8-331">
+       id="linearGradient3702-501-757">
       <stop
-         offset="0"
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3222" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop2899"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3224" />
+         offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3702-501-757-6-946">
-      <stop
-         offset="0"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3228" />
-      <stop
-         offset="0.5"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3230" />
-      <stop
-         offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3232" />
-    </linearGradient>
-    <linearGradient
+       x1="38.999996"
+       y1="5.9999938"
+       x2="38.999996"
+       y2="41.945408"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-6-946"
-       id="linearGradient4395"
-       y2="39.999443"
-       x2="25.058096"
+       gradientTransform="translate(4e-6,1.0000062)" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient1191"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
        y1="47.027729"
-       x1="25.058096" />
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(1.1428571,0,0,0.6428571,-3.428569,16.035716)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
+       id="linearGradient3600-9-51">
       <stop
          offset="0"
-         style="stop-color:#919caf;stop-opacity:1"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         id="stop3602-0-0" />
       <stop
          offset="1"
-         style="stop-color:#444c5c;stop-opacity:1"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
+         style="stop-color:#abacae;stop-opacity:1;"
+         id="stop3604-9-04" />
     </linearGradient>
     <linearGradient
-       gradientTransform="translate(1.17e-5,1.00001)"
+       id="linearGradient3104-6">
+      <stop
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4187"
-       id="linearGradient3153"
-       y2="41.890972"
-       x2="23.99999"
-       y1="6.1111298"
-       x1="23.99999" />
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,10.835333,-0.132171)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.99699018,0,0,0.95890674,-49.780952,0.86944042)"
+       x1="74.838791"
+       y1="4.535933"
+       x2="74.838791"
+       y2="49.779099" />
     <radialGradient
-       gradientTransform="matrix(0,9.4975523,-11.65996,0,140.93055,-79.160972)"
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6-5-76"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient4144"
-       fy="9.9571075"
-       fx="6.2001843"
-       r="12.671875"
-       cy="9.9571075"
-       cx="6.7304144" />
+       gradientTransform="matrix(2.003784,0,0,0.89999994,29.98813,4.8500025)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-1-6-9"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.003784,0,0,0.89999994,-18.01187,-83.149997)" />
     <linearGradient
-       gradientTransform="matrix(0.95490733,0,0,0.94360272,0.60477361,1.0661197)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696"
+       id="linearGradient3273"
+       xlink:href="#linearGradient4213-9"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3851"
-       id="linearGradient3100"
-       y2="23.605091"
-       x2="26.313066"
-       y1="9.8269262"
-       x1="26.313066" />
+       gradientTransform="matrix(0.8795372,0,0,0.89430039,4.0608709,0.74875386)" />
     <linearGradient
-       gradientTransform="matrix(0.95490733,0,0,0.96385,-7.6710875,8.9548616)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3851"
-       id="linearGradient3102"
-       y2="23.605091"
-       x2="26.313066"
-       y1="9.8269262"
-       x1="26.313066" />
+       id="linearGradient4213-9">
+      <stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
+    </linearGradient>
     <linearGradient
-       gradientTransform="matrix(0.95490733,0,0,0.96385,0.60477413,17.309291)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient8766"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3851"
-       id="linearGradient3104"
-       y2="23.605091"
-       x2="26.313066"
-       y1="9.8269262"
-       x1="26.313066" />
+       gradientTransform="matrix(0.8795372,0,0,0.89430039,-6.4391294,0.74875386)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
     <linearGradient
-       gradientTransform="matrix(0.95490733,0,0,0.96385,8.8806357,8.9548616)"
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient8770"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3851"
-       id="linearGradient3106"
-       y2="23.605091"
-       x2="26.313066"
-       y1="9.8269262"
-       x1="26.313066" />
+       gradientTransform="matrix(0.8795372,0,0,0.89430039,-6.4391294,11.248619)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213-9"
+       id="linearGradient8774"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8795372,0,0,0.89430039,4.0608709,11.248619)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
   </defs>
   <metadata
-     id="metadata4410">
+     id="metadata6654">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     style="opacity:0.4"
-     id="g3712-0"
-     transform="matrix(1.1578952,0,0,0.57142859,-3.789476,19.142856)">
-    <rect
-       style="fill:url(#radialGradient3013-896);fill-opacity:1;stroke:none"
-       id="rect2801-4"
-       y="40"
-       x="38"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#radialGradient3015-826);fill-opacity:1;stroke:none"
-       id="rect3696-8"
-       transform="scale(-1,-1)"
-       y="-47"
-       x="-10"
-       height="7"
-       width="5" />
-    <rect
-       style="fill:url(#linearGradient4395);fill-opacity:1;stroke:none"
-       id="rect3700-7"
-       y="40"
-       x="10"
-       height="7.0000005"
-       width="28" />
-  </g>
   <rect
-     style="color:#000000;fill:url(#radialGradient4144);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect5505-21"
+     style="opacity:0.4;fill:url(#radialGradient3013-6-5-76);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect2801-3-7-7-2"
+     y="41.75"
+     x="40"
+     height="4.4999995"
+     width="5" />
+  <rect
+     style="opacity:0.4;fill:url(#radialGradient3015-1-6-9);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect3696-6-3-5-0"
+     transform="scale(-1)"
+     y="-46.25"
+     x="-8"
+     height="4.4999995"
+     width="5" />
+  <rect
+     style="opacity:0.4;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect3700-4-6-9-6"
+     y="41.75"
+     x="8"
+     height="4.5"
+     width="32" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
      y="5.5"
-     x="4.5000067"
-     ry="2"
-     rx="2"
+     x="4.5"
+     ry="4"
+     rx="4"
      height="39"
      width="39" />
+  <path
+     id="rect9659"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 24,12.960999 17.636719,19.32428 24,25.689514 30.363281,19.32428 Z m -7.423828,7.423828 -6.365234,6.365234 6.365234,6.363281 6.363281,-6.363281 z m 14.847656,0 -6.363281,6.365234 6.363281,6.363282 6.365235,-6.363282 z M 24,27.810608 17.636719,34.173889 24,40.537171 30.363281,34.17389 Z" />
   <rect
-     style="opacity:0.3;fill:none;stroke:url(#linearGradient3153);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-     id="rect6741-1"
-     y="6.5"
-     x="5.5000081"
-     ry="1"
-     rx="1"
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:0.3"
+     id="rect6741-2-8-4"
+     y="6.4999952"
+     x="5.5000153"
+     ry="3"
+     rx="3"
      height="37"
      width="37" />
   <rect
-     style="opacity:0.5;color:#000000;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-     id="rect5505-21-6"
-     y="5.5"
-     x="4.5000081"
-     ry="2"
-     rx="2"
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3453"
+     width="9.000001"
+     height="9.000001"
+     x="-10.633553"
+     y="35.5746"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3923"
+     width="9.000001"
+     height="9.000001"
+     x="-0.13355318"
+     y="35.5746"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3925"
+     width="9.000001"
+     height="9.000001"
+     x="-10.633553"
+     y="25.074749"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3927"
+     width="9.000001"
+     height="9.000001"
+     x="-0.13355318"
+     y="25.074749"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3273);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4240"
+     width="8.0000553"
+     height="8.0000553"
+     x="0.36639243"
+     y="25.574749"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient8766);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect8764"
+     width="8.0000553"
+     height="8.0000553"
+     x="-10.133607"
+     y="25.574749"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient8770);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect8768"
+     width="8.0000553"
+     height="8.0000553"
+     x="-10.133607"
+     y="36.0746"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient8774);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect8772"
+     width="8.0000553"
+     height="8.0000553"
+     x="0.36639243"
+     y="36.0746"
+     transform="rotate(-45)" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-2-8"
+     y="5.4999952"
+     x="4.5000153"
+     ry="4"
+     rx="4"
      height="39"
      width="39" />
-  <path
-     d="M 24.000003,27.67405 30.724141,34.462025 24.000004,41.25 17.275865,34.462026 Z m -8.275863,-8.354431 6.724138,6.787976 -6.724139,6.787977 -6.7241369,-6.787976 z m 16.551723,0.28481 6.724135,6.645574 -6.724135,6.645573 -6.724139,-6.64557 z m -8.275861,-8.35443 6.724134,6.645573 -6.724134,6.645574 -6.724138,-6.645571 z"
-     id="rect4120-5-3"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5"
-     d="m 24.000003,26.424049 6.724138,6.787975 -6.724138,6.787975 -6.724137,-6.787974 z M 15.72414,18.06962 22.448278,24.857595 15.72414,31.645569 9.0000021,24.857595 Z m 16.551723,0.28481 6.724135,6.645572 -6.724135,6.645573 -6.724138,-6.64557 z M 24.000002,10 l 6.724135,6.645572 -6.724135,6.645573 -6.724138,-6.645569 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3100);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5"
-     d="m 24.000003,10.759494 6.206895,6.004749 -6.206895,6.004745 -6.206897,-6.004743 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3102);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-1"
-     d="m 15.724141,18.85623 6.206895,6.133595 -6.206895,6.133593 -6.206897,-6.133591 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3104);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-9"
-     d="m 24.000003,27.210661 6.206895,6.133593 -6.206895,6.133593 -6.206897,-6.13359 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3106);stroke-width:0.99999988;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-2"
-     d="m 32.275864,18.85623 6.206896,6.133595 -6.206896,6.133593 -6.206897,-6.133591 z" />
 </svg>

--- a/elementary-xfce/mimetypes/64/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/64/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/64/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/64/application-x-msdownload.svg
@@ -1,280 +1,352 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
+   id="svg13986"
+   height="64"
+   width="64"
+   version="1.1"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
-   width="64px"
-   height="64px"
-   id="svg4332"
-   version="1.1">
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10482"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="5.6568543"
+     inkscape:cx="41.896077"
+     inkscape:cy="7.3362328"
+     inkscape:window-width="1404"
+     inkscape:window-height="952"
+     inkscape:window-x="708"
+     inkscape:window-y="72"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg13986" />
   <defs
-     id="defs4334">
+     id="defs13988">
     <linearGradient
-       id="linearGradient4213-9">
-      <stop
-         offset="0"
-         style="stop-color:#000000;stop-opacity:1"
-         id="stop4215-4" />
-      <stop
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0"
-         id="stop4217-1" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4270"
-       id="linearGradient3904"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.4324324,0,0,1.4362832,-2.3783747,-2.4707827)"
-       x1="23.99999"
-       y1="5.9093657"
-       x2="23.99999"
-       y2="42.091705" />
-    <linearGradient
-       id="linearGradient4270">
+       id="linearGradient3924-2-2-5-8">
       <stop
          offset="0"
          style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4272" />
+         id="stop3926-9-4-9-6" />
       <stop
-         offset="0.0348749"
+         offset="0.08639996"
          style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4274" />
+         id="stop3928-9-8-6-5" />
       <stop
-         offset="0.96216321"
+         offset="0.91353345"
          style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4276" />
+         id="stop3930-3-5-1-7" />
       <stop
          offset="1"
          style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4278" />
+         id="stop3932-8-0-4-8" />
     </linearGradient>
-    <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient4147"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,13.393984,-16.443533,0,196.90205,-114.89368)"
-       cx="6.7304144"
-       cy="9.9571075"
-       fx="6.2001843"
-       fy="9.9571075"
-       r="12.671875" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
+       id="linearGradient3688-166-749-4-0-3-8">
       <stop
          offset="0"
-         style="stop-color:#919caf;stop-opacity:1;"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1;"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1;"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2883-4-0-1-8" />
       <stop
          offset="1"
-         style="stop-color:#444c5c;stop-opacity:1;"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2885-9-2-9-6" />
     </linearGradient>
+    <linearGradient
+       id="linearGradient3702-501-757-8-4-1-1">
+      <stop
+         offset="0"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2895-8-9-9-1" />
+      <stop
+         offset="0.5"
+         style="stop-color:#181818;stop-opacity:1"
+         id="stop2897-7-8-7-7" />
+      <stop
+         offset="1"
+         style="stop-color:#181818;stop-opacity:0"
+         id="stop2899-4-5-1-5" />
+    </linearGradient>
+    <linearGradient
+       y2="42.147511"
+       x2="23.99999"
+       y1="5.8522105"
+       x1="23.99999"
+       gradientTransform="matrix(1.4324324,0,0,1.4324325,-2.378381,-2.3783731)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3647"
+       xlink:href="#linearGradient3924-2-2-5-8" />
     <radialGradient
        cx="4.9929786"
        cy="43.5"
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient2873-966-168-714"
-       xlink:href="#linearGradient3688-166-749-654"
+       id="radialGradient3337-2-2-3"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)" />
-    <linearGradient
-       id="linearGradient3688-166-749-654">
-      <stop
-         id="stop3088"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3090"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,41.985755,15.500001)" />
     <radialGradient
        cx="4.9929786"
        cy="43.5"
        r="2.5"
        fx="4.9929786"
        fy="43.5"
-       id="radialGradient2875-742-326-419"
-       xlink:href="#linearGradient3688-464-309-604"
+       id="radialGradient3339-1-4-5"
+       xlink:href="#linearGradient3688-166-749-4-0-3-8"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)" />
-    <linearGradient
-       id="linearGradient3688-464-309-604">
-      <stop
-         id="stop3094"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0" />
-      <stop
-         id="stop3096"
-         style="stop-color:#181818;stop-opacity:0"
-         offset="1" />
-    </linearGradient>
+       gradientTransform="matrix(2.4045407,0,0,0.99999998,-22.014244,-102.5)" />
     <linearGradient
        x1="25.058096"
        y1="47.027729"
        x2="25.058096"
        y2="39.999443"
-       id="linearGradient2877-634-617-908"
-       xlink:href="#linearGradient3702-501-757-795"
-       gradientUnits="userSpaceOnUse" />
+       id="linearGradient6394"
+       xlink:href="#linearGradient3702-501-757-8-4-1-1"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.5714286,0,0,0.7142857,-5.7142853,27.928572)" />
     <linearGradient
-       id="linearGradient3702-501-757-795">
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.80749686,0,0,0.89471714,10.835333,-0.132171)"
+       x1="12.879265"
+       y1="66.950981"
+       x2="12.879265"
+       y2="4.7802162" />
+    <linearGradient
+       id="linearGradient3104-6">
       <stop
-         id="stop3100"
-         style="stop-color:#181818;stop-opacity:0"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
+      <stop
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.4060117,0,0,1.3523043,-72.050063,-2.0302765)"
+       x1="74.838791"
+       y1="4.828999"
+       x2="74.838791"
+       y2="45.50032" />
+    <linearGradient
+       id="linearGradient3600-9-51">
+      <stop
+         offset="0"
+         style="stop-color:#d4d4d4;stop-opacity:1;"
+         id="stop3602-0-0" />
+      <stop
+         offset="1"
+         style="stop-color:#abacae;stop-opacity:1;"
+         id="stop3604-9-04" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4213-9">
+      <stop
+         id="stop4215-4"
+         style="stop-color:#000000;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop3102"
-         style="stop-color:#181818;stop-opacity:1"
-         offset="0.5" />
-      <stop
-         id="stop3104"
-         style="stop-color:#181818;stop-opacity:0"
+         id="stop4217-1"
+         style="stop-color:#000000;stop-opacity:0"
          offset="1" />
     </linearGradient>
     <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3300"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696"
+       id="linearGradient3273"
        xlink:href="#linearGradient4213-9"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3368705,0,0,1.3493902,10.832887,9.5368028)" />
+       gradientTransform="matrix(1.3193141,0,0,1.341459,6.5996564,-5.0424467)" />
     <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3303"
+       inkscape:collect="always"
        xlink:href="#linearGradient4213-9"
+       id="linearGradient11366"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3368705,0,0,1.3767693,-0.753321,20.60337)" />
+       gradientTransform="matrix(1.3193141,0,0,1.341459,-8.4003456,-5.0424478)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
     <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3306"
+       inkscape:collect="always"
        xlink:href="#linearGradient4213-9"
+       id="linearGradient11370"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3368705,0,0,1.3767693,-12.339529,8.9071674)" />
+       gradientTransform="matrix(1.3193141,0,0,1.341459,6.5996568,9.9575579)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
     <linearGradient
-       x1="26.313066"
-       y1="9.8269262"
-       x2="26.313066"
-       y2="23.605091"
-       id="linearGradient3309"
+       inkscape:collect="always"
        xlink:href="#linearGradient4213-9"
+       id="linearGradient11374"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.3375236,0,0,1.3449927,-0.78176581,-2.130498)" />
+       gradientTransform="matrix(1.3193141,0,0,1.341459,-8.4003456,9.9575579)"
+       x1="4.8952737"
+       y1="27.760237"
+       x2="-5.4997888"
+       y2="37.983696" />
   </defs>
   <metadata
-     id="metadata4337">
+     id="metadata13991">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <g
-     transform="matrix(1.5000021,0,0,0.5555561,-4.0000114,35.888881)"
-     id="g2036"
-     style="display:inline">
-    <g
-       transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-       id="g3712"
-       style="opacity:0.4">
-      <rect
-         width="5"
-         height="7"
-         x="38"
-         y="40"
-         id="rect2801"
-         style="fill:url(#radialGradient2873-966-168-714);fill-opacity:1;stroke:none" />
-      <rect
-         width="5"
-         height="7"
-         x="-10"
-         y="-47"
-         transform="scale(-1,-1)"
-         id="rect3696"
-         style="fill:url(#radialGradient2875-742-326-419);fill-opacity:1;stroke:none" />
-      <rect
-         width="28"
-         height="7.0000005"
-         x="10"
-         y="40"
-         id="rect3700"
-         style="fill:url(#linearGradient2877-634-617-908);fill-opacity:1;stroke:none" />
-    </g>
+     id="g2207">
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient3337-2-2-3);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect2801-5-5-7-9"
+       y="56.5"
+       x="54"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.4;fill:url(#radialGradient3339-1-4-5);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3696-3-0-3-7"
+       transform="scale(-1)"
+       y="-61.5"
+       x="-10"
+       height="5"
+       width="6" />
+    <rect
+       style="opacity:0.4;fill:url(#linearGradient6394);fill-opacity:1;stroke:none;stroke-width:1.06199"
+       id="rect3700-5-6-8-4"
+       y="56.5"
+       x="10"
+       height="5.0000005"
+       width="44" />
   </g>
   <rect
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient4147);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99999994;marker:none;enable-background:accumulate"
-     id="rect5505-21-3-8-5-2-9"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
      y="4.5"
      x="4.5"
-     ry="3"
-     rx="3"
+     ry="6"
+     rx="6"
      height="55"
      width="55" />
+  <path
+     id="rect11376"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 32,13.826004 22.80664,23.017411 32,32.21077 41.19336,23.017411 Z m -10.607422,10.605469 -9.191407,9.19336 9.191407,9.191406 9.19336,-9.191406 z m 21.214844,0 -9.19336,9.19336 9.19336,9.191406 9.191407,-9.191406 z M 32,35.038895 22.80664,44.232255 32,53.423661 41.19336,44.232255 Z" />
   <rect
      width="53"
-     height="53.142479"
-     rx="2"
-     ry="2"
-     x="5.5"
-     y="5.428761"
-     id="rect6741"
-     style="opacity:0.3;fill:none;stroke:url(#linearGradient3904);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+     height="53.000004"
+     rx="5"
+     ry="4.9999995"
+     x="5.4999986"
+     y="5.5"
+     id="rect6741-5-0-2-3"
+     style="fill:none;stroke:url(#linearGradient3647);stroke-width:0.999997;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:0.3" />
+  <g
+     id="layer4-0"
+     transform="matrix(0.9047486,0,0,0.9047486,-570.51497,-675.56047)" />
+  <g
+     id="layer4-0-7"
+     transform="matrix(0.9047486,0,0,0.9047486,-570.51497,-668.32248)" />
+  <g
+     id="layer1-3"
+     transform="matrix(0.9047486,0,0,0.9047486,-73.807987,0.49666306)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3453"
+     width="13"
+     height="13"
+     x="-14.441941"
+     y="46.696781"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3923"
+     width="13"
+     height="13"
+     x="0.55806279"
+     y="46.696781"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3925"
+     width="13"
+     height="13"
+     x="-14.441941"
+     y="31.696766"
+     transform="rotate(-45)" />
+  <rect
+     style="fill:#0e141f;fill-opacity:0.8;fill-rule:evenodd;stroke:none;stroke-width:3;stroke-linecap:round;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect3927"
+     width="13"
+     height="13"
+     x="0.55806279"
+     y="31.696766"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient3273);stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect4240"
+     width="12.000158"
+     height="12.000158"
+     x="1.0579039"
+     y="32.196774"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11366);stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11364"
+     width="12.000158"
+     height="12.000158"
+     x="-13.9421"
+     y="32.196774"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11370);stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11368"
+     width="12.000158"
+     height="12.000158"
+     x="1.057904"
+     y="47.196781"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient11374);stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect11372"
+     width="12.000158"
+     height="12.000158"
+     x="-13.9421"
+     y="47.196781"
+     transform="rotate(-45)" />
   <rect
      width="55"
      height="55"
-     rx="3"
-     ry="3"
-     x="4.5"
-     y="4.5"
-     id="rect5505-21-9"
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.5;fill:none;stroke:#1c2c38;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5-3"
-     d="M 32.000004,35.49367 41.413799,44.996835 32.000006,54.5 22.586209,44.996836 Z M 20.413794,23.797468 29.827589,33.300634 20.413793,42.803801 11,33.300635 Z M 43.58621,24.196202 53,33.500004 43.58621,42.803806 34.172414,33.500009 Z M 32.000003,12.5 l 9.413789,9.303802 -9.413789,9.303803 -9.413795,-9.303799 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate;clip-rule:nonzero;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter-blend-mode:normal;filter-gaussianBlur-deviation:0;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto"
-     id="rect4120-5"
-     d="M 32.000004,33.993668 41.413799,43.496833 32.000004,53 22.586211,43.496835 Z M 20.413794,22.297465 29.827589,31.800632 20.413794,41.303797 11,31.800632 Z M 43.58621,22.6962 53,32.000002 43.58621,41.303804 34.172415,32.000006 Z m -11.586207,-11.696203 9.41379,9.303802 -9.41379,9.303803 -9.413795,-9.303798 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3309);stroke-width:0.9999997;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5"
-     d="m 31.987561,11.686246 8.6939,8.559052 -8.6939,8.559046 -8.693901,-8.559043 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3306);stroke-width:0.99999982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-1"
-     d="m 20.413796,23.050343 8.689654,8.761265 -8.689654,8.761262 -8.689657,-8.761259 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3303);stroke-width:0.99999982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-9"
-     d="m 32.000004,34.746547 8.689655,8.761264 -8.689655,8.76126 -8.689657,-8.761258 z" />
-  <path
-     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:0.1;fill:none;stroke:url(#linearGradient3300);stroke-width:0.99999982;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
-     id="rect4120-5-5-2"
-     d="m 43.586211,23.39872 8.689656,8.587034 -8.689656,8.587031 -8.689657,-8.587028 z" />
+     rx="6"
+     ry="6"
+     x="4.4999986"
+     y="4.5000019"
+     id="rect5505-21-3-8-9-1-1"
+     style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate;font-variation-settings:normal;vector-effect:none;fill-opacity:1;-inkscape-stroke:none;stop-color:#000000;stop-opacity:1" />
 </svg>

--- a/elementary-xfce/mimetypes/96/application-vnd.microsoft.portable-executable.svg
+++ b/elementary-xfce/mimetypes/96/application-vnd.microsoft.portable-executable.svg
@@ -1,0 +1,1 @@
+application-x-msdownload.svg

--- a/elementary-xfce/mimetypes/96/application-x-msdownload.svg
+++ b/elementary-xfce/mimetypes/96/application-x-msdownload.svg
@@ -1,333 +1,341 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
    width="96"
    height="96"
-   id="svg4295"
-   version="1.1"
-   sodipodi:docname="application-x-ms-dos-executable.svg"
-   inkscape:version="1.0.2 (e86c870879, 2021-01-15)">
+   id="svg6649"
+   sodipodi:docname="application-x-msdownload.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <sodipodi:namedview
+     id="namedview111598"
      pagecolor="#ffffff"
      bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
-     inkscape:pageopacity="0"
-     inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1030"
-     id="namedview57"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
      showgrid="false"
-     inkscape:zoom="2.0651042"
-     inkscape:cx="11.180231"
-     inkscape:cy="47.277551"
-     inkscape:window-x="0"
-     inkscape:window-y="0"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="layer1" />
+     inkscape:zoom="6.9532168"
+     inkscape:cx="59.468878"
+     inkscape:cy="34.804035"
+     inkscape:window-width="1411"
+     inkscape:window-height="853"
+     inkscape:window-x="910"
+     inkscape:window-y="123"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6649" />
   <defs
-     id="defs4297">
+     id="defs6651">
     <linearGradient
-       id="linearGradient995">
+       id="linearGradient1201">
       <stop
-         id="stop991"
-         style="stop-color:#1c2c38;stop-opacity:1"
+         id="stop1193"
+         style="stop-color:#ffffff;stop-opacity:1"
          offset="0" />
       <stop
-         id="stop993"
-         style="stop-color:#1c2c38;stop-opacity:1"
+         id="stop1195"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.06781636" />
+      <stop
+         id="stop1197"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.94694352" />
+      <stop
+         id="stop1199"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
          offset="1" />
     </linearGradient>
     <linearGradient
-       id="linearGradient4213">
+       id="linearGradient3688-166-749">
       <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop4215" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop4217" />
-    </linearGradient>
-    <linearGradient
-       xlink:href="#linearGradient4270"
-       id="linearGradient3107-996"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.189189,0,0,2.189189,-4.540534,-36.540518)"
-       x1="23.99999"
-       y1="4.999989"
-       x2="23.99999"
-       y2="43" />
-    <radialGradient
-       r="19.99999"
-       fy="8.3484516"
-       fx="-1.2139106"
-       cy="8.3484516"
-       cx="-1.2139106"
-       gradientTransform="matrix(4.1347938e-8,11.949717,-5.2614918,-2.2015939e-7,92.45853,-53.072466)"
-       gradientUnits="userSpaceOnUse"
-       id="radialGradient3164-608"
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5" />
-    <linearGradient
-       y2="3.8990016"
-       x2="24"
-       y1="44"
-       x1="24"
-       gradientTransform="matrix(2.1282142,0,0,2.128212,-3.0772211,-35.076952)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3166-272"
-       xlink:href="#linearGradient995" />
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,27.98813,-17.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-166-749-654"
-       id="radialGradient2873-966-168-714"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
-    <linearGradient
-       id="linearGradient3688-166-749-654">
-      <stop
-         offset="0"
+         id="stop2883"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3088" />
+         offset="0" />
       <stop
-         offset="1"
+         id="stop2885"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3090" />
+         offset="1" />
     </linearGradient>
-    <radialGradient
-       gradientTransform="matrix(2.003784,0,0,1.4,-20.01187,-104.4)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3688-464-309-604"
-       id="radialGradient2875-742-326-419"
-       fy="43.5"
-       fx="4.9929786"
-       r="2.5"
-       cy="43.5"
-       cx="4.9929786" />
     <linearGradient
-       id="linearGradient3688-464-309-604">
+       id="linearGradient3702-501-757">
       <stop
-         offset="0"
+         id="stop2895"
+         style="stop-color:#181818;stop-opacity:0"
+         offset="0" />
+      <stop
+         id="stop2897"
          style="stop-color:#181818;stop-opacity:1"
-         id="stop3094" />
+         offset="0.5" />
       <stop
-         offset="1"
+         id="stop2899"
          style="stop-color:#181818;stop-opacity:0"
-         id="stop3096" />
+         offset="1" />
     </linearGradient>
     <linearGradient
+       x1="38.999996"
+       y1="5.9999938"
+       x2="38.999996"
+       y2="41.945408"
+       id="linearGradient3058-5"
+       xlink:href="#linearGradient1201"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient3702-501-757-795"
-       id="linearGradient2877-634-617-908"
-       y2="39.999443"
-       x2="25.058096"
+       gradientTransform="matrix(2.0810811,0,0,2.0810811,-1.945972,0.05407603)" />
+    <linearGradient
+       xlink:href="#linearGradient3702-501-757"
+       id="linearGradient1191"
+       gradientUnits="userSpaceOnUse"
+       x1="25.058096"
        y1="47.027729"
-       x1="25.058096" />
+       x2="25.058096"
+       y2="39.999443"
+       gradientTransform="matrix(2.2857142,0,0,1.2857142,-6.857138,32.071432)" />
     <linearGradient
-       id="linearGradient3702-501-757-795">
+       id="linearGradient3600-9-51">
       <stop
          offset="0"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3100" />
-      <stop
-         offset="0.5"
-         style="stop-color:#181818;stop-opacity:1"
-         id="stop3102" />
+         style="stop-color:#d4d4d4;stop-opacity:1"
+         id="stop3602-0-0" />
       <stop
          offset="1"
-         style="stop-color:#181818;stop-opacity:0"
-         id="stop3104" />
+         style="stop-color:#abacae;stop-opacity:1"
+         id="stop3604-9-04" />
     </linearGradient>
     <linearGradient
-       xlink:href="#linearGradient4213"
-       id="linearGradient4150"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3166735,0,0,-2.3190404,-2.7836844,65.366794)"
-       x1="38.856056"
-       y1="14.906816"
-       x2="38.856056"
-       y2="49.200115" />
-    <linearGradient
-       xlink:href="#linearGradient4213"
-       id="linearGradient4215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.5390978,0,0,-1.5406701,14.546609,67.456039)"
-       x1="38.856056"
-       y1="14.906816"
-       x2="38.856056"
-       y2="49.200115" />
-    <linearGradient
-       xlink:href="#linearGradient4213"
-       id="linearGradient4227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.544449,0,0,-1.5460269,31.54421,50.097783)"
-       x1="38.856056"
-       y1="14.906816"
-       x2="38.856056"
-       y2="49.200115" />
-    <linearGradient
-       xlink:href="#linearGradient4213"
-       id="linearGradient4239"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.544449,0,0,-1.5460269,48.94421,67.497783)"
-       x1="38.856056"
-       y1="14.906816"
-       x2="38.856056"
-       y2="49.200115" />
-    <linearGradient
-       id="linearGradient4270">
+       id="linearGradient3104-6">
       <stop
          offset="0"
-         style="stop-color:#ffffff;stop-opacity:1"
-         id="stop4272" />
-      <stop
-         offset="0.0348749"
-         style="stop-color:#ffffff;stop-opacity:0.23529412"
-         id="stop4274" />
-      <stop
-         offset="0.96216321"
-         style="stop-color:#ffffff;stop-opacity:0.15686275"
-         id="stop4276" />
+         style="stop-color:#000000;stop-opacity:0.31782946"
+         id="stop3106-3" />
       <stop
          offset="1"
-         style="stop-color:#ffffff;stop-opacity:0.39215687"
-         id="stop4278" />
+         style="stop-color:#000000;stop-opacity:0.24031007"
+         id="stop3108-9" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3104-6"
+       id="linearGradient3170"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.6356971,0,0,1.8123739,21.333135,-0.90870646)"
+       x1="-51.786404"
+       y1="50.786446"
+       x2="-51.786404"
+       y2="2.9062471" />
+    <linearGradient
+       xlink:href="#linearGradient3600-9-51"
+       id="linearGradient1512"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.0195442,0,0,1.9424009,-101.45372,1.1201486)"
+       x1="74.838791"
+       y1="4.8311114"
+       x2="74.838791"
+       y2="45.500134" />
+    <linearGradient
+       id="linearGradient8662-7">
+      <stop
+         id="stop8664-0"
+         style="stop-color:#000000;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop8666-1"
+         style="stop-color:#000000;stop-opacity:0"
+         offset="1" />
     </linearGradient>
     <radialGradient
-       xlink:href="#linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5"
-       id="radialGradient4147"
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3013-6-5-76"
+       xlink:href="#linearGradient3688-166-749"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,19.858403,-24.379774,0,189.39775,-170.34018)"
-       cx="6.7495289"
-       cy="5.7998009"
-       fx="6.2192988"
-       fy="5.7998009"
-       r="12.671875" />
+       gradientTransform="matrix(4.007568,0,0,1.7999999,59.97626,9.700006)" />
+    <radialGradient
+       cx="4.9929786"
+       cy="43.5"
+       r="2.5"
+       fx="4.9929786"
+       fy="43.5"
+       id="radialGradient3015-1-6-9"
+       xlink:href="#linearGradient3688-166-749"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(4.007568,0,0,1.7999999,-36.02374,-166.3)" />
     <linearGradient
-       id="linearGradient2867-449-88-871-390-598-476-591-434-148-57-177-8-3-3-6-4-8-8-8-5">
-      <stop
-         offset="0"
-         style="stop-color:#919caf;stop-opacity:1;"
-         id="stop3750-1-0-7-6-6-1-3-9-3" />
-      <stop
-         offset="0.26238"
-         style="stop-color:#68758e;stop-opacity:1;"
-         id="stop3752-3-7-4-0-32-8-923-0-7" />
-      <stop
-         offset="0.704952"
-         style="stop-color:#485a6c;stop-opacity:1;"
-         id="stop3754-1-8-5-2-7-6-7-1-9" />
-      <stop
-         offset="1"
-         style="stop-color:#444c5c;stop-opacity:1;"
-         id="stop3756-1-6-2-6-6-1-96-6-0" />
-    </linearGradient>
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662-7"
+       id="linearGradient6356"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7801307,0,0,1.8182852,-0.27936662,6.6721965)"
+       x1="8.81355"
+       y1="25.188654"
+       x2="-0.37887391"
+       y2="34.188187" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662-7"
+       id="linearGradient6873"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7801307,0,0,1.8182852,-19.685521,6.6721975)"
+       x1="8.81355"
+       y1="25.188654"
+       x2="-0.37887391"
+       y2="34.188187" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662-7"
+       id="linearGradient6877"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7801307,0,0,1.8182852,-0.27936731,26.078344)"
+       x1="8.81355"
+       y1="25.188654"
+       x2="-0.37887391"
+       y2="34.188187" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient8662-7"
+       id="linearGradient6881"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.7801307,0,0,1.8182852,-19.685521,26.078351)"
+       x1="8.81355"
+       y1="25.188654"
+       x2="-0.37887391"
+       y2="34.188187" />
   </defs>
   <metadata
-     id="metadata4300">
+     id="metadata6654">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <g
-     id="layer1"
-     transform="translate(0,32)">
-    <g
-       transform="matrix(2.2636491,0,0,0.83838728,-6.3276009,21.868822)"
-       id="g2036"
-       style="display:inline">
-      <g
-         transform="matrix(1.052632,0,0,1.285713,-1.263158,-13.42854)"
-         id="g3712"
-         style="opacity:0.4">
-        <rect
-           width="5"
-           height="7"
-           x="38"
-           y="40"
-           id="rect2801"
-           style="fill:url(#radialGradient2873-966-168-714);fill-opacity:1;stroke:none" />
-        <rect
-           width="5"
-           height="7"
-           x="-10"
-           y="-47"
-           transform="scale(-1,-1)"
-           id="rect3696"
-           style="fill:url(#radialGradient2875-742-326-419);fill-opacity:1;stroke:none" />
-        <rect
-           width="28"
-           height="7.0000005"
-           x="10"
-           y="40"
-           id="rect3700"
-           style="fill:url(#linearGradient2877-634-617-908);fill-opacity:1;stroke:none" />
-      </g>
-    </g>
-    <rect
-       width="83.000351"
-       height="83.000252"
-       rx="4.5272923"
-       ry="4.5272865"
-       x="6.499743"
-       y="-25.5"
-       id="rect5505-21"
-       style="color:#000000;fill:url(#radialGradient3164-608);fill-opacity:1.0;fill-rule:nonzero;stroke:url(#linearGradient3166-272);stroke-width:0.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-    <rect
-       width="81"
-       height="81"
-       rx="3.0566034"
-       ry="3.0484085"
-       x="7.5"
-       y="-24.5"
-       id="rect6741"
-       style="opacity:0.5;fill:none;stroke:url(#linearGradient3107-996);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
-    <g
-       id="g4256"
-       transform="translate(1,0)">
-      <path
-         d="M 46.550006,20.790505 60.670698,35.045253 46.550008,49.3 32.429313,35.045254 Z M 29.170691,3.246202 43.291383,17.500951 29.170689,31.755701 15.05,17.500952 Z M 63.929315,3.844303 78.049999,17.800006 63.929315,31.755709 49.808621,17.800013 Z M 46.550004,-13.7 60.670687,0.255703 46.550004,14.211408 32.429311,0.255709 Z"
-         style="opacity:0.1;color:#000000;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4120-5-3" />
-      <path
-         d="M 46.500006,19.490502 60.620698,33.745249 46.500006,48 32.379317,33.745252 Z M 29.120691,1.946197 43.241383,16.200948 29.120691,30.455695 15,16.200948 Z M 63.847174,2.1586045 78.03214,16.242872 63.975738,30.519988 49.790763,16.242878 Z M 46.545459,-15.318187 60.643417,-1.2033935 46.545459,13.047766 32.424766,-1.1579315 Z"
-         style="color:#000000;fill:#455365;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.70000005;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         id="rect4120-5" />
-      <path
-         id="rect4120-5-5-9"
-         d="M 46.5,20.303001 59.899999,33.7 46.567392,47.297059 33.1,33.7 Z"
-         style="opacity:0.1;color:#000000;fill:none;stroke:url(#linearGradient4150);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
-      <path
-         style="opacity:0.1;color:#000000;fill:none;stroke:url(#linearGradient4215);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 29.105456,2.7936124 42.505455,16.190614 29.172848,29.787673 15.705456,16.190614 Z"
-         id="rect4120-5-5-9-1" />
-      <path
-         style="opacity:0.1;color:#000000;fill:none;stroke:url(#linearGradient4227);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 46.505456,-14.606385 59.905455,-1.209388 46.572848,12.387673 33.105456,-1.209388 Z"
-         id="rect4120-5-5-9-19" />
-      <path
-         style="opacity:0.1;color:#000000;fill:none;stroke:url(#linearGradient4239);stroke-width:0.99999988;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-         d="M 63.905456,2.7936118 77.305455,16.190614 63.972848,29.787673 50.505456,16.190614 Z"
-         id="rect4120-5-5-9-4" />
-    </g>
-  </g>
+  <rect
+     style="opacity:0.4;fill:url(#radialGradient3013-6-5-76);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect2801-3-7-7-2"
+     y="83.5"
+     x="80"
+     height="8.999999"
+     width="10" />
+  <rect
+     style="opacity:0.4;fill:url(#radialGradient3015-1-6-9);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect3696-6-3-5-0"
+     transform="scale(-1)"
+     y="-92.5"
+     x="-16"
+     height="8.999999"
+     width="10" />
+  <rect
+     style="opacity:0.4;fill:url(#linearGradient1191);fill-opacity:1;stroke:none;stroke-width:0.862764"
+     id="rect3700-4-6-9-6"
+     y="83.5"
+     x="16"
+     height="9"
+     width="64" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1512);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-7-2-9"
+     y="10.5"
+     x="8.5"
+     ry="8"
+     rx="8"
+     height="79"
+     width="79" />
+  <path
+     id="rect6810"
+     style="opacity:0.3;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.999993;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     d="M 48,26.5 35.722656,38.777343 48,51.054687 60.277344,38.777343 Z M 34.277344,40.222656 22,52.499999 34.277344,64.777343 46.554688,52.5 Z m 27.445312,0 L 49.445312,52.499999 61.722656,64.777343 74,52.499999 Z M 48,53.945312 35.722656,66.222655 48,78.499999 60.277343,66.222655 Z" />
+  <rect
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     id="rect5505-21-1-2-8"
+     y="10.50003"
+     x="8.5000696"
+     ry="8"
+     rx="8"
+     height="78.999924"
+     width="78.999924" />
+  <rect
+     style="fill:none;stroke:url(#linearGradient3058-5);stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;opacity:0.3"
+     id="rect6741-2-8-4"
+     y="11.499999"
+     x="9.499999"
+     ry="7"
+     rx="7"
+     height="77"
+     width="77" />
+  <rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.80000001;fill-rule:evenodd;stroke:none;stroke-width:0.999993;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect6226"
+     width="17.3634"
+     height="17.3634"
+     x="-20.85965"
+     y="51.972351"
+     transform="rotate(-45)" />
+  <rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.80000001;fill-rule:evenodd;stroke:none;stroke-width:0.999993;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect6600"
+     width="17.3634"
+     height="17.3634"
+     x="-1.453495"
+     y="51.972351"
+     transform="rotate(-45)" />
+  <rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.80000001;fill-rule:evenodd;stroke:none;stroke-width:0.999993;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect6602"
+     width="17.3634"
+     height="17.3634"
+     x="-20.85965"
+     y="71.378494"
+     transform="rotate(-45)" />
+  <rect
+     style="opacity:1;fill:#0e141f;fill-opacity:0.80000001;fill-rule:evenodd;stroke:none;stroke-width:0.999993;stroke-linejoin:round;paint-order:markers fill stroke;stop-color:#000000"
+     id="rect6604"
+     width="17.3634"
+     height="17.3634"
+     x="-1.453495"
+     y="71.378494"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6356);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect6242"
+     width="16.363716"
+     height="16.363716"
+     x="-0.95381171"
+     y="52.472351"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6873);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect6871"
+     width="16.363716"
+     height="16.363716"
+     x="-20.359966"
+     y="52.472351"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6877);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect6875"
+     width="16.363716"
+     height="16.363716"
+     x="-0.95381171"
+     y="71.878494"
+     transform="rotate(-45)" />
+  <rect
+     style="font-variation-settings:normal;opacity:0.1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient6881);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;paint-order:markers fill stroke;stop-color:#000000;stop-opacity:1"
+     id="rect6879"
+     width="16.363716"
+     height="16.363716"
+     x="-20.359966"
+     y="71.878494"
+     transform="rotate(-45)" />
 </svg>


### PR DESCRIPTION
Updates the `exe` icon to look more rounded like other executables. Colors depart from upstream slightly as the darker upstream color with darker emblem is somewhat difficult to see. This one uses a stronger contrast between the two.

Add a `portable-executable` symlink as some `exe` files were not using the correct icon. Now all files with the `exe` extension will get the same icon.

This has the unfortunate side effect that `dll` files will also use this icon, but that's an issue with the FreeDesktop.org shared-mime-info database. Until they're given unique entries in the database (if possible), they'll have to share an icon.