### PR TITLE
MimeTypes: Add lossless audio symlinks

### DIFF
--- a/elementary-xfce/mimetypes/128/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/128/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/128/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/128/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/128/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/16/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/16/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/16/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/16/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/16/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/16/text.svg
+++ b/elementary-xfce/mimetypes/16/text.svg
@@ -1,0 +1,1 @@
+text-x-generic.svg

--- a/elementary-xfce/mimetypes/24/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/24/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/24/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/24/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/24/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/32/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/32/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/32/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/32/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/32/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/48/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/48/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/48/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/48/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/48/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/64/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/64/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/64/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/64/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/64/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/96/audio-x-aiff.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-aiff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/96/audio-x-dff.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-dff.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/96/audio-x-dsf.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-dsf.svg
@@ -1,0 +1,1 @@
+audio-flac.svg

--- a/elementary-xfce/mimetypes/96/audio-x-tak.svg
+++ b/elementary-xfce/mimetypes/96/audio-x-tak.svg
@@ -1,0 +1,1 @@
+audio-flac.svg


### PR DESCRIPTION
Add lossless audio symlinks for these audio files:
- AIFF - Audio Interchange File Format (Apple's WAV equivalent)
- Tom's lossless Audio Kompressor
- Direct Stream Digital (dff and dss)