### PR TITLE
MimeTypes: New design for broken symlink icon

### DIFF
--- a/elementary-xfce/mimetypes/128/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/128/inode-symlink.svg
@@ -4,8 +4,8 @@
    width="128"
    height="128"
    id="svg3172"
-   sodipodi:docname="inode-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="inode-symlink.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,15 +23,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="5.328125"
-     inkscape:cx="61.841642"
-     inkscape:cy="63.906158"
+     inkscape:zoom="3.7675533"
+     inkscape:cx="65.161654"
+     inkscape:cy="99.93223"
      inkscape:window-width="1317"
      inkscape:window-height="890"
-     inkscape:window-x="150"
-     inkscape:window-y="284"
+     inkscape:window-x="724"
+     inkscape:window-y="218"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3172" />
+     inkscape:current-layer="svg3172"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3174">
     <linearGradient
@@ -209,8 +211,19 @@
      id="path4160-6-1"
      style="display:inline;fill:none;stroke:url(#linearGradient3148);stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
   <path
-     id="path2"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.499998;marker:none"
-     d="m 55,30 v 5 H 39.25 c 0,0 -2.25,0 -2.25,2.25 V 44 H 91 V 37.25 C 91,35 88.75,35 88.75,35 H 73 V 30 Z M 42,48 v 41.5 c 0,0 0,4.5 4.5,4.5 H 81.365234 C 81.500234,94 86,94 86,89.5 V 48 Z m 9,8 h 4 v 30 h -4 z m 11,0 h 4 v 30 h -4 z m 11,0 h 4 v 30 h -4 z"
-     sodipodi:nodetypes="cccsccsccccccsssccccccccccccccccc" />
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:3.99998;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 83,38.5 c -1.507213,0 -2.5,1.41945 -2.5,2.556641 C 80.345571,48.583214 74.014925,54 64.544922,54 H 60.000031 V 43.572266 c 0,-1.704325 -1.443443,-3.072266 -3.240234,-3.072266 -0.9684,0 -1.830539,0.394996 -2.423828,1.029297 L 35.888672,58.896555 C 35.340282,59.447524 35,60.182545 35,61.00007 c 0,0.817527 0.340278,1.558404 0.888672,2.109375 L 54.335969,80.464844 C 54.929258,81.09917 55.791397,81.5 56.759797,81.5 c 1.796791,0 3.240234,-1.373793 3.240234,-3.078125 V 68 h 4.544891 c 2.412686,0 2.845425,-0.429191 3.845703,-0.642582 C 71.020969,62.35987 76.13837,58.858703 82.076172,58.52734 83.851415,55.775653 85.05157,52.16963 85,47.5 V 41.056641 C 85,39.729541 84.392086,38.5 83,38.5 Z"
+     sodipodi:nodetypes="scscssccsccsscccccss" />
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="83"
+     cy="75"
+     r="13.999999" />
+  <path
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 81.000003,66 v 11 h 4 V 66 Z m 3.999971,14 h -3.999938 v 4 h 3.999938 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/elementary-xfce/mimetypes/16/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/16/inode-symlink.svg
@@ -4,8 +4,8 @@
    width="16"
    height="16"
    id="svg3810"
-   sodipodi:docname="inode-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="inode-symlink.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -27,14 +27,16 @@
      inkscape:window-height="893"
      id="namedview28"
      showgrid="false"
-     inkscape:zoom="35.04598"
-     inkscape:cx="8.2320426"
-     inkscape:cy="7.047884"
-     inkscape:window-x="601"
-     inkscape:window-y="135"
+     inkscape:zoom="24.78125"
+     inkscape:cx="10.108449"
+     inkscape:cy="11.419924"
+     inkscape:window-x="574"
+     inkscape:window-y="120"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3810"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3812">
     <linearGradient
@@ -129,80 +131,18 @@
        style="fill:none;stroke:url(#linearGradient3988);stroke-width:1;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0" />
   </g>
   <path
-     d="M 6,3 V 4 H 4.0000002 V 5 H 12 V 4 H 10 V 3 Z M 5,6 v 6 c 0,0 0,1 1,1 H 9.97 C 10,13 11,13 11,12 V 6 Z"
-     fill="#666666"
-     overflow="visible"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.5;marker:none"
-     id="path2"
-     sodipodi:nodetypes="cccccccccccssscc" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect2659"
-     width="1"
-     height="1"
-     x="7"
-     y="8" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5582"
-     width="1"
-     height="1"
-     x="6"
-     y="9" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5584"
-     width="1"
-     height="1"
-     x="6"
-     y="11" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5586"
-     width="1"
-     height="1"
-     x="8"
-     y="7" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5588"
-     width="1"
-     height="1"
-     x="7"
-     y="10" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5590"
-     width="1"
-     height="1"
-     x="8"
-     y="9" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5957"
-     width="1"
-     height="1"
-     x="9"
-     y="8" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5959"
-     width="1"
-     height="1"
-     x="9"
-     y="10" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5961"
-     width="1"
-     height="1"
-     x="8"
-     y="11" />
-  <rect
-     style="opacity:1;fill:#e7e7e7;fill-opacity:1;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.4"
-     id="rect5963"
-     width="1"
-     height="1"
-     x="6"
-     y="7" />
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:3.99999;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 11.599609 2.5 C 11.327683 2.5 11.181641 2.6178826 11.181641 2.8691406 C 11.153851 4.2208491 10.020725 4.9134106 8.3183594 5 L 7 5 L 7 3.5527344 C 7 3.2466524 6.7394321 3 6.4160156 3 C 6.2417073 3 6.0872584 3.0696792 5.9804688 3.1835938 L 3.1601562 6.1210938 C 3.0614475 6.2200435 3 6.3531796 3 6.5 C 3 6.6468201 3.0614482 6.7799568 3.1601562 6.8789062 L 5.7246094 9.6875 C 6.2718166 8.1282307 7.7617064 7 9.5 7 C 9.8489313 7 10.188327 7.0455782 10.511719 7.1308594 C 10.793075 6.9545593 11.047246 6.7734186 11.255859 6.6074219 C 11.851569 6.0066908 12.011919 5.2050757 12 4.1308594 L 12 2.8691406 C 12 2.630805 11.936469 2.5 11.599609 2.5 z " />
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="9.5"
+     cy="10.999999"
+     r="3" />
+  <path
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 9,9 v 2.00001 H 9.999999 V 9 Z m 0.999991,3.000001 H 9.000009 v 0.999997 h 0.999982 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/elementary-xfce/mimetypes/24/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/24/inode-symlink.svg
@@ -4,8 +4,8 @@
    height="24"
    width="24"
    version="1.1"
-   sodipodi:docname="inode-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="inode-symlink.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -28,13 +28,15 @@
      id="namedview38"
      showgrid="false"
      inkscape:zoom="16.520834"
-     inkscape:cx="18.915511"
-     inkscape:cy="18.279949"
-     inkscape:window-x="731"
-     inkscape:window-y="121"
+     inkscape:cx="13.104666"
+     inkscape:cy="10.834804"
+     inkscape:window-x="599"
+     inkscape:window-y="120"
      inkscape:window-maximized="0"
      inkscape:current-layer="svg3828"
-     inkscape:pagecheckerboard="0" />
+     inkscape:pagecheckerboard="0"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3830">
     <linearGradient
@@ -180,10 +182,19 @@
      id="path4160-3-1"
      d="m 3.4999601,1.4999569 c 3.8955809,0 17.0000589,0.00136 17.0000589,0.00136 l 2.1e-5,20.9987161 c 0,0 -11.3333862,0 -17.0000799,0 0,-7.000018 0,-14.000035 0,-21.0000538 z" />
   <path
-     d="M 9.9999998,6 V 7 H 7.5 C 7.5,7 7,7 7,7.5 V 9 H 17 V 7.5 C 17,7 16.5,7 16.5,7 H 14 V 6 Z M 8,10 v 8 c 0,0 0,1 1,1 h 5.97 C 15,19 16,19 16,18 v -8 z m 1.9999998,2 H 11 v 5 H 9.9999998 Z M 13,12 h 1 v 5 h -1 z"
-     fill="#666666"
-     overflow="visible"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.5;marker:none"
-     id="path2"
-     sodipodi:nodetypes="cccsccsccccccssscccccccccccc" />
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:3.99999;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 15,6.951293 c -0.03397,1.6521537 -1.416558,3.048832 -3.5,3.048832 H 10.003906 V 7.6759062 c 0,-0.3741151 -0.3175879,-0.6738281 -0.7128904,-0.6738281 -0.213052,0 -0.402677,0.085375 -0.5332031,0.2246094 L 5.1956562,11.029422 c -0.1206482,0.120943 -0.1953125,0.283437 -0.1953125,0.462891 0,0.179454 0.074664,0.341947 0.1953125,0.46289 l 3.5621563,3.81836 c 0.1305261,0.13924 0.3201511,0.228515 0.5332031,0.228515 0.3953025,0 0.7128904,-0.301663 0.7128904,-0.675781 v -2.31836 L 11.5,12.992313 c 0.427878,-0.0041 0.750284,-0.05296 0.986328,-0.115235 0.649627,-0.745165 1.568461,-1.249297 2.603516,-1.355469 3.18e-4,-3.2e-4 0.0016,3.21e-4 0.002,0 C 15.819961,10.787353 16.014569,9.8068622 16,8.4938789 V 6.951293 C 16,6.6599821 15.922601,6.5001211 15.510862,6.5001211 15.178492,6.5001211 15,6.6441875 15,6.951293 Z"
+     sodipodi:nodetypes="cscssccsccssccccccscc" />
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="15.5"
+     cy="15.500126"
+     r="3.5" />
+  <path
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 15,13.000121 v 3.00001 h 0.999999 v -3.00001 z m 0.999991,4.000001 h -0.999982 v 0.999997 h 0.999982 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/elementary-xfce/mimetypes/32/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/32/inode-symlink.svg
@@ -4,8 +4,8 @@
    width="32"
    height="32"
    id="svg3182"
-   sodipodi:docname="inode-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="inode-symlink.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,15 +23,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="21.3125"
-     inkscape:cx="16.02346"
-     inkscape:cy="16"
+     inkscape:zoom="42.624999"
+     inkscape:cx="20.750734"
+     inkscape:cy="16.140763"
      inkscape:window-width="1317"
      inkscape:window-height="893"
-     inkscape:window-x="831"
+     inkscape:window-x="599"
      inkscape:window-y="115"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3182" />
+     inkscape:current-layer="svg3182"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3184">
     <linearGradient
@@ -197,10 +199,18 @@
      id="path4160-6-1"
      d="m 4.499961,0.499944 c 5.27048,0 23.000054,0.002 23.000054,0.002 l 2.4e-5,28.998112 c 0,0 -15.333385,0 -23.000078,0 0,-9.666722 0,-19.333346 0,-28.999956 z" />
   <path
-     d="m 14,9 v 1 h -3.5 c 0,0 -0.5,0 -0.5,0.5 V 12 H 22 V 10.5 C 22,10 21.5,10 21.5,10 H 18 V 9 Z m -3,4 v 9 c 0,0 0,1 1,1 h 7.97 C 20,23 21,23 21,22 v -9 z m 3,2 h 1 v 6 h -1 z m 3,0 h 1 v 6 h -1 z"
-     fill="#666666"
-     overflow="visible"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.5;marker:none"
-     id="path2"
-     sodipodi:nodetypes="cccsccsccccccssscccccccccccc" />
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:3.99999;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 20.421875 8.4453125 C 20.029089 8.4453125 19.816406 8.6041738 19.816406 8.9453125 C 19.776266 10.780559 18.143317 11.951669 15.681641 12 L 14 12 L 14 9.7519531 C 14 9.3363793 13.625362 9.0019531 13.158203 9.0019531 C 12.906423 9.0019531 12.681596 9.0972843 12.527344 9.2519531 L 8.2304688 13.476562 C 8.0878902 13.61091 8 13.790897 8 13.990234 C 8 14.189578 8.0878901 14.36956 8.2304688 14.503906 L 12.527344 18.746094 C 12.681596 18.900766 12.906423 19 13.158203 19 C 13.625362 19 14 18.665578 14 18.25 L 14 16 L 15.681641 16 C 15.897058 16 16.104406 15.983655 16.304688 15.953125 C 16.323753 15.930623 16.343864 15.908909 16.363281 15.886719 C 16.393354 15.85235 16.424176 15.818768 16.455078 15.785156 C 16.48719 15.75023 16.519746 15.715727 16.552734 15.681641 C 16.579038 15.65446 16.604008 15.626248 16.630859 15.599609 C 16.671389 15.559403 16.714109 15.521362 16.755859 15.482422 C 16.779464 15.460404 16.802185 15.437622 16.826172 15.416016 C 16.860876 15.384758 16.896151 15.354599 16.931641 15.324219 C 16.960376 15.299613 16.988338 15.274022 17.017578 15.25 C 17.065928 15.2103 17.11632 15.172831 17.166016 15.134766 C 17.186237 15.119263 17.206123 15.103119 17.226562 15.087891 C 17.268336 15.056798 17.31085 15.026018 17.353516 14.996094 C 17.385145 14.973896 17.417111 14.953186 17.449219 14.931641 C 17.463615 14.921984 17.477696 14.911868 17.492188 14.902344 C 17.553263 14.862187 17.615015 14.822917 17.677734 14.785156 C 17.745619 14.744313 17.813082 14.703969 17.882812 14.666016 C 17.889178 14.662547 17.895963 14.659694 17.902344 14.65625 C 17.974311 14.61745 18.047269 14.580561 18.121094 14.544922 C 18.125563 14.542761 18.13029 14.541212 18.134766 14.539062 C 18.277623 14.470454 18.422996 14.407845 18.572266 14.351562 C 18.585937 14.346414 18.599559 14.34098 18.613281 14.335938 C 18.614628 14.335442 18.615841 14.334479 18.617188 14.333984 C 18.643577 14.324311 18.670691 14.315918 18.697266 14.306641 C 18.753379 14.287026 18.810276 14.267823 18.867188 14.25 C 19.119051 14.171124 19.378844 14.110329 19.644531 14.068359 C 19.651694 14.06723 19.658844 14.065555 19.666016 14.064453 C 19.747714 14.051883 19.829296 14.042103 19.912109 14.033203 C 19.916809 14.030003 19.921311 14.026637 19.925781 14.023438 C 20.78625 13.207842 21 12.120148 21 10.660156 L 21 8.9453125 C 21 8.6217189 20.90846 8.4453125 20.421875 8.4453125 z " />
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="20.5"
+     cy="19.5"
+     r="4.5" />
+  <path
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 19.999829,16.999688 v 3.000008 h 0.999999 v -3.000008 z m 0.999991,3.999999 h -0.999982 v 0.999997 h 0.999982 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/elementary-xfce/mimetypes/48/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/48/inode-symlink.svg
@@ -4,8 +4,8 @@
    width="48"
    height="48"
    id="svg3901"
-   sodipodi:docname="inode-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="inode-symlink.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -24,14 +24,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="10.046809"
-     inkscape:cx="32.199279"
-     inkscape:cy="34.239728"
+     inkscape:cx="21.947267"
+     inkscape:cy="31.054636"
      inkscape:window-width="1317"
      inkscape:window-height="893"
-     inkscape:window-x="895"
-     inkscape:window-y="95"
+     inkscape:window-x="599"
+     inkscape:window-y="120"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3901" />
+     inkscape:current-layer="svg3901"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3903">
     <linearGradient
@@ -197,8 +199,19 @@
      id="path4160-6-1"
      d="m 6.4999605,0.4999623 c 8.0202885,0 35.0000415,0.00298 35.0000415,0.00298 l 3.7e-5,43.9970957 c 0,0 -23.333385,0 -35.0000785,0 0,-14.666738 0,-29.333326 0,-43.9998923 z" />
   <path
-     id="path2"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.5;marker:none"
-     d="m 21,12 v 2 h -6.25 c 0,0 -0.75,0 -0.75,0.75 V 17 H 34 V 14.75 C 34,14 33.25,14 33.25,14 H 27 v -2 z m -5,6 v 15.5 c 0,0 0,1.5 1.5,1.5 h 12.954295 c 0.045,0 1.54541,0 1.54541,-1.5 V 18 Z m 3,3 h 2 v 11 h -2 z m 4,0 h 2 v 11 h -2 z m 4,0 h 2 v 11 h -2 z"
-     sodipodi:nodetypes="cccsccsccccccsssccccccccccccccccc" />
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:3.99999;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="M 30.056641,14.240598 C 29.42156,14.22347 29,14.576466 29,14.992552 c -0.05868,2.753876 -2.174842,5.007812 -5.773438,5.007812 h -2.226391 v -3.876953 c 0,-0.623592 -0.547688,-1.123047 -1.230468,-1.123047 -0.367991,0 -0.696426,0.14487 -0.921875,0.376953 l -6.509937,6.337891 C 12.129503,21.916801 12,22.185616 12,22.484739 c 0,0.299123 0.129501,0.569892 0.337891,0.771484 l 6.509937,6.367188 c 0.225449,0.232092 0.553884,0.378906 0.921875,0.378906 0.682781,0 1.230468,-0.503361 1.230468,-1.126953 v -3.863281 l 2.226391,-0.02344 c 0.38157,-0.01293 0.754196,-0.04852 1.117188,-0.101562 1.189167,-1.629451 3.062941,-2.728139 5.191406,-2.869141 C 30.463774,20.809535 31,19.275895 31,17.494505 v -2.501953 c 0,-0.618414 -0.308281,-0.734826 -0.943359,-0.751954 z"
+     sodipodi:nodetypes="scscssccsccssccccsss" />
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="30"
+     cy="29.000729"
+     r="6" />
+  <path
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 28.999997,25.000726 v 5 h 2 v -5 z m 1.999985,6 h -1.999969 v 2 h 1.999969 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/elementary-xfce/mimetypes/64/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/64/inode-symlink.svg
@@ -5,7 +5,7 @@
    width="64"
    version="1.1"
    sodipodi:docname="inode-symlink.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,15 +23,17 @@
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      showgrid="false"
-     inkscape:zoom="15.070213"
-     inkscape:cx="35.268247"
-     inkscape:cy="38.08838"
-     inkscape:window-width="1317"
-     inkscape:window-height="893"
-     inkscape:window-x="928"
-     inkscape:window-y="442"
+     inkscape:zoom="8.0000004"
+     inkscape:cx="49.624998"
+     inkscape:cy="38.562498"
+     inkscape:window-width="1324"
+     inkscape:window-height="828"
+     inkscape:window-x="563"
+     inkscape:window-y="129"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3844" />
+     inkscape:current-layer="svg3844"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3846">
     <linearGradient
@@ -157,25 +159,6 @@
        x2="302.85715"
        y1="366.64789"
        x1="302.85715" />
-    <linearGradient
-       xlink:href="#linearGradient920"
-       id="linearGradient922"
-       x1="32"
-       y1="1"
-       x2="32"
-       y2="59"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient920">
-      <stop
-         style="stop-color:#ed5353;stop-opacity:1"
-         offset="0"
-         id="stop916" />
-      <stop
-         style="stop-color:#c6262e;stop-opacity:1"
-         offset="1"
-         id="stop918" />
-    </linearGradient>
   </defs>
   <metadata
      id="metadata3849">
@@ -207,6 +190,11 @@
      d="m 9,0.9998799 c 10.540935,0 45.999945,0.004 45.999945,0.004 L 55,59.00002 c 0,0 -30.666666,0 -46,0 0,-19.3334 0,-38.6665 0,-57.9998201 z"
      id="path4160-6"
      style="display:inline;fill:url(#linearGradient3096);fill-opacity:1;stroke:none" />
+  <path
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:3.99999;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 39.0625,20 c -0.512019,1e-6 -0.894531,0.489949 -0.894531,0.990234 C 38.100019,24.301399 35.166896,27 31,27 h -1.999906 v -4.648219 c 0,-0.749783 -0.635175,-1.351562 -1.425781,-1.351562 -0.426107,0 -0.805354,0.174077 -1.066407,0.453125 l -8.117281,7.620898 C 18.149328,29.316631 18,29.64037 18,30.000023 c 0,0.359654 0.149326,0.685346 0.390625,0.927735 l 8.117281,7.616921 c 0.261053,0.279059 0.6403,0.455078 1.066407,0.455078 0.790606,0 1.425781,-0.603727 1.425781,-1.353515 V 33 H 31 c 2.299325,0 3.074219,-0.714844 3.074219,-0.714844 0.996272,-1.581407 2.60499,-2.741042 4.490234,-3.136718 0.989381,-1.444404 1.474927,-3.225286 1.433594,-5.150391 V 20.990234 C 39.998047,20.406403 39.673989,20 39.0625,20 Z"
+     sodipodi:nodetypes="scscssccsccsscscccss" />
   <path
      d="m 54.499999,58.50002 -44.9999992,0 0,-57.0000401 44.9999992,0 z"
      id="rect6741-1-8"
@@ -251,9 +239,15 @@
        style="display:inline"
        id="layer12" />
   </g>
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="40"
+     cy="36"
+     r="6" />
   <path
-     id="path2"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.5;marker:none"
-     d="m 28,17 v 2 h -7 c 0,0 -1,0 -1,1 v 3 h 24 v -3 c 0,-1 -1,-1 -1,-1 h -7 v -2 z m -6,8 v 18 c 0,0 0,2 2,2 H 39.939453 C 39.999453,45 42,45 42,43 V 25 H 23.939453 Z m 4,3 h 2 v 14 h -2 z m 5,0 h 2 v 14 h -2 z m 5,0 h 2 v 14 h -2 z"
-     sodipodi:nodetypes="cccsccsccccccssscccccccccccccccccc" />
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 38.999998,31.999998 v 5 h 2 v -5 z m 1.999985,6 h -1.999969 v 2 h 1.999969 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>

--- a/elementary-xfce/mimetypes/96/inode-symlink.svg
+++ b/elementary-xfce/mimetypes/96/inode-symlink.svg
@@ -4,8 +4,8 @@
    height="96"
    width="96"
    version="1.1"
-   sodipodi:docname="inode-symbolic.svg"
-   inkscape:version="1.1.2 (0a00cf5339, 2022-02-04)"
+   sodipodi:docname="inode-symlink.svg"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -23,14 +23,16 @@
      inkscape:pagecheckerboard="0"
      showgrid="false"
      inkscape:zoom="2.8284272"
-     inkscape:cx="73.539103"
-     inkscape:cy="36.946328"
+     inkscape:cx="41.365746"
+     inkscape:cy="61.341512"
      inkscape:window-width="1396"
      inkscape:window-height="896"
-     inkscape:window-x="1151"
-     inkscape:window-y="541"
+     inkscape:window-x="505"
+     inkscape:window-y="69"
      inkscape:window-maximized="0"
-     inkscape:current-layer="svg3901" />
+     inkscape:current-layer="svg3901"
+     inkscape:showpageshadow="2"
+     inkscape:deskcolor="#d1d1d1" />
   <defs
      id="defs3903">
     <linearGradient
@@ -194,8 +196,19 @@
      style="display:inline;fill:none;stroke:url(#linearGradient3170);stroke-width:0.999922;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
      sodipodi:nodetypes="ccccc" />
   <path
-     id="path2"
-     style="fill:#ed5353;fill-opacity:1;stroke-width:0.5;marker:none"
-     d="m 40,20 v 4 H 26 c 0,0 -2,0 -2,2 v 6 h 48 v -6 c 0,-2 -2,-2 -2,-2 H 56 V 20 Z M 28,36 v 36 c 0,0 0,4 4,4 H 63.878906 C 63.998906,76 68,76 68,72 V 36 H 31.878906 Z m 8,6 h 4 v 28 h -4 z m 10,0 h 4 v 28 h -4 z m 10,0 h 4 v 28 h -4 z"
-     sodipodi:nodetypes="cccsccsccccccssscccccccccccccccccc" />
+     id="path873-5-3-7-3-6"
+     style="fill:#555761;stroke:none;stroke-width:4;stroke-linecap:round;stroke-linejoin:round;stop-color:#000000"
+     d="m 61.380859,27.5 c -0.884375,2e-6 -1.546875,0.694796 -1.546875,1.554688 -0.117366,5.691236 -5.183657,9.945656 -12.380859,9.945656 H 44 V 31.32261 c 0,-1.288728 -1.134439,-2.322266 -2.5,-2.322266 -0.735984,0 -1.390896,0.299668 -1.841797,0.779297 L 25.673828,42.908547 C 25.257051,43.325166 25,43.882172 25,44.500344 c 0,0.618174 0.257048,1.179085 0.673828,1.595703 l 13.984375,13.123047 c 0.450901,0.479647 1.105813,0.78125 1.841797,0.78125 1.36556,0 2.5,-1.037438 2.5,-2.326172 v -7.673828 h 3.453125 c 1.424459,0 2.505768,-0.206699 3.3125,-0.470703 1.869752,-3.819584 5.630542,-6.55438 10.050781,-6.972656 1.50852,-2.398018 2.246807,-5.289579 2.179688,-8.400391 v -5.101906 c 0,-1.00349 -0.55905,-1.554688 -1.615235,-1.554688 z"
+     sodipodi:nodetypes="scscssccsccsscscccss" />
+  <circle
+     style="font-variation-settings:normal;fill:#f24040;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     id="path6156"
+     cx="61.999996"
+     cy="55.000469"
+     r="11" />
+  <path
+     id="circle6158-2"
+     style="font-variation-settings:normal;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.5;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;paint-order:markers fill stroke;stop-color:#000000"
+     d="m 60,48.000344 v 8.999882 h 4.000021 v -8.999882 z m 3.999991,10.999882 h -3.999959 v 4.000118 h 3.999959 z"
+     sodipodi:nodetypes="cccccccccc" />
 </svg>


### PR DESCRIPTION
Proposal for a new broken symlink icon; one that is hopefully more clear and understandable.

---

The `inode-symlink` icon, in all major file managers, only shows if a symlink is broken. Previously a trash emblem was used since they're empty and safe to delete, but it doesn't really symbolize "broken symlink" and it's not always best to delete them or symbolize them as trash.
    
This new design uses the symlink emblem with the error symbol to let the user know something is wrong. Hopefully this is a more clear symbol.