### PR TITLE
Index: Remove inherited themes from HiDPI

### DIFF
--- a/elementary-xfce/index-hidpi.theme
+++ b/elementary-xfce/index-hidpi.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=elementary Xfce (HiDPI)
 Comment=Scalable icons for 2x+ Window Scaling
-Inherits=elementary,Adwaita,gnome,hicolor
+Inherits=hicolor
 
 Example=directory-x-normal
 


### PR DESCRIPTION
FreeDesktop.org Icon Theme spec was updated stating that inherited themes should be present on the system if the icon theme is to be installed (inhereted themes considered dependencies).

This just follows the change to the main theme made previously.

See #461