### PR TITLE
MimeTypes: Add text to 32px archive icons

### DIFF
--- a/elementary-xfce/mimetypes/32/application-gzip.svg
+++ b/elementary-xfce/mimetypes/32/application-gzip.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-gzip.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview3381"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="74.953319"
+     inkscape:cx="10.613273"
+     inkscape:cy="26.136268"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="6"
+     inkscape:window-y="413"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     d="m 14.50412,18.352374 c -0.003,0.513942 0.117021,1.189699 -0.411938,0.400875 -1.628193,-1.253571 -4.3016209,-0.305806 -4.8456559,1.666025 -0.659185,1.848746 0.330662,4.308171 2.3889839,4.669669 1.042827,0.237804 2.216921,-0.0832 2.868608,-0.96457 0.169849,1.428755 -1.238328,2.555123 -2.59132,2.036038 -0.634102,-0.357712 -1.131566,-0.786701 -1.909789,-0.620038 -0.6271909,-0.06916 -1.1888549,-0.02657 -0.4626049,0.689528 1.3917789,1.957394 5.0105259,1.964288 6.1181519,-0.290715 0.591171,-1.493473 0.298261,-3.134065 0.369562,-4.701095 0,-0.961906 0,-1.923811 0,-2.885717 -0.507999,0 -1.015999,0 -1.523998,0 z m -1.992001,1.307999 c 1.457805,-0.09191 2.302931,1.617593 1.784062,2.857499 -0.50064,1.638565 -3.249057,1.530402 -3.556995,-0.183606 -0.348044,-1.205308 0.365878,-2.744812 1.772933,-2.673893 z m 4.345875,5.34 c 1.688,0 3.376,0 5.063999,0 0,-0.476 0,-0.952001 0,-1.428001 -1.051999,0 -2.103998,0 -3.155998,0 0.975999,-1.264 1.951998,-2.528 2.927998,-3.792 0,-0.475999 0,-0.951999 0,-1.427998 -1.5,0 -3,0 -4.5,0 0,0.475999 0,0.951999 0,1.427998 0.863999,0 1.727999,0 2.591999,0 -0.975999,1.264 -1.951999,2.528 -2.927998,3.792 0,0.476 0,0.952001 0,1.428001 z"
+     id="text3329"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-java-archive.svg
+++ b/elementary-xfce/mimetypes/32/application-java-archive.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-java-archive.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview5302"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13.25"
+     inkscape:cx="7.6603774"
+     inkscape:cy="8.6792453"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="496"
+     inkscape:window-y="349"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     d="m 9.5378819,19.495001 c -0.0059,2.204164 0.01205,4.408725 -0.0095,6.612628 0.184595,0.688873 -0.812482,0.483109 -0.650508,1.047914 0,0.402486 0,0.804972 0,1.207458 1.088793,0.05202 2.1135941,-0.807571 2.2034071,-1.905052 0.09432,-2.318041 0.05259,-4.642358 0.05259,-6.962948 -0.531999,0 -1.063999,0 -1.5959991,0 z m 0,-0.720001 c 0.5320001,0 1.0640001,0 1.5959991,0 0,-0.5 0,-1 0,-1.5 -0.531999,0 -1.063999,0 -1.5959991,0 0,0.5 0,1 0,1.5 z m 9.6331871,0.720001 c -0.488,0 -0.976,0 -1.463999,0 0,0.296 0,0.592 0,0.888 -0.586313,-0.873692 -1.71207,-1.177234 -2.710233,-1.005845 -1.43786,0.165821 -2.615857,1.39817 -2.79608,2.821426 -0.264329,1.466639 0.401434,3.141916 1.805429,3.775873 1.156261,0.543738 2.707707,0.450044 3.58156,-0.565348 0.22237,-0.297462 0.07853,0.344186 0.119324,0.513141 -0.103716,0.341265 0.286049,0.189049 0.491896,0.220752 0.324034,0 0.648068,0 0.972103,0 0,-2.216 0,-4.432 0,-6.647999 z m -3.467999,1.307998 c 1.020032,-0.04883 1.911868,0.83476 1.946557,1.84109 0.104806,0.944516 -0.477117,2.01841 -1.483058,2.151161 -0.955762,0.215892 -2.084431,-0.305936 -2.325629,-1.303504 -0.314659,-1.044195 0.225573,-2.375825 1.35415,-2.627433 0.165862,-0.04175 0.33703,-0.06135 0.50798,-0.06131 z M 20.360945,26.143 c 0.532,0 1.063999,0 1.595999,0 0.0128,-1.352723 -0.02676,-2.707612 0.02199,-4.058859 0.0257,-0.727717 0.701391,-1.253367 1.406016,-1.209141 0,-0.512001 0,-1.024001 0,-1.536001 -0.632967,-0.0731 -1.252543,0.243878 -1.56,0.804001 -0.02792,-0.200696 0.05421,-0.511432 -0.03784,-0.647999 -0.475387,0 -0.950774,0 -1.426161,0 0,2.215999 0,4.431999 0,6.647999 z"
+     id="text2427"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:125%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Book';text-align:start;writing-mode:lr-tb;text-anchor:start;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-vnd.ms-cab-compressed.svg
+++ b/elementary-xfce/mimetypes/32/application-vnd.ms-cab-compressed.svg
@@ -1,1 +1,333 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-vnd.ms-cab-compressed.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview5770"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="15.502982"
+     inkscape:cy="32.553595"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="304"
+     inkscape:window-y="83"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="matrix(0.90694722,0,0,0.90694722,-5.841103,-11.644274)"
+     id="text2867"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.1026">
+    <path
+       d="m 17.5567,38.697957 c -0.395999,0.611998 -0.852,0.875999 -1.512,0.875999 -1.103999,0 -1.932,-0.864001 -1.932,-2.028 0,-1.163999 0.792001,-2.004 1.896,-2.004 0.72,0 1.224001,0.3 1.548,0.912 h 1.8 c -0.227999,-0.672 -0.444,-1.020001 -0.9,-1.439999 -0.647999,-0.600001 -1.524001,-0.936001 -2.448,-0.936001 -1.967998,0 -3.504,1.524002 -3.504,3.48 0,1.931998 1.584002,3.48 3.552,3.48 1.547999,0 2.748001,-0.852002 3.3,-2.339999 h -1.8"
+       id="path3652"
+       style="stroke-width:1.1026" />
+    <path
+       d="m 27.0635,34.133956 h -1.464 v 0.888 c -0.551999,-0.732 -1.212001,-1.044 -2.172,-1.044 -1.967998,0 -3.384,1.476002 -3.384,3.504 0,2.003998 1.404002,3.456 3.348,3.456 0.935999,0 1.572001,-0.300001 2.208,-1.02 v 0.864 h 1.464 v -6.648 m -3.468,1.308 c 1.139999,0 1.956,0.852001 1.956,2.064 0,0.479999 -0.192,1.032 -0.48,1.368 -0.323999,0.383999 -0.84,0.6 -1.452,0.6 -1.163999,0 -1.968,-0.792001 -1.968,-1.956 0,-1.211999 0.804001,-2.076 1.944,-2.076"
+       id="path3654"
+       style="stroke-width:1.1026" />
+    <path
+       d="m 28.4924,40.781956 h 1.464 v -0.852 c 0.684,0.731999 1.320001,1.008 2.304,1.008 1.031999,0 1.848001,-0.384001 2.46,-1.164 0.504,-0.648 0.78,-1.476001 0.78,-2.364 0,-2.003998 -1.440002,-3.516 -3.348,-3.516 -0.863999,0 -1.452,0.24 -2.064,0.852 v -2.832 h -1.596 v 8.868 m 3.432,-5.424 c 1.139999,0 1.968,0.876001 1.968,2.064 0,1.211999 -0.792001,2.052 -1.932,2.052 -1.151999,0 -1.968,-0.852001 -1.968,-2.064 0,-1.199999 0.816001,-2.052 1.932,-2.052"
+       id="path3656"
+       style="stroke-width:1.1026" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-vnd.rar.svg
+++ b/elementary-xfce/mimetypes/32/application-vnd.rar.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-vnd.rar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview7015"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="37.476659"
+     inkscape:cx="15.72979"
+     inkscape:cy="25.242378"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="540"
+     inkscape:window-y="159"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 8.5000129,25.739362 c 0.5395704,0 1.079141,0 1.6187111,0 0.01296,-1.371974 -0.02712,-2.746144 0.02229,-4.116618 0.02607,-0.738074 0.711372,-1.271204 1.426024,-1.226348 0,-0.519288 0,-1.038573 0,-1.557858 -0.64196,-0.0741 -1.270377,0.247322 -1.5821988,0.815441 -0.0455,-0.199411 0.0949,-0.584725 -0.07752,-0.65722 -0.4691067,0 -0.9382135,0 -1.4073203,0 0,2.247532 0,4.495068 0,6.742603 z M 19.226256,18.996759 c -0.494943,0 -0.989886,0 -1.484832,0 0,0.300212 0,0.600424 0,0.900638 -0.612444,-0.913484 -1.801112,-1.205944 -2.836607,-1.006359 -1.455851,0.205292 -2.611685,1.491939 -2.76131,2.938407 -0.23093,1.463586 0.451056,3.109554 1.84437,3.738973 1.172683,0.551718 2.746336,0.455193 3.632526,-0.573393 0.226142,-0.301121 0.07926,0.354395 0.121021,0.526896 -0.10461,0.345026 0.299732,0.181141 0.503829,0.217441 0.327002,0 0.654004,0 0.981003,0 0,-2.247535 0,-4.495071 0,-6.742603 z m -3.51735,1.326611 c 1.034547,-0.04953 1.939077,0.846641 1.974258,1.867289 0.10629,0.957957 -0.483906,2.047134 -1.504161,2.181772 -0.969363,0.218971 -2.114092,-0.310289 -2.358725,-1.322051 -0.319136,-1.059054 0.228781,-2.409635 1.37342,-2.664823 0.168211,-0.04236 0.341828,-0.06222 0.515208,-0.06219 z m 4.724158,5.415992 c 0.539571,0 1.079143,0 1.618711,0 0.0129,-1.371974 -0.027,-2.746144 0.0222,-4.116618 0.0261,-0.738074 0.711373,-1.271204 1.426026,-1.226348 0,-0.519288 0,-1.038573 -3e-6,-1.557858 -0.641959,-0.0741 -1.270376,0.247322 -1.582198,0.815441 -0.04551,-0.199411 0.09489,-0.584725 -0.07752,-0.65722 -0.469107,0 -0.938214,0 -1.407321,0 0,2.247532 0,4.495068 0,6.742603 z"
+     id="text3329" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-7z-compressed.svg
+++ b/elementary-xfce/mimetypes/32/application-x-7z-compressed.svg
@@ -1,1 +1,321 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-7z-compressed.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9195"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="18.396226"
+     inkscape:cy="22.886792"
+     inkscape:window-width="1423"
+     inkscape:window-height="642"
+     inkscape:window-x="463"
+     inkscape:window-y="358"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     d="M 6.1718934,25.449253 H 7.8919728 L 10.988113,18.408399 V 16.975 H 5.9998865 v 1.433399 h 3.3828209 z m 5.2399806,0 h 4.839152 v -1.364598 h -3.015869 l 2.797992,-3.623631 V 19.09643 h -4.300197 v 1.364594 h 2.476913 l -2.797992,3.623631 z m 5.67554,0 h 1.525135 V 19.09643 h -1.525135 z m 0,-7.040854 h 1.525135 V 16.975 h -1.525135 z m 2.754813,9.162285 h 1.525137 v -2.717726 c 1.435979,1.394764 4.117734,0.732503 4.826329,-1.11772 0.758981,-1.660005 0.0813,-3.986818 -1.742459,-4.597698 -1.080492,-0.388081 -2.440473,-0.204203 -3.210009,0.704257 -0.07854,-0.239312 0.192228,-0.827931 -0.208188,-0.745367 h -1.19081 z m 3.291082,-7.224332 c 1.412796,-0.05419 2.262806,1.688286 1.608974,2.859754 -0.545626,1.247756 -2.478293,1.317031 -3.155833,0.15726 -0.808384,-1.205901 0.01397,-3.068686 1.546861,-3.017013 z"
+     id="text3329"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccsccss" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-ace.svg
+++ b/elementary-xfce/mimetypes/32/application-x-ace.svg
@@ -1,1 +1,333 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-ace.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview9996"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="10.539894"
+     inkscape:cy="18.144627"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="789"
+     inkscape:window-y="502"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="matrix(1.0178065,0,0,1.097179,-8.1060373,-18.837315)"
+     id="text51"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:11px;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none">
+    <path
+       d="m 19.803,34.629 h -1.342 v 0.814 c -0.505999,-0.671 -1.111001,-0.957 -1.991,-0.957 -1.803998,0 -3.102,1.353001 -3.102,3.212 0,1.836998 1.287002,3.168 3.069,3.168 0.857999,0 1.441001,-0.275001 2.024,-0.935 v 0.792 h 1.342 v -6.094 m -3.179,1.199 c 1.044999,0 1.793,0.781001 1.793,1.892 0,0.439999 -0.176,0.946 -0.44,1.254 -0.297,0.351999 -0.77,0.55 -1.331,0.55 -1.066999,0 -1.804,-0.726001 -1.804,-1.793 0,-1.110999 0.737001,-1.903 1.782,-1.903"
+       id="path3686"
+       style="font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';fill:#000000" />
+    <path
+       d="m 25.260719,38.721 c -0.363,0.560999 -0.781001,0.803 -1.386,0.803 -1.011999,0 -1.771,-0.792001 -1.771,-1.859 0,-1.066999 0.726001,-1.837 1.738,-1.837 0.659999,0 1.122,0.275 1.419,0.836 h 1.65 c -0.209,-0.616 -0.407001,-0.935001 -0.825,-1.32 -0.594,-0.55 -1.397001,-0.858 -2.244,-0.858 -1.803998,0 -3.212,1.397001 -3.212,3.19 0,1.770998 1.452002,3.19 3.256,3.19 1.418998,0 2.519,-0.781002 3.025,-2.145 h -1.65"
+       id="path3688"
+       style="font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';fill:#000000" />
+    <path
+       d="m 33.979594,38.325 c 0.044,-0.209 0.055,-0.341001 0.055,-0.561 0,-1.891999 -1.331002,-3.278 -3.146,-3.278 -1.792998,0 -3.212,1.419001 -3.212,3.212 0,1.781998 1.441002,3.168 3.3,3.168 1.000999,0 1.782,-0.363001 2.42,-1.1 0.231,-0.286 0.385,-0.539001 0.484,-0.847 h -1.595 c -0.374,0.439999 -0.737001,0.605 -1.342,0.605 -0.868999,0 -1.507,-0.462001 -1.683,-1.199 h 4.719 m -4.763,-1.287 c 0.231,-0.781 0.825001,-1.21 1.694,-1.21 0.901999,0 1.496,0.429 1.683,1.21 h -3.377"
+       id="path3690"
+       style="font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';fill:#000000" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-archive.svg
+++ b/elementary-xfce/mimetypes/32/application-x-archive.svg
@@ -1,1 +1,321 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-archive.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10303"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="11.415094"
+     inkscape:cy="16"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="131"
+     inkscape:window-y="446"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     d="m 17.027216,19.4954 h -1.463999 v 0.888 c -0.586313,-0.873692 -1.71207,-1.177234 -2.710233,-1.005845 -1.43786,0.165821 -2.615856,1.39817 -2.79608,2.821426 -0.2643291,1.466639 0.401434,3.141916 1.805429,3.775873 1.156262,0.543738 2.707707,0.450044 3.58156,-0.565348 0.22237,-0.297462 0.07853,0.344186 0.119324,0.513141 -0.103716,0.341265 0.286049,0.189049 0.491896,0.220752 h 0.972103 z m -3.467998,1.308001 c 1.020032,-0.04883 1.911867,0.834757 1.946556,1.841087 0.104806,0.944516 -0.477117,2.01841 -1.483058,2.151161 -0.955762,0.215892 -2.08443,-0.305936 -2.325629,-1.303504 -0.314658,-1.044195 0.225574,-2.375825 1.354151,-2.627433 0.165862,-0.04175 0.337029,-0.06135 0.50798,-0.06131 z m 5.486035,5.339998 h 1.595995 c 0.0128,-1.352723 -0.02676,-2.707612 0.02199,-4.058859 0.0257,-0.727717 0.701391,-1.253367 1.406016,-1.209141 v -1.536001 c -0.632967,-0.0731 -1.252543,0.243878 -1.56,0.804001 -0.02792,-0.200696 0.05421,-0.511432 -0.03784,-0.647999 h -1.426161 z"
+     id="text2427"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:125%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Book';text-align:start;writing-mode:lr-tb;text-anchor:start;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none"
+     sodipodi:nodetypes="cccccccccccsccccssccccccccc" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-arj.svg
+++ b/elementary-xfce/mimetypes/32/application-x-arj.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-arj.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview10950"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="11.713958"
+     inkscape:cy="31.166065"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="680"
+     inkscape:window-y="151"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     d="m 21.015137,18.495001 c -0.0059,2.204164 0.01206,4.408725 -0.0095,6.612628 0.184595,0.688873 -0.812482,0.483109 -0.650508,1.047914 0,0.402486 0,0.804972 0,1.207458 1.088793,0.05202 2.113594,-0.807571 2.203407,-1.905052 0.09432,-2.318041 0.05259,-4.642358 0.05259,-6.962948 -0.531999,0 -1.063999,0 -1.595999,0 z m 10e-6,-0.720001 c 0.532,0 1.064,0 1.595999,0 0,-0.5 0,-1 0,-1.5 -0.531999,0 -1.063999,0 -1.595999,0 0,0.5 0,1 0,1.5 z m -6.987931,0.720001 c -0.488,0 -0.976,0 -1.463999,0 0,0.296 0,0.592 0,0.888 -0.586313,-0.873692 -1.71207,-1.177234 -2.7102334,-1.005845 -1.4378596,0.165821 -2.6158566,1.39817 -2.7960796,2.821426 -0.264329,1.466639 0.401434,3.141916 1.805429,3.775873 1.156261,0.543738 2.707707,0.450044 3.58156,-0.565348 0.22237,-0.297462 0.07853,0.344186 0.119324,0.513141 -0.103716,0.341265 0.286049,0.189049 0.491896,0.220752 0.324034,0 0.648068,0 0.972103,0 0,-2.216 0,-4.432 0,-6.647999 z m -3.467999,1.308001 c 1.020032,-0.04883 1.911868,0.834757 1.946557,1.841087 0.104806,0.944516 -0.477117,2.01841 -1.483058,2.151161 -0.955762,0.215892 -2.084431,-0.305936 -2.325629,-1.303504 -0.314659,-1.044195 0.225573,-2.375825 1.35415,-2.627433 0.165862,-0.04175 0.33703,-0.06135 0.50798,-0.06131 z M 16.045253,25.143 c 0.532,0 1.063995,0 1.595995,0 0.0128,-1.352723 -0.02676,-2.707612 0.02199,-4.058859 0.0257,-0.727717 0.701391,-1.253367 1.406016,-1.209141 0,-0.512001 0,-1.024001 0,-1.536001 -0.632967,-0.0731 -1.252543,0.243878 -1.56,0.804001 -0.02792,-0.200696 0.05421,-0.511432 -0.03784,-0.647999 -0.475387,0 -0.950774,0 -1.426161,0 0,2.215999 0,4.431999 0,6.647999 z"
+     id="text2427"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:125%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Book';text-align:start;writing-mode:lr-tb;text-anchor:start;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-bzip2-compressed-tar.svg
+++ b/elementary-xfce/mimetypes/32/application-x-bzip2-compressed-tar.svg
@@ -1,1 +1,331 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-bzip2-compressed-tar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview11707"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="12.886792"
+     inkscape:cy="19.924528"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="957"
+     inkscape:window-y="7"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 11,25.999994 h 1.22867 c 0,-0.939785 0.480457,0 1.648351,0 2.180691,0 3.390923,-2.070707 2.919078,-3.831876 -0.31238,-2.037612 -3.067017,-3.113152 -4.456647,-1.543475 V 18.147458 H 11 Z m 2.880326,-4.840036 c 1.561375,-0.08789 2.216176,2.233192 1.087037,3.212684 -0.95989,0.900809 -2.701475,0.151763 -2.700552,-1.222791 -0.133712,-0.997259 0.604435,-2.037262 1.613515,-1.989893 z m 3.425736,4.840036 h 4.246666 V 24.655307 H 18.90736 l 2.150161,-2.784341 V 20.08931 h -3.466448 v 1.249088 h 2.172328 l -2.457339,3.316909 z m 4.83348,-0.09559 h 4.813969 c -0.04965,-0.410466 0.09819,-1.026769 -0.07156,-1.312067 h -2.859123 c 0.98979,-1.0495 2.337024,-1.852043 2.848855,-3.285422 0.563747,-1.621827 -0.81506,-3.499925 -2.47647,-3.290909 -1.375905,0.02134 -2.449704,1.40371 -2.306029,2.808069 l 1.319309,1e-6 c -0.326403,-1.802687 2.524595,-2.038693 2.223779,-0.128031 -0.302008,1.163978 -1.39643,1.80179 -2.14309,2.648481 -0.432822,0.476437 -1.00334,0.89112 -1.349643,1.406362 z"
+     id="text3329"
+     sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccc" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 9,26 h 1 V 25 H 9 Z"
+     id="text3329-7"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 6.2504081,26 H 7.7502222 V 21.5 H 8.8057778 V 20 H 7.7502222 V 18 H 6.2504081 l -3.718e-4,2 H 5.2502222 v 1.5 h 1.0001859 z"
+     id="text3329-6"
+     sodipodi:nodetypes="ccccccccccccc" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-bzip2.svg
+++ b/elementary-xfce/mimetypes/32/application-x-bzip2.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-bzip2.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview11409"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="11.415094"
+     inkscape:cy="25.056604"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="80"
+     inkscape:window-y="338"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     id="text3329"
+     d="m 7,26.014011 h 1.456652 v -0.564039 c 0.482814,0.322085 1.5370862,0.765336 2.2926,0.719468 2.233395,0.121244 3.681886,-2.401906 3.122488,-4.405227 C 13.501398,19.44644 10.235632,18.223019 8.588153,20.008517 V 17.190731 H 7 Z m 3.414939,-5.396568 c 1.851092,-0.09998 2.627393,2.540247 1.28874,3.654413 -1.138,1.024665 -3.202741,0.17263 -3.201646,-1.390919 -0.158523,-1.134376 0.71659,-2.317375 1.912906,-2.263494 z m 4.061389,5.396778 h 5.038544 v -1.420835 h -3.140121 l 2.913266,-3.772968 v -1.42083 h -4.477415 v 1.42083 h 2.57903 l -2.913304,3.772968 z m 5.730343,0 h 5.707212 c -0.05886,-0.466905 0.116409,-1.167946 -0.08483,-1.492472 H 22.43941 c 1.173447,-1.1938 2.770663,-2.106688 3.377465,-3.73715 0.668353,-1.84482 -0.966296,-3.981147 -2.935983,-3.743392 -1.631207,0.02427 -2.904253,1.596713 -2.733918,3.194164 l 1.56411,1e-6 c -0.386969,-2.050547 2.993039,-2.319002 2.636405,-0.145634 -0.358046,1.324018 -1.65554,2.049526 -2.540744,3.012632 -0.513134,0.541946 -1.189512,1.013646 -1.600073,1.599732 z"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.994981" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-compressed-tar.svg
+++ b/elementary-xfce/mimetypes/32/application-x-compressed-tar.svg
@@ -1,1 +1,322 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-compressed-tar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview12175"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="37.476659"
+     inkscape:cx="16.663705"
+     inkscape:cy="26.709958"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="493"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860"
+     showguides="true" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="M 7.2002091,25 H 8.75 V 20.5 H 10 v -2 H 8.75 V 16 H 7.2002091 l -4.183e-4,2.5 H 5.75 v 2 H 7.2002091 Z M 10.75,25 h 1.75 v -1.5 h -1.75 z m 7.419798,-6.948285 c -0.003,0.513942 0.117021,1.189699 -0.411938,0.400875 -1.628192,-1.253571 -4.301621,-0.305806 -4.845656,1.666025 -0.659185,1.848746 0.330663,4.308171 2.388985,4.669669 1.042826,0.237804 2.21692,-0.0832 2.868607,-0.96457 0.169849,1.428755 -1.238328,2.755626 -2.591319,2.236541 -1.173613,-0.526076 -2.666273,-0.65658 -2.372394,0.06949 1.391779,1.957394 5.010525,1.864071 6.118152,-0.390932 0.591171,-1.493473 0.298261,-3.234351 0.369561,-4.801381 v -2.885717 z m -1.992,1.307999 c 1.457803,-0.09191 2.302929,1.617593 1.784061,2.857499 -0.50064,1.638565 -3.249057,1.530402 -3.556995,-0.183606 -0.348043,-1.205307 0.365879,-2.744811 1.772934,-2.673893 z M 20.774,24.8 h 5.063999 v -1.428001 h -3.155998 l 2.927998,-3.792 v -1.427998 h -4.5 v 1.427998 h 2.591999 l -2.927998,3.792 z"
+     id="text3329"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccccc" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-cpio.svg
+++ b/elementary-xfce/mimetypes/32/application-x-cpio.svg
@@ -1,1 +1,337 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-cpio.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview12643"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13.25"
+     inkscape:cx="7.2075472"
+     inkscape:cy="32.754717"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="35"
+     inkscape:window-y="572"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     id="text2865"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.16183"
+     transform="matrix(0.86071354,0,0,0.86071354,-5.3285624,-9.5300898)">
+    <path
+       d="m 17.052,38.778406 c -0.395999,0.612 -0.852,0.876 -1.512,0.876 -1.103999,0 -1.932,-0.864001 -1.932,-2.028 0,-1.163999 0.792001,-2.004 1.896,-2.004 0.72,0 1.224001,0.300001 1.548,0.912 h 1.8 c -0.227999,-0.671999 -0.444,-1.02 -0.9,-1.44 -0.647999,-0.599999 -1.524001,-0.936 -2.448,-0.936 -1.967998,0 -3.504,1.524002 -3.504,3.48 0,1.931998 1.584002,3.48 3.552,3.48 1.547999,0 2.748001,-0.852001 3.3,-2.34 h -1.8"
+       id="path3644"
+       style="stroke-width:1.16183" />
+    <path
+       d="m 19.9755,43.182406 h 1.596 v -2.844 c 0.6,0.54 1.224001,0.78 2.04,0.78 1.919998,0 3.324,-1.488002 3.324,-3.504 0,-2.003998 -1.392002,-3.456 -3.312,-3.456 -0.899999,0 -1.668,0.336001 -2.184,0.936 v -0.78 h -1.464 v 8.868 m 3.444,-7.56 c 1.079999,0 1.908,0.876001 1.908,2.028 0,1.127999 -0.828001,2.004 -1.884,2.004 -1.127999,0 -1.968,-0.864001 -1.968,-2.028 0,-1.139999 0.840001,-2.004 1.944,-2.004"
+       id="path3646"
+       style="stroke-width:1.16183" />
+    <path
+       d="m 27.897375,40.962406 h 1.596 v -6.648 h -1.596 v 6.648 m 0,-7.368 h 1.596 v -1.5 h -1.596 v 1.5"
+       id="path3648"
+       style="stroke-width:1.16183" />
+    <path
+       d="m 34.008188,34.158406 c -1.931998,0 -3.516,1.572002 -3.516,3.48 0,1.919998 1.584002,3.48 3.528,3.48 1.931998,0 3.54,-1.560002 3.54,-3.432 0,-1.979998 -1.548002,-3.528 -3.552,-3.528 m 0.012,1.464 c 1.067999,0 1.932,0.912001 1.932,2.016 0,1.115999 -0.864001,2.016 -1.92,2.016 -1.079999,0 -1.932,-0.900001 -1.932,-2.04 0,-1.091999 0.876001,-1.992 1.92,-1.992"
+       id="path3650"
+       style="stroke-width:1.16183" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-lha.svg
+++ b/elementary-xfce/mimetypes/32/application-x-lha.svg
@@ -1,1 +1,330 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-lha.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13328"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="12.886792"
+     inkscape:cy="16.037736"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="801"
+     inkscape:window-y="24"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="text2866" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     id="text2866"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none"
+     transform="translate(-8,-14)">
+    <path
+       d="m 16,41 h 1.596 V 32.132 H 16 V 41"
+       id="path3643" />
+    <path
+       d="m 19.8,41 h 1.596 v -3.372 c 0,-0.66 0.06,-1.032001 0.228,-1.332 0.228,-0.408 0.648,-0.636 1.176,-0.636 0.935999,0 1.296,0.552001 1.296,1.944 V 41 h 1.596 v -3.756 c 0,-0.971999 -0.120001,-1.512001 -0.444,-2.004 -0.444,-0.684 -1.212001,-1.056 -2.16,-1.056 -0.684,0 -1.212001,0.192 -1.692,0.624 V 32.132 H 19.8 V 41"
+       id="path3645" />
+    <path
+       d="m 33.52,34.196002 h -1.464 v 0.888 c -0.551999,-0.731999 -1.212001,-1.044 -2.172,-1.044 -1.967998,0 -3.384,1.476002 -3.384,3.504 0,2.003998 1.404002,3.456 3.348,3.456 0.935999,0 1.572001,-0.300001 2.208,-1.02 v 0.864 h 1.464 v -6.648 m -3.468,1.308 c 1.139999,0 1.956,0.852001 1.956,2.064 0,0.479999 -0.192,1.032 -0.48,1.368 -0.323999,0.383999 -0.84,0.6 -1.452,0.6 -1.163999,0 -1.968,-0.792001 -1.968,-1.956 0,-1.211999 0.804001,-2.076 1.944,-2.076"
+       id="path3647" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-lhz.svg
+++ b/elementary-xfce/mimetypes/32/application-x-lhz.svg
@@ -1,1 +1,335 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-lhz.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview13810"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="3.5660377"
+     inkscape:cy="16"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="304"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     id="text2866"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none"
+     transform="translate(-8,-14)">
+    <path
+       d="m 16,41 h 1.596 V 32.132 H 16 V 41"
+       id="path3643" />
+    <path
+       d="m 20,41 h 1.596 v -3.372 c 0,-0.66 0.06,-1.032001 0.228,-1.332 0.228,-0.408 0.648,-0.636 1.176,-0.636 0.935999,0 1.296,0.552001 1.296,1.944 V 41 h 1.596 v -3.756 c 0,-0.971999 -0.120001,-1.512001 -0.444,-2.004 -0.444,-0.684 -1.212001,-1.056 -2.16,-1.056 -0.684,0 -1.212001,0.192 -1.692,0.624 V 32.132 H 20 V 41"
+       id="path3645" />
+  </g>
+  <g
+     id="text2865"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none"
+     transform="translate(-8,-14)">
+    <path
+       d="m 27.836922,40.962406 h 5.064 v -1.428 h -3.156 l 2.928,-3.792 v -1.428 h -4.5 v 1.428 h 2.592 l -2.928,3.792 v 1.428"
+       id="path3646" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-lzma-compressed-tar.svg
+++ b/elementary-xfce/mimetypes/32/application-x-lzma-compressed-tar.svg
@@ -1,1 +1,346 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-lzma-compressed-tar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview15175"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="9.04563"
+     inkscape:cy="30.685765"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="867"
+     inkscape:window-y="290"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="matrix(0.901168,0,0,0.901168,-12.289966,-9.5665299)"
+     id="text2877"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.10967">
+    <path
+       d="m 20.295845,40.421055 h 1.33 v -7.39 h -1.33 v 7.39"
+       id="path3662"
+       style="stroke-width:1.10967" />
+    <path
+       d="m 22.535358,40.421055 h 4.22 v -1.19 h -2.63 l 2.44,-3.16 v -1.19 h -3.75 v 1.19 h 2.16 l -2.44,3.16 v 1.19"
+       id="path3664"
+       style="stroke-width:1.10967" />
+    <path
+       d="m 27.484733,40.421055 h 1.33 v -2.73 c 0,-0.55 0.05,-0.92 0.14,-1.15 0.16,-0.36 0.500001,-0.57 0.94,-0.57 0.36,0 0.670001,0.13 0.85,0.35 0.16,0.21 0.23,0.54 0.23,1.06 v 3.04 h 1.33 v -2.73 c 0,-0.62 0.05,-0.93 0.19,-1.19 0.17,-0.34 0.510001,-0.53 0.93,-0.53 0.33,0 0.610001,0.12 0.79,0.34 0.18,0.21 0.25,0.52 0.25,1.07 v 3.04 h 1.33 v -3.2 c 0,-0.669999 -0.12,-1.210001 -0.36,-1.59 -0.349999,-0.56 -1.05,-0.88 -1.88,-0.88 -0.779999,0 -1.33,0.26 -1.78,0.86 -0.379999,-0.6 -0.87,-0.86 -1.63,-0.86 -0.649999,0 -1.05,0.18 -1.44,0.65 v -0.52 h -1.22 v 5.54"
+       id="path3666"
+       style="stroke-width:1.10967" />
+    <path
+       d="m 42.489265,34.881055 h -1.22 v 0.74 c -0.46,-0.61 -1.010001,-0.87 -1.81,-0.87 -1.639999,0 -2.82,1.230002 -2.82,2.92 0,1.669998 1.170001,2.88 2.79,2.88 0.779999,0 1.31,-0.250001 1.84,-0.85 v 0.72 h 1.22 v -5.54 m -2.89,1.09 c 0.949999,0 1.63,0.710001 1.63,1.72 0,0.399999 -0.160001,0.86 -0.4,1.14 -0.27,0.32 -0.700001,0.5 -1.21,0.5 -0.969999,0 -1.64,-0.660001 -1.64,-1.63 0,-1.009999 0.670001,-1.73 1.62,-1.73"
+       id="path3668"
+       style="stroke-width:1.10967" />
+  </g>
+  <path
+     d="m 14,20 h 1 v -4 h 1 V 15 H 15.000001 V 14 H 14 v 1 h -1 v 1 h 1"
+     id="path3654"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1"
+     sodipodi:nodetypes="cccccccccccc" />
+  <path
+     d="m 16,20 h 1.999999 V 18 H 16 v 2"
+     id="path3660"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.999999" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-lzma.svg
+++ b/elementary-xfce/mimetypes/32/application-x-lzma.svg
@@ -1,1 +1,337 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-lzma.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview14652"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="-1.0406477"
+     inkscape:cy="22.41395"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="202"
+     inkscape:window-y="307"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="matrix(0.80234869,0,0,0.80234869,-3.8258355,-6.5799035)"
+     id="text2865"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.24634">
+    <path
+       d="m 11,40.844002 h 1.596 v -8.868 H 11 v 8.868"
+       id="path3644"
+       style="stroke-width:1.24634" />
+    <path
+       d="m 14.175,40.844002 h 5.064 v -1.428 h -3.156 l 2.928,-3.792 v -1.428 h -4.5 v 1.428 h 2.592 l -2.928,3.792 v 1.428"
+       id="path3646"
+       style="stroke-width:1.24634" />
+    <path
+       d="m 20.414063,40.844002 h 1.596 v -3.276 c 0,-0.66 0.06,-1.104001 0.168,-1.38 0.192,-0.432 0.6,-0.684 1.128,-0.684 0.431999,0 0.804,0.156 1.02,0.42 0.192,0.252 0.276,0.648 0.276,1.272 v 3.648 h 1.596 v -3.276 c 0,-0.743999 0.06,-1.116001 0.228,-1.428 0.204,-0.408 0.612,-0.636 1.116,-0.636 0.395999,0 0.732,0.144 0.948,0.408 0.216,0.252 0.3,0.624 0.3,1.284 v 3.648 h 1.596 v -3.84 c 0,-0.803999 -0.144001,-1.452001 -0.432,-1.908 -0.42,-0.672 -1.260001,-1.056 -2.256,-1.056 -0.935999,0 -1.596001,0.312 -2.136,1.032 -0.456,-0.72 -1.044001,-1.032 -1.956,-1.032 -0.779999,0 -1.260001,0.216 -1.728,0.78 v -0.624 h -1.464 v 6.648"
+       id="path3648"
+       style="stroke-width:1.24634" />
+    <path
+       d="m 38.4195,34.196002 h -1.464 v 0.888 c -0.551999,-0.731999 -1.212001,-1.044 -2.172,-1.044 -1.967998,0 -3.384,1.476002 -3.384,3.504 0,2.003998 1.404002,3.456 3.348,3.456 0.935999,0 1.572001,-0.300001 2.208,-1.02 v 0.864 h 1.464 v -6.648 m -3.468,1.308 c 1.139999,0 1.956,0.852001 1.956,2.064 0,0.479999 -0.192,1.032 -0.48,1.368 -0.323999,0.383999 -0.84,0.6 -1.452,0.6 -1.163999,0 -1.968,-0.792001 -1.968,-1.956 0,-1.211999 0.804001,-2.076 1.944,-2.076"
+       id="path3650"
+       style="stroke-width:1.24634" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-lzop.svg
+++ b/elementary-xfce/mimetypes/32/application-x-lzop.svg
@@ -1,1 +1,330 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-lzop.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview17253"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="13.25"
+     inkscape:cx="1.6981132"
+     inkscape:cy="11.320755"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="502"
+     inkscape:window-y="267"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="translate(-8,-14.900002)"
+     id="text2865"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none">
+    <path
+       d="m 17,40.844002 h 1.596 v -8.868 H 17 v 8.868"
+       id="path3663" />
+    <path
+       d="m 19.974812,40.844002 h 5.064 v -1.428 h -3.156 l 2.928,-3.792 v -1.428 h -4.5 v 1.428 h 2.592 l -2.928,3.792 v 1.428"
+       id="path3665" />
+    <path
+       d="m 29.142062,34.040002 c -1.931998,0 -3.516,1.572002 -3.516,3.48 0,1.919998 1.584002,3.48 3.528,3.48 1.931998,0 3.54,-1.560002 3.54,-3.432 0,-1.979998 -1.548002,-3.528 -3.552,-3.528 m 0.012,1.464 c 1.067999,0 1.932,0.912001 1.932,2.016 0,1.115999 -0.864001,2.016 -1.92,2.016 -1.079999,0 -1.932,-0.900001 -1.932,-2.04 0,-1.091999 0.876001,-1.992 1.92,-1.992"
+       id="path3667" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-pak.svg
+++ b/elementary-xfce/mimetypes/32/application-x-pak.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-pak.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview17745"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.3691649"
+     inkscape:cx="6.8842849"
+     inkscape:cy="11.206975"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="634"
+     inkscape:window-y="83"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     id="path40426"
+     style="font-weight:bold;font-size:32.6318px;line-height:1.25;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Bold';letter-spacing:0.150461px;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2"
+     d="m 20.985091,17 v 8.797851 h 1.599154 v -3.083724 l 2.273046,3.083724 h 2.152735 l -2.766471,-3.369466 2.381185,-3.226237 h -1.91211 l -2.128385,3.107357 V 17 Z M 8.668099,19.047461 c -0.91394,0 -1.683619,0.321697 -2.200716,0.928842 V 19.202148 H 5 V 28 h 1.59987 v -2.821614 c 0.613301,0.535715 1.226145,0.774155 2.04388,0.774155 1.924083,0 3.331511,-1.476167 3.331511,-3.476174 0,-1.988097 -1.395105,-3.428906 -3.307162,-3.428906 z m 7.427148,0 c -1.972185,0 -3.39095,1.464264 -3.39095,3.476172 0,1.988098 1.407009,3.428908 3.355143,3.428908 0.93799,0 1.574822,-0.285725 2.212175,-1.011916 v 0.857226 h 1.467382 v -6.595703 h -1.467382 v 0.88086 c -0.553174,-0.726192 -1.214326,-1.035547 -2.176368,-1.035547 z m -7.643424,1.452344 c 1.082297,0 1.912109,0.86951 1.912109,2.012369 0,1.119051 -0.83023,1.988022 -1.888476,1.988022 -1.130398,0 -1.972266,-0.857604 -1.972266,-2.01237 0,-1.130954 0.842286,-1.988021 1.948633,-1.988021 z m 7.811719,0 c 1.142423,0 1.960091,0.845795 1.960091,2.048176 0,0.476191 -0.192638,1.023763 -0.48125,1.357097 -0.32469,0.392857 -0.841191,0.595118 -1.454493,0.595118 -1.166475,0 -1.972265,-0.78599 -1.972265,-1.940757 0,-1.202381 0.805492,-2.059634 1.947917,-2.059634 z" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-par2.svg
+++ b/elementary-xfce/mimetypes/32/application-x-par2.svg
@@ -1,1 +1,321 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-par2.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview18498"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="6.625"
+     inkscape:cx="-0.98113207"
+     inkscape:cy="43.320755"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="578"
+     inkscape:window-y="629"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     id="text3329-3"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.99999"
+     d="m 25.044251,16.935751 c -0.108211,-0.0028 -0.217911,0.0022 -0.328915,0.01553 -1.470866,0.02188 -2.618514,1.346289 -2.464923,2.786718 h 1.410192 c -0.348931,-1.848984 2.699095,-1.997933 2.377515,-0.0382 -0.322854,1.193873 -1.493209,1.848352 -2.2914,2.716791 -0.462696,0.488674 -1.072362,0.914089 -1.442567,1.442564 v 1.18293 h 5.069699 v -1.345446 h -3.056711 c 1.058102,-1.076455 2.498549,-1.899895 3.045705,-3.370089 0.564991,-1.559516 -0.695425,-3.349729 -2.318595,-3.390807 z m -3.788354,1.990973 c -0.490625,0.0174 -0.946762,0.289913 -1.188109,0.729702 v -0.58143 h -1.313072 v 5.967095 h 1.432206 c 0.01154,-1.213647 -0.0244,-2.431647 0.01941,-3.643968 0.02308,-0.652899 0.629091,-1.124837 1.261275,-1.085162 v -1.377819 c -0.07098,-0.0082 -0.141634,-0.0109 -0.211723,-0.0085 z m -7.029595,0.0039 c -0.181922,0.0055 -0.362635,0.02731 -0.538049,0.06475 -1.285121,0.214686 -2.272951,1.384428 -2.376219,2.666286 -0.178083,1.297059 0.463884,2.734758 1.708029,3.257429 1.02772,0.451795 2.379948,0.354754 3.146711,-0.538051 l 0.107479,-0.187116 c -0.0031,0.178495 -0.01869,0.771242 0,0.848185 h 1.313073 v -5.967136 h -1.313073 v 0.797038 c -0.452928,-0.678325 -1.259621,-0.964972 -2.04795,-0.941367 z m -6.4222658,0.0071 c -0.7487028,-0.005 -1.4943996,0.261783 -1.9890331,0.842359 -0.0262,-0.220302 0.052374,-0.550294 -0.039485,-0.705094 h -1.275518 v 7.956143 h 1.4335015 v -2.541999 c 1.3089967,1.268724 3.7375343,0.73139 4.4714354,-0.914229 0.74735,-1.486304 0.28056,-3.611523 -1.3040069,-4.343885 C 8.7034561,19.04176 8.2532654,18.940711 7.8040452,18.937714 Z m 6.6721898,1.31113 c 0.915165,-0.04383 1.715105,0.748831 1.746231,1.651699 0.09403,0.847406 -0.428035,1.811008 -1.330555,1.930111 -0.8575,0.193699 -1.86975,-0.274966 -2.086151,-1.169977 -0.28231,-0.936844 0.202108,-2.131056 1.214657,-2.356799 0.148808,-0.03746 0.302445,-0.05503 0.455818,-0.05503 z m -6.8832662,0.0052 c 1.0761595,-0.0392 1.8844677,1.080511 1.6937842,2.099738 -0.092017,0.998996 -1.1526967,1.760332 -2.1262938,1.465874 -1.1894539,-0.255948 -1.679583,-1.817171 -1.0223581,-2.78542 0.3089851,-0.490216 0.8774054,-0.787655 1.4548677,-0.780203 z"
+     sodipodi:nodetypes="scccccccccccssccccccccssccccccccccssccccccccsccccccccccc" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-shar.svg
+++ b/elementary-xfce/mimetypes/32/application-x-shar.svg
@@ -1,1 +1,337 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-shar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview18787"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.3691649"
+     inkscape:cx="3.2553595"
+     inkscape:cy="6.7241852"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="95"
+     inkscape:window-y="260"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="matrix(0.94039326,0,0,0.94037841,-7.3168887,-12.163814)"
+     id="text3638"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12.0001px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.06339">
+    <path
+       d="m 12.565901,38.832304 c 0.072,0.648005 0.180002,0.984008 0.444003,1.344011 0.432003,0.576004 1.188011,0.924007 1.992016,0.924007 1.332009,0 2.376019,-0.996009 2.376019,-2.268018 0,-0.576004 -0.216002,-1.056009 -0.624005,-1.380011 -0.252002,-0.216001 -0.648006,-0.384003 -1.22401,-0.564004 -0.648004,-0.204002 -0.648005,-0.204002 -0.804006,-0.276002 -0.216001,-0.096 -0.324003,-0.252003 -0.324003,-0.444004 0,-0.324002 0.264003,-0.564004 0.612005,-0.564004 0.336003,0 0.552005,0.180001 0.624005,0.528004 h 1.560012 c -0.024,-0.564004 -0.156001,-0.900008 -0.480003,-1.26001 -0.420003,-0.468003 -1.044009,-0.732006 -1.704014,-0.732006 -1.236008,0 -2.208017,0.888008 -2.208017,2.028016 0,0.972007 0.528005,1.524013 1.848014,1.968016 0.612005,0.204001 0.660006,0.228001 0.828007,0.336002 0.192001,0.120001 0.300002,0.300003 0.300002,0.516004 0,0.372003 -0.312003,0.648005 -0.720005,0.648005 -0.468004,0 -0.732006,-0.240002 -0.888007,-0.804006 h -1.608013"
+       id="path3643"
+       style="stroke-width:1.06339" />
+    <path
+       d="m 18.259383,40.944321 h 1.596013 v -3.372027 c 0,-0.660004 0.06,-1.032008 0.228002,-1.33201 0.228001,-0.408003 0.648005,-0.636005 1.176009,-0.636005 0.936006,0 1.29601,0.552005 1.29601,1.944015 v 3.396027 h 1.596013 v -3.75603 c 0,-0.972007 -0.120002,-1.512012 -0.444004,-2.004016 -0.444003,-0.684004 -1.21201,-1.056008 -2.160017,-1.056008 -0.684005,0 -1.21201,0.192002 -1.692013,0.624005 v -2.676021 h -1.596013 v 8.86807"
+       id="path3645"
+       style="stroke-width:1.06339" />
+    <path
+       d="m 32.186806,34.296268 h -1.464012 v 0.888007 c -0.552004,-0.732005 -1.212011,-1.044008 -2.172017,-1.044008 -1.968014,0 -3.384027,1.476014 -3.384027,3.504028 0,2.004013 1.404013,3.456027 3.348027,3.456027 0.936006,0 1.572013,-0.300003 2.208017,-1.020008 v 0.864007 h 1.464012 v -6.648053 m -3.468028,1.308011 c 1.140008,0 1.956016,0.852008 1.956016,2.064016 0,0.480003 -0.192002,1.032008 -0.480004,1.368011 -0.324002,0.384002 -0.840007,0.600004 -1.452012,0.600004 -1.164008,0 -1.968015,-0.792007 -1.968015,-1.956015 0,-1.212008 0.804007,-2.076016 1.944015,-2.076016"
+       id="path3647"
+       style="stroke-width:1.06339" />
+    <path
+       d="m 33.999731,40.944321 h 1.596012 v -3.696029 c 0,-1.032007 0.468005,-1.548013 1.428011,-1.572013 v -1.536012 h -0.120001 c -0.684004,0 -1.020008,0.192002 -1.440011,0.804006 v -0.648005 h -1.464011 v 6.648053"
+       id="path3649"
+       style="stroke-width:1.06339" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-stuffit.svg
+++ b/elementary-xfce/mimetypes/32/application-x-stuffit.svg
@@ -1,1 +1,334 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-stuffit.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview19287"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="53.000001"
+     inkscape:cx="16.367924"
+     inkscape:cy="21"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="786"
+     inkscape:window-y="102"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="text2866" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     id="text2866"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.841548"
+     transform="matrix(1.2742099,0,0,1.108156,-14.935777,-19.544105)">
+    <path
+       d="m 17.607599,38.831 c 0.072,0.647999 0.180001,0.984 0.444,1.344 0.432,0.575999 1.188001,0.924 1.992,0.924 1.331999,0 2.376,-0.996002 2.376,-2.268 0,-0.576 -0.216,-1.056001 -0.624,-1.38 -0.251999,-0.216 -0.648,-0.384001 -1.224,-0.564 -0.647999,-0.204 -0.648,-0.204 -0.804,-0.276 -0.215999,-0.096 -0.324,-0.252001 -0.324,-0.444 0,-0.324 0.264001,-0.564 0.612,-0.564 0.336,0 0.552,0.18 0.624,0.528 h 1.56 c -0.024,-0.564 -0.156,-0.900001 -0.48,-1.26 -0.419999,-0.468 -1.044,-0.732 -1.704,-0.732 -1.235998,0 -2.208,0.888001 -2.208,2.028 0,0.971999 0.528002,1.524 1.848,1.968 0.612,0.203999 0.660001,0.228 0.828,0.336 0.192,0.119999 0.3,0.3 0.3,0.516 0,0.371999 -0.312,0.648 -0.72,0.648 -0.467999,0 -0.732,-0.240001 -0.888,-0.804 h -1.608"
+       id="path2864"
+       style="stroke-width:0.841548" />
+    <path
+       d="m 23.493599,40.943 h 1.596 v -6.160799 h -1.596 V 40.943 m 0,-7.368 h 1.596 v -1.5 h -1.596"
+       id="path2866"
+       style="stroke-width:0.841548"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       d="m 27.216,40.943 h 1.596 v -5.196 h 0.96 v -1.452 h -0.96 v -2.22 h -1.596 v 2.22 h -0.78 v 1.452 h 0.78 v 5.196"
+       id="path2868"
+       style="stroke-width:0.841548" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-tar.svg
+++ b/elementary-xfce/mimetypes/32/application-x-tar.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-tar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview19779"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="14.809217"
+     inkscape:cy="18.571559"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="162"
+     inkscape:window-y="286"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 9.232,26.143 c 0.532,0 1.064,0 1.596,0 0,-1.732 0,-3.464 0,-5.196 0.32,0 0.64,0 0.96,0 0,-0.483999 0,-0.967999 0,-1.451999 -0.32,0 -0.64,0 -0.96,0 0,-0.740001 0,-1.480001 0,-2.220001 -0.532,0 -1.064,0 -1.596,0 0,0.74 0,1.48 0,2.220001 -0.26,0 -0.52,0 -0.78,0 0,0.484 0,0.968 0,1.451999 0.26,0 0.52,0 0.78,0 0,1.732 0,3.464 0,5.196 z m 10.101375,-6.647999 c -0.488,0 -0.976,0 -1.464,0 0,0.296 0,0.592 0,0.888 -0.62133,-0.930603 -1.839697,-1.199196 -2.882437,-0.976618 -1.432383,0.239285 -2.532947,1.543101 -2.648047,2.971853 -0.198489,1.445692 0.517142,3.047722 1.903854,3.630286 1.145487,0.503569 2.652677,0.395695 3.507307,-0.599415 0.223725,-0.296146 0.07766,0.356059 0.119323,0.527579 -0.102181,0.338598 0.307452,0.165382 0.502937,0.206314 0.320354,0 0.640708,0 0.961063,0 0,-2.216 0,-4.432 0,-6.647999 z m -3.468,1.307998 c 1.020032,-0.04883 1.911869,0.83476 1.946558,1.84109 0.104805,0.944516 -0.477117,2.01841 -1.483058,2.151161 -0.955762,0.215892 -2.084431,-0.305937 -2.32563,-1.303504 -0.314659,-1.044195 0.225574,-2.375825 1.35415,-2.627433 0.165862,-0.04175 0.337031,-0.06135 0.50798,-0.06131 z M 20.523249,26.143 c 0.532,0 1.064001,0 1.596001,0 0.01288,-1.35272 -0.02688,-2.707617 0.02198,-4.058859 0.0257,-0.727717 0.701391,-1.253367 1.406016,-1.209141 0,-0.512001 0,-1.024001 -1e-6,-1.536001 -0.632935,-0.07298 -1.252565,0.243793 -1.559999,0.804001 -0.04664,-0.195156 0.09653,-0.580116 -0.07737,-0.647999 -0.462209,0 -0.924417,0 -1.386626,0 0,2.215999 0,4.431999 0,6.647999 z"
+     id="text3329" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-xz-compressed-tar.svg
+++ b/elementary-xfce/mimetypes/32/application-x-xz-compressed-tar.svg
@@ -1,1 +1,321 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-xz-compressed-tar.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20902"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="13.048121"
+     inkscape:cy="28.230904"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="729"
+     inkscape:window-y="91"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     id="text3329-5"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.5"
+     d="m 7.791748,17.945 v 2.252929 H 7 v 1.473633 H 7.791748 V 26.945 h 1.620117 v -5.273438 h 0.974122 V 20.197929 H 9.411865 V 17.945 Z m 5.902105,2.256592 2.070557,3.264404 -2.387695,3.482668 h 1.948974 l 1.412843,-2.313724 1.412839,2.313724 h 1.948244 L 17.7002,23.465996 19.759039,20.201592 h -1.827393 l -1.193115,2.033935 -1.218018,-2.033935 z m 7.075929,0 v 1.449463 h 2.630127 l -2.971438,3.848875 v 1.448734 h 5.139406 V 25.49993 h -3.202882 l 2.971434,-3.848875 V 20.201592 Z M 10.370123,25.39007 v 1.558594 H 11.99024 V 25.39007 Z"
+     sodipodi:nodetypes="cccccccccccccccccccccccccccccccccccccccccc" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-xz.svg
+++ b/elementary-xfce/mimetypes/32/application-x-xz.svg
@@ -1,1 +1,324 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-xz.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview20247"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="26.5"
+     inkscape:cx="11.415094"
+     inkscape:cy="22.037736"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="80"
+     inkscape:window-y="233"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     d="m 9.957,25.993071 h 1.931862 l 1.400601,-2.294085 1.400599,2.294085 h 1.931861 L 14.243319,22.539869 16.283847,19.304 h -1.81112 L 13.289463,21.320381 12.082049,19.304 h -1.811121 l 2.052603,3.235869 z"
+     id="path954-0"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;line-height:1.25;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Bold';letter-spacing:0px;word-spacing:0px;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.45278" />
+  <path
+     d="m 16.947917,25.993071 h 5.095287 v -1.436819 h -3.1755 l 2.94609,-3.81543 V 19.304 h -4.5278 v 1.436822 h 2.608013 l -2.946089,3.81543 z"
+     id="path956-3"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:26.6667px;line-height:1.25;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Bold';letter-spacing:0px;word-spacing:0px;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.45278" />
+</svg>

--- a/elementary-xfce/mimetypes/32/application-x-zoo.svg
+++ b/elementary-xfce/mimetypes/32/application-x-zoo.svg
@@ -1,1 +1,330 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-x-zoo.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21191"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="18.73833"
+     inkscape:cx="4.5628399"
+     inkscape:cy="21.826918"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="669"
+     inkscape:window-y="420"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <g
+     transform="translate(-8.518563,-13.51615)"
+     id="text2865"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;font-family:'URW Gothic L';-inkscape-font-specification:'Andale Mono Bold';opacity:0.5;fill:#000000;fill-opacity:1;stroke:none">
+    <path
+       d="m 14.315188,40.06015 h 5.064 v -1.428 h -3.156 l 2.928,-3.792 v -1.428 h -4.5 v 1.428 h 2.592 l -2.928,3.792 v 1.428"
+       id="path3642" />
+    <path
+       d="m 23.482438,33.25615 c -1.931998,0 -3.516,1.572002 -3.516,3.48 0,1.919998 1.584002,3.48 3.528,3.48 1.931998,0 3.54,-1.560002 3.54,-3.432 0,-1.979998 -1.548002,-3.528 -3.552,-3.528 m 0.012,1.464 c 1.067999,0 1.932,0.912001 1.932,2.016 0,1.115999 -0.864001,2.016 -1.92,2.016 -1.079999,0 -1.932,-0.900001 -1.932,-2.04 0,-1.091999 0.876001,-1.992 1.92,-1.992"
+       id="path3644" />
+    <path
+       d="m 31.169938,33.25615 c -1.931998,0 -3.516,1.572002 -3.516,3.48 0,1.919998 1.584002,3.48 3.528,3.48 1.931998,0 3.54,-1.560002 3.54,-3.432 0,-1.979998 -1.548002,-3.528 -3.552,-3.528 m 0.012,1.464 c 1.067999,0 1.932,0.912001 1.932,2.016 0,1.115999 -0.864001,2.016 -1.92,2.016 -1.079999,0 -1.932,-0.900001 -1.932,-2.04 0,-1.091999 0.876001,-1.992 1.92,-1.992"
+       id="path3646" />
+  </g>
+</svg>

--- a/elementary-xfce/mimetypes/32/application-zip.svg
+++ b/elementary-xfce/mimetypes/32/application-zip.svg
@@ -1,1 +1,320 @@
-package-x-generic.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   version="1.1"
+   width="32"
+   height="32"
+   id="svg6860"
+   sodipodi:docname="application-zip.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview21683"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="9.3691649"
+     inkscape:cx="15.743132"
+     inkscape:cy="20.919687"
+     inkscape:window-width="1423"
+     inkscape:window-height="1051"
+     inkscape:window-x="93"
+     inkscape:window-y="258"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg6860" />
+  <defs
+     id="defs6862">
+    <linearGradient
+       xlink:href="#linearGradient121303"
+       id="linearGradient121764"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.68006824,0,0,0.57741648,-0.31214791,4.5822458)"
+       x1="25.086039"
+       y1="-1.3623691"
+       x2="25.086039"
+       y2="18.299334" />
+    <linearGradient
+       id="linearGradient121303">
+      <stop
+         id="stop121295"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop121297"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.11419468" />
+      <stop
+         id="stop121299"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.93896598" />
+      <stop
+         id="stop121301"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient3924-2-2-5-8"
+       id="linearGradient121760"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.67567599,0,0,0.56756767,-0.2162231,4.378376)"
+       x1="23.99999"
+       y1="6.4195485"
+       x2="23.99999"
+       y2="41.544617" />
+    <linearGradient
+       id="linearGradient3924-2-2-5-8">
+      <stop
+         id="stop3926-9-4-9-6"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop3928-9-8-6-5"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.07611413" />
+      <stop
+         id="stop3930-3-5-1-7"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.9069767" />
+      <stop
+         id="stop3932-8-0-4-8"
+         style="stop-color:#ffffff;stop-opacity:0.39215687"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#d"
+       id="linearGradient121758"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.83927807,0,0,0.76888647,-3.730718,-3.10373)"
+       x1="23.452"
+       y1="30.555"
+       x2="43.007"
+       y2="45.933998" />
+    <linearGradient
+       id="d">
+      <stop
+         offset="0"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop65" />
+      <stop
+         offset="1"
+         stop-color="#fff"
+         stop-opacity="0"
+         id="stop67" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient121756"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.91410403,27.630994,-10.542232)"
+       x1="-5.8870335"
+       y1="19.239614"
+       x2="-5.8870335"
+       y2="43.792946" />
+    <linearGradient
+       id="linearGradient106305">
+      <stop
+         offset="0"
+         stop-color="#dac197"
+         id="stop106301"
+         style="stop-color:#e7c591;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#b19974"
+         id="stop106303"
+         style="stop-color:#cfa25e;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#linearGradient106305"
+       id="linearGradient1703"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8443639,0,0,0.90745565,27.630994,-10.25101)"
+       x1="-5.8870335"
+       y1="11.482978"
+       x2="-5.8870335"
+       y2="22.148865" />
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,-14.229948,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="k-0-7-3-9-3"
+       r="5" />
+    <linearGradient
+       id="g">
+      <stop
+         offset="0"
+         id="stop13" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop15" />
+    </linearGradient>
+    <linearGradient
+       xlink:href="#h"
+       id="linearGradient121754"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.1304332,0,0,1.45455,-83.781828,-18.434784)"
+       x1="17.554001"
+       y1="46"
+       x2="17.554001"
+       y2="35" />
+    <linearGradient
+       id="h">
+      <stop
+         offset="0"
+         stop-opacity="0"
+         id="stop54" />
+      <stop
+         offset=".5"
+         id="stop56" />
+      <stop
+         offset="1"
+         stop-opacity="0"
+         id="stop58" />
+    </linearGradient>
+    <radialGradient
+       cx="5"
+       cy="41.5"
+       fx="5"
+       fy="41.5"
+       gradientTransform="matrix(1.0028871,0,0,1.6,53.201858,-106.87522)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#g"
+       id="i-6-9-7-8-9"
+       r="5" />
+    <linearGradient
+       y2="8.3470001"
+       y1="21.915001"
+       x2="24.537001"
+       x1="24.537001"
+       id="n"
+       xlink:href="#g-3"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9899,0,0,0.6901,-7.737,-3.78)" />
+    <linearGradient
+       id="g-3">
+      <stop
+         id="stop18"
+         stop-color="#fff"
+         offset="0" />
+      <stop
+         id="stop20"
+         stop-color="#fff"
+         offset="0.35662466" />
+      <stop
+         id="stop22"
+         stop-opacity=".643"
+         stop-color="#fff"
+         offset="0.46007031" />
+      <stop
+         id="stop24"
+         stop-opacity=".391"
+         stop-color="#fff"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata6865">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g2277"
+     transform="matrix(0.50847457,0,0,0.5625,33.144155,4.732691)"
+     style="stroke-width:1.86984">
+    <rect
+       fill="url(#i)"
+       height="16"
+       opacity="0.4"
+       transform="scale(-1)"
+       width="5"
+       x="58.216839"
+       y="-48.475216"
+       id="rect77-9-90-2-7-8"
+       style="fill:url(#i-6-9-7-8-9);stroke-width:1.86984" />
+    <rect
+       fill="url(#j)"
+       height="16"
+       opacity="0.4"
+       width="49"
+       x="-58.216839"
+       y="32.475216"
+       id="rect79-7-2-0-1-4"
+       style="fill:url(#linearGradient121754);stroke-width:1.86984" />
+    <rect
+       fill="url(#k)"
+       height="16"
+       opacity="0.4"
+       transform="scale(1,-1)"
+       width="5"
+       x="-9.2168379"
+       y="-48.475216"
+       id="rect81-3-8-6-7-8"
+       style="fill:url(#k-0-7-3-9-3);stroke-width:1.86984" />
+  </g>
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-10"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient1703);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 h 27.000008 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-3"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:url(#linearGradient121756);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.3;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 5.455426,6.9999997 c -1.227273,0 -2.945455,1.0775483 -2.945455,3.7087933 v 15.824184 c 0,0.124618 0.01007,0.246631 0.02494,0.367017 0.0034,0.02792 0.0083,0.05539 0.01246,0.08306 0.01482,0.09723 0.03358,0.193045 0.05753,0.286851 0.0061,0.02421 0.01154,0.04847 0.01821,0.07244 0.06723,0.23804 0.161842,0.464468 0.281889,0.67415 3.54e-4,6.43e-4 4.91e-4,0.0013 9.82e-4,0.0019 0.508258,0.886334 1.456214,1.481589 2.549434,1.481589 h 21.109098 c 1.09322,0 2.041176,-0.595255 2.549468,-1.481586 2.75e-4,-6.43e-4 4.91e-4,-0.0013 9.82e-4,-0.0019 0.120047,-0.209682 0.21465,-0.43611 0.28189,-0.67415 0.0067,-0.02395 0.01213,-0.04823 0.01821,-0.07244 0.02396,-0.0938 0.04271,-0.189622 0.05753,-0.286851 0.0039,-0.02767 0.0091,-0.05514 0.01246,-0.08306 0.01488,-0.120389 0.02489,-0.242402 0.02489,-0.36702 V 10.956045 c 0,-1.8522532 -0.736365,-3.9560453 -2.945456,-3.9560453 z" />
+  <path
+     d="m 6.754122,6.5941804 h 18.099824 c 1.056927,0 1.710818,0.3642546 2.153619,1.3657092 l 1.524273,4.2021824 v 15.148966 c 0,0.9558 -0.536073,1.437382 -1.59251,1.437382 H 4.859212 c -1.056437,0 -1.487455,-0.529691 -1.487455,-1.485491 V 12.16109 L 4.84694,7.8690715 C 5.141485,7.093435 5.697685,6.5936894 6.754122,6.5936894 Z"
+     display="block"
+     fill="none"
+     opacity="0.505"
+     overflow="visible"
+     stroke="url(#m)"
+     stroke-width="0.741999"
+     style="stroke:url(#linearGradient121758);marker:none"
+     id="path85-1-8-5-7-0" />
+  <rect
+     style="opacity:0.3;fill:none;stroke:url(#linearGradient121760);stroke-width:0.999993;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+     id="rect6741-5-0-2-3-4-2-4"
+     y="7.4999967"
+     x="3.4999945"
+     ry="2"
+     height="21.000006"
+     width="25"
+     rx="2" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-4"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#804b00;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.5;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="m 7.409088,2.499998 c -1.631783,0 -2.282728,0.9634046 -2.945456,2.4545458 C 3.95565,6.0944933 3.364609,7.2739536 2.895025,8.3909079 2.64528,8.8239575 2.499996,9.3258405 2.499996,9.8636354 V 26.554547 c 0,1.631782 1.313673,2.945455 2.945455,2.945455 h 21.109098 c 1.631782,0 2.945455,-1.313673 2.945455,-2.945455 V 9.8636354 c 0,-0.5377949 -0.145285,-1.0396779 -0.39503,-1.4727275 C 28.622661,7.2796103 28.058552,6.0881021 27.536366,4.9545438 26.853561,3.4724877 26.222694,2.499998 24.590911,2.499998 Z" />
+  <path
+     id="rect5505-21-1-5-0-6-5-1-2-5-1-7-7"
+     style="color:#000000;font-variation-settings:normal;display:inline;overflow:visible;visibility:visible;opacity:0.15;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient121764);stroke-width:0.999985;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;enable-background:accumulate;stop-color:#000000"
+     d="M 27.939447,8.24764 26.713012,5.5891427 C 26.389792,4.8875574 26.095663,4.2796771 25.745409,3.9440426 25.395152,3.608408 25.000475,3.4999945 24.308599,3.4999945 H 7.6918375 c -0.6927864,0 -1.1115917,0.1147024 -1.4630502,0.4487205 C 5.8773288,4.2827333 5.6023931,4.8801917 5.2901985,5.5826531 v 9.495e-4 L 4.0510426,8.24764" />
+  <path
+     id="path87"
+     style="overflow:visible;opacity:0.3;fill:url(#n);marker:none"
+     overflow="visible"
+     d="m 14.37,2 h 3.3 L 18,8.331 v 3.071 c -0.39,0 -0.78,-0.532 -1.17,-0.532 -0.398,0 -0.797,0.532 -1.196,0.532 -0.322,0 -0.643,-0.466 -0.964,-0.466 -0.21,0 -0.42,0.466 -0.63,0.466 0,0 -0.09,-1.325 0,-3.07 z" />
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:12px;line-height:100%;font-family:'URW Gothic L';-inkscape-font-specification:'URW Gothic L Semi-Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.5;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 8.1074097,25.143 c 1.688,0 3.3760003,0 5.0640013,0 0,-0.476 0,-0.952001 0,-1.428002 -1.052001,0 -2.104001,0 -3.156001,0 0.976,-1.264 1.952,-2.528 2.928,-3.792 0,-0.475999 0,-0.951998 0,-1.427997 -1.5,0 -3.0000003,0 -4.5000003,0 0,0.476 0,0.951999 0,1.427997 0.864,0 1.7280003,0 2.5920013,0 -0.976001,1.264 -1.9520013,2.528 -2.9280013,3.792 0,0.476001 0,0.952002 0,1.428002 z m 5.9392503,0 c 0.532,0 1.064,0 1.596,0 0,-2.216 0,-4.432 0,-6.647999 -0.532,0 -1.064,0 -1.596,0 0,2.216 0,4.431999 0,6.647999 z m 0,-7.368 c 0.532,0 1.064,0 1.596,0 0,-0.5 0,-1 0,-1.5 -0.532,0 -1.064,0 -1.596,0 0,0.5 0,1 0,1.5 z m 2.882813,9.588001 c 0.532,0 1.063999,0 1.595999,0 0,-0.948001 0,-1.896001 0,-2.844002 1.457684,1.412828 4.162499,0.814539 4.979771,-1.017984 0.832227,-1.655121 0.31225,-4.021925 -1.45229,-4.837471 -1.180319,-0.562008 -2.778174,-0.422974 -3.659481,0.611456 -0.02924,-0.245332 0.05846,-0.607607 -0.04372,-0.779999 -0.473428,0 -0.946856,0 -1.420283,0 0,2.956 0,5.912 0,8.868 z m 3.443999,-7.560002 c 1.198389,-0.0437 2.099006,1.203095 1.886663,2.338092 -0.102474,1.112462 -1.284034,1.960654 -2.368213,1.632779 -1.324547,-0.285041 -1.87034,-2.023696 -1.138449,-3.101924 0.344079,-0.545901 0.976963,-0.877247 1.619999,-0.868945 z"
+     id="text3329" />
+</svg>


### PR DESCRIPTION
Tries to use the text from the 48px icons untouched. Proportionally the text is larger compared to the icon, but keeping the 48px text size makes it more legible.

A few had to be made a bit smaller to fit, some shortened (tar.xyz shortened to t.xyz for example).

Any input would be appreciated!


--

#523 should be merged before this one so that the `application-x-archive` icon doesn't only exist at 32px.