### PR TITLE
Status: Add 48px symbolic mic and volume icons

### DIFF
--- a/elementary-xfce/status/48/audio-volume-high-symbolic.svg
+++ b/elementary-xfce/status/48/audio-volume-high-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="audio-volume-high-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="20.24093"
+     inkscape:cy="21.213202"
+     inkscape:window-width="1507"
+     inkscape:window-height="898"
+     inkscape:window-x="220"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14">
+    <linearGradient
+       id="linearGradient5662">
+      <stop
+         id="stop5654"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5656"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02474486" />
+      <stop
+         id="stop5658"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.31732139" />
+      <stop
+         id="stop5660"
+         style="stop-color:#ffffff;stop-opacity:0.5;"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     style="color:#000000;fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers fill stroke;font-variation-settings:normal;opacity:1;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stop-color:#000000;stop-opacity:1"
+     d="m 36.482962,6.5909336 a 1.5,1.5 0 0 0 -1.0625,0.441406 1.5,1.5 0 0 0 0,2.121094 c 3.938668,3.9386694 6.152344,9.2775404 6.152344,14.8476584 0,5.570116 -2.213676,10.908988 -6.152344,14.847654 a 1.5,1.5 0 0 0 0,2.121094 1.5,1.5 0 0 0 2.121094,0 c 4.500462,-4.50046 7.03125,-10.604134 7.03125,-16.968748 0,-6.364614 -2.530788,-12.468289 -7.03125,-16.9687524 a 1.5,1.5 0 0 0 -1.058594,-0.441406 z"
+     id="circle4163" />
+  <path
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 30.678227,11.274529 a 1.5,1.5 0 0 0 0,2.121094 c 2.813452,2.81345 4.394532,6.626648 4.394532,10.605468 0,3.97882 -1.58108,7.792018 -4.394532,10.605468 a 1.5,1.5 0 0 0 0,2.121094 1.5,1.5 0 0 0 2.125,0 c 3.375244,-3.375244 5.269532,-7.953246 5.269532,-12.726562 0,-4.773316 -1.894286,-9.351318 -5.269532,-12.726562 a 1.5,1.5 0 0 0 -2.125,0 z"
+     id="circle4167" />
+  <path
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 26.998727,15.075311 a 1.5,1.5 0 0 0 -1.0625,0.441406 1.5,1.5 0 0 0 0,2.121094 c 1.688232,1.688232 2.636718,3.975758 2.636718,6.36328 0,2.387522 -0.948486,4.675048 -2.636718,6.363282 a 1.5,1.5 0 0 0 0,2.121092 1.5,1.5 0 0 0 2.121094,0 c 2.250026,-2.250026 3.515624,-5.302356 3.515624,-8.484374 0,-3.182018 -1.265598,-6.234348 -3.515624,-8.484374 a 1.5,1.5 0 0 0 -1.058594,-0.441406 z"
+     id="circle4171" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;fill-opacity:1"
+     d="M 20.439453,6.1835937 C 19.495713,5.8008444 18.414132,6.0287489 17.705078,6.7597656 L 10.246094,14.451172 6.0097656,15.298828 C 4.8413394,15.532585 4.0002363,16.55842 4,17.75 v 12.5 c -6.949e-4,1.192314 0.8406192,2.219224 2.0097656,2.453125 l 4.2363284,0.845703 7.458984,7.691406 C 19.268597,42.852134 21.999487,41.745621 22,39.5 V 8.5 C 21.999783,7.4822062 21.382625,6.566125 20.439453,6.1835937 Z"
+     id="path3-9"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/elementary-xfce/status/48/audio-volume-low-symbolic.svg
+++ b/elementary-xfce/status/48/audio-volume-low-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="audio-volume-low-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="20.196737"
+     inkscape:cy="21.124814"
+     inkscape:window-width="1507"
+     inkscape:window-height="898"
+     inkscape:window-x="220"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14">
+    <linearGradient
+       id="linearGradient5662">
+      <stop
+         id="stop5654"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5656"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02474486" />
+      <stop
+         id="stop5658"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.31732139" />
+      <stop
+         id="stop5660"
+         style="stop-color:#ffffff;stop-opacity:0.5;"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     style="color:#000000;fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers fill stroke;font-variation-settings:normal;opacity:0.3;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stop-color:#000000;stop-opacity:1"
+     d="m 36.482962,6.5909336 a 1.5,1.5 0 0 0 -1.0625,0.441406 1.5,1.5 0 0 0 0,2.121094 c 3.938668,3.9386694 6.152344,9.2775404 6.152344,14.8476584 0,5.570116 -2.213676,10.908988 -6.152344,14.847654 a 1.5,1.5 0 0 0 0,2.121094 1.5,1.5 0 0 0 2.121094,0 c 4.500462,-4.50046 7.03125,-10.604134 7.03125,-16.968748 0,-6.364614 -2.530788,-12.468289 -7.03125,-16.9687524 a 1.5,1.5 0 0 0 -1.058594,-0.441406 z"
+     id="circle4163" />
+  <path
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke;opacity:0.3"
+     d="m 30.678227,11.274529 a 1.5,1.5 0 0 0 0,2.121094 c 2.813452,2.81345 4.394532,6.626648 4.394532,10.605468 0,3.97882 -1.58108,7.792018 -4.394532,10.605468 a 1.5,1.5 0 0 0 0,2.121094 1.5,1.5 0 0 0 2.125,0 c 3.375244,-3.375244 5.269532,-7.953246 5.269532,-12.726562 0,-4.773316 -1.894286,-9.351318 -5.269532,-12.726562 a 1.5,1.5 0 0 0 -2.125,0 z"
+     id="circle4167" />
+  <path
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 26.998727,15.075311 a 1.5,1.5 0 0 0 -1.0625,0.441406 1.5,1.5 0 0 0 0,2.121094 c 1.688232,1.688232 2.636718,3.975758 2.636718,6.36328 0,2.387522 -0.948486,4.675048 -2.636718,6.363282 a 1.5,1.5 0 0 0 0,2.121092 1.5,1.5 0 0 0 2.121094,0 c 2.250026,-2.250026 3.515624,-5.302356 3.515624,-8.484374 0,-3.182018 -1.265598,-6.234348 -3.515624,-8.484374 a 1.5,1.5 0 0 0 -1.058594,-0.441406 z"
+     id="circle4171" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;fill-opacity:1"
+     d="M 20.439453,6.1835937 C 19.495713,5.8008444 18.414132,6.0287489 17.705078,6.7597656 L 10.246094,14.451172 6.0097656,15.298828 C 4.8413394,15.532585 4.0002363,16.55842 4,17.75 v 12.5 c -6.949e-4,1.192314 0.8406192,2.219224 2.0097656,2.453125 l 4.2363284,0.845703 7.458984,7.691406 C 19.268597,42.852134 21.999487,41.745621 22,39.5 V 8.5 C 21.999783,7.4822062 21.382625,6.566125 20.439453,6.1835937 Z"
+     id="path3-9"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/elementary-xfce/status/48/audio-volume-medium-symbolic.svg
+++ b/elementary-xfce/status/48/audio-volume-medium-symbolic.svg
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="audio-volume-medium-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="20.24093"
+     inkscape:cy="21.213202"
+     inkscape:window-width="1507"
+     inkscape:window-height="898"
+     inkscape:window-x="220"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14">
+    <linearGradient
+       id="linearGradient5662">
+      <stop
+         id="stop5654"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5656"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02474486" />
+      <stop
+         id="stop5658"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.31732139" />
+      <stop
+         id="stop5660"
+         style="stop-color:#ffffff;stop-opacity:0.5;"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     style="color:#000000;fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers fill stroke;font-variation-settings:normal;opacity:0.3;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stop-color:#000000;stop-opacity:1"
+     d="m 36.482962,6.5909336 a 1.5,1.5 0 0 0 -1.0625,0.441406 1.5,1.5 0 0 0 0,2.121094 c 3.938668,3.9386694 6.152344,9.2775404 6.152344,14.8476584 0,5.570116 -2.213676,10.908988 -6.152344,14.847654 a 1.5,1.5 0 0 0 0,2.121094 1.5,1.5 0 0 0 2.121094,0 c 4.500462,-4.50046 7.03125,-10.604134 7.03125,-16.968748 0,-6.364614 -2.530788,-12.468289 -7.03125,-16.9687524 a 1.5,1.5 0 0 0 -1.058594,-0.441406 z"
+     id="circle4163" />
+  <path
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 30.678227,11.274529 a 1.5,1.5 0 0 0 0,2.121094 c 2.813452,2.81345 4.394532,6.626648 4.394532,10.605468 0,3.97882 -1.58108,7.792018 -4.394532,10.605468 a 1.5,1.5 0 0 0 0,2.121094 1.5,1.5 0 0 0 2.125,0 c 3.375244,-3.375244 5.269532,-7.953246 5.269532,-12.726562 0,-4.773316 -1.894286,-9.351318 -5.269532,-12.726562 a 1.5,1.5 0 0 0 -2.125,0 z"
+     id="circle4167" />
+  <path
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke"
+     d="m 26.998727,15.075311 a 1.5,1.5 0 0 0 -1.0625,0.441406 1.5,1.5 0 0 0 0,2.121094 c 1.688232,1.688232 2.636718,3.975758 2.636718,6.36328 0,2.387522 -0.948486,4.675048 -2.636718,6.363282 a 1.5,1.5 0 0 0 0,2.121092 1.5,1.5 0 0 0 2.121094,0 c 2.250026,-2.250026 3.515624,-5.302356 3.515624,-8.484374 0,-3.182018 -1.265598,-6.234348 -3.515624,-8.484374 a 1.5,1.5 0 0 0 -1.058594,-0.441406 z"
+     id="circle4171" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;fill-opacity:1"
+     d="M 20.439453,6.1835937 C 19.495713,5.8008444 18.414132,6.0287489 17.705078,6.7597656 L 10.246094,14.451172 6.0097656,15.298828 C 4.8413394,15.532585 4.0002363,16.55842 4,17.75 v 12.5 c -6.949e-4,1.192314 0.8406192,2.219224 2.0097656,2.453125 l 4.2363284,0.845703 7.458984,7.691406 C 19.268597,42.852134 21.999487,41.745621 22,39.5 V 8.5 C 21.999783,7.4822062 21.382625,6.566125 20.439453,6.1835937 Z"
+     id="path3-9"
+     sodipodi:nodetypes="cccccccccccc" />
+</svg>

--- a/elementary-xfce/status/48/audio-volume-muted-symbolic.svg
+++ b/elementary-xfce/status/48/audio-volume-muted-symbolic.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   id="svg2"
+   version="1.1"
+   sodipodi:docname="audio-volume-muted-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     id="namedview49079"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="11.313709"
+     inkscape:cx="15.644737"
+     inkscape:cy="18.915106"
+     inkscape:window-width="1507"
+     inkscape:window-height="898"
+     inkscape:window-x="329"
+     inkscape:window-y="119"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2"
+     showguides="true" />
+  <metadata
+     id="metadata16">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs14">
+    <linearGradient
+       id="linearGradient5662">
+      <stop
+         id="stop5654"
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="0" />
+      <stop
+         id="stop5656"
+         style="stop-color:#ffffff;stop-opacity:0.23529412"
+         offset="0.02474486" />
+      <stop
+         id="stop5658"
+         style="stop-color:#ffffff;stop-opacity:0.15686275"
+         offset="0.31732139" />
+      <stop
+         id="stop5660"
+         style="stop-color:#ffffff;stop-opacity:0.5;"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <path
+     id="circle4163"
+     style="color:#000000;fill:#555761;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1;-inkscape-stroke:none;paint-order:markers fill stroke;font-variation-settings:normal;opacity:0.3;vector-effect:none;fill-opacity:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stop-color:#000000;stop-opacity:1"
+     d="M 36.482422 6.5917969 A 1.5 1.5 0 0 0 35.419922 7.0332031 A 1.5 1.5 0 0 0 35.419922 9.1542969 C 39.35859 13.092966 41.572266 18.431835 41.572266 24.001953 C 41.572266 28.898067 39.862279 33.614489 36.773438 37.359375 L 38.902344 39.488281 C 42.548349 35.174058 44.572266 29.693188 44.572266 24.001953 C 44.572266 17.637339 42.041478 11.533667 37.541016 7.0332031 A 1.5 1.5 0 0 0 36.482422 6.5917969 z M 35.427734 38.841797 C 35.425365 38.844168 35.422292 38.847239 35.419922 38.849609 A 1.5 1.5 0 0 0 35.419922 40.970703 A 1.5 1.5 0 0 0 37.541016 40.970703 C 37.543386 40.968333 37.546459 40.965262 37.548828 40.962891 L 35.427734 38.841797 z " />
+  <path
+     id="circle4167"
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke;opacity:0.3"
+     d="M 31.740234 10.833984 A 1.5 1.5 0 0 0 30.677734 11.275391 A 1.5 1.5 0 0 0 30.677734 13.396484 C 33.491186 16.209934 35.072266 20.023133 35.072266 24.001953 C 35.072266 27.184131 34.061072 30.259155 32.216797 32.802734 L 34.363281 34.949219 C 36.756961 31.825024 38.072266 27.981398 38.072266 24.001953 C 38.072266 19.228637 36.17798 14.650635 32.802734 11.275391 A 1.5 1.5 0 0 0 31.740234 10.833984 z M 30.931641 34.345703 C 30.848119 34.433365 30.76356 34.521597 30.677734 34.607422 A 1.5 1.5 0 0 0 30.677734 36.728516 A 1.5 1.5 0 0 0 32.802734 36.728516 C 32.887887 36.643363 32.97338 36.557371 33.056641 36.470703 L 30.931641 34.345703 z " />
+  <path
+     id="circle4171"
+     style="color:#000000;fill:#555761;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:0.35;-inkscape-stroke:none;paint-order:markers fill stroke;opacity:0.3"
+     d="M 26.998047 15.076172 A 1.5 1.5 0 0 0 25.935547 15.517578 A 1.5 1.5 0 0 0 25.935547 17.638672 C 27.623779 19.326904 28.572266 21.614431 28.572266 24.001953 C 28.572266 25.458887 28.219506 26.877481 27.560547 28.146484 L 29.757812 30.34375 C 30.934043 28.455502 31.572266 26.262078 31.572266 24.001953 C 31.572266 20.819935 30.306667 17.767604 28.056641 15.517578 A 1.5 1.5 0 0 0 26.998047 15.076172 z M 26.423828 29.837891 C 26.26917 30.019358 26.105392 30.195389 25.935547 30.365234 A 1.5 1.5 0 0 0 25.935547 32.486328 A 1.5 1.5 0 0 0 28.056641 32.486328 C 28.22624 32.316729 28.390536 32.141318 28.548828 31.962891 L 26.423828 29.837891 z " />
+  <path
+     id="path3-9"
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:0.3;vector-effect:none;fill:#555761;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;fill-opacity:1"
+     d="M 19.345703 6.0058594 C 18.736109 6.0434331 18.148237 6.3028802 17.705078 6.7597656 L 12.027344 12.613281 L 22 22.585938 L 22 8.5 C 21.999783 7.4822062 21.382625 6.566125 20.439453 6.1835938 C 20.085551 6.0400628 19.711459 5.9833151 19.345703 6.0058594 z M 10.634766 14.048828 L 10.246094 14.451172 L 6.0097656 15.298828 C 4.8413394 15.532585 4.0002363 16.55842 4 17.75 L 4 30.25 C 3.9993051 31.442314 4.8406192 32.469224 6.0097656 32.703125 L 10.246094 33.548828 L 17.705078 41.240234 C 19.268597 42.852134 21.999487 41.745621 22 39.5 L 22 25.414062 L 10.634766 14.048828 z " />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#666666;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="m 6.3222656,6.3222656 a 1,1 0 0 0 0,1.4140625 L 40.263672,41.677734 a 1,1 0 0 0 1.414062,0 1,1 0 0 0 0,-1.414062 L 7.7363281,6.3222656 a 1,1 0 0 0 -1.4140625,0 z"
+     id="path4" />
+</svg>

--- a/elementary-xfce/status/48/audio-volume-off-symbolic.svg
+++ b/elementary-xfce/status/48/audio-volume-off-symbolic.svg
@@ -1,0 +1,1 @@
+audio-volume-muted-symbolic.svg

--- a/elementary-xfce/status/48/microphone-sensitivity-high-symbolic.svg
+++ b/elementary-xfce/status/48/microphone-sensitivity-high-symbolic.svg
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="microphone-sensitivity-high-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="8"
+     inkscape:cx="33.3125"
+     inkscape:cy="31.25"
+     inkscape:window-width="1643"
+     inkscape:window-height="986"
+     inkscape:window-x="886"
+     inkscape:window-y="241"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 18,4 a 6,6 0 0 0 -6,6 v 16 a 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 V 10 A 6,6 0 0 0 18,4 Z"
+     id="path3" />
+  <path
+     id="rect4"
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.5,18 C 4.669,18 4,18.669 4,19.5 4,20.331 4.669,21 5.5,21 H 7 v 5 c 0,5.018108 3.392119,9.270352 8,10.582031 V 41 h -1.5 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 9 C 23.331,44 24,43.331 24,42.5 24,41.669 23.331,41 22.5,41 H 21 V 36.582031 C 25.607881,35.270352 29,31.018108 29,26 v -5 h 1.5 C 31.331,21 32,20.331 32,19.5 32,18.669 31.331,18 30.5,18 h -3 C 26.669,18 26,18.669 26,19.5 V 26 c 0,4.436045 -3.563955,8 -8,8 -4.436045,0 -8,-3.563955 -8,-8 V 19.5 C 10,18.669 9.331,18 8.5,18 Z" />
+  <circle
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="circle11"
+     cx="39.5"
+     cy="23.5"
+     r="4.5" />
+  <circle
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="circle13"
+     cx="39.5"
+     cy="34.5"
+     r="4.5" />
+  <circle
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="circle14"
+     cx="39.5"
+     cy="12.5"
+     r="4.5" />
+</svg>

--- a/elementary-xfce/status/48/microphone-sensitivity-low-symbolic.svg
+++ b/elementary-xfce/status/48/microphone-sensitivity-low-symbolic.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="microphone-sensitivity-low-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16"
+     inkscape:cx="37.34375"
+     inkscape:cy="25.0625"
+     inkscape:window-width="1643"
+     inkscape:window-height="986"
+     inkscape:window-x="176"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 18,4 a 6,6 0 0 0 -6,6 v 16 a 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 V 10 A 6,6 0 0 0 18,4 Z"
+     id="path3" />
+  <path
+     id="rect4"
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.5,18 C 4.669,18 4,18.669 4,19.5 4,20.331 4.669,21 5.5,21 H 7 v 5 c 0,5.018108 3.392119,9.270352 8,10.582031 V 41 h -1.5 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 9 C 23.331,44 24,43.331 24,42.5 24,41.669 23.331,41 22.5,41 H 21 V 36.582031 C 25.607881,35.270352 29,31.018108 29,26 v -5 h 1.5 C 31.331,21 32,20.331 32,19.5 32,18.669 31.331,18 30.5,18 h -3 C 26.669,18 26,18.669 26,19.5 V 26 c 0,4.436045 -3.563955,8 -8,8 -4.436045,0 -8,-3.563955 -8,-8 V 19.5 C 10,18.669 9.331,18 8.5,18 Z" />
+  <circle
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="circle13"
+     cx="39.5"
+     cy="34.5"
+     r="4.5" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#555761;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 39.5,8 C 37.020641,8 35,10.020641 35,12.5 35,14.979359 37.020641,17 39.5,17 41.979359,17 44,14.979359 44,12.5 44,10.020641 41.979359,8 39.5,8 Z m 0,1 C 41.438919,9 43,10.561081 43,12.5 43,14.438919 41.438919,16 39.5,16 37.561081,16 36,14.438919 36,12.5 36,10.561081 37.561081,9 39.5,9 Z"
+     id="circle14" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#555761;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 39.5,19 C 37.020641,19 35,21.020641 35,23.5 35,25.979359 37.020641,28 39.5,28 41.979359,28 44,25.979359 44,23.5 44,21.020641 41.979359,19 39.5,19 Z m 0,1 C 41.438919,20 43,21.561081 43,23.5 43,25.438919 41.438919,27 39.5,27 37.561081,27 36,25.438919 36,23.5 36,21.561081 37.561081,20 39.5,20 Z"
+     id="circle15" />
+</svg>

--- a/elementary-xfce/status/48/microphone-sensitivity-medium-symbolic.svg
+++ b/elementary-xfce/status/48/microphone-sensitivity-medium-symbolic.svg
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="48"
+   width="48"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="microphone-sensitivity-medium-symbolic.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="16"
+     inkscape:cx="37.34375"
+     inkscape:cy="25.0625"
+     inkscape:window-width="1643"
+     inkscape:window-height="986"
+     inkscape:window-x="176"
+     inkscape:window-y="31"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 18,4 a 6,6 0 0 0 -6,6 v 16 a 6,6 0 0 0 6,6 6,6 0 0 0 6,-6 V 10 A 6,6 0 0 0 18,4 Z"
+     id="path3" />
+  <path
+     id="rect4"
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 5.5,18 C 4.669,18 4,18.669 4,19.5 4,20.331 4.669,21 5.5,21 H 7 v 5 c 0,5.018108 3.392119,9.270352 8,10.582031 V 41 h -1.5 c -0.831,0 -1.5,0.669 -1.5,1.5 0,0.831 0.669,1.5 1.5,1.5 h 9 C 23.331,44 24,43.331 24,42.5 24,41.669 23.331,41 22.5,41 H 21 V 36.582031 C 25.607881,35.270352 29,31.018108 29,26 v -5 h 1.5 C 31.331,21 32,20.331 32,19.5 32,18.669 31.331,18 30.5,18 h -3 C 26.669,18 26,18.669 26,19.5 V 26 c 0,4.436045 -3.563955,8 -8,8 -4.436045,0 -8,-3.563955 -8,-8 V 19.5 C 10,18.669 9.331,18 8.5,18 Z" />
+  <circle
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="circle11"
+     cx="39.5"
+     cy="23.5"
+     r="4.5" />
+  <circle
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     id="circle13"
+     cx="39.5"
+     cy="34.5"
+     r="4.5" />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;vector-effect:none;fill:#555761;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1;opacity:1"
+     d="M 39.5,8 C 37.020641,8 35,10.020641 35,12.5 35,14.979359 37.020641,17 39.5,17 41.979359,17 44,14.979359 44,12.5 44,10.020641 41.979359,8 39.5,8 Z m 0,1 C 41.438919,9 43,10.561081 43,12.5 43,14.438919 41.438919,16 39.5,16 37.561081,16 36,14.438919 36,12.5 36,10.561081 37.561081,9 39.5,9 Z"
+     id="circle14" />
+</svg>

--- a/elementary-xfce/status/48/microphone-sensitivity-muted-symbolic.svg
+++ b/elementary-xfce/status/48/microphone-sensitivity-muted-symbolic.svg
@@ -3,17 +3,43 @@
    height="48"
    width="48"
    version="1.1"
-   id="svg136"
+   id="svg1"
+   sodipodi:docname="microphone-sensitivity-muted-symbolicab1.svg"
+   inkscape:version="1.4.2 (ebf0e940d0, 2025-05-08)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg">
   <defs
-     id="defs140" />
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="11.313709"
+     inkscape:cx="22.052893"
+     inkscape:cy="14.760854"
+     inkscape:window-width="1643"
+     inkscape:window-height="986"
+     inkscape:window-x="253"
+     inkscape:window-y="44"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg1" />
   <path
-     id="path132"
-     style="font-variation-settings:normal;opacity:0.5;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000"
-     d="M 24 8 C 21.230003 8 19 10.19869 19 12.929688 L 19 19.585938 L 28.185547 28.771484 C 28.699346 27.996905 29 27.070613 29 26.072266 L 29 12.929688 C 29 10.19969 26.769997 8.0019531 24 8.0019531 L 24 8 z M 13 19 L 13 21 L 15 21 L 15 26 C 15 30.294996 17.988004 33.842001 22 34.75 L 22 38 L 20 38 L 20 40 L 28 40 L 28 38 L 26 38 L 26 34.75 C 27.34213 34.446248 28.564103 33.841196 29.603516 33.017578 L 28.191406 31.605469 C 27.023659 32.478487 25.576706 33 24 33 C 20.122004 33 17 29.878996 17 26 L 17 20.414062 L 15.585938 19 L 13 19 z M 31 19 L 31 26 C 31 27.576827 30.478329 29.02382 29.605469 30.191406 L 31.027344 31.613281 C 32.261094 30.080737 33 28.133399 33 26 L 33 21 L 35 21 L 35 19 L 31 19 z M 19 22.414062 L 19 26.072266 C 19 28.802263 21.230003 31.001953 24 31.001953 C 25.02546 31.001953 25.975876 30.699585 26.767578 30.181641 L 19 22.414062 z " />
+     id="path3"
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;fill-opacity:1;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="M 24 4 A 6 6 0 0 0 18 10 L 18 18.585938 L 28.890625 29.476562 A 6 6 0 0 0 30 26 L 30 10 A 6 6 0 0 0 24 4 z M 18 21.414062 L 18 26 A 6 6 0 0 0 24 32 A 6 6 0 0 0 27.476562 30.890625 L 18 21.414062 z " />
   <path
-     id="path2"
-     d="m 13.039062,11.625 c -0.195868,-0.195869 -0.511162,-0.195869 -0.707031,0 L 11.625,12.332031 c -0.195869,0.195869 -0.195869,0.511163 0,0.707031 L 34.960938,36.375 c 0.195868,0.195869 0.511162,0.195869 0.707031,0 L 36.375,35.667969 c 0.195869,-0.195869 0.195869,-0.511163 0,-0.707031 z"
-     style="font-variation-settings:normal;vector-effect:none;fill:#555761;fill-opacity:1;stroke:none;stroke-width:0.992;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;-inkscape-stroke:none;marker:none;stop-color:#000000" />
+     id="rect4"
+     style="fill:#555761;fill-opacity:1;stroke:none;stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-dasharray:none;stroke-opacity:1"
+     d="M 11.5 18 C 10.669 18 10 18.669 10 19.5 C 10 20.331 10.669 21 11.5 21 L 13 21 L 13 26 C 13 31.018108 16.392119 35.270352 21 36.582031 L 21 41 L 19.5 41 C 18.669 41 18 41.669 18 42.5 C 18 43.331 18.669 44 19.5 44 L 28.5 44 C 29.331 44 30 43.331 30 42.5 C 30 41.669 29.331 41 28.5 41 L 27 41 L 27 36.582031 C 28.497286 36.155814 29.865368 35.419837 31.03125 34.447266 L 28.912109 32.326172 C 27.558743 33.376294 25.855539 34 24 34 C 19.563955 34 16 30.436045 16 26 L 16 19.5 C 16 19.469673 15.997851 19.440028 15.996094 19.410156 L 14.589844 18.003906 C 14.559972 18.002149 14.530327 18 14.5 18 L 11.5 18 z M 33.5 18 C 32.669 18 32 18.669 32 19.5 L 32 26 C 32 27.855663 31.376422 29.558699 30.326172 30.912109 L 32.447266 33.033203 C 34.040325 31.124342 35 28.670239 35 26 L 35 21 L 36.5 21 C 37.331 21 38 20.331 38 19.5 C 38 18.669 37.331 18 36.5 18 L 33.5 18 z " />
+  <path
+     style="baseline-shift:baseline;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#555761;stroke-linecap:round;stroke-linejoin:round;enable-background:accumulate;stop-color:#000000;stop-opacity:1"
+     d="m 8.4436508,8.4436508 a 1,1 0 0 0 0,1.4142136 L 38.142136,39.556349 a 1,1 0 0 0 1.414213,0 1,1 0 0 0 0,-1.414213 L 9.8578644,8.4436508 a 1,1 0 0 0 -1.4142136,0 z"
+     id="path15" />
 </svg>


### PR DESCRIPTION
Added symbolic audio-volume icons at 48px to
match the new rounder style of the rest of the volume icons.

Added symbolic microphone-sensitivity icons at 48px. Only the mute icon was present, so fixes an issue where notification icons for mic would jump between 48px and 16px at different steps.

48px symbolic icons are not ideal, but 16px icons stretched to 48px look pretty bad, so probably better to have these for now.

Fixes #538