### PR TITLE
CHG: Shorter list of build dependencies (without GTK3 header files).

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,19 @@ We'd like to encourage you to not only consider contributing to this, but also t
 You can use the Makefile to install the theme locally (default prefix is /usr/local).
 
 ### Build dependencies
-- optipng
-- GTK3
+
+> Arch Linux:
+```
+sudo pacman -S gcc gdk-pixbuf2 gtk-update-icon-cache librsvg make optipng pkgconf
+```
+> Debian/Ubuntu and derivatives:
+```
+sudo apt install gcc gtk-update-icon-cache libgdk-pixbuf-2.0-dev librsvg2-common make optipng pkgconf
+```
+> Fedora:
+```
+sudo dnf install gcc gdk-pixbuf2-devel gtk-update-icon-cache make optipng pkgconf rsvg-pixbuf-loader
+```
 
 ### Installation for the current user only (without admin privileges)
 

--- a/svgtopng/Makefile
+++ b/svgtopng/Makefile
@@ -7,7 +7,6 @@ all: svgtopng
 svgtopng:
 	${CC} -Wall -Werror -O0 -pipe \
 	svgtopng.c -o svgtopng \
-	`pkg-config --libs --cflags gtk+-3.0` \
 	`pkg-config --libs --cflags gdk-pixbuf-2.0`
 
 convert: svgtopng | $(ICONDIR)

--- a/svgtopng/svgtopng.c
+++ b/svgtopng/svgtopng.c
@@ -28,7 +28,7 @@
 #include <unistd.h>
 #include <errno.h>
 
-#include <gtk/gtk.h>
+#include <gdk-pixbuf/gdk-pixbuf.h>
 
 
 static void


### PR DESCRIPTION
See [#491](https://github.com/shimmerproject/elementary-xfce/issues/491).